### PR TITLE
Bump provisioning generator dependencies

### DIFF
--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260513.3</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20260512.2</AzureGeneratorVersion>
-    <AzureManagementGeneratorVersion>1.0.0-alpha.20260421.1</AzureManagementGeneratorVersion>
+    <AzureManagementGeneratorVersion>1.0.0-alpha.20260512.4</AzureManagementGeneratorVersion>
   </PropertyGroup>
 
   <!-- Packages used by the TypeSpec generators -->

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -9,9 +9,7 @@
       "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260512.2",
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260512.4",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260511.7"
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260512.4"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.67.0",

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -9,14 +9,16 @@
       "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260424.2"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260512.2",
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260512.4",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260511.7"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.67.0",
-        "@azure-tools/typespec-azure-core": "0.67.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.67.0",
+        "@azure-tools/typespec-azure-core": "0.67.1",
+        "@azure-tools/typespec-azure-resource-manager": "0.67.1",
         "@azure-tools/typespec-azure-rulesets": "0.67.0",
-        "@azure-tools/typespec-client-generator-core": "0.67.2",
+        "@azure-tools/typespec-client-generator-core": "0.67.4",
         "@azure-tools/typespec-liftr-base": "0.13.0",
         "@eslint/js": "^9.2.0",
         "@types/node": "~22.12.0",
@@ -80,9 +82,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.67.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.67.0.tgz",
-      "integrity": "sha512-6DO/fOlVihMlPG0oDXrgURf5MNF4iBzPx5SMA5aaFDx/fW6MjiD+TN9Yy9O+l9mVNh1XaEMjhjA8/lmnHZ/U0g==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.67.1.tgz",
+      "integrity": "sha512-HBvigwr8Ub7rsg4RDpTO3WTHS+CIqAw32X3RzxsDNb8NfLoSLSZDANz05VPiDTzAXO7eMfEP42RXkKPV0tlZLg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -94,9 +96,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.67.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.67.0.tgz",
-      "integrity": "sha512-NFE1O4zlpo6Y+Lkh3XCo59g+7r141+oBomYib1LncbbpqoGDakHvBH4sLelt9ZCMnYAxlKGbjXrO9E6jd53P2Q==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.67.1.tgz",
+      "integrity": "sha512-cIPVscR29WgUOk6NDWco95Fc0swSe1jmJz+5G24cCqt6iR/mgIiNdT7D+Njg0VkANoI1AaCT69eIa6yWpAaOIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -132,9 +134,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.67.2.tgz",
-      "integrity": "sha512-sI2Lw7F6aTXWNrLGQU6fjyx4H3ztq/Y3VKOUfe4nNQY664NgrBA6B8e0Wa4wVTEXDs9BeZZYMgzTeAIl5eu6sg==",
+      "version": "0.67.4",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.67.4.tgz",
+      "integrity": "sha512-Q9mlU5wZzPCFtdwVKKgqb6Nw4PM0taOeRsr7Aj9WkRYx7n9B8Y+ITtMLYaJWd3OQVkpZoiFOgq+0ZnrcC3IjCw==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -145,7 +147,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.67.0",
+        "@azure-tools/typespec-azure-core": "^0.67.1",
         "@typespec/compiler": "^1.11.0",
         "@typespec/events": "^0.81.0",
         "@typespec/http": "^1.11.0",
@@ -164,60 +166,22 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260415.3",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260415.3.tgz",
-      "integrity": "sha1-7mnjfMQlQhwPuUlSMED5X8HeFeg=",
+      "version": "1.0.0-alpha.20260512.2",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260512.2.tgz",
+      "integrity": "sha1-0vmWqZRUvlpV38fLzDh+5AssJEY=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260414.6"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260511.7"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260424.2",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260424.2.tgz",
-      "integrity": "sha1-Bo9HmBHB1+hVO4kEmRMl1BuN/Xk=",
+      "version": "1.0.0-alpha.20260512.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260512.4.tgz",
+      "integrity": "sha1-w9RW7dxsoBmYZJ6aZtwFNRkQhIk=",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260415.3",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260414.6"
-      }
-    },
-    "node_modules/@azure-typespec/http-client-csharp-mgmt/node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260414.6",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260414.6.tgz",
-      "integrity": "sha512-RrSeMd+waCsFvLYSonmwpzetj51I495+6R8Vlogl6+I70Z2MVOksi7ocQ5D/sg3Sml2QlD96oyUmv/envNFfmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/identity": "^4.13.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.67.1 <0.68.0 || ~0.68.0-0",
-        "@typespec/compiler": "^1.11.0",
-        "@typespec/http": "^1.11.0",
-        "@typespec/openapi": "^1.11.0",
-        "@typespec/rest": ">=0.81.0 <0.82.0 || ~0.82.0-0",
-        "@typespec/sse": ">=0.81.0 <0.82.0 || ~0.82.0-0",
-        "@typespec/streams": ">=0.81.0 <0.82.0 || ~0.82.0-0",
-        "@typespec/versioning": ">=0.81.0 <0.82.0 || ~0.82.0-0"
-      }
-    },
-    "node_modules/@azure-typespec/http-client-csharp/node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260414.6",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260414.6.tgz",
-      "integrity": "sha512-RrSeMd+waCsFvLYSonmwpzetj51I495+6R8Vlogl6+I70Z2MVOksi7ocQ5D/sg3Sml2QlD96oyUmv/envNFfmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/identity": "^4.13.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.67.1 <0.68.0 || ~0.68.0-0",
-        "@typespec/compiler": "^1.11.0",
-        "@typespec/http": "^1.11.0",
-        "@typespec/openapi": "^1.11.0",
-        "@typespec/rest": ">=0.81.0 <0.82.0 || ~0.82.0-0",
-        "@typespec/sse": ">=0.81.0 <0.82.0 || ~0.82.0-0",
-        "@typespec/streams": ">=0.81.0 <0.82.0 || ~0.82.0-0",
-        "@typespec/versioning": ">=0.81.0 <0.82.0 || ~0.82.0-0"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260512.2",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260511.7"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -1022,24 +986,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.3.tgz",
-      "integrity": "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.0.tgz",
-      "integrity": "sha512-/HjF1LN0a1h4/OFsbGKHNDtWICFU/dqXCdym719HFTyJo9IG7Otr+ziGWc9S0iQuohRZllh+WprSgd5UW5Fw0g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.5.tgz",
+      "integrity": "sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1054,13 +1018,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.8.tgz",
-      "integrity": "sha512-Di6dgmiZ9xCSUxWUReWTqDtbhXCuG2MQm2xmgSAIruzQzBqNf49b8E07/vbCYY506kDe8BiwJbegXweG8M1klw==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+      "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1075,14 +1039,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.5.tgz",
-      "integrity": "sha512-QQPAX+lka8GyLcZ7u7Nb1h6q72iZ/oy0blilC3IB2nSt1Qqxp7akt94Jqhi/DzARuN3Eo9QwJRvtl4tmVe4T5A==",
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+      "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3",
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -1101,14 +1065,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.8.tgz",
-      "integrity": "sha512-sLcpbb9B3XqUEGrj1N66KwhDhEckzZ4nI/W6SvLXyBX8Wic3LDLENlWRvkOGpCPoserabe+MxQkpiMoI8irvyA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.2.tgz",
+      "integrity": "sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/external-editor": "^2.0.3",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/external-editor": "^3.0.0",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1123,13 +1087,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.8.tgz",
-      "integrity": "sha512-QieW3F1prNw3j+hxO7/NKkG1pk3oz7pOB6+5Upwu3OIwADfPX0oZVppsqlL+Vl/uBHHDSOBY0BirLctLnXwGGg==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.14.tgz",
+      "integrity": "sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1144,9 +1108,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.3.tgz",
-      "integrity": "sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -1165,22 +1129,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.3.tgz",
-      "integrity": "sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.8.tgz",
-      "integrity": "sha512-p0IJslw0AmedLEkOU+yrEX3Aj2RTpQq7ZOf8nc1DIhjzaxRWrrgeuE5Kyh39fVRgtcACaMXx/9WNo8+GjgBOfw==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.13.tgz",
+      "integrity": "sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1195,13 +1159,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.8.tgz",
-      "integrity": "sha512-uGLiQah9A0F9UIvJBX52m0CnqtLaym0WpT9V4YZrjZ+YRDKZdwwoEPz06N6w8ChE2lrnsdyhY9sL+Y690Kh9gQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.13.tgz",
+      "integrity": "sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1216,14 +1180,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.8.tgz",
-      "integrity": "sha512-zt1sF4lYLdvPqvmvHdmjOzuUUjuCQ897pdUCO8RbXMUDKXJTTyOQgtn23le+jwcb+MpHl3VAFvzIdxRAf6aPlA==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.13.tgz",
+      "integrity": "sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1238,21 +1202,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.0.tgz",
-      "integrity": "sha512-JAj66kjdH/F1+B7LCigjARbwstt3SNUOSzMdjpsvwJmzunK88gJeXmcm95L9nw1KynvFVuY4SzXh/3Y0lvtgSg==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.3.tgz",
+      "integrity": "sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.1.0",
-        "@inquirer/confirm": "^6.0.8",
-        "@inquirer/editor": "^5.0.8",
-        "@inquirer/expand": "^5.0.8",
-        "@inquirer/input": "^5.0.8",
-        "@inquirer/number": "^4.0.8",
-        "@inquirer/password": "^5.0.8",
-        "@inquirer/rawlist": "^5.2.4",
-        "@inquirer/search": "^4.1.4",
-        "@inquirer/select": "^5.1.0"
+        "@inquirer/checkbox": "^5.1.5",
+        "@inquirer/confirm": "^6.0.13",
+        "@inquirer/editor": "^5.1.2",
+        "@inquirer/expand": "^5.0.14",
+        "@inquirer/input": "^5.0.13",
+        "@inquirer/number": "^4.0.13",
+        "@inquirer/password": "^5.0.13",
+        "@inquirer/rawlist": "^5.2.9",
+        "@inquirer/search": "^4.1.9",
+        "@inquirer/select": "^5.1.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1267,13 +1231,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.4.tgz",
-      "integrity": "sha512-fTuJ5Cq9W286isLxwj6GGyfTjx1Zdk4qppVEPexFuA6yioCCXS4V1zfKroQqw7QdbDPN73xs2DiIAlo55+kBqg==",
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.9.tgz",
+      "integrity": "sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1288,14 +1252,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.4.tgz",
-      "integrity": "sha512-9yPTxq7LPmYjrGn3DRuaPuPbmC6u3fiWcsE9ggfLcdgO/ICHYgxq7mEy1yJ39brVvgXhtOtvDVjDh9slJxE4LQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.9.tgz",
+      "integrity": "sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1310,15 +1274,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.0.tgz",
-      "integrity": "sha512-OyYbKnchS1u+zRe14LpYrN8S0wH1vD0p2yKISvSsJdH2TpI87fh4eZdWnpdbrGauCRWDph3NwxRmM4Pcm/hx1Q==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.5.tgz",
+      "integrity": "sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/core": "^11.1.5",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1333,9 +1297,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.3.tgz",
-      "integrity": "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -2199,16 +2163,15 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260421.4",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260421.4.tgz",
-      "integrity": "sha512-QA003cNpe0F4fuN1Cw3a7vb3V+EhP+xGfRsGqg+KEDVm+ZxdFtwQzOI5sZVPZgu80n3i9Hs0ShE2xNpK5moV0Q==",
+      "version": "1.0.0-alpha.20260511.7",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260511.7.tgz",
+      "integrity": "sha512-ikccnAWh2/47UU0V0R4h03DOywhyFjW7rNDO6BDPfA12vj/bh/w07iGKi6WXnsMirlgL0gcjFaV4d6+091x/Xg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/identity": "^4.13.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.67.1 <0.68.0 || ~0.68.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.67.4 <0.68.0 || ~0.68.0-0",
         "@typespec/compiler": "^1.11.0",
         "@typespec/http": "^1.11.0",
         "@typespec/openapi": "^1.11.0",
@@ -5000,9 +4963,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -36,9 +36,7 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260512.2",
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260512.4",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260511.7"
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260512.4"
   },
   "peerDependencies": {
     "@azure-typespec/http-client-csharp": "^1.0.0-alpha",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -36,7 +36,9 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260424.2"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260512.2",
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260512.4",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260511.7"
   },
   "peerDependencies": {
     "@azure-typespec/http-client-csharp": "^1.0.0-alpha",
@@ -44,10 +46,10 @@
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.67.0",
-    "@azure-tools/typespec-azure-core": "0.67.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.67.0",
+    "@azure-tools/typespec-azure-core": "0.67.1",
+    "@azure-tools/typespec-azure-resource-manager": "0.67.1",
     "@azure-tools/typespec-azure-rulesets": "0.67.0",
-    "@azure-tools/typespec-client-generator-core": "0.67.2",
+    "@azure-tools/typespec-client-generator-core": "0.67.4",
     "@azure-tools/typespec-liftr-base": "0.13.0",
     "@eslint/js": "^9.2.0",
     "@types/node": "~22.12.0",


### PR DESCRIPTION
## Description

Bumps the provisioning generator dependency graph to the released management generator stack that includes the MTG constructor virtual-dispatch fix.

## Changes

- Update `AzureManagementGeneratorVersion` to `1.0.0-alpha.20260512.4` while retaining the latest unbranded generator version already on `main`.
- Align provisioning npm generator dependencies with the released management generator package graph.
- Refresh `package-lock.json` via `npm install`.

## Validation

- `npm install` in `eng/packages/http-client-csharp-provisioning`
- `pwsh .\eng\packages\http-client-csharp-provisioning\eng\scripts\Generate.ps1 -filter Provisioning-TypeSpec`