### PR TITLE
[Storage] [DataMovement] Rerecord Blobs.Files.Shares tests due to sub migration

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares_600278e994"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares_a2a7e016b7"
 }


### PR DESCRIPTION
Had to rerecord some Azure.Storage.DataMovement.Blobs.Files.Shares files test due to this PR: https://github.com/Azure/azure-sdk-for-net/pull/58893
Looks like there was a subscription mpg migration and this required some recordings to some our tests.

I checked the diff between the recordings and looks like things align with adding the subscription migration or from the changes I made this in PR with order properties are applied.
https://github.com/Azure/azure-sdk-assets/commit/a2a7e016b76c8eba54d8246754bb8c31e79dd193

This should fix the DataMovement CI.