### PR TITLE
[Mgmt Generator] Emit `result.Content` for BinaryData responses (fix #57055)

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Snippets/ResourceMethodSnippets.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Snippets/ResourceMethodSnippets.cs
@@ -114,6 +114,7 @@ namespace Azure.Generator.Management.Snippets
 
             // For enum/extensible enum types: Response<T> response = Response.FromValue(new T(JsonDocument.Parse(result.Content, ModelSerializationExtensions.JsonDocumentOptions).RootElement.GetString()), result);
             // For string types: read JSON directly; MRW's AOT-safe context overload needs a String builder that generated contexts don't provide.
+            // For BinaryData responses (e.g. TypeSpec `unknown` body): use result.Content directly, since BinaryData has no FromResponse and does not implement IPersistableModel<BinaryData>.
             // For framework/system types (e.g. OperationStatusResult): use ModelReaderWriter.Read<T>(result.Content) since they don't have a FromResponse method
             // For model types: Response<T> response = Response.FromValue(T.FromResponse(result), result);
             ValueExpression deserializedValue;
@@ -124,6 +125,12 @@ namespace Azure.Generator.Management.Snippets
             else if (responseGenericType.IsFrameworkType && responseGenericType.FrameworkType == typeof(string))
             {
                 deserializedValue = Static(typeof(JsonDocument)).Invoke(nameof(JsonDocument.Parse), [resultVariable.Property("Content"), Static(new ModelSerializationExtensionsDefinition().Type).Property("JsonDocumentOptions")]).Property(nameof(JsonDocument.RootElement)).Invoke(nameof(JsonElement.GetString));
+            }
+            else if (responseGenericType.IsFrameworkType && responseGenericType.FrameworkType == typeof(BinaryData))
+            {
+                // BinaryData has no static FromResponse and does not implement IPersistableModel<BinaryData>,
+                // so the content of the response is already a BinaryData; use it directly.
+                deserializedValue = resultVariable.Property(nameof(Response.Content));
             }
             else if (responseGenericType.IsFrameworkType)
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceMethodSnippetsTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceMethodSnippetsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.Generator.Management.Snippets;
 using Azure.Generator.Management.Tests.TestHelpers;
 using Azure.ResourceManager.Models;
@@ -63,6 +64,37 @@ namespace Azure.Generator.Management.Tests.Providers
             Assert.That(code, Does.Contain("JsonDocument.Parse(result.Content"));
             Assert.That(code, Does.Contain("ModelSerializationExtensions.JsonDocumentOptions"));
             Assert.That(code, Does.Contain("RootElement.GetString()"));
+        }
+
+        [Test]
+        public void CreateGenericResponsePipelineProcessing_WithBinaryData_UsesResultContent()
+        {
+            // Arrange: BinaryData is the framework type used for `unknown`/bytes-bodied responses
+            // (e.g. TypeSpec `Response = ArmResponse<unknown>`). It has no static FromResponse method
+            // (causing CS0117) and does not implement IPersistableModel<BinaryData> (causing runtime
+            // errors with ModelReaderWriter.Read<BinaryData>). The only correct emission is to use
+            // result.Content directly, since the response content is already a BinaryData.
+            var messageVar = new VariableExpression(typeof(Azure.Core.HttpMessage), "message");
+            var contextVar = new VariableExpression(typeof(Azure.RequestContext), "context");
+            CSharpType responseType = typeof(BinaryData);
+            Assert.That(responseType.IsFrameworkType, Is.True, "BinaryData should be a framework type");
+
+            // Act
+            var statements = ResourceMethodSnippets.CreateGenericResponsePipelineProcessing(
+                messageVar,
+                contextVar,
+                responseType,
+                isAsync: false,
+                out _);
+
+            // Assert
+            var code = string.Join("\n", statements.Select(s => s.ToDisplayString()));
+            Assert.That(code, Does.Not.Contain("BinaryData.FromResponse(result)"),
+                "BinaryData has no static FromResponse(Response) method — emitting it causes CS0117.");
+            Assert.That(code, Does.Not.Contain("ModelReaderWriter"),
+                "BinaryData does not implement IPersistableModel<BinaryData>, so ModelReaderWriter.Read<BinaryData> is wrong.");
+            Assert.That(code, Does.Contain("result.Content"),
+                "For BinaryData responses, the generator should use result.Content directly.");
         }
     }
 }


### PR DESCRIPTION
## Fix

The mgmt generator's `CreateGenericResponsePipelineProcessing` snippet emitted `BinaryData.FromResponse(result)` whenever a resource operation's `Response<T>` had `T = BinaryData` (e.g. TypeSpec `Response = ArmResponse<unknown>`).

- `BinaryData` has no static `FromResponse(Response)` method → generated code fails to compile (**CS0117**).
- Routing through the existing framework-type branch (`ModelReaderWriter.Read<T>(result.Content)`) compiles but throws at runtime because `BinaryData` does not implement `IPersistableModel<BinaryData>`.

This PR adds a dedicated branch that emits `result.Content` directly for `BinaryData`, which is functionally equivalent to `Response.Content` and matches the expectation called out in the issue.

Both the fake-LRO path (e.g. `Delete` returning `ArmOperation<BinaryData>`) and the non-LRO path (e.g. `RunPlaybook` returning `Response<BinaryData>`) route through this same snippet, so a single change covers all four reported emission sites in SecurityInsights.

A unit test `CreateGenericResponsePipelineProcessing_WithBinaryData_UsesResultContent` is added.

Fixes #57055