### PR TITLE
Fix clientName wrapper naming for multiple-path resources

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -435,10 +435,15 @@ function convertResolvedResourceToMetadata(
   // Build resource type string
   const resourceType = formatResourceType(resolvedResource.resourceType);
 
+  const sdkModel = getClientType(
+    sdkContext,
+    resolvedResource.type
+  ) as SdkModelType;
+
   // Use the explicit ResourceName if provided via the OverrideResourceName template parameter.
   // The spec should always define unique resource names for extension resources targeting
   // different parent types — the emitter should not auto-generate disambiguated names.
-  let resourceName = resolvedResource.resourceName;
+  let resourceName = sdkModel?.name ?? resolvedResource.resourceName;
   const explicitName = getExplicitResourceNameFromOperations(resolvedResource);
   if (explicitName) {
     resourceName = explicitName;
@@ -459,10 +464,6 @@ function convertResolvedResourceToMetadata(
   const apiVersions: string[] = [];
 
   // Extract RBAC roles and name constraint overrides from @@clientOption decorator
-  const sdkModel = getClientType(
-    sdkContext,
-    resolvedResource.type
-  ) as SdkModelType;
   const rbacRoles = extractRbacRoles(sdkModel);
 
   // Override name constraints from @@clientOption decorator if present

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -290,8 +290,7 @@ export function buildArmProviderSchema(
           methods: [],
           parentResourceId: undefined, // this will be populated later
           parentResourceModelId: undefined,
-          // Use model name as default; will be updated later if multiple paths exist
-          resourceName: model?.name ?? "Unknown",
+          resourceName: models.get(modelId)?.name ?? model?.name ?? "Unknown",
           nameConstraints: {},
           apiVersions: [],
           rbacRoles: []

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -476,7 +476,12 @@ export function buildArmProviderSchema(
           // Try to derive from client name using pluralize.singular
           const clientName = resourcePathToClientName.get(metadataKey);
           if (clientName) {
-            resource.metadata.resourceName = pluralize.singular(clientName);
+            const sdkModel = models.get(resource.resourceModelId);
+            const typespecModel = sdkModel?.__raw as Model | undefined;
+            const clientResourceName = pluralize.singular(clientName);
+            if (clientResourceName !== typespecModel?.name) {
+              resource.metadata.resourceName = clientResourceName;
+            }
           }
         }
       }

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -132,8 +132,8 @@ export function buildArmProviderSchema(
     }
   }
 
-  // Track client-derived resource names that disambiguate multiple paths for the same model
-  const resourcePathToClientResourceName = new Map<string, string>();
+  // Track client names associated with each resource path for name derivation
+  const resourcePathToClientName = new Map<string, string>();
 
   // Track explicit resource names from TypeSpec (e.g., from LegacyOperations ResourceName parameter)
   const resourcePathToExplicitName = new Map<string, string>();
@@ -272,15 +272,9 @@ export function buildArmProviderSchema(
       let entry = resourcePathToMetadataMap.get(metadataKey);
       if (!entry) {
         const model = resourceModelMap.get(modelId);
-        // Store the client-derived name only when it disambiguates from the raw model name.
-        const clientResourceName = pluralize.singular(client.name);
-        const sdkModel = models.get(modelId);
-        const typespecModel = sdkModel?.__raw as Model | undefined;
-        if (
-          clientResourceName !== typespecModel?.name &&
-          !resourcePathToClientResourceName.has(metadataKey)
-        ) {
-          resourcePathToClientResourceName.set(metadataKey, clientResourceName);
+        // Store the client name for this resource path for later use (fallback if no explicit name)
+        if (!resourcePathToClientName.has(metadataKey)) {
+          resourcePathToClientName.set(metadataKey, client.name);
         }
 
         entry = {
@@ -479,10 +473,15 @@ export function buildArmProviderSchema(
         if (explicitName) {
           resource.metadata.resourceName = explicitName;
         } else {
-          const clientResourceName =
-            resourcePathToClientResourceName.get(metadataKey);
-          if (clientResourceName) {
-            resource.metadata.resourceName = clientResourceName;
+          // Try to derive from client name using pluralize.singular
+          const clientName = resourcePathToClientName.get(metadataKey);
+          if (clientName) {
+            const sdkModel = models.get(resource.resourceModelId);
+            const typespecModel = sdkModel?.__raw as Model | undefined;
+            const clientResourceName = pluralize.singular(clientName);
+            if (clientResourceName !== typespecModel?.name) {
+              resource.metadata.resourceName = clientResourceName;
+            }
           }
         }
       }

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -479,8 +479,8 @@ export function buildArmProviderSchema(
             const sdkModel = models.get(resource.resourceModelId);
             const typespecModel = sdkModel?.__raw as Model | undefined;
             const clientResourceName = pluralize.singular(clientName);
-            // For multi-scope resources, the same model can have multiple resource
-            // paths. Only use the client-derived name when it disambiguates from
+            // For multiple-path resources, the same model can have multiple
+            // resource paths. Only use the client-derived name when it disambiguates from
             // the raw TypeSpec model name; otherwise keep the clientName-adjusted
             // model name already assigned as the default resource name.
             if (clientResourceName !== typespecModel?.name) {

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -132,8 +132,8 @@ export function buildArmProviderSchema(
     }
   }
 
-  // Track client names associated with each resource path for name derivation
-  const resourcePathToClientName = new Map<string, string>();
+  // Track client-derived resource names that disambiguate multiple paths for the same model
+  const resourcePathToClientResourceName = new Map<string, string>();
 
   // Track explicit resource names from TypeSpec (e.g., from LegacyOperations ResourceName parameter)
   const resourcePathToExplicitName = new Map<string, string>();
@@ -272,9 +272,15 @@ export function buildArmProviderSchema(
       let entry = resourcePathToMetadataMap.get(metadataKey);
       if (!entry) {
         const model = resourceModelMap.get(modelId);
-        // Store the client name for this resource path for later use (fallback if no explicit name)
-        if (!resourcePathToClientName.has(metadataKey)) {
-          resourcePathToClientName.set(metadataKey, client.name);
+        // Store the client-derived name only when it disambiguates from the raw model name.
+        const clientResourceName = pluralize.singular(client.name);
+        const sdkModel = models.get(modelId);
+        const typespecModel = sdkModel?.__raw as Model | undefined;
+        if (
+          clientResourceName !== typespecModel?.name &&
+          !resourcePathToClientResourceName.has(metadataKey)
+        ) {
+          resourcePathToClientResourceName.set(metadataKey, clientResourceName);
         }
 
         entry = {
@@ -473,15 +479,10 @@ export function buildArmProviderSchema(
         if (explicitName) {
           resource.metadata.resourceName = explicitName;
         } else {
-          // Try to derive from client name using pluralize.singular
-          const clientName = resourcePathToClientName.get(metadataKey);
-          if (clientName) {
-            const sdkModel = models.get(resource.resourceModelId);
-            const typespecModel = sdkModel?.__raw as Model | undefined;
-            const clientResourceName = pluralize.singular(clientName);
-            if (clientResourceName !== typespecModel?.name) {
-              resource.metadata.resourceName = clientResourceName;
-            }
+          const clientResourceName =
+            resourcePathToClientResourceName.get(metadataKey);
+          if (clientResourceName) {
+            resource.metadata.resourceName = clientResourceName;
           }
         }
       }

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -479,6 +479,10 @@ export function buildArmProviderSchema(
             const sdkModel = models.get(resource.resourceModelId);
             const typespecModel = sdkModel?.__raw as Model | undefined;
             const clientResourceName = pluralize.singular(clientName);
+            // For multi-scope resources, the same model can have multiple resource
+            // paths. Only use the client-derived name when it disambiguates from
+            // the raw TypeSpec model name; otherwise keep the clientName-adjusted
+            // model name already assigned as the default resource name.
             if (clientResourceName !== typespecModel?.name) {
               resource.metadata.resourceName = clientResourceName;
             }

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -256,7 +256,7 @@ interface Employees2 {
     );
   });
 
-  it("uses clientName-adjusted model name as default resource wrapper name", async () => {
+  it("uses clientName-adjusted model name as default resource wrapper name for multi-scope resources", async () => {
     const program = await typeSpecCompile(
       `
 /** Container app job properties */
@@ -268,8 +268,15 @@ model JobProperties {
 /** Container app job resource */
 @@clientName(Job, "ContainerAppJob", "csharp");
 model Job is TrackedResource<JobProperties> {
-  ...ResourceNameParameter<Job>;
+  ...ResourceNameParameter<
+    Resource = Job,
+    KeyName = "jobName",
+    SegmentName = "jobs"
+  >;
 }
+
+/** Container app jobs collection */
+model JobsCollection is Azure.Core.Page<Job>;
 
 interface Operations extends Azure.ResourceManager.Operations {}
 
@@ -278,7 +285,14 @@ interface Jobs {
   get is ArmResourceRead<Job>;
   createOrUpdate is ArmResourceCreateOrReplaceAsync<Job>;
   delete is ArmResourceDeleteWithoutOkAsync<Job>;
-  listByResourceGroup is ArmResourceListByParent<Job>;
+  listByResourceGroup is ArmResourceListByParent<
+    Job,
+    Response = ArmResponse<JobsCollection>
+  >;
+  listBySubscription is ArmListBySubscription<
+    Job,
+    Response = ArmResponse<JobsCollection>
+  >;
 }
 `,
       runner
@@ -288,18 +302,127 @@ interface Jobs {
     const [root] = createModel(sdkContext);
 
     const armProviderSchema = buildArmProviderSchema(sdkContext, root);
-    const jobResource = armProviderSchema.resources.find(
+    const jobResources = armProviderSchema.resources.filter(
       (r) => r.metadata.resourceType === "Microsoft.ContosoProviderHub/jobs"
+    );
+    strictEqual(jobResources.length, 1);
+    const [jobResource] = jobResources;
+    strictEqual(jobResource.metadata.resourceName, "ContainerAppJob");
+    strictEqual(
+      jobResource.metadata.methods.filter((m) => m.kind === "List").length,
+      2
+    );
+
+    const resolvedSchema = resolveArmResources(program, sdkContext);
+    const resolvedJobResources = resolvedSchema.resources.filter(
+      (r) => r.metadata.resourceType === "Microsoft.ContosoProviderHub/jobs"
+    );
+    strictEqual(resolvedJobResources.length, 1);
+    const [resolvedJobResource] = resolvedJobResources;
+    strictEqual(resolvedJobResource.metadata.resourceName, "ContainerAppJob");
+    strictEqual(
+      resolvedJobResource.metadata.methods.filter((m) => m.kind === "List")
+        .length,
+      2
+    );
+  });
+
+  it("keeps clientName-adjusted model name when legacy multi-resource fallback matches the raw model name", async () => {
+    const program = await typeSpecCompile(
+      `
+/** Container app job properties */
+model JobProperties {
+  /** Display name */
+  displayName?: string;
+}
+
+/** Container app job resource shared by multiple resource paths */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For sample purpose"
+@@clientName(Job, "ContainerAppJob", "csharp");
+@tenantResource
+model Job is ProxyResource<JobProperties> {
+  ...ResourceNameParameter<
+    Resource = Job,
+    KeyName = "jobName",
+    SegmentName = "jobs"
+  >;
+  ...Azure.ResourceManager.Legacy.ExtendedLocationOptionalProperty;
+}
+
+alias JobOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+  },
+  {
+    @segment("jobs")
+    @key
+    @TypeSpec.Http.path
+    jobName: string;
+  }
+>;
+
+alias JobVersionOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+    @segment("jobs")
+    @key
+    @TypeSpec.Http.path
+    jobName: string;
+  },
+  {
+    @segment("versions")
+    @key
+    @TypeSpec.Http.path
+    versionName: string;
+  }
+>;
+
+interface Operations extends Azure.ResourceManager.Operations {}
+
+@armResourceOperations
+interface Jobs {
+  get is JobOps.Read<Job>;
+  createOrUpdate is JobOps.CreateOrUpdateSync<Job>;
+  delete is JobOps.DeleteSync<Job>;
+}
+
+@armResourceOperations
+interface JobVersions {
+  get is JobVersionOps.Read<Job>;
+  createOrUpdate is JobVersionOps.CreateOrUpdateSync<Job>;
+  delete is JobVersionOps.DeleteSync<Job>;
+}
+`,
+      runner
+    );
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const [root] = createModel(sdkContext);
+
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+    const jobModel = root.models.find((m) => m.name === "ContainerAppJob");
+    ok(jobModel, "ClientName-adjusted Job model should exist");
+
+    const jobResources = armProviderSchema.resources.filter(
+      (r) => r.resourceModelId === jobModel.crossLanguageDefinitionId
+    );
+    strictEqual(jobResources.length, 2);
+
+    const jobResource = jobResources.find(
+      (r) =>
+        r.metadata.resourceIdPattern.path.includes("/jobs/{jobName}") &&
+        !r.metadata.resourceIdPattern.path.includes("/versions")
     );
     ok(jobResource, "Job resource should be detected");
     strictEqual(jobResource.metadata.resourceName, "ContainerAppJob");
 
-    const resolvedSchema = resolveArmResources(program, sdkContext);
-    const resolvedJobResource = resolvedSchema.resources.find(
-      (r) => r.metadata.resourceType === "Microsoft.ContosoProviderHub/jobs"
+    const jobVersionResource = jobResources.find((r) =>
+      r.metadata.resourceIdPattern.path.includes("/versions/{versionName}")
     );
-    ok(resolvedJobResource, "Job resource should be resolved");
-    strictEqual(resolvedJobResource.metadata.resourceName, "ContainerAppJob");
+    ok(jobVersionResource, "Job version resource should be detected");
+    strictEqual(jobVersionResource.metadata.resourceName, "JobVersion");
   });
 
   it("singleton resource", async () => {

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -256,6 +256,52 @@ interface Employees2 {
     );
   });
 
+  it("uses clientName-adjusted model name as default resource wrapper name", async () => {
+    const program = await typeSpecCompile(
+      `
+/** Container app job properties */
+model JobProperties {
+  /** Display name */
+  displayName?: string;
+}
+
+/** Container app job resource */
+@@clientName(Job, "ContainerAppJob", "csharp");
+model Job is TrackedResource<JobProperties> {
+  ...ResourceNameParameter<Job>;
+}
+
+interface Operations extends Azure.ResourceManager.Operations {}
+
+@armResourceOperations
+interface Jobs {
+  get is ArmResourceRead<Job>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<Job>;
+  delete is ArmResourceDeleteWithoutOkAsync<Job>;
+  listByResourceGroup is ArmResourceListByParent<Job>;
+}
+`,
+      runner
+    );
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const [root] = createModel(sdkContext);
+
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+    const jobResource = armProviderSchema.resources.find(
+      (r) => r.metadata.resourceType === "Microsoft.ContosoProviderHub/jobs"
+    );
+    ok(jobResource, "Job resource should be detected");
+    strictEqual(jobResource.metadata.resourceName, "ContainerAppJob");
+
+    const resolvedSchema = resolveArmResources(program, sdkContext);
+    const resolvedJobResource = resolvedSchema.resources.find(
+      (r) => r.metadata.resourceType === "Microsoft.ContosoProviderHub/jobs"
+    );
+    ok(resolvedJobResource, "Job resource should be resolved");
+    strictEqual(resolvedJobResource.metadata.resourceName, "ContainerAppJob");
+  });
+
   it("singleton resource", async () => {
     const program = await typeSpecCompile(
       `

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -256,7 +256,7 @@ interface Employees2 {
     );
   });
 
-  it("uses clientName-adjusted model name as default resource wrapper name for multi-scope resources", async () => {
+  it("uses clientName-adjusted model name as default resource wrapper name for list operations at multiple scopes", async () => {
     const program = await typeSpecCompile(
       `
 /** Container app job properties */
@@ -327,7 +327,7 @@ interface Jobs {
     );
   });
 
-  it("keeps clientName-adjusted model name when legacy multi-resource fallback matches the raw model name", async () => {
+  it("keeps clientName-adjusted model name when legacy multiple-path fallback matches the raw model name", async () => {
     const program = await typeSpecCompile(
       `
 /** Container app job properties */


### PR DESCRIPTION
Fixes #59208

## Description
- Derives default ARM resource wrapper names from the client-name-adjusted SDK model name instead of the raw TypeSpec model name.
- Applies the same SDK-model-name fallback in both the legacy resource detection path and the `resolveArmResources` converter path.
- Preserves clientName-adjusted wrapper names for legacy multiple-path resources when the singularized client name does not actually disambiguate from the raw TypeSpec model name. This covers the ContainerApps `@@clientName(Job, "ContainerAppJob", "csharp")` case while still allowing disambiguated names such as `JobVersion` for another resource path sharing the same model.
- Adds regression coverage for both the ContainerApps-style list operations at multiple scopes and the legacy multiple-path fallback path.

## Validation
- `npm run build:emitter`
- `npx vitest run -c ./emitter/vitest.config.ts --passWithNoTests emitter/test/resource-detection.test.ts`
- `npm run lint`
- `npm run prettier`
- Verified in PR #59179 temp worktree: after removing `ContainerAppJobCollection.cs` and `ContainerAppJobResource.cs`, `RegenSdkLocal.ps1 -Services "Azure.ResourceManager.AppContainers" -Parallel 1` regenerated `Generated/ContainerAppJobCollection.cs` and `Generated/ContainerAppJobResource.cs` instead of `JobCollection.cs`/`JobResource.cs`.
