### PR TITLE
Fix mgmt generator LRO pageable operation sources

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -420,9 +420,16 @@ namespace Azure.Generator.Management
 
         private void ProcessLroMethod(InputServiceMethod inputMethod, Dictionary<CSharpType, OperationSourceProvider> operationSources)
         {
-            if (inputMethod is InputLongRunningServiceMethod lroMethod)
+            var lroMetadata = inputMethod switch
             {
-                var returnType = lroMethod.LongRunningServiceMetadata.ReturnType;
+                InputLongRunningServiceMethod lroMethod => lroMethod.LongRunningServiceMetadata,
+                InputLongRunningPagingServiceMethod lroPagingMethod => lroPagingMethod.LongRunningServiceMetadata,
+                _ => null
+            };
+
+            if (lroMetadata != null)
+            {
+                var returnType = lroMetadata.ReturnType;
                 if (returnType is InputModelType inputModelType)
                 {
                     var returnCSharpType = ManagementClientGenerator.Instance.TypeFactory.CreateCSharpType(inputModelType);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
@@ -230,7 +230,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             return new MethodSignature(
                 _methodName,
                 _description,
-                _convenienceMethod.Signature.Modifiers,
+                GetMethodModifiers(),
                 ReturnType,
                 _convenienceMethod.Signature.ReturnDescription,
                 GetOperationMethodParameters(),
@@ -239,6 +239,25 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
                 _convenienceMethod.Signature.GenericParameterConstraints,
                 _convenienceMethod.Signature.ExplicitInterface,
                 _convenienceMethod.Signature.NonDocumentComment);
+        }
+
+        private MethodSignatureModifiers GetMethodModifiers()
+        {
+            var modifiers = _convenienceMethod.Signature.Modifiers;
+            if (_serviceMethod is not InputLongRunningPagingServiceMethod)
+            {
+                return modifiers;
+            }
+
+            // LRO paging support is not finalized for management SDKs yet. Keep only
+            // these operation methods internal until the public API shape is ready.
+            return (modifiers
+                & ~MethodSignatureModifiers.Public
+                & ~MethodSignatureModifiers.Protected
+                & ~MethodSignatureModifiers.Private
+                & ~MethodSignatureModifiers.Virtual
+                & ~MethodSignatureModifiers.Override)
+                | MethodSignatureModifiers.Internal;
         }
 
         private TryExpression BuildTryExpression()

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/InputServiceMethodExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/InputServiceMethodExtensions.cs
@@ -36,6 +36,10 @@ namespace Azure.Generator.Management.Utilities
             {
                 responseBodyType = GetLongRunningResponseBodyType(lroMethod);
             }
+            else if (method is InputLongRunningPagingServiceMethod lroPagingMethod)
+            {
+                responseBodyType = lroPagingMethod.LongRunningServiceMetadata.ReturnType;
+            }
             else
             {
                 responseBodyType = GetOperationResponseBodyType(method);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/OperationSourceProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/OperationSourceProviderTests.cs
@@ -166,6 +166,112 @@ namespace Azure.Generator.Management.Tests.Providers
         }
 
         [TestCase]
+        public void Verify_LongRunningPagingMethod_GeneratesOperationSource()
+        {
+            var resourceModel = InputFactory.Model("ManagedNetworkData",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                ],
+                decorators: []);
+            var listResultModel = InputFactory.Model("OutboundRuleListResult",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("nextLink", InputPrimitiveType.String),
+                    InputFactory.Property("value", InputFactory.Array(resourceModel)),
+                ],
+                decorators: []);
+
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+            var subscriptionIdParameter = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var resourceGroupParameter = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var resourceNameParameter = InputFactory.PathParameter("managedNetworkName", InputPrimitiveType.String, isRequired: true);
+            var subscriptionIdMethodParam = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var resourceGroupMethodParam = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var resourceNameMethodParam = InputFactory.MethodParameter("managedNetworkName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+
+            var readOperation = InputFactory.Operation(
+                name: "getManagedNetwork",
+                responses: [InputFactory.OperationResponse([200], resourceModel)],
+                parameters: [subscriptionIdParameter, resourceGroupParameter, resourceNameParameter],
+                path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/managedNetworks/{managedNetworkName}");
+            var readMethod = InputFactory.BasicServiceMethod(
+                "getManagedNetwork",
+                readOperation,
+                parameters: [resourceNameMethodParam, subscriptionIdMethodParam, resourceGroupMethodParam],
+                response: InputFactory.ServiceMethodResponse(resourceModel, null));
+
+            var actionOperation = InputFactory.Operation(
+                name: "batchOutboundRules",
+                responses: [InputFactory.OperationResponse([200], listResultModel), InputFactory.OperationResponse([202])],
+                parameters: [subscriptionIdParameter, resourceGroupParameter, resourceNameParameter],
+                path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/managedNetworks/{managedNetworkName}/batchOutboundRules",
+                httpMethod: "POST");
+            var actionMethod = new InputLongRunningPagingServiceMethod(
+                "batchOutboundRules",
+                "public",
+                [],
+                null,
+                null,
+                actionOperation,
+                [resourceNameMethodParam, subscriptionIdMethodParam, resourceGroupMethodParam],
+                InputFactory.ServiceMethodResponse(listResultModel, null),
+                null,
+                false,
+                true,
+                true,
+                "Test.ManagedNetworks.batchOutboundRules",
+                InputFactory.LongRunningServiceMetadata(1, InputFactory.OperationResponse([200], listResultModel), null),
+                InputFactory.NextLinkPagingMetadata("value", "nextLink", InputResponseLocation.Body));
+
+            var resourceIdPattern = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/managedNetworks/{managedNetworkName}";
+            var armProviderDecorator = BuildArmProviderSchema(
+                resourceModel,
+                [
+                    new ResourceMethod(ResourceOperationKind.Read, readMethod, new RequestPathPattern(readOperation.Path), new ArmScopeInfo(ResourceScope.ResourceGroup, new RequestPathPattern(resourceIdPattern), null), null!),
+                    new ResourceMethod(ResourceOperationKind.Action, actionMethod, new RequestPathPattern(actionOperation.Path), new ArmScopeInfo(ResourceScope.ResourceGroup, new RequestPathPattern(resourceIdPattern), null), null!)
+                ],
+                resourceIdPattern,
+                "Microsoft.Tests/managedNetworks",
+                null,
+                ResourceScope.ResourceGroup,
+                "ManagedNetwork");
+            var client = InputFactory.Client(
+                "ManagedNetworksClient",
+                methods: [readMethod, actionMethod],
+                decorators: [armProviderDecorator],
+                crossLanguageDefinitionId: "Test.ManagedNetworksClient");
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [resourceModel, listResultModel], clients: () => [client]);
+            var outputLibrary = plugin.Object.OutputLibrary as ManagementOutputLibrary;
+
+            Assert.That(outputLibrary, Is.Not.Null);
+            var operationSources = outputLibrary!.OperationSourceDict;
+            Assert.That(operationSources.Keys.Any(type => type.Name == "OutboundRuleListResult"), Is.True);
+            Assert.That(operationSources.Values.Any(source => source.Name == "OutboundRuleListResultOperationSource"), Is.True);
+
+            var resourceProvider = outputLibrary.TypeProviders.OfType<ResourceClientProvider>().Single();
+            var lroPagingMethods = resourceProvider.Methods
+                .Where(method => method.Signature.Name.Contains("BatchOutboundRules"))
+                .ToList();
+            Assert.That(lroPagingMethods, Has.Count.EqualTo(2));
+            Assert.That(lroPagingMethods, Is.All.Matches<MethodProvider>(method =>
+                method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal)
+                && !method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)));
+
+            var readMethods = resourceProvider.Methods
+                .Where(method => method.Signature.Name.Contains("Get"))
+                .ToList();
+            Assert.That(readMethods, Is.Not.Empty);
+            Assert.That(readMethods, Is.All.Matches<MethodProvider>(method =>
+                method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)
+                && !method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal)));
+        }
+
+        [TestCase]
         public void Verify_CreateResult()
         {
             var validateIdMethod = GetOperationSourceProviderMethodByName("CreateResult");


### PR DESCRIPTION
Fixes #59230

This updates the management generator to handle LRO pageable methods without crashing during operation-source registration.

Changes:
- registers operation sources for `InputLongRunningPagingServiceMethod`
- resolves the final LRO pageable response body type from long-running metadata
- keeps only LRO pageable resource operation methods internal while .NET SDK support for LRO paging APIs is not finalized
- adds regression coverage for the Cognitive Services `batchOutboundRules` shape and verifies normal resource operations remain public
