### PR TITLE
Fix CS0117 for enum/union body parameters in MPG codegen (#58627)

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/OperationContexts/ParameterContextRegistry.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/OperationContexts/ParameterContextRegistry.cs
@@ -113,6 +113,33 @@ internal class ParameterContextRegistry : IReadOnlyDictionary<string, ParameterC
                             arguments.Add(createContent);
                         }
                     }
+                    else if (bodyParameter.Type.IsEnum)
+                    {
+                        // Enum/union body parameters do not have a generated ToRequestContent helper
+                        // (that helper is only synthesized on MRW model types by SerializationVisitor).
+                        // Serialize the enum value to its string form and route through RequestContent.Create.
+                        ValueExpression bodyExpr = bodyParameter;
+                        ValueExpression stringForm = bodyParameter.Type.IsStruct
+                            // Extensible enum (readonly struct): use ToString().
+                            ? (bodyParameter.Type.IsNullable
+                                ? bodyExpr.NullConditional().InvokeToString()
+                                : bodyExpr.InvokeToString())
+                            // Fixed enum: use generated ToSerialString() extension.
+                            : (bodyParameter.Type.IsNullable
+                                ? bodyExpr.NullConditional().Invoke("ToSerialString")
+                                : bodyExpr.Invoke("ToSerialString"));
+                        var createContent = Static(typeof(RequestContent)).Invoke(
+                            nameof(RequestContent.Create),
+                            [stringForm]);
+                        if (bodyParameter.Type.IsNullable)
+                        {
+                            arguments.Add(new TernaryConditionalExpression(bodyParameter.NotEqual(Null), createContent, Null));
+                        }
+                        else
+                        {
+                            arguments.Add(createContent);
+                        }
+                    }
                     else
                     {
                         arguments.Add(Static(bodyParameter.Type).Invoke(SerializationVisitor.ToRequestContentMethodName, [bodyParameter]));

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/OperationContextTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/OperationContextTests.cs
@@ -1022,6 +1022,153 @@ namespace Azure.Generator.Mgmt.Tests
             });
         }
 
+        [TestCase]
+        public void PopulateArguments_NonNullableFixedEnumBody_UsesRequestContentCreateToSerialString()
+        {
+            // Regression test for issue #58627: a non-MRW body type (here a fixed enum) used to
+            // fall through to <BodyType>.ToRequestContent(body) which is never generated, causing
+            // CS0117. Fixed-enum body parameters should now serialize via RequestContent.Create(body.ToSerialString()).
+            var registry = new ParameterContextRegistry(new List<ParameterContextMapping>());
+
+            var requestContentParam = new ParameterProvider("content", $"", typeof(RequestContent));
+            requestContentParam.Update(wireInfo: new WireInformation(default, string.Empty));
+
+            var contextVariable = new VariableExpression(typeof(RequestContext), "context");
+
+            var fixedEnumType = CreateFixedEnumCSharpType("TestFixedEnum", "TestNs", isNullable: false);
+            var bodyParam = new ParameterProvider("body", $"", fixedEnumType);
+            bodyParam.Update(wireInfo: new WireInformation(default, string.Empty), location: ParameterLocation.Body);
+
+            var arguments = registry.PopulateArguments(
+                _idVariable,
+                new List<ParameterProvider> { requestContentParam },
+                contextVariable,
+                new List<ParameterProvider> { bodyParam });
+
+            Assert.That(arguments.Count, Is.EqualTo(1));
+            var displayString = arguments[0].ToDisplayString();
+            Assert.That(displayString, Does.Not.Contain("TestFixedEnum.ToRequestContent"));
+            Assert.That(displayString, Does.Contain("RequestContent.Create"));
+            Assert.That(displayString, Does.Contain("body.ToSerialString()"));
+            Assert.That(displayString, Does.Not.Contain("?.ToSerialString()"));
+        }
+
+        [TestCase]
+        public void PopulateArguments_NullableFixedEnumBody_UsesTernaryWithNullConditionalToSerialString()
+        {
+            var registry = new ParameterContextRegistry(new List<ParameterContextMapping>());
+
+            var requestContentParam = new ParameterProvider("content", $"", typeof(RequestContent));
+            requestContentParam.Update(wireInfo: new WireInformation(default, string.Empty));
+
+            var contextVariable = new VariableExpression(typeof(RequestContext), "context");
+
+            var fixedEnumType = CreateFixedEnumCSharpType("TestFixedEnum", "TestNs", isNullable: true);
+            var bodyParam = new ParameterProvider("body", $"", fixedEnumType);
+            bodyParam.Update(wireInfo: new WireInformation(default, string.Empty), location: ParameterLocation.Body);
+
+            var arguments = registry.PopulateArguments(
+                _idVariable,
+                new List<ParameterProvider> { requestContentParam },
+                contextVariable,
+                new List<ParameterProvider> { bodyParam });
+
+            Assert.That(arguments.Count, Is.EqualTo(1));
+            var displayString = arguments[0].ToDisplayString();
+            Assert.That(displayString, Does.Not.Contain("TestFixedEnum.ToRequestContent"));
+            Assert.That(displayString, Does.Contain("RequestContent.Create"));
+            Assert.That(displayString, Does.Contain("?.ToSerialString()"));
+            // Nullable body should be guarded by a body != null check.
+            Assert.That(displayString, Does.Contain("body != null"));
+        }
+
+        [TestCase]
+        public void PopulateArguments_NonNullableExtensibleEnumBody_UsesRequestContentCreateToString()
+        {
+            // Regression test for issue #58627: extensible-enum / union body parameters used to
+            // fall through to <BodyType>.ToRequestContent(body) which is never generated, causing
+            // CS0117. They should now serialize via RequestContent.Create(body.ToString()).
+            var registry = new ParameterContextRegistry(new List<ParameterContextMapping>());
+
+            var requestContentParam = new ParameterProvider("content", $"", typeof(RequestContent));
+            requestContentParam.Update(wireInfo: new WireInformation(default, string.Empty));
+
+            var contextVariable = new VariableExpression(typeof(RequestContext), "context");
+
+            var extensibleEnumType = CreateExtensibleEnumCSharpType("TestExtensibleEnum", "TestNs", isNullable: false);
+            var bodyParam = new ParameterProvider("body", $"", extensibleEnumType);
+            bodyParam.Update(wireInfo: new WireInformation(default, string.Empty), location: ParameterLocation.Body);
+
+            var arguments = registry.PopulateArguments(
+                _idVariable,
+                new List<ParameterProvider> { requestContentParam },
+                contextVariable,
+                new List<ParameterProvider> { bodyParam });
+
+            Assert.That(arguments.Count, Is.EqualTo(1));
+            var displayString = arguments[0].ToDisplayString();
+            Assert.That(displayString, Does.Not.Contain("TestExtensibleEnum.ToRequestContent"));
+            Assert.That(displayString, Does.Contain("RequestContent.Create"));
+            Assert.That(displayString, Does.Contain("body.ToString()"));
+            Assert.That(displayString, Does.Not.Contain("?.ToString()"));
+            Assert.That(displayString, Does.Not.Contain("ToSerialString"));
+        }
+
+        [TestCase]
+        public void PopulateArguments_NullableExtensibleEnumBody_UsesTernaryWithNullConditionalToString()
+        {
+            var registry = new ParameterContextRegistry(new List<ParameterContextMapping>());
+
+            var requestContentParam = new ParameterProvider("content", $"", typeof(RequestContent));
+            requestContentParam.Update(wireInfo: new WireInformation(default, string.Empty));
+
+            var contextVariable = new VariableExpression(typeof(RequestContext), "context");
+
+            var extensibleEnumType = CreateExtensibleEnumCSharpType("TestExtensibleEnum", "TestNs", isNullable: true);
+            var bodyParam = new ParameterProvider("body", $"", extensibleEnumType);
+            bodyParam.Update(wireInfo: new WireInformation(default, string.Empty), location: ParameterLocation.Body);
+
+            var arguments = registry.PopulateArguments(
+                _idVariable,
+                new List<ParameterProvider> { requestContentParam },
+                contextVariable,
+                new List<ParameterProvider> { bodyParam });
+
+            Assert.That(arguments.Count, Is.EqualTo(1));
+            var displayString = arguments[0].ToDisplayString();
+            Assert.That(displayString, Does.Not.Contain("TestExtensibleEnum.ToRequestContent"));
+            Assert.That(displayString, Does.Contain("RequestContent.Create"));
+            Assert.That(displayString, Does.Contain("?.ToString()"));
+            Assert.That(displayString, Does.Contain("body != null"));
+            Assert.That(displayString, Does.Not.Contain("ToSerialString"));
+        }
+
+        /// <summary>
+        /// Creates a CSharpType that simulates a generated extensible enum (IsEnum=true, IsStruct=true).
+        /// </summary>
+        private static CSharpType CreateExtensibleEnumCSharpType(string name, string ns, bool isNullable)
+        {
+            var ctor = typeof(CSharpType).GetConstructor(
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null,
+                new[] { typeof(string), typeof(string), typeof(bool), typeof(bool), typeof(CSharpType),
+                        typeof(IReadOnlyList<CSharpType>), typeof(bool), typeof(bool), typeof(CSharpType), typeof(Type) },
+                null);
+
+            bool isValueType = true;
+            CSharpType? declaringType = null;
+            IReadOnlyList<CSharpType> args = Array.Empty<CSharpType>();
+            bool isPublic = true;
+            bool isStruct = true; // true = extensible enum (readonly struct)
+            CSharpType? baseType = null;
+            Type underlyingEnumType = typeof(string); // non-null marks this as an enum type
+
+            return (CSharpType)ctor!.Invoke(new object?[] {
+                name, ns, isValueType, isNullable, declaringType,
+                args, isPublic, isStruct, baseType, underlyingEnumType
+            });
+        }
+
         [Test]
         public void ValidateParameterMapping_ContextualPathConstant_SubstitutedAndContextual()
         {


### PR DESCRIPTION
Fixes #58627

## Problem
For Management Plane code generation, when a TypeSpec operation uses an extensible-enum / union (or any non-MRW, non-primitive type) as `@bodyRoot`, the generator emits:

```csharp
<BodyType>.ToRequestContent(body)
```

…but `ToRequestContent` is only synthesized on MRW model types by `SerializationVisitor` (it renames the implicit operator on `MrwSerializationTypeDefinition`). For extensible-enum / union structs (and fixed enums) the helper is never generated, so the output fails to compile with **CS0117**.

This was confirmed locally by adding a `@action(""setProvisioningState"") setProvisioningState is ArmResourceActionSync<Foo, FooProvisioningState, ArmResponse<Foo>>;` to `TestProjects/Local/Mgmt-TypeSpec/foo.tsp`, which reproduced the exact CS0117 from the marketplace SDK.

## Fix
In `ParameterContextRegistry.PopulateArguments` (the only call site that emits `<BodyType>.ToRequestContent(...)`), add a new branch that handles enum body parameters using the same enum-to-string convention already used for path/query parameters elsewhere in the same file:

- **Extensible enum** (`IsStruct=true`, readonly struct) → `RequestContent.Create(body.ToString())`
- **Fixed enum** (`IsStruct=false`) → `RequestContent.Create(body.ToSerialString())`
- **Nullable** variants → wrapped in `body != null ? RequestContent.Create(body?.ToString()) : null` (and the same with `ToSerialString`)

The fallback to `Static(bodyType).Invoke(""ToRequestContent"", ...)` is untouched, so all existing MRW-model body paths continue to work.

This matches the hand-written marketplace workaround:

```csharp
internal static RequestContent ToRequestContent(PrivateStoreOperation? payload)
{
    if (payload == null) return null;
    return RequestContent.Create(payload.Value.ToString());
}
```

## Tests
- Added 4 unit tests in `OperationContextTests` covering `{fixed, extensible} x {nullable, non-nullable}` enum body parameters.
- Full mgmt generator test suite: **201/201 pass** (was 197).
- Regenerated both local mgmt test projects (`Mgmt-TypeSpec` and `Mgmt-TypeSpec-MultiService`) — both build cleanly.
- Validated by adding the union-body action to `foo.tsp` (now reverted) — the generated call site went from `FooProvisioningState.ToRequestContent(body)` to `RequestContent.Create(body.ToString())`.

## Impact
Any MPG TypeSpec spec that uses an extensible-enum / union as a body parameter will now compile out-of-the-box. The hand-written `Customize/Models/PrivateStoreOperation.cs` workaround in `Azure.ResourceManager.Marketplace` (and any similar workarounds in other libraries) can be removed on next regeneration.