### PR TITLE
[Mgmt Generator] Propagate ancestor flatten map to derived public ctor

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -592,20 +592,40 @@ namespace Azure.Generator.Management.Visitors
 
             var propertyNameMap = propertyMap.ToDictionary(kvp => kvp.Key.Name.ToVariableName(), kvp => kvp.Value);
 
+            // Build the effective map for updating this model's public constructor: start with
+            // this model's own flattened properties, then overlay every already-flattened ancestor's
+            // map. This ensures inherited ctor parameters and base(...) initializer arguments are
+            // rewritten to match the base type's already-flattened public ctor signature, even when
+            // this derived model has flattening of its own.
+            var effectiveMap = new Dictionary<string, List<FlattenPropertyInfo>>(propertyNameMap);
+            for (var ancestor = model.BaseModelProvider as ModelProvider; ancestor is not null; ancestor = ancestor.BaseModelProvider as ModelProvider)
+            {
+                if (_flattenedModelTypes.TryGetValue(ancestor.Type, out var ancestorMap))
+                {
+                    foreach (var kvp in ancestorMap)
+                    {
+                        if (!effectiveMap.ContainsKey(kvp.Key))
+                        {
+                            effectiveMap[kvp.Key] = kvp.Value;
+                        }
+                    }
+                }
+            }
+
             if (isSafeFlatten || isFlattenProperty)
             {
                 var flattenedProperties = propertyMap.Values.SelectMany(x => x.Select(item => item.FlattenedProperty));
                 model.Update(properties: [.. model.Properties, .. flattenedProperties]);
                 _flattenedModelTypes.Add(model.Type, propertyNameMap);
-                UpdatePublicConstructor(model, propertyNameMap);
+                UpdatePublicConstructor(model, effectiveMap);
             }
-            else if (model.BaseModelProvider is ModelProvider flattenedBase && _flattenedModelTypes.TryGetValue(flattenedBase.Type, out var basePropertyNameMap))
+            else if (effectiveMap.Count > 0)
             {
-                // This model has no flattenable properties of its own, but its base model was
-                // safe-flattened. The base's public constructor signature changed (e.g. an
+                // This model has no flattenable properties of its own, but an ancestor model was
+                // flattened. The ancestor's public constructor signature changed (e.g. an
                 // ExportDeliveryInfo param became ExportDeliveryDestination), so update this
                 // model's public constructor params and base initializer call to match.
-                UpdatePublicConstructor(model, basePropertyNameMap);
+                UpdatePublicConstructor(model, effectiveMap);
             }
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -117,29 +117,23 @@ namespace Azure.Generator.Management.Visitors
         }
 
         private bool TryGetFlattenPropertyInfo(CSharpType returnType, [NotNullWhen(true)] out Dictionary<string, List<FlattenPropertyInfo>>? propertyNameMap)
+            => TryBuildFlattenPropertyMap(returnType, out propertyNameMap, mergeDuplicateKeyValues: true);
+
+        private bool TryBuildFlattenPropertyMap(
+            CSharpType type,
+            [NotNullWhen(true)] out Dictionary<string, List<FlattenPropertyInfo>>? propertyNameMap,
+            bool mergeDuplicateKeyValues,
+            Dictionary<string, List<FlattenPropertyInfo>>? seedPropertyNameMap = null,
+            bool includeCurrentType = true)
         {
-            Dictionary<string, List<FlattenPropertyInfo>>? mergedPropertyNameMap = null;
-            var currentType = returnType;
-            var foundFlattenedProperties = false;
+            Dictionary<string, List<FlattenPropertyInfo>>? mergedPropertyNameMap = seedPropertyNameMap?.ToDictionary(
+                kvp => kvp.Key,
+                kvp => new List<FlattenPropertyInfo>(kvp.Value));
+            var foundFlattenedProperties = mergedPropertyNameMap is { Count: > 0 };
+            var currentType = type;
             var visited = new HashSet<CSharpType>(new CSharpTypeNameComparer());
+            var shouldIncludeCurrentType = includeCurrentType;
 
-            void MergeFlattenedProperties(Dictionary<string, List<FlattenPropertyInfo>> source)
-            {
-                mergedPropertyNameMap ??= new Dictionary<string, List<FlattenPropertyInfo>>();
-                foreach (var (parameterName, flattenInfoList) in source)
-                {
-                    if (mergedPropertyNameMap.TryGetValue(parameterName, out var existing))
-                    {
-                        existing.AddRange(flattenInfoList);
-                    }
-                    else
-                    {
-                        mergedPropertyNameMap[parameterName] = [.. flattenInfoList];
-                    }
-                }
-
-                foundFlattenedProperties = true;
-            }
             // Walk up the inheritance chain because flattened properties can come from
             // both the current leaf model and any ancestor model in the hierarchy.
             ModelProvider? currentModel;
@@ -153,9 +147,11 @@ namespace Azure.Generator.Management.Visitors
                     break;
                 }
 
-                if (_flattenedModelTypes.TryGetValue(currentType, out var value))
+                if (shouldIncludeCurrentType && _flattenedModelTypes.TryGetValue(currentType, out var value))
                 {
-                    MergeFlattenedProperties(value);
+                    mergedPropertyNameMap ??= new Dictionary<string, List<FlattenPropertyInfo>>();
+                    MergeFlattenPropertyMap(mergedPropertyNameMap, value, mergeDuplicateKeyValues);
+                    foundFlattenedProperties = true;
                 }
 
                 currentModel = ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(currentType, out var typeProvider)
@@ -167,12 +163,34 @@ namespace Azure.Generator.Management.Visitors
                 if (currentModel is not null)
                 {
                     currentType = currentModel.BaseType!;
+                    shouldIncludeCurrentType = true;
                 }
             }
             while (currentModel is not null);
 
             propertyNameMap = mergedPropertyNameMap;
             return foundFlattenedProperties;
+        }
+
+        private static void MergeFlattenPropertyMap(
+            Dictionary<string, List<FlattenPropertyInfo>> target,
+            Dictionary<string, List<FlattenPropertyInfo>> source,
+            bool mergeDuplicateKeyValues)
+        {
+            foreach (var (parameterName, flattenInfoList) in source)
+            {
+                if (target.TryGetValue(parameterName, out var existing))
+                {
+                    if (mergeDuplicateKeyValues)
+                    {
+                        existing.AddRange(flattenInfoList);
+                    }
+                }
+                else
+                {
+                    target[parameterName] = [.. flattenInfoList];
+                }
+            }
         }
 
         private void UpdateModelFactoryMethod(MethodProvider method, Dictionary<string, List<FlattenPropertyInfo>> propertyNameMap)
@@ -597,20 +615,13 @@ namespace Azure.Generator.Management.Visitors
             // map. This ensures inherited ctor parameters and base(...) initializer arguments are
             // rewritten to match the base type's already-flattened public ctor signature, even when
             // this derived model has flattening of its own.
-            var effectiveMap = new Dictionary<string, List<FlattenPropertyInfo>>(propertyNameMap);
-            for (var ancestor = model.BaseModelProvider as ModelProvider; ancestor is not null; ancestor = ancestor.BaseModelProvider as ModelProvider)
-            {
-                if (_flattenedModelTypes.TryGetValue(ancestor.Type, out var ancestorMap))
-                {
-                    foreach (var kvp in ancestorMap)
-                    {
-                        if (!effectiveMap.ContainsKey(kvp.Key))
-                        {
-                            effectiveMap[kvp.Key] = kvp.Value;
-                        }
-                    }
-                }
-            }
+            _ = TryBuildFlattenPropertyMap(
+                model.Type,
+                out var effectiveMap,
+                mergeDuplicateKeyValues: false,
+                seedPropertyNameMap: propertyNameMap,
+                includeCurrentType: false);
+            effectiveMap ??= new Dictionary<string, List<FlattenPropertyInfo>>();
 
             if (isSafeFlatten || isFlattenProperty)
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -1188,6 +1188,126 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         /// <summary>
+        /// Regression test for https://github.com/Azure/azure-sdk-for-net/issues/57058.
+        ///
+        /// When both the derived model AND its base model have their own flattenable property,
+        /// the derived model's public ctor previously only had its own flatten map applied,
+        /// leaving the inherited (base-flattened) parameter unrewritten. That caused the
+        /// generated derived ctor to declare the unflattened wrapper type and to pass it to
+        /// <c>base(...)</c>, while the base's public ctor expected the flattened scalar
+        /// — producing CS1503.
+        ///
+        /// The fix overlays every flattened-ancestor's map on top of the derived's own
+        /// map before driving the public-ctor rewrite, so inherited ctor parameters and
+        /// the <c>base(...)</c> initializer are rewritten consistently.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenUpdatesDerivedClassCtorWhenBothBaseAndDerivedHaveFlatten()
+        {
+            // BaseWrapper: single required property (triggers safe-flatten in BaseModel).
+            var baseInnerValueProp = InputFactory.Property("baseValue", InputPrimitiveType.String, isRequired: true, serializedName: "baseValue");
+            var baseWrapperModel = InputFactory.Model(
+                "BaseWrapper",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [baseInnerValueProp]);
+
+            // DerivedWrapper: single required property (triggers safe-flatten in DerivedModel).
+            var derivedInnerValueProp = InputFactory.Property("derivedValue", InputPrimitiveType.String, isRequired: true, serializedName: "derivedValue");
+            var derivedWrapperModel = InputFactory.Model(
+                "DerivedWrapper",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [derivedInnerValueProp]);
+
+            // BaseModel has a required wrapper that will be safe-flattened.
+            var baseWrapperProp = InputFactory.Property("baseWrapper", baseWrapperModel, isRequired: true, serializedName: "baseWrapper");
+            var baseModel = InputFactory.Model(
+                "BaseModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [baseWrapperProp]);
+
+            // DerivedModel : BaseModel — also has its own required wrapper to safe-flatten.
+            var derivedWrapperProp = InputFactory.Property("derivedWrapper", derivedWrapperModel, isRequired: true, serializedName: "derivedWrapper");
+            var derivedModel = InputFactory.Model(
+                "DerivedModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                baseModel: baseModel,
+                properties: [derivedWrapperProp]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [baseWrapperModel, derivedWrapperModel, baseModel, derivedModel]);
+
+            var baseModelProvider = plugin.Object.TypeFactory.CreateModel(baseModel)!;
+            var derivedModelProvider = plugin.Object.TypeFactory.CreateModel(derivedModel)!;
+            Assert.That(baseModelProvider, Is.Not.Null);
+            Assert.That(derivedModelProvider, Is.Not.Null);
+
+            // Run FlattenPropertyVisitor; base must be processed first so the derived can pick up
+            // the cached ancestor flatten map when its own flatten is applied.
+            var visitor = new FlattenPropertyVisitor();
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(visitTypeCore, Is.Not.Null);
+
+            // Precondition snapshot of derived's pre-flatten public ctor.
+            var preDerivedPublicCtor = derivedModelProvider.Constructors
+                .SingleOrDefault(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            Assert.That(preDerivedPublicCtor, Is.Not.Null);
+            Assert.That(
+                preDerivedPublicCtor!.Signature.Parameters.Any(p => p.Type.Name == "BaseWrapper"),
+                Is.True,
+                "Precondition: DerivedModel ctor should have BaseWrapper param before flatten");
+            Assert.That(
+                preDerivedPublicCtor.Signature.Parameters.Any(p => p.Type.Name == "DerivedWrapper"),
+                Is.True,
+                "Precondition: DerivedModel ctor should have DerivedWrapper param before flatten");
+
+            visitTypeCore!.Invoke(visitor, [baseModelProvider]);
+            visitTypeCore!.Invoke(visitor, [derivedModelProvider]);
+
+            var publicCtor = derivedModelProvider.Constructors
+                .SingleOrDefault(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            Assert.That(publicCtor, Is.Not.Null, "DerivedModel should still have a public ctor after flatten");
+
+            // The derived ctor must no longer expose either wrapper type, and must expose both flattened scalars.
+            Assert.That(
+                publicCtor!.Signature.Parameters.Any(p => p.Type.Name == "BaseWrapper"),
+                Is.False,
+                "DerivedModel public ctor should NOT have BaseWrapper param (inherited flatten must propagate)");
+            Assert.That(
+                publicCtor.Signature.Parameters.Any(p => p.Type.Name == "DerivedWrapper"),
+                Is.False,
+                "DerivedModel public ctor should NOT have DerivedWrapper param (own flatten)");
+            Assert.That(
+                publicCtor.Signature.Parameters.Any(p => p.Name == "baseValue"),
+                Is.True,
+                "DerivedModel public ctor should expose the flattened scalar from the base wrapper");
+            Assert.That(
+                publicCtor.Signature.Parameters.Any(p => p.Name == "derivedValue"),
+                Is.True,
+                "DerivedModel public ctor should expose the flattened scalar from the derived wrapper");
+
+            // The base initializer must pass the flattened scalar — NOT the old BaseWrapper variable.
+            var initializer = publicCtor.Signature.Initializer;
+            Assert.That(initializer, Is.Not.Null, "DerivedModel public ctor should have a base initializer");
+            Assert.That(initializer!.IsBase, Is.True, "Initializer should be a base call");
+
+            var initializerArgNames = initializer.Arguments
+                .OfType<VariableExpression>()
+                .Select(v => v.Declaration.RequestedName)
+                .ToList();
+
+            Assert.That(
+                initializerArgNames.Contains("baseWrapper"),
+                Is.False,
+                $"Base initializer must NOT pass the unflattened 'baseWrapper'. Args: [{string.Join(", ", initializerArgNames)}]");
+            Assert.That(
+                initializerArgNames.Contains("baseValue"),
+                Is.True,
+                $"Base initializer must pass the flattened 'baseValue'. Args: [{string.Join(", ", initializerArgNames)}]");
+        }
+
+        /// <summary>
         /// Verifies that <see cref="FlattenPropertyVisitor.FilterAttributesForFlatten"/> drops any
         /// WirePath attribute attached to the inner property while preserving other attributes.
         /// When a property is flattened, its wire path changes (e.g., "left" -> "properties.left"),


### PR DESCRIPTION
## Summary

Fixes #57058.

When a derived model has its own flattenable property AND its base model was also flattened, the mgmt generator previously only applied the derived model's own flatten map to its public constructor. Inherited ctor parameters and the `base(...)` initializer were therefore left referencing the unflattened wrapper type, while the base's public ctor expected the flattened scalar — producing **CS1503** build errors in the generated SDK.

### Repro (from issue)

`csharp
public partial class MCASDataConnectorDataTypes : SecurityInsightsAlertsDataTypeOfDataConnector
{
    // BUG: passes raw inner model; base expects SecurityInsightsDataTypeConnectionState?
    public MCASDataConnectorDataTypes(DataConnectorDataTypeCommon alerts) : base(alerts)
}
`

## Root cause

In `FlattenPropertyVisitor.FlattenModel` the two branches that drove `UpdatePublicConstructor` were mutually exclusive:

- **Branch A** (model has own flatten): passed only the model's own flatten map.
- **Branch B** (model has no own flatten, base does): passed only the base's flatten map.

The case 'derived has own flatten **and** an ancestor was flattened' silently fell into Branch A, dropping the inherited flatten info.

## Fix

Build a single `effectiveMap` that overlays every flattened-ancestor's map on top of the derived's own map (walking the full inheritance chain), and drive `UpdatePublicConstructor` with it in every relevant case. The model's own map is still the one cached in `_flattenedModelTypes` so consumers like `TryGetFlattenPropertyInfo` (model factory rewrite) remain unaffected.

Internal full-shape serialization constructors and the `_flattenedModelTypes` cache contract are intentionally untouched.

## Validation

- Added regression unit test `TestSafeFlattenUpdatesDerivedClassCtorWhenBothBaseAndDerivedHaveFlatten` — verified to fail on `main` and pass with the fix.
- Reproduced the bug in the local Mgmt-TypeSpec test project (CS1503) and confirmed it's gone after the fix.
- Full `eng/scripts/Generate.ps1 -filter Mgmt-TypeSpec` regen + build is clean (0 errors).
- Other `FlattenPropertyVisitorTests` continue to pass (the single failure unrelated to flatten is pre-existing on `main`).