### PR TITLE
[Storage] [DataMovement] Ignore tests blocked by missing Blobs.Files.Shares OAuth recording (refs #59220)

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs
@@ -305,6 +305,7 @@ namespace Azure.Storage.DataMovement.Tests
         [TestCase(0, 10)]
         [TestCase(DataMovementTestConstants.KB / 2, 10)]
         [TestCase(DataMovementTestConstants.KB, 10)]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/59220")]
         public async Task DirectoryToDirectory_SmallSize(long size, int waitTimeInSec)
         {
             // Arrange
@@ -382,6 +383,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/59220")]
         public async Task DirectoryToDirectory_EmptyFolder()
         {
             // Arrange
@@ -971,6 +973,7 @@ namespace Azure.Storage.DataMovement.Tests
         [TestCase((int)TransferPropertiesTestType.Preserve)]
         [TestCase((int)TransferPropertiesTestType.NoPreserve)]
         [TestCase((int)TransferPropertiesTestType.NewProperties)]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/59220")]
         public async Task CopyRemoteObjects_VerifyProperties(int propertiesType)
         {
             // Arrange


### PR DESCRIPTION
## Summary

Three tests in `Azure.Storage.DataMovement/tests/Shared/StartTransferDirectoryCopyTestBase.cs` are failing in playback in the `internal/net - core` pipeline (`MacOS_NET90_ProjectRef_Release_DependencyGroup18`). The Blob → Share-directory fixtures route through OAuth (see comment in `StartTransferCopyToShareDirectoryTestBase.cs`: _"Blob to File always needs OAuth source container"_), but the session recordings under `Azure.Storage.DataMovement.Blobs.Files.Shares` are missing the `Storage_TestConfigOAuth` variable, so `TenantConfiguration.Parse(null)` throws and 18 tests (3 methods × 6 fixture variants) fail.

This PR temporarily marks the three test methods `[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/59220")]` so the build leg can pass while the recordings are regenerated.

Tracking issue: #59220 — full investigation and reproduction details are there. **This PR is intentionally not closing the issue** — the issue should remain open until the Blobs.Files.Shares OAuth recordings are regenerated and the `[Ignore]` attributes are removed.

## Tests affected

| Test | Failing variant(s) | Other variants |
| --- | --- | --- |
| `CopyRemoteObjects_VerifyProperties(int propertiesType)` | `(2)` (`NoPreserve`) | `(0)`, `(1)`, `(3)` were passing |
| `DirectoryToDirectory_SmallSize(long size, int waitTimeInSec)` | `(0, 10)` | `(KB/2, 10)`, `(KB, 10)` were passing |
| `DirectoryToDirectory_EmptyFolder()` | (only variant) | — |

## Scope note

The `[Ignore]` is applied on the shared base `StartTransferDirectoryCopyTestBase`, which matches the existing pattern in this codebase (e.g. `StartTransferUploadTestBase.cs`, `StartTransferDownloadTestBase.cs`). As a side-effect this also skips the same three method names in the Blob→Blob, Share→Share, and Share→Blob fixtures, even though only the Blob→Share-directory path is actually broken. They should be re-enabled together with the recording regeneration in the issue follow-up.

## Validation

`dotnet build Azure.Storage.DataMovement.Blobs.Files.Shares.Tests.csproj -f net9.0 -c Release` — succeeded (0 warnings, 0 errors).

Refs #59220