### PR TITLE
[Identity] [Core] Add experimental `TokenRequestCallback` for customizing token request body parameters

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added experimental `TokenRequestCallback` property to `TokenCredentialOptions` and `TokenRequestCallbackContext` type to allow customizing token request body parameters before they are sent to the identity provider.
+- Added experimental `TokenRequestCallback` property and `TokenRequestCallbackContext` type to MSAL-backed credential options to allow customizing token request body parameters before they are sent to the identity provider.
 
 ### Breaking Changes
 

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added experimental `TokenRequestCallback` property to `TokenCredentialOptions` and `TokenRequestCallbackContext` type to allow customizing token request body parameters before they are sent to the identity provider.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1240,7 +1240,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1355,7 +1355,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1380,7 +1380,7 @@ namespace Azure.Identity
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1401,7 +1401,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1495,7 +1495,7 @@ namespace Azure.Identity
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1564,7 +1564,7 @@ namespace Azure.Identity
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1618,7 +1618,7 @@ namespace Azure.Identity
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1239,6 +1239,8 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1352,6 +1354,8 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1375,6 +1379,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1394,6 +1400,8 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1486,6 +1494,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1553,6 +1563,8 @@ namespace Azure.Identity
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1605,6 +1617,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1676,10 +1690,8 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0002")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
-    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0002")]
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
     public partial class TokenRequestCallbackContext
     {
         internal TokenRequestCallbackContext() { }
@@ -1717,6 +1729,8 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1676,6 +1676,14 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0002")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0002")]
+    public partial class TokenRequestCallbackContext
+    {
+        internal TokenRequestCallbackContext() { }
+        public System.Collections.Generic.IDictionary<string, string> BodyParameters { get { throw null; } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public abstract partial class UnsafeTokenCacheOptions : Azure.Identity.TokenCachePersistenceOptions

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1729,8 +1729,6 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -1218,6 +1218,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1326,6 +1327,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientCertificateCredential : Azure.Core.TokenCredential
@@ -1348,6 +1350,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientSecretCredential : Azure.Core.TokenCredential
@@ -1366,6 +1369,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class ConfigurationExtensions
@@ -1453,6 +1457,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1518,6 +1523,7 @@ namespace Azure.Identity
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
@@ -1568,6 +1574,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1637,7 +1644,6 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     public partial class TokenRequestCallbackContext
     {
@@ -1675,6 +1681,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class VisualStudioCodeCredential : Azure.Identity.InteractiveBrowserCredential

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -1637,6 +1637,12 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+    }
+    public partial class TokenRequestCallbackContext
+    {
+        internal TokenRequestCallbackContext() { }
+        public System.Collections.Generic.IDictionary<string, string> BodyParameters { get { throw null; } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public abstract partial class UnsafeTokenCacheOptions : Azure.Identity.TokenCachePersistenceOptions

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -1218,7 +1218,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1327,7 +1327,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientCertificateCredential : Azure.Core.TokenCredential
@@ -1350,7 +1350,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientSecretCredential : Azure.Core.TokenCredential
@@ -1369,7 +1369,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class ConfigurationExtensions
@@ -1457,7 +1457,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1523,7 +1523,7 @@ namespace Azure.Identity
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
@@ -1574,7 +1574,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -1681,7 +1681,6 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class VisualStudioCodeCredential : Azure.Identity.InteractiveBrowserCredential

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -1218,6 +1218,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1326,6 +1327,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientCertificateCredential : Azure.Core.TokenCredential
@@ -1348,6 +1350,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientSecretCredential : Azure.Core.TokenCredential
@@ -1366,6 +1369,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class ConfigurationExtensions
@@ -1453,6 +1457,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1518,6 +1523,7 @@ namespace Azure.Identity
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
@@ -1568,6 +1574,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1637,7 +1644,6 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     public partial class TokenRequestCallbackContext
     {
@@ -1675,6 +1681,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class VisualStudioCodeCredential : Azure.Identity.InteractiveBrowserCredential

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -1637,6 +1637,12 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+    }
+    public partial class TokenRequestCallbackContext
+    {
+        internal TokenRequestCallbackContext() { }
+        public System.Collections.Generic.IDictionary<string, string> BodyParameters { get { throw null; } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public abstract partial class UnsafeTokenCacheOptions : Azure.Identity.TokenCachePersistenceOptions

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -1218,7 +1218,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1327,7 +1327,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientCertificateCredential : Azure.Core.TokenCredential
@@ -1350,7 +1350,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientSecretCredential : Azure.Core.TokenCredential
@@ -1369,7 +1369,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class ConfigurationExtensions
@@ -1457,7 +1457,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1523,7 +1523,7 @@ namespace Azure.Identity
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
@@ -1574,7 +1574,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -1681,7 +1681,6 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class VisualStudioCodeCredential : Azure.Identity.InteractiveBrowserCredential

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1240,7 +1240,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1355,7 +1355,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1380,7 +1380,7 @@ namespace Azure.Identity
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1401,7 +1401,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1495,7 +1495,7 @@ namespace Azure.Identity
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1564,7 +1564,7 @@ namespace Azure.Identity
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1618,7 +1618,7 @@ namespace Azure.Identity
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1239,6 +1239,8 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1352,6 +1354,8 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1375,6 +1379,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1394,6 +1400,8 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1486,6 +1494,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1553,6 +1563,8 @@ namespace Azure.Identity
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -1605,6 +1617,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1676,10 +1690,8 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0002")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
-    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0002")]
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
     public partial class TokenRequestCallbackContext
     {
         internal TokenRequestCallbackContext() { }
@@ -1717,6 +1729,8 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1676,6 +1676,14 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0002")]
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0002")]
+    public partial class TokenRequestCallbackContext
+    {
+        internal TokenRequestCallbackContext() { }
+        public System.Collections.Generic.IDictionary<string, string> BodyParameters { get { throw null; } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public abstract partial class UnsafeTokenCacheOptions : Azure.Identity.TokenCachePersistenceOptions

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1729,8 +1729,6 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0003")]
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -1218,6 +1218,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1326,6 +1327,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientCertificateCredential : Azure.Core.TokenCredential
@@ -1348,6 +1350,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientSecretCredential : Azure.Core.TokenCredential
@@ -1366,6 +1369,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class ConfigurationExtensions
@@ -1453,6 +1457,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1518,6 +1523,7 @@ namespace Azure.Identity
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
@@ -1568,6 +1574,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
@@ -1637,7 +1644,6 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     public partial class TokenRequestCallbackContext
     {
@@ -1675,6 +1681,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class VisualStudioCodeCredential : Azure.Identity.InteractiveBrowserCredential

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -1637,6 +1637,12 @@ namespace Azure.Identity
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }
+        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+    }
+    public partial class TokenRequestCallbackContext
+    {
+        internal TokenRequestCallbackContext() { }
+        public System.Collections.Generic.IDictionary<string, string> BodyParameters { get { throw null; } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public abstract partial class UnsafeTokenCacheOptions : Azure.Identity.TokenCachePersistenceOptions

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -1218,7 +1218,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class AzureAuthorityHosts
@@ -1327,7 +1327,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientCertificateCredential : Azure.Core.TokenCredential
@@ -1350,7 +1350,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ClientSecretCredential : Azure.Core.TokenCredential
@@ -1369,7 +1369,7 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class ConfigurationExtensions
@@ -1457,7 +1457,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1523,7 +1523,7 @@ namespace Azure.Identity
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
@@ -1574,7 +1574,7 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public bool SendCertificateChain { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
+        public System.Action<Azure.Identity.TokenRequestCallbackContext> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.ObsoleteAttribute("This credential is deprecated. Consider using other dev tool credentials, such as VisualStudioCredential.")]
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -1681,7 +1681,6 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }
-        public System.Func<Azure.Identity.TokenRequestCallbackContext, System.Threading.Tasks.Task> TokenRequestCallback { get { throw null; } set { } }
     }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public partial class VisualStudioCodeCredential : Azure.Identity.InteractiveBrowserCredential

--- a/sdk/core/Azure.Core/src/Identity/Credentials/AuthorizationCodeCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/AuthorizationCodeCredentialOptions.cs
@@ -21,7 +21,7 @@ namespace Azure.Identity
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class AuthorizationCodeCredentialOptions : TokenCredentialOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
+    public class AuthorizationCodeCredentialOptions : TokenCredentialOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenRequestCallback
     {
         /// <summary>
         /// The redirect Uri that will be sent with the GetToken request.
@@ -35,6 +35,11 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        /// <inheritdoc/>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/AuthorizationCodeCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/AuthorizationCodeCredentialOptions.cs
@@ -39,7 +39,7 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+        public Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/AuthorizationCodeCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/AuthorizationCodeCredentialOptions.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -37,9 +38,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get; set; }
 
         /// <inheritdoc/>
-#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
-#pragma warning restore AZID0003
+        [Experimental("AZID0003")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientAssertionCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientAssertionCredentialOptions.cs
@@ -35,7 +35,7 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+        public Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientAssertionCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientAssertionCredentialOptions.cs
@@ -3,8 +3,10 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -13,7 +15,7 @@ namespace Azure.Identity
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class ClientAssertionCredentialOptions : TokenCredentialOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenCachePersistenceOptions
+    public class ClientAssertionCredentialOptions : TokenCredentialOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenCachePersistenceOptions, ISupportsTokenRequestCallback
     {
         internal CredentialPipeline Pipeline { get; set; }
 
@@ -29,6 +31,11 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public TokenCachePersistenceOptions TokenCachePersistenceOptions { get; set; }
+
+        /// <inheritdoc/>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientAssertionCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientAssertionCredentialOptions.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -33,9 +34,8 @@ namespace Azure.Identity
         public TokenCachePersistenceOptions TokenCachePersistenceOptions { get; set; }
 
         /// <inheritdoc/>
-#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
-#pragma warning restore AZID0003
+        [Experimental("AZID0003")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientCertificateCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientCertificateCredentialOptions.cs
@@ -3,8 +3,10 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -13,7 +15,7 @@ namespace Azure.Identity
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class ClientCertificateCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
+    public class ClientCertificateCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenRequestCallback
     {
         /// <summary>
         /// Specifies the <see cref="TokenCachePersistenceOptions"/> to be used by the credential. If no options are specified, the token cache will not be persisted to disk.
@@ -32,6 +34,11 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        /// <inheritdoc/>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientCertificateCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientCertificateCredentialOptions.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -36,9 +37,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get; set; }
 
         /// <inheritdoc/>
-#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
-#pragma warning restore AZID0003
+        [Experimental("AZID0003")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientCertificateCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientCertificateCredentialOptions.cs
@@ -38,7 +38,7 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+        public Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientSecretCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientSecretCredentialOptions.cs
@@ -33,7 +33,7 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+        public Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientSecretCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientSecretCredentialOptions.cs
@@ -3,8 +3,10 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -13,7 +15,7 @@ namespace Azure.Identity
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class ClientSecretCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
+    public class ClientSecretCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenRequestCallback
     {
         /// <summary>
         /// Specifies the <see cref="TokenCachePersistenceOptions"/> to be used by the credential. If not options are specified, the token cache will not be persisted to disk.
@@ -27,6 +29,11 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        /// <inheritdoc/>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientSecretCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientSecretCredentialOptions.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -31,9 +32,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get; set; }
 
         /// <inheritdoc/>
-#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
-#pragma warning restore AZID0003
+        [Experimental("AZID0003")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/DeviceCodeCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/DeviceCodeCredentialOptions.cs
@@ -70,7 +70,7 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+        public Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/DeviceCodeCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/DeviceCodeCredentialOptions.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -68,9 +69,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get; set; }
 
         /// <inheritdoc/>
-#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
-#pragma warning restore AZID0003
+        [Experimental("AZID0003")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/DeviceCodeCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/DeviceCodeCredentialOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.Identity
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class DeviceCodeCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTenantId
+    public class DeviceCodeCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTenantId, ISupportsTokenRequestCallback
     {
         private string _tenantId;
 
@@ -66,6 +66,11 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        /// <inheritdoc/>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ISupportsTokenRequestCallback.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ISupportsTokenRequestCallback.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using System.Threading.Tasks;
+
+namespace Azure.Identity
+{
+    internal interface ISupportsTokenRequestCallback
+    {
+        /// <summary>
+        /// Gets or sets an optional callback that is invoked before each token request is sent to the identity provider.
+        /// This callback can be used to customize the token request.
+        /// </summary>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
+    }
+}

--- a/sdk/core/Azure.Core/src/Identity/Credentials/ISupportsTokenRequestCallback.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ISupportsTokenRequestCallback.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -15,7 +14,7 @@ namespace Azure.Identity
         /// This callback can be used to customize the token request.
         /// </summary>
 #pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+        Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
 #pragma warning restore AZID0003
     }
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/InteractiveBrowserCredentialOptions.cs
@@ -75,7 +75,7 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+        public Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
 
         /// <summary>
         /// The options for customizing the browser for interactive authentication.

--- a/sdk/core/Azure.Core/src/Identity/Credentials/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/InteractiveBrowserCredentialOptions.cs
@@ -74,9 +74,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get; set; }
 
         /// <inheritdoc/>
-#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
-#pragma warning restore AZID0003
+        [Experimental("AZID0003")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
 
         /// <summary>
         /// The options for customizing the browser for interactive authentication.

--- a/sdk/core/Azure.Core/src/Identity/Credentials/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/InteractiveBrowserCredentialOptions.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -16,7 +17,7 @@ namespace Azure.Identity
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class InteractiveBrowserCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTenantId
+    public class InteractiveBrowserCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTenantId, ISupportsTokenRequestCallback
     {
         private string _tenantId;
 
@@ -71,6 +72,11 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        /// <inheritdoc/>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
 
         /// <summary>
         /// The options for customizing the browser for interactive authentication.

--- a/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredentialOptions.cs
@@ -3,8 +3,10 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -13,7 +15,7 @@ namespace Azure.Identity
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class OnBehalfOfCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
+    public class OnBehalfOfCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenRequestCallback
     {
         /// <summary>
         /// The <see cref="TokenCachePersistenceOptions"/>.
@@ -32,6 +34,11 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        /// <inheritdoc/>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredentialOptions.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -36,9 +37,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get; set; }
 
         /// <inheritdoc/>
-#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
-#pragma warning restore AZID0003
+        [Experimental("AZID0003")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredentialOptions.cs
@@ -38,7 +38,7 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+        public Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
     }
 #pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Extensions.Configuration;
 
@@ -75,6 +76,13 @@ namespace Azure.Identity
         public IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; } = new Dictionary<string, (string Value, bool IncludeInCacheKey)>();
 
         /// <summary>
+        /// Gets or sets an optional callback that is invoked before each token request is sent to the identity provider.
+        /// This callback can be used to customize the token request by adding custom body parameters.
+        /// </summary>
+        [Experimental("AZID0002")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+
+        /// <summary>
         /// Gets or sets whether this credential is part of a chained credential.
         /// </summary>
         internal bool IsChainedCredential { get; set; }
@@ -95,6 +103,11 @@ namespace Azure.Identity
 #pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
             CloneListItems(AdditionalQueryParameters, clone.AdditionalQueryParameters);
 #pragma warning restore AZID0001
+
+            // copy TokenRequestCallback callback
+#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+            clone.TokenRequestCallback = TokenRequestCallback;
+#pragma warning restore AZID0002
 
             // copy TokenCredentialDiagnosticsOptions specific options
             clone.Diagnostics.IsAccountIdentifierLoggingEnabled = Diagnostics.IsAccountIdentifierLoggingEnabled;

--- a/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Extensions.Configuration;
 
@@ -76,13 +75,6 @@ namespace Azure.Identity
         public IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; } = new Dictionary<string, (string Value, bool IncludeInCacheKey)>();
 
         /// <summary>
-        /// Gets or sets an optional callback that is invoked before each token request is sent to the identity provider.
-        /// This callback can be used to customize the token request.
-        /// </summary>
-        [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
-
-        /// <summary>
         /// Gets or sets whether this credential is part of a chained credential.
         /// </summary>
         internal bool IsChainedCredential { get; set; }
@@ -104,10 +96,8 @@ namespace Azure.Identity
             CloneListItems(AdditionalQueryParameters, clone.AdditionalQueryParameters);
 #pragma warning restore AZID0001
 
-            // copy TokenRequestCallback callback
-#pragma warning disable AZID0003 // TokenRequestCallback is experimental
-            clone.TokenRequestCallback = TokenRequestCallback;
-#pragma warning restore AZID0003
+            // copy ISupportsTokenRequestCallback
+            CloneIfImplemented<ISupportsTokenRequestCallback>(this, clone, (o, c) => c.TokenRequestCallback = o.TokenRequestCallback);
 
             // copy TokenCredentialDiagnosticsOptions specific options
             clone.Diagnostics.IsAccountIdentifierLoggingEnabled = Diagnostics.IsAccountIdentifierLoggingEnabled;

--- a/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
@@ -77,7 +77,7 @@ namespace Azure.Identity
 
         /// <summary>
         /// Gets or sets an optional callback that is invoked before each token request is sent to the identity provider.
-        /// This callback can be used to customize the token request by adding custom body parameters.
+        /// This callback can be used to customize the token request.
         /// </summary>
         [Experimental("AZID0002")]
         public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
@@ -79,7 +79,7 @@ namespace Azure.Identity
         /// Gets or sets an optional callback that is invoked before each token request is sent to the identity provider.
         /// This callback can be used to customize the token request.
         /// </summary>
-        [Experimental("AZID0002")]
+        [Experimental("AZID0003")]
         public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
 
         /// <summary>
@@ -105,9 +105,9 @@ namespace Azure.Identity
 #pragma warning restore AZID0001
 
             // copy TokenRequestCallback callback
-#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+#pragma warning disable AZID0003 // TokenRequestCallback is experimental
             clone.TokenRequestCallback = TokenRequestCallback;
-#pragma warning restore AZID0002
+#pragma warning restore AZID0003
 
             // copy TokenCredentialDiagnosticsOptions specific options
             clone.Diagnostics.IsAccountIdentifierLoggingEnabled = Diagnostics.IsAccountIdentifierLoggingEnabled;

--- a/sdk/core/Azure.Core/src/Identity/Credentials/UsernamePasswordCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/UsernamePasswordCredentialOptions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -17,7 +18,7 @@ namespace Azure.Identity
     [Obsolete("This credential is deprecated because it doesn't support multifactor authentication (MFA). See https://aka.ms/azsdk/identity/mfa for details about MFA enforcement for Microsoft Entra ID and migration guidance.")]
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class UsernamePasswordCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
+    public class UsernamePasswordCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenRequestCallback
     {
         /// <summary>
         /// Specifies the <see cref="TokenCachePersistenceOptions"/> to be used by the credential. If no options are specified, the token cache will not be persisted to disk.
@@ -31,6 +32,11 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
+
+        /// <inheritdoc/>
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
 
         internal AuthenticationRecord AuthenticationRecord { get; set; }
     }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/UsernamePasswordCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/UsernamePasswordCredentialOptions.cs
@@ -4,11 +4,9 @@
 #nullable disable
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -19,7 +17,7 @@ namespace Azure.Identity
     [Obsolete("This credential is deprecated because it doesn't support multifactor authentication (MFA). See https://aka.ms/azsdk/identity/mfa for details about MFA enforcement for Microsoft Entra ID and migration guidance.")]
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
-    public class UsernamePasswordCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants, ISupportsTokenRequestCallback
+    public class UsernamePasswordCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions, ISupportsDisableInstanceDiscovery, ISupportsAdditionallyAllowedTenants
     {
         /// <summary>
         /// Specifies the <see cref="TokenCachePersistenceOptions"/> to be used by the credential. If no options are specified, the token cache will not be persisted to disk.
@@ -33,10 +31,6 @@ namespace Azure.Identity
 
         /// <inheritdoc/>
         public bool DisableInstanceDiscovery { get; set; }
-
-        /// <inheritdoc/>
-        [Experimental("AZID0003")]
-        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
 
         internal AuthenticationRecord AuthenticationRecord { get; set; }
     }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/UsernamePasswordCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/UsernamePasswordCredentialOptions.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -34,9 +35,8 @@ namespace Azure.Identity
         public bool DisableInstanceDiscovery { get; set; }
 
         /// <inheritdoc/>
-#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-        Func<TokenRequestCallbackContext, Task> ISupportsTokenRequestCallback.TokenRequestCallback { get; set; }
-#pragma warning restore AZID0003
+        [Experimental("AZID0003")]
+        public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
 
         internal AuthenticationRecord AuthenticationRecord { get; set; }
     }

--- a/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
@@ -24,7 +24,7 @@ namespace Azure.Identity
         private readonly bool _logAccountDetails;
         private readonly TokenCachePersistenceOptions _tokenCachePersistenceOptions;
 #pragma warning disable AZID0003 // TokenRequestCallback is experimental
-        private readonly Func<TokenRequestCallbackContext, Task> _onBeforeTokenRequestCallback;
+        private readonly Action<TokenRequestCallbackContext> _onBeforeTokenRequestCallback;
 #pragma warning restore AZID0003
         protected internal bool IsSupportLoggingEnabled { get; }
         protected internal bool DisableInstanceDiscovery { get; }
@@ -126,7 +126,11 @@ namespace Azure.Identity
             {
                 var callback = _onBeforeTokenRequestCallback;
 #pragma warning disable AZID0003 // TokenRequestCallback is experimental
-                builder.OnBeforeTokenRequest(data => callback(new TokenRequestCallbackContext(data)));
+                builder.OnBeforeTokenRequest(data =>
+                {
+                    callback(new TokenRequestCallbackContext(data));
+                    return Task.CompletedTask;
+                });
 #pragma warning restore AZID0003
             }
         }

--- a/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensibility;
 
 namespace Azure.Identity
 {
@@ -22,6 +23,9 @@ namespace Azure.Identity
         private readonly AsyncLockWithValue<(TClient Client, TokenCache Cache)> _clientWithCaeAsyncLock;
         private readonly bool _logAccountDetails;
         private readonly TokenCachePersistenceOptions _tokenCachePersistenceOptions;
+#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+        private readonly Func<TokenRequestCallbackContext, Task> _onBeforeTokenRequestCallback;
+#pragma warning restore AZID0002
         protected internal bool IsSupportLoggingEnabled { get; }
         protected internal bool DisableInstanceDiscovery { get; }
         protected internal IReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; }
@@ -57,6 +61,9 @@ namespace Azure.Identity
                 ? new ReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)>(new Dictionary<string, (string Value, bool IncludeInCacheKey)>(options.AdditionalQueryParameters))
                 : null;
 #pragma warning restore AZID0001
+#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+            _onBeforeTokenRequestCallback = options?.TokenRequestCallback;
+#pragma warning restore AZID0002
             Pipeline = pipeline;
             TenantId = tenantId;
             ClientId = clientId;
@@ -109,6 +116,18 @@ namespace Azure.Identity
             {
                 var accountDetails = TokenHelper.ParseAccountInfoFromToken(result.AccessToken);
                 AzureIdentityEventSource.Singleton.AuthenticatedAccountDetails(accountDetails.ClientId, accountDetails.TenantId ?? result.TenantId, accountDetails.Upn ?? result.Account?.Username, accountDetails.ObjectId ?? result.UniqueId);
+            }
+        }
+
+        protected void ApplyTokenRequestCallback<T>(AbstractAcquireTokenParameterBuilder<T> builder)
+            where T : AbstractAcquireTokenParameterBuilder<T>
+        {
+            if (_onBeforeTokenRequestCallback != null)
+            {
+                var callback = _onBeforeTokenRequestCallback;
+#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+                builder.OnBeforeTokenRequest(data => callback(new TokenRequestCallbackContext(data)));
+#pragma warning restore AZID0002
             }
         }
 

--- a/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
@@ -23,9 +23,9 @@ namespace Azure.Identity
         private readonly AsyncLockWithValue<(TClient Client, TokenCache Cache)> _clientWithCaeAsyncLock;
         private readonly bool _logAccountDetails;
         private readonly TokenCachePersistenceOptions _tokenCachePersistenceOptions;
-#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+#pragma warning disable AZID0003 // TokenRequestCallback is experimental
         private readonly Func<TokenRequestCallbackContext, Task> _onBeforeTokenRequestCallback;
-#pragma warning restore AZID0002
+#pragma warning restore AZID0003
         protected internal bool IsSupportLoggingEnabled { get; }
         protected internal bool DisableInstanceDiscovery { get; }
         protected internal IReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; }
@@ -61,9 +61,9 @@ namespace Azure.Identity
                 ? new ReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)>(new Dictionary<string, (string Value, bool IncludeInCacheKey)>(options.AdditionalQueryParameters))
                 : null;
 #pragma warning restore AZID0001
-#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+#pragma warning disable AZID0003 // TokenRequestCallback is experimental
             _onBeforeTokenRequestCallback = options?.TokenRequestCallback;
-#pragma warning restore AZID0002
+#pragma warning restore AZID0003
             Pipeline = pipeline;
             TenantId = tenantId;
             ClientId = clientId;
@@ -125,9 +125,9 @@ namespace Azure.Identity
             if (_onBeforeTokenRequestCallback != null)
             {
                 var callback = _onBeforeTokenRequestCallback;
-#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+#pragma warning disable AZID0003 // TokenRequestCallback is experimental
                 builder.OnBeforeTokenRequest(data => callback(new TokenRequestCallbackContext(data)));
-#pragma warning restore AZID0002
+#pragma warning restore AZID0003
             }
         }
 

--- a/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
@@ -62,7 +62,7 @@ namespace Azure.Identity
                 : null;
 #pragma warning restore AZID0001
 #pragma warning disable AZID0003 // TokenRequestCallback is experimental
-            _onBeforeTokenRequestCallback = options?.TokenRequestCallback;
+            _onBeforeTokenRequestCallback = (options as ISupportsTokenRequestCallback)?.TokenRequestCallback;
 #pragma warning restore AZID0003
             Pipeline = pipeline;
             TenantId = tenantId;

--- a/sdk/core/Azure.Core/src/Identity/MsalConfidentialClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalConfidentialClient.cs
@@ -186,6 +186,7 @@ namespace Azure.Identity
             {
                 builder.WithClaims(claims);
             }
+            ApplyTokenRequestCallback(builder);
             return await builder
                 .ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
@@ -227,6 +228,7 @@ namespace Azure.Identity
             {
                 builder.WithClaims(claims);
             }
+            ApplyTokenRequestCallback(builder);
             return await builder
                 .ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
@@ -269,6 +271,7 @@ namespace Azure.Identity
             {
                 builder.WithClaims(claims);
             }
+            ApplyTokenRequestCallback(builder);
             return await builder
                 .ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
@@ -311,6 +314,7 @@ namespace Azure.Identity
             {
                 builder.WithClaims(claims);
             }
+            ApplyTokenRequestCallback(builder);
             return await builder
                 .ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);

--- a/sdk/core/Azure.Core/src/Identity/MsalPublicClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalPublicClient.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensibility;
 
 namespace Azure.Identity
 {
@@ -143,6 +144,7 @@ namespace Azure.Identity
                 builder.WithProofOfPossession(context.ProofOfPossessionNonce, new(context.ResourceRequestMethod), context.ResourceRequestUri);
             }
 
+            ApplyTokenRequestCallback(builder);
             return await builder
                 .ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
@@ -202,6 +204,7 @@ namespace Azure.Identity
                 builder.WithProofOfPossession(context.ProofOfPossessionNonce, new(context.ResourceRequestMethod), context.ResourceRequestUri);
             }
 
+            ApplyTokenRequestCallback(builder);
             return await builder.ExecuteAsync(async, cancellationToken)
                            .ConfigureAwait(false);
         }
@@ -310,6 +313,7 @@ namespace Azure.Identity
             {
                 builder.WithProofOfPossession(tokenRequestContext.ProofOfPossessionNonce, new(tokenRequestContext.ResourceRequestMethod), tokenRequestContext.ResourceRequestUri);
             }
+            ApplyTokenRequestCallback(builder);
             return await builder
                 .ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
@@ -338,6 +342,7 @@ namespace Azure.Identity
             {
                 builder.WithTenantId(tenantId);
             }
+            ApplyTokenRequestCallback(builder);
             return await builder.ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -363,6 +368,7 @@ namespace Azure.Identity
                 builder.WithTenantId(TenantId);
             }
 
+            ApplyTokenRequestCallback(builder);
             return await builder.ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -389,6 +395,7 @@ namespace Azure.Identity
                 builder.WithTenantId(TenantId);
             }
 
+            ApplyTokenRequestCallback(builder);
             return await builder.ExecuteAsync(async, cancellationToken)
                 .ConfigureAwait(false);
         }

--- a/sdk/core/Azure.Core/src/Identity/MsalPublicClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalPublicClient.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.Extensibility;
 
 namespace Azure.Identity
 {

--- a/sdk/core/Azure.Core/src/Identity/TokenRequestCallbackContext.cs
+++ b/sdk/core/Azure.Core/src/Identity/TokenRequestCallbackContext.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Identity.Client.Extensibility;
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Provides access to customize the token request before it is sent.
+    /// </summary>
+#pragma warning disable AZC0034 // Type in Azure.Identity namespace defined in Azure.Core assembly
+    [Experimental("AZID0002")]
+    public class TokenRequestCallbackContext
+    {
+        private readonly OnBeforeTokenRequestData _data;
+
+        internal TokenRequestCallbackContext(OnBeforeTokenRequestData data)
+        {
+            _data = data;
+        }
+
+        /// <summary>
+        /// Gets the body parameters of the token request. Adding or modifying entries in this
+        /// dictionary will cause them to be included in the token request body sent to the identity provider.
+        /// </summary>
+        public IDictionary<string, string> BodyParameters => _data.BodyParameters;
+    }
+#pragma warning restore AZC0034
+}

--- a/sdk/core/Azure.Core/src/Identity/TokenRequestCallbackContext.cs
+++ b/sdk/core/Azure.Core/src/Identity/TokenRequestCallbackContext.cs
@@ -12,7 +12,6 @@ namespace Azure.Identity
     /// <summary>
     /// Provides access to customize the token request before it is sent.
     /// </summary>
-#pragma warning disable AZC0034 // Type in Azure.Identity namespace defined in Azure.Core assembly
     [Experimental("AZID0002")]
     public class TokenRequestCallbackContext
     {
@@ -29,5 +28,4 @@ namespace Azure.Identity
         /// </summary>
         public IDictionary<string, string> BodyParameters => _data.BodyParameters;
     }
-#pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/TokenRequestCallbackContext.cs
+++ b/sdk/core/Azure.Core/src/Identity/TokenRequestCallbackContext.cs
@@ -3,8 +3,10 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Microsoft.Identity.Client.Extensibility;
 
 namespace Azure.Identity
@@ -27,5 +29,20 @@ namespace Azure.Identity
         /// dictionary will cause them to be included in the token request body sent to the identity provider.
         /// </summary>
         public IDictionary<string, string> BodyParameters => _data.BodyParameters;
+
+        /// <summary>
+        /// Gets the headers of the token request.
+        /// </summary>
+        internal IDictionary<string, string> Headers => _data.Headers;
+
+        /// <summary>
+        /// Gets the URI of the token request.
+        /// </summary>
+        internal Uri RequestUri => _data.RequestUri;
+
+        /// <summary>
+        /// Gets the cancellation token for the token request.
+        /// </summary>
+        internal CancellationToken CancellationToken => _data.CancellationToken;
     }
 }

--- a/sdk/core/Azure.Core/src/Identity/TokenRequestCallbackContext.cs
+++ b/sdk/core/Azure.Core/src/Identity/TokenRequestCallbackContext.cs
@@ -12,7 +12,7 @@ namespace Azure.Identity
     /// <summary>
     /// Provides access to customize the token request before it is sent.
     /// </summary>
-    [Experimental("AZID0002")]
+    [Experimental("AZID0003")]
     public class TokenRequestCallbackContext
     {
         private readonly OnBeforeTokenRequestData _data;

--- a/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
+++ b/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
@@ -56,3 +56,101 @@ Or in your project file:
   <NoWarn>$(NoWarn);SCME0002</NoWarn>
 </PropertyGroup>
 ```
+
+## AZID0001 - Identity: AdditionalQueryParameters Experimental API
+
+### Description
+
+The `AdditionalQueryParameters` property on `TokenCredentialOptions` allows forwarding extra query string parameters to MSAL during authentication. Each entry maps a parameter name to its value and a flag that controls whether the parameter is part of the token cache key.
+
+### Affected APIs
+
+- `Azure.Identity.TokenCredentialOptions.AdditionalQueryParameters`
+
+### Suppression
+
+```csharp
+#pragma warning disable AZID0001
+```
+
+Or in your project file:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);AZID0001</NoWarn>
+</PropertyGroup>
+```
+
+## AZID0002 - Identity: IsAzureProxyEnabled Experimental API
+
+### Description
+
+The `IsAzureProxyEnabled` property on `WorkloadIdentityCredentialOptions` enables the Azure Kubernetes Service proxy for workload identity authentication.
+
+### Affected APIs
+
+- `Azure.Identity.WorkloadIdentityCredentialOptions.IsAzureProxyEnabled`
+
+### Suppression
+
+```csharp
+#pragma warning disable AZID0002
+```
+
+Or in your project file:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);AZID0002</NoWarn>
+</PropertyGroup>
+```
+
+## AZID0003 - Identity: TokenRequestCallback Experimental API
+
+### Description
+
+The `TokenRequestCallback` property on MSAL-backed credential options types allows customizing the token request before it is sent to the identity provider. The callback receives a `TokenRequestCallbackContext` which exposes `BodyParameters` for adding custom body parameters to the OAuth token request.
+
+### Affected APIs
+
+- `Azure.Identity.TokenRequestCallbackContext`
+- `TokenRequestCallback` property on:
+  - `Azure.Identity.ClientSecretCredentialOptions`
+  - `Azure.Identity.ClientCertificateCredentialOptions`
+  - `Azure.Identity.ClientAssertionCredentialOptions`
+  - `Azure.Identity.OnBehalfOfCredentialOptions`
+  - `Azure.Identity.AuthorizationCodeCredentialOptions`
+  - `Azure.Identity.DeviceCodeCredentialOptions`
+  - `Azure.Identity.InteractiveBrowserCredentialOptions`
+  - `Azure.Identity.UsernamePasswordCredentialOptions`
+
+### Example Usage
+
+```csharp
+#pragma warning disable AZID0003
+
+var credential = new ClientSecretCredential(tenantId, clientId, clientSecret, new ClientSecretCredentialOptions
+{
+    TokenRequestCallback = data =>
+    {
+        data.BodyParameters["custom_param"] = "value";
+        return Task.CompletedTask;
+    }
+});
+
+#pragma warning restore AZID0003
+```
+
+### Suppression
+
+```csharp
+#pragma warning disable AZID0003
+```
+
+Or in your project file:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);AZID0003</NoWarn>
+</PropertyGroup>
+```

--- a/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
+++ b/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
@@ -122,7 +122,6 @@ The `TokenRequestCallback` property on MSAL-backed credential options types allo
   - `Azure.Identity.AuthorizationCodeCredentialOptions`
   - `Azure.Identity.DeviceCodeCredentialOptions`
   - `Azure.Identity.InteractiveBrowserCredentialOptions`
-  - `Azure.Identity.UsernamePasswordCredentialOptions`
 
 ### Example Usage
 
@@ -134,7 +133,6 @@ var credential = new ClientSecretCredential(tenantId, clientId, clientSecret, ne
     TokenRequestCallback = data =>
     {
         data.BodyParameters["custom_param"] = "value";
-        return Task.CompletedTask;
     }
 });
 

--- a/sdk/core/Azure.Core/tests/Identity/DefaultAzureCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/DefaultAzureCredentialOptionsTests.cs
@@ -146,6 +146,10 @@ namespace Azure.Core.Tests.Identity
                     dict[Guid.NewGuid().ToString()] = (Guid.NewGuid().ToString(), true);
                     dict[Guid.NewGuid().ToString()] = (Guid.NewGuid().ToString(), false);
                 }
+                else if (typeof(Delegate).IsAssignableFrom(propInfo.PropertyType))
+                {
+                    // Skip delegate properties during setup — they default to null and are tested via reference equality below
+                }
                 else
                 {
                     Assert.Fail($"test doesn't support property type {propInfo.PropertyType} for property {propInfo.Name}");

--- a/sdk/core/Azure.Core/tests/Identity/DefaultAzureCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/DefaultAzureCredentialOptionsTests.cs
@@ -146,10 +146,6 @@ namespace Azure.Core.Tests.Identity
                     dict[Guid.NewGuid().ToString()] = (Guid.NewGuid().ToString(), true);
                     dict[Guid.NewGuid().ToString()] = (Guid.NewGuid().ToString(), false);
                 }
-                else if (typeof(Delegate).IsAssignableFrom(propInfo.PropertyType))
-                {
-                    // Skip delegate properties during setup — they default to null and are tested via reference equality below
-                }
                 else
                 {
                     Assert.Fail($"test doesn't support property type {propInfo.PropertyType} for property {propInfo.Name}");

--- a/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
@@ -173,7 +173,7 @@ namespace Azure.Core.Tests.Identity
         }
 #pragma warning restore AZID0001
 
-#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+#pragma warning disable AZID0003 // TokenRequestCallback is experimental
         [Test]
         public async Task TokenRequestCallbackBodyParametersAreIncludedInRequests()
         {
@@ -228,7 +228,7 @@ namespace Azure.Core.Tests.Identity
 
             Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
         }
-#pragma warning restore AZID0002
+#pragma warning restore AZID0003
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions
         {

--- a/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;

--- a/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
@@ -199,7 +199,6 @@ namespace Azure.Core.Tests.Identity
                 TokenRequestCallback = data =>
                 {
                     data.BodyParameters["custom_param"] = "custom_value";
-                    return Task.CompletedTask;
                 }
             };
 

--- a/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
@@ -170,6 +173,63 @@ namespace Azure.Core.Tests.Identity
             Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
         }
 #pragma warning restore AZID0001
+
+#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+        [Test]
+        public async Task TokenRequestCallbackBodyParametersAreIncludedInRequests()
+        {
+            string capturedBody = null;
+            var mockTransport = new MockTransport(req =>
+            {
+                if (req.Uri.Path.Contains("/oauth2/v2.0/token"))
+                {
+                    using var ms = new MemoryStream();
+                    req.Content.WriteTo(ms, CancellationToken.None);
+                    capturedBody = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+                }
+                var response = new MockResponse(400);
+                response.SetContent("{\"error\":\"invalid_grant\",\"error_description\":\"bad request\"}");
+                return response;
+            });
+
+            var options = new ClientSecretCredentialOptions
+            {
+                Transport = mockTransport,
+                Retry = { MaxRetries = 0 },
+                DisableInstanceDiscovery = true,
+                TokenRequestCallback = data =>
+                {
+                    data.BodyParameters["custom_param"] = "custom_value";
+                    return Task.CompletedTask;
+                }
+            };
+
+            var credential = new ClientSecretCredential("tenant", "client", "secret", options);
+
+            Assert.ThrowsAsync<AuthenticationFailedException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
+
+            Assert.IsNotNull(capturedBody, "Expected a token request to /oauth2/v2.0/token");
+            Assert.IsTrue(capturedBody.Contains("custom_param=custom_value"), $"Expected 'custom_param=custom_value' in body: {capturedBody}");
+        }
+
+        [Test]
+        public void DefaultNullTokenRequestCallbackDoesNotThrow()
+        {
+            var options = new ClientSecretCredentialOptions
+            {
+                Transport = new MockTransport(),
+                DisableInstanceDiscovery = true,
+            };
+
+            Assert.IsNull(options.TokenRequestCallback);
+
+            var pipeline = CredentialPipeline.GetInstance(options);
+            var client = new MockMsalConfidentialClient(pipeline, "tenant", "client", "secret", "https://redirect", options);
+
+            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+        }
+#pragma warning restore AZID0002
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions
         {

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -173,7 +173,7 @@ namespace Azure.Core.Tests.Identity
         }
 #pragma warning restore AZID0001
 
-#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+#pragma warning disable AZID0003 // TokenRequestCallback is experimental
         [Test]
         public async Task TokenRequestCallbackBodyParametersAreIncludedInRequests()
         {
@@ -215,7 +215,7 @@ namespace Azure.Core.Tests.Identity
             Assert.IsNotNull(capturedBody, "Expected a token request to /oauth2/v2.0/token");
             Assert.IsTrue(capturedBody.Contains("custom_param=custom_value"), $"Expected 'custom_param=custom_value' in body: {capturedBody}");
         }
-#pragma warning restore AZID0002
+#pragma warning restore AZID0003
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions
         {

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -195,7 +195,7 @@ namespace Azure.Core.Tests.Identity
                 return response;
             });
 
-            var options = new UsernamePasswordCredentialOptions
+            var options = new DeviceCodeCredentialOptions
             {
                 Transport = mockTransport,
                 Retry = { MaxRetries = 0 },
@@ -207,13 +207,11 @@ namespace Azure.Core.Tests.Identity
                 }
             };
 
-            var credential = new UsernamePasswordCredential("username", "password", "tenant", "client", options);
+            var pipeline = CredentialPipeline.GetInstance(options);
+            var client = new MockMsalPublicClient(pipeline, "tenant", options.ClientId, "https://redirect", options);
 
-            Assert.ThrowsAsync<AuthenticationFailedException>(
-                async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
-
-            Assert.IsNotNull(capturedBody, "Expected a token request to /oauth2/v2.0/token");
-            Assert.IsTrue(capturedBody.Contains("custom_param=custom_value"), $"Expected 'custom_param=custom_value' in body: {capturedBody}");
+            var stored = (options as ISupportsTokenRequestCallback)?.TokenRequestCallback;
+            Assert.IsNotNull(stored, "TokenRequestCallback should be set on DeviceCodeCredentialOptions");
         }
 #pragma warning restore AZID0003
 

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
@@ -170,6 +173,50 @@ namespace Azure.Core.Tests.Identity
             Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
         }
 #pragma warning restore AZID0001
+
+#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+        [Test]
+        public async Task TokenRequestCallbackBodyParametersAreIncludedInRequests()
+        {
+            string capturedBody = null;
+            var mockTransport = new MockTransport(req =>
+            {
+                if (req.Uri.Path.Contains("/oauth2/v2.0/token"))
+                {
+                    using var ms = new MemoryStream();
+                    req.Content.WriteTo(ms, CancellationToken.None);
+                    capturedBody = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+                    var errorResponse = new MockResponse(400);
+                    errorResponse.SetContent("{\"error\":\"invalid_grant\",\"error_description\":\"bad request\"}");
+                    return errorResponse;
+                }
+                // Return a managed user realm response for user realm discovery
+                var response = new MockResponse(200);
+                response.SetContent("{\"ver\":\"1.0\",\"account_type\":\"Managed\",\"domain_name\":\"tenant\",\"cloud_instance_name\":\"microsoftonline.com\",\"cloud_audience_urn\":\"urn:federation:MicrosoftOnline\"}");
+                return response;
+            });
+
+            var options = new UsernamePasswordCredentialOptions
+            {
+                Transport = mockTransport,
+                Retry = { MaxRetries = 0 },
+                DisableInstanceDiscovery = true,
+                TokenRequestCallback = data =>
+                {
+                    data.BodyParameters["custom_param"] = "custom_value";
+                    return Task.CompletedTask;
+                }
+            };
+
+            var credential = new UsernamePasswordCredential("username", "password", "tenant", "client", options);
+
+            Assert.ThrowsAsync<AuthenticationFailedException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
+
+            Assert.IsNotNull(capturedBody, "Expected a token request to /oauth2/v2.0/token");
+            Assert.IsTrue(capturedBody.Contains("custom_param=custom_value"), $"Expected 'custom_param=custom_value' in body: {capturedBody}");
+        }
+#pragma warning restore AZID0002
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions
         {

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -203,7 +203,6 @@ namespace Azure.Core.Tests.Identity
                 TokenRequestCallback = data =>
                 {
                     data.BodyParameters["custom_param"] = "custom_value";
-                    return Task.CompletedTask;
                 }
             };
 

--- a/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
@@ -251,7 +251,7 @@ namespace Azure.Core.Tests.Identity
             public TokenCachePersistenceOptions TokenCachePersistenceOptions { get; set; }
 
 #pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
-            public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+            public Action<TokenRequestCallbackContext> TokenRequestCallback { get; set; }
 #pragma warning restore AZID0003
 
             public static T CreatePopulatedOptions<T>(bool setTransport)
@@ -275,7 +275,6 @@ namespace Azure.Core.Tests.Identity
                     TokenRequestCallback = data =>
                     {
                         data.BodyParameters["test"] = "value";
-                        return Task.CompletedTask;
                     },
 #pragma warning restore AZID0003
                     Retry =

--- a/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
@@ -167,7 +167,10 @@ namespace Azure.Core.Tests.Identity
 #pragma warning restore AZID0001
 
 #pragma warning disable AZID0003 // TokenRequestCallback is experimental
-            Assert.AreEqual(original.TokenRequestCallback, clone.TokenRequestCallback, "TokenRequestCallback should be copied to the clone.");
+            if (original is ISupportsTokenRequestCallback origCallback && clone is ISupportsTokenRequestCallback cloneCallback)
+            {
+                Assert.AreEqual(origCallback.TokenRequestCallback, cloneCallback.TokenRequestCallback, "TokenRequestCallback should be copied to the clone.");
+            }
 #pragma warning restore AZID0003
 
             if (original is ISupportsAdditionallyAllowedTenants && clone is ISupportsAdditionallyAllowedTenants)
@@ -239,13 +242,17 @@ namespace Azure.Core.Tests.Identity
 
         public class SupportsTokenCachePersistenceOptions : CloneTestOptions, ISupportsTokenCachePersistenceOptions { }
 
-        public class CloneTestOptions : TokenCredentialOptions
+        public class CloneTestOptions : TokenCredentialOptions, ISupportsTokenRequestCallback
         {
             public IList<string> AdditionallyAllowedTenants { get; } = new List<string>();
 
             public bool DisableInstanceDiscovery { get; set; }
 
             public TokenCachePersistenceOptions TokenCachePersistenceOptions { get; set; }
+
+#pragma warning disable AZID0003 // TokenRequestCallbackContext is experimental
+            public Func<TokenRequestCallbackContext, Task> TokenRequestCallback { get; set; }
+#pragma warning restore AZID0003
 
             public static T CreatePopulatedOptions<T>(bool setTransport)
                 where T : CloneTestOptions, new()

--- a/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
@@ -315,7 +315,8 @@ namespace Azure.Core.Tests.Identity
             typeof(ISupportsAdditionallyAllowedTenants),
             typeof(ISupportsDisableInstanceDiscovery),
             typeof(ISupportsTokenCachePersistenceOptions),
-            typeof(ISupportsTenantId)
+            typeof(ISupportsTenantId),
+            typeof(ISupportsTokenRequestCallback)
         };
 
         public static IEnumerable<TestCaseData> CredentialOptionsCloneTypeTestMatrix()

--- a/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
@@ -165,6 +166,10 @@ namespace Azure.Core.Tests.Identity
             Assert.AreNotSame(original.AdditionalQueryParameters, clone.AdditionalQueryParameters, "AdditionalQueryParameters should be deep-copied, not shared.");
 #pragma warning restore AZID0001
 
+#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+            Assert.AreEqual(original.TokenRequestCallback, clone.TokenRequestCallback, "TokenRequestCallback should be copied to the clone.");
+#pragma warning restore AZID0002
+
             if (original is ISupportsAdditionallyAllowedTenants && clone is ISupportsAdditionallyAllowedTenants)
             {
                 CollectionAssert.AreEqual(original.AdditionallyAllowedTenants, clone.AdditionallyAllowedTenants);
@@ -259,6 +264,13 @@ namespace Azure.Core.Tests.Identity
                         ["session_id"] = (Guid.NewGuid().ToString(), true)
                     },
 #pragma warning restore AZID0001
+#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+                    TokenRequestCallback = data =>
+                    {
+                        data.BodyParameters["test"] = "value";
+                        return Task.CompletedTask;
+                    },
+#pragma warning restore AZID0002
                     Retry =
                     {
                         MaxRetries = 15,

--- a/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
@@ -166,9 +166,9 @@ namespace Azure.Core.Tests.Identity
             Assert.AreNotSame(original.AdditionalQueryParameters, clone.AdditionalQueryParameters, "AdditionalQueryParameters should be deep-copied, not shared.");
 #pragma warning restore AZID0001
 
-#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+#pragma warning disable AZID0003 // TokenRequestCallback is experimental
             Assert.AreEqual(original.TokenRequestCallback, clone.TokenRequestCallback, "TokenRequestCallback should be copied to the clone.");
-#pragma warning restore AZID0002
+#pragma warning restore AZID0003
 
             if (original is ISupportsAdditionallyAllowedTenants && clone is ISupportsAdditionallyAllowedTenants)
             {
@@ -264,13 +264,13 @@ namespace Azure.Core.Tests.Identity
                         ["session_id"] = (Guid.NewGuid().ToString(), true)
                     },
 #pragma warning restore AZID0001
-#pragma warning disable AZID0002 // TokenRequestCallback is experimental
+#pragma warning disable AZID0003 // TokenRequestCallback is experimental
                     TokenRequestCallback = data =>
                     {
                         data.BodyParameters["test"] = "value";
                         return Task.CompletedTask;
                     },
-#pragma warning restore AZID0002
+#pragma warning restore AZID0003
                     Retry =
                     {
                         MaxRetries = 15,


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-net/issues/59188

## Summary

Introduces an experimental API surface that wraps MSAL's `OnBeforeTokenRequestData` extensibility point, allowing customers to add custom body parameters to OAuth token requests without dropping down to MSAL directly.

The callback is only available on MSAL-backed credential options types via the internal `ISupportsTokenRequestCallback` interface — non-MSAL credentials (AzureCLI, AzurePowerShell, etc.) are not affected.

### New types

- **`TokenRequestCallbackContext`** — Wraps MSAL's `OnBeforeTokenRequestData`. Exposes `BodyParameters` (`IDictionary<string, string>`) publicly; `Headers`, `RequestUri`, and `CancellationToken` are internal. Marked `[Experimental("AZID0003")]`.
- **`ISupportsTokenRequestCallback`** — Internal interface for credential options that support the callback.

### Changes to existing types

- **`ClientSecretCredentialOptions`**, **`ClientCertificateCredentialOptions`**, **`ClientAssertionCredentialOptions`**, **`OnBehalfOfCredentialOptions`**, **`AuthorizationCodeCredentialOptions`**, **`DeviceCodeCredentialOptions`**, **`InteractiveBrowserCredentialOptions`** — Implement `ISupportsTokenRequestCallback` with a public `TokenRequestCallback` property (`Action<TokenRequestCallbackContext>`) marked `[Experimental("AZID0003")]`.
- **`MsalClientBase`** — Reads the callback via interface cast and exposes `ApplyTokenRequestCallback()` helper. Wraps the `Action` into a `Task`-returning delegate for MSAL internally.
- **`MsalConfidentialClient`** — Calls `ApplyTokenRequestCallback(builder)` in all 4 acquire-token methods.
- **`MsalPublicClient`** — Calls `ApplyTokenRequestCallback(builder)` in all 6 acquire-token methods.
- **`TokenCredentialOptions.Clone<T>()`** — Copies callback via `CloneIfImplemented<ISupportsTokenRequestCallback>`.

### Tests

- End-to-end test for confidential client flow verifying custom body parameters appear in the token request.
- Public client test verifying callback is stored via `DeviceCodeCredentialOptions`.
- Null callback (default) does not affect existing behavior.
- Clone tests updated to cover the new interface.
- `ISupportsTokenRequestCallback` registered in known interfaces list for `VerifyCloneHandlesISupportsForAllTypes`.

### Documentation

- Added `AZID0001`, `AZID0002`, `AZID0003` entries to `ExperimentalFeatures.md`.
- Updated changelog entry.

### Example usage

```csharp
#pragma warning disable AZID0003

var credential = new ClientSecretCredential(tenantId, clientId, clientSecret, new ClientSecretCredentialOptions
{
    TokenRequestCallback = data =>
    {
        data.BodyParameters["custom_param"] = "value";
    }
});

#pragma warning restore AZID0003
```

---
🤖 PR Description generated by JonathanCrd's copilot