### PR TITLE
[MPG Generator] Fix OperationSourceProvider for cross-assembly common types (OperationStatusResult)

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationSourceProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationSourceProvider.cs
@@ -5,12 +5,15 @@ using Azure.Core;
 using Azure.Generator.Management.Primitives;
 using Azure.ResourceManager;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
+using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Statements;
 using System;
 using System.ClientModel.Primitives;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
@@ -95,8 +98,7 @@ namespace Azure.Generator.Management.Providers
                 body = new MethodBodyStatement[]
                 {
                     UsingDeclare("document", typeof(JsonDocument), Static(typeof(JsonDocument)).Invoke(nameof(JsonDocument.ParseAsync), [KnownAzureParameters.Response.Property(nameof(Response.ContentStream)), Default, KnownAzureParameters.CancellationTokenWithoutDefault], true), out var documentVariable),
-                    Declare("result", _resultType, Static(_resultType).Invoke($"Deserialize{_resultType.Name}", documentVariable.Property(nameof(JsonDocument.RootElement)), Static<ModelSerializationExtensionsDefinition>().Property("WireOptions").As<ModelReaderWriterOptions>()), out var resultVariable),
-                    Return(resultVariable),
+                    Return(BuildDeserializeNonResource(documentVariable)),
                 };
             }
 
@@ -132,12 +134,40 @@ namespace Azure.Generator.Management.Providers
                 body = new MethodBodyStatement[]
                 {
                     UsingDeclare("document", typeof(JsonDocument), Static(typeof(JsonDocument)).Invoke(nameof(JsonDocument.Parse), [KnownAzureParameters.Response.Property(nameof(Response.ContentStream))]), out var documentVariable),
-                    Declare("result", _resultType, Static(_resultType).Invoke($"Deserialize{_resultType.Name}", documentVariable.Property(nameof(JsonDocument.RootElement)), Static<ModelSerializationExtensionsDefinition>().Property("WireOptions").As<ModelReaderWriterOptions>()), out var resultVariable),
-                    Return(resultVariable),
+                    Return(BuildDeserializeNonResource(documentVariable)),
                 };
             }
 
             return new MethodProvider(signature, body, this);
+        }
+
+        // Deserialize the document into _resultType.
+        // For framework/cross-assembly types (e.g. OperationStatusResult, defined in Azure.ResourceManager), the
+        // generated `Deserialize{TypeName}` factory method is internal to the defining assembly and not callable from
+        // consumer SDKs, so we must use ModelReaderWriter.Read<T>(...) with the SDK's generated ModelReaderWriterContext.
+        // For SDK-generated model types, the factory is accessible and is preferred.
+        private ValueExpression BuildDeserializeNonResource(VariableExpression documentVariable)
+        {
+            var rootElement = documentVariable.Property(nameof(JsonDocument.RootElement));
+            var wireOptions = Static<ModelSerializationExtensionsDefinition>().Property("WireOptions").As<ModelReaderWriterOptions>();
+
+            if (_resultType.IsFrameworkType)
+            {
+                // new BinaryData(Encoding.UTF8.GetBytes(document.RootElement.GetRawText()))
+                var binaryData = New.Instance(
+                    typeof(BinaryData),
+                    Static(typeof(Encoding)).Property(nameof(Encoding.UTF8)).Invoke(
+                        nameof(Encoding.UTF8.GetBytes),
+                        rootElement.Invoke(nameof(JsonElement.GetRawText))));
+
+                return Static(typeof(ModelReaderWriter)).Invoke(
+                    nameof(ModelReaderWriter.Read),
+                    [binaryData, wireOptions, ModelReaderWriterContextSnippets.Default],
+                    [_resultType],
+                    false);
+            }
+
+            return Static(_resultType).Invoke($"Deserialize{_resultType.Name}", rootElement, wireOptions);
         }
 
         protected override FieldProvider[] BuildFields()

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/OperationSourceProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/OperationSourceProviderTests.cs
@@ -5,6 +5,7 @@ using Azure.Generator.Management.Models;
 using Azure.Generator.Management.Providers;
 using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
+using Azure.ResourceManager.Models;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
@@ -203,6 +204,45 @@ namespace Azure.Generator.Management.Tests.Providers
             Assert.That(bodyStatements, Is.Not.Null);
             var exptected = Helpers.GetExpectedFromFile();
             Assert.That(bodyStatements, Is.EqualTo(exptected));
+        }
+
+        [TestCase]
+        public void Verify_NonResourceFrameworkType_CreateResult_UsesModelReaderWriter()
+        {
+            // Regression test for #58709: for cross-assembly framework result types (e.g. OperationStatusResult,
+            // defined in Azure.ResourceManager), the generated CreateResult must NOT call the inaccessible internal
+            // Deserialize{Name} factory, and must instead use ModelReaderWriter.Read<T> with the SDK's generated
+            // ModelReaderWriterContext.
+            var (createResult, createResultAsync) = GetNonResourceFrameworkOperationSourceMethods();
+
+            foreach (var (method, isAsync) in new[] { (createResult, false), (createResultAsync, true) })
+            {
+                var body = method.BodyStatements?.ToDisplayString();
+                Assert.That(body, Is.Not.Null);
+
+                // Must use ModelReaderWriter.Read with the generated context, not the internal factory.
+                Assert.That(body, Does.Contain("global::System.ClientModel.Primitives.ModelReaderWriter.Read"),
+                    $"{(isAsync ? "CreateResultAsync" : "CreateResult")} should use ModelReaderWriter.Read for framework result types.");
+                Assert.That(body, Does.Contain("Context.Default"),
+                    $"{(isAsync ? "CreateResultAsync" : "CreateResult")} should pass the generated ModelReaderWriterContext to ModelReaderWriter.Read.");
+                Assert.That(body, Does.Contain("ModelSerializationExtensions.WireOptions"),
+                    $"{(isAsync ? "CreateResultAsync" : "CreateResult")} should pass WireOptions to ModelReaderWriter.Read.");
+                Assert.That(body, Does.Not.Contain("DeserializeOperationStatusResult"),
+                    $"{(isAsync ? "CreateResultAsync" : "CreateResult")} must not call the inaccessible internal Deserialize factory.");
+            }
+        }
+
+        private static (MethodProvider CreateResult, MethodProvider CreateResultAsync) GetNonResourceFrameworkOperationSourceMethods()
+        {
+            // Bootstrap the mock plugin so TypeProvider machinery (ModelReaderWriterContextDefinition, etc.) is available.
+            _ = ManagementMockHelpers.LoadMockPlugin();
+
+            var provider = new OperationSourceProvider(typeof(OperationStatusResult));
+            var createResult = provider.Methods.FirstOrDefault(m => m.Signature.Name == "CreateResult");
+            var createResultAsync = provider.Methods.FirstOrDefault(m => m.Signature.Name == "CreateResultAsync");
+            Assert.That(createResult, Is.Not.Null);
+            Assert.That(createResultAsync, Is.Not.Null);
+            return (createResult!, createResultAsync!);
         }
 
         private static MethodProvider GetOperationSourceProviderMethodByName(string methodName)

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/LongRunningOperation/FooActionResultOperationSource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/LongRunningOperation/FooActionResultOperationSource.cs
@@ -28,8 +28,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         FooActionResult IOperationSource<FooActionResult>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using JsonDocument document = JsonDocument.Parse(response.ContentStream);
-            FooActionResult result = FooActionResult.DeserializeFooActionResult(document.RootElement, ModelSerializationExtensions.WireOptions);
-            return result;
+            return FooActionResult.DeserializeFooActionResult(document.RootElement, ModelSerializationExtensions.WireOptions);
         }
 
         /// <param name="response"> The response from the service. </param>
@@ -38,8 +37,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         async ValueTask<FooActionResult> IOperationSource<FooActionResult>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using JsonDocument document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            FooActionResult result = FooActionResult.DeserializeFooActionResult(document.RootElement, ModelSerializationExtensions.WireOptions);
-            return result;
+            return FooActionResult.DeserializeFooActionResult(document.RootElement, ModelSerializationExtensions.WireOptions);
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/LongRunningOperation/NetworkSiblingSetOperationSource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/LongRunningOperation/NetworkSiblingSetOperationSource.cs
@@ -28,8 +28,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         NetworkSiblingSet IOperationSource<NetworkSiblingSet>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using JsonDocument document = JsonDocument.Parse(response.ContentStream);
-            NetworkSiblingSet result = NetworkSiblingSet.DeserializeNetworkSiblingSet(document.RootElement, ModelSerializationExtensions.WireOptions);
-            return result;
+            return NetworkSiblingSet.DeserializeNetworkSiblingSet(document.RootElement, ModelSerializationExtensions.WireOptions);
         }
 
         /// <param name="response"> The response from the service. </param>
@@ -38,8 +37,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         async ValueTask<NetworkSiblingSet> IOperationSource<NetworkSiblingSet>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using JsonDocument document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            NetworkSiblingSet result = NetworkSiblingSet.DeserializeNetworkSiblingSet(document.RootElement, ModelSerializationExtensions.WireOptions);
-            return result;
+            return NetworkSiblingSet.DeserializeNetworkSiblingSet(document.RootElement, ModelSerializationExtensions.WireOptions);
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #58709.

For long-running operations whose result is the cross-assembly framework type `Azure.ResourceManager.Models.OperationStatusResult`, the MPG emitter was generating an `IOperationSource<T>.CreateResult` body that called the internal `Deserialize{TypeName}` factory on the result type:

```csharp
OperationStatusResult result = OperationStatusResult.DeserializeOperationStatusResult(
    document.RootElement, ModelSerializationExtensions.WireOptions);
```

`OperationStatusResult.DeserializeOperationStatusResult` is `internal` to `Azure.ResourceManager`, so consumer SDKs fail to build with **CS0117: 'OperationStatusResult' does not contain a definition for 'DeserializeOperationStatusResult'**.

## Root cause

`OperationSourceProvider.BuildCreateResult` / `BuildCreateResultAsync` unconditionally emitted `Static(_resultType).Invoke($"Deserialize{_resultType.Name}", ...)`, with no branch for cross-assembly framework types. The same generator already handles this correctly in `ResourceMethodSnippets.CreateGenericResponsePipelineProcessing` by branching on `IsFrameworkType`; that branching was missing here.

## Fix

Branch on `_resultType.IsFrameworkType` in the non-resource path of `OperationSourceProvider`:

- **Framework type** → emit `ModelReaderWriter.Read<T>(new BinaryData(Encoding.UTF8.GetBytes(document.RootElement.GetRawText())), ModelSerializationExtensions.WireOptions, <SdkContext>.Default)` using `ModelReaderWriterContextSnippets.Default`. This matches the legacy autorest.csharp output and the manual workaround SDKs currently ship.
- **SDK-generated model** → keep the existing `Deserialize{Name}` factory path.

Applied to both `BuildCreateResult` and `BuildCreateResultAsync`.

## Verification

- Generator builds: 0 errors
- `OperationSourceProviderTests` (3 tests, cover the resource path): all pass
- Regenerated `Azure.ResourceManager.ComputeLimit` with its custom workaround file deleted → emitted file matches the workaround verbatim; `dotnet build` succeeds with 0 errors.
- Regenerated `Azure.ResourceManager.Redis` with its custom workaround file deleted → `dotnet build` succeeds with 0 errors.

## Follow-up

After this lands, the following SDKs can delete their hand-rolled `Custom/LongRunningOperation/OperationStatusResultOperationSource.cs` workaround in a separate PR (each on the next regen):

- `sdk/redis/Azure.ResourceManager.Redis`
- `sdk/computelimit/Azure.ResourceManager.ComputeLimit`
- `sdk/workloadssapvirtualinstance/Azure.ResourceManager.WorkloadsSapVirtualInstance`
- `sdk/azurelargeinstance/Azure.ResourceManager.LargeInstance`
