### PR TITLE
[Mgmt Emitter] Recognize @armResourceCollectionAction to avoid clobbering resource List

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -39,6 +39,7 @@ import pluralize from "pluralize";
 import {
   armProviderSchema,
   armResourceActionName,
+  armResourceCollectionActionName,
   armResourceCreateOrUpdateName,
   armResourceDeleteName,
   armResourceInternal,
@@ -315,10 +316,17 @@ export function buildArmProviderSchema(
     } else {
       // we treat this method as a non-resource method when it does not have a kind or an associated resource model
       const operationPath = new RequestPath(method.operation.path);
+      const hasCollectionActionDecorator =
+        serviceMethod?.__raw?.decorators?.some(
+          (d) => d.definition?.name === armResourceCollectionActionName
+        ) ?? false;
       nonResourceMethods.set(method.crossLanguageDefinitionId, {
         methodId: method.crossLanguageDefinitionId,
         operationPath: operationPath,
-        scope: buildScopeInfoFromPath(operationPath)
+        scope: buildScopeInfoFromPath(operationPath),
+        ...(hasCollectionActionDecorator
+          ? { isCollectionAction: true }
+          : {})
       });
     }
   };
@@ -614,6 +622,22 @@ function parseResourceOperation(
             ? ResourceOperationKind.List
             : ResourceOperationKind.Action,
           modelId: getResourceModelId(sdkContext, decorator),
+          explicitResourceName: undefined
+        };
+      case armResourceCollectionActionName:
+        // @armResourceCollectionAction is applied by ArmProviderAction[Sync|Async]
+        // for POST actions whose path stops at the collection segment (no
+        // `{resourceName}`). Unlike @armResourceAction, this decorator takes no
+        // resource-model argument, so there is no modelId to attach. Without an
+        // explicit case here the operation would fall through to the type-match
+        // fallback in assignNonResourceMethodsToResources, which hard-codes
+        // kind=List on any non-resource method whose path resourceType matches a
+        // known resource — clobbering the resource's real paginated list.
+        // Returning kind=Action with no modelId routes the op into
+        // nonResourceMethods AND prevents the List misclassification downstream.
+        return {
+          kind: ResourceOperationKind.Action,
+          modelId: undefined,
           explicitResourceName: undefined
         };
       case extensionResourceOperationName:

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -429,6 +429,16 @@ export interface NonResourceMethod {
   scope: ArmScopeInfo;
   /** The cross-language definition ID of the resource model this method originally belonged to */
   resourceModelId?: string;
+  /**
+   * True when the method carries the `@armResourceCollectionAction` decorator
+   * (typically via `ArmProviderAction[Sync|Async]`). Such operations are POST
+   * actions whose path stops at a collection segment (no `{resourceName}`).
+   * They must NOT be coerced into List by the type-match fallback in
+   * `assignNonResourceMethodsToResources`, since doing so would create a
+   * second List on the type-matching resource and clobber its real paginated
+   * list in the downstream C# collection generator.
+   */
+  isCollectionAction?: boolean;
 }
 
 export function convertMethodMetadataToArguments(
@@ -1016,6 +1026,13 @@ export function assignNonResourceMethodsToResources(
       }
     } else {
       // Both prefix and model ID matching failed — try matching by resource type.
+      // Skip this fallback for collection actions (POST ops with
+      // @armResourceCollectionAction whose path stops at the collection segment):
+      // coercing them to List here would create a second List on the type-matching
+      // resource and clobber its real paginated list downstream.
+      if (method.isCollectionAction) {
+        continue;
+      }
       const operationType = method.operationPath.resourceType;
       if (operationType !== undefined) {
         const match = resources.find((r) => {

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
@@ -47,6 +47,18 @@ export const armResourceAction = "Azure.ResourceManager.@armResourceAction";
 export const armResourceActionName = "@armResourceAction";
 const armResourceActionRegex = "Azure\\.ResourceManager\\.@armResourceAction";
 
+// https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-resource-manager/README.md#armResourceCollectionAction
+// Applied by ArmProviderAction[Sync|Async] templates for POST actions scoped to a
+// resource collection (path has no `{resourceName}` segment). Without this case the
+// emitter would drop such operations into nonResourceMethods and the type-match
+// fallback in resource-metadata.ts would misclassify them as List, clobbering the
+// real paginated list method on the resource.
+export const armResourceCollectionAction =
+  "Azure.ResourceManager.@armResourceCollectionAction";
+export const armResourceCollectionActionName = "@armResourceCollectionAction";
+const armResourceCollectionActionRegex =
+  "Azure\\.ResourceManager\\.@armResourceCollectionAction";
+
 // https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-resource-manager/README.md#armResourceList
 export const armResourceList = "Azure.ResourceManager.@armResourceList";
 export const armResourceListName = "@armResourceList";
@@ -147,6 +159,7 @@ export const azureSDKContextOptions: CreateSdkContextOptions = {
     nonResourceMethodMetadataRegex,
     armProviderNamespaceRegex,
     armResourceActionRegex,
+    armResourceCollectionActionRegex,
     armResourceCreateOrUpdateRegex,
     armResourceDeleteRegex,
     armResourceInternalRegex,

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -1266,6 +1266,99 @@ interface ScheduledActionExtension {
     );
   });
 
+  it("ArmProviderAction with @armResourceCollectionAction does not clobber resource list", async () => {
+    // Regression test for: when a POST action on a resource collection is modeled via
+    // ArmProviderAction[Sync|Async] (which applies @armResourceCollectionAction), the
+    // operation must NOT be misclassified as List on the type-matching resource. If it
+    // were, the real paginated list method would be overwritten downstream.
+    const program = await typeSpecCompile(
+      `
+interface Operations extends Azure.ResourceManager.Operations {}
+
+/** Job resource */
+model Job is TrackedResource<JobProperties> {
+  ...ResourceNameParameter<Job>;
+}
+
+/** Job properties */
+model JobProperties {
+  /** State */
+  state?: string;
+}
+
+/** Export request */
+model JobQuery {
+  /** Filter */
+  filter: string;
+}
+
+@armResourceOperations
+interface Jobs {
+  get is ArmResourceRead<Job>;
+  list is ArmResourceListByParent<Job>;
+}
+
+@armResourceOperations
+interface JobOps {
+  @action("jobs/export")
+  export is ArmProviderActionAsync<
+    Request = JobQuery,
+    Response = Job,
+    Scope = Extension.ResourceGroup
+  >;
+}
+`,
+      runner
+    );
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const [root] = createModel(sdkContext);
+
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+    ok(armProviderSchema);
+    ok(armProviderSchema.resources);
+
+    const jobResource = armProviderSchema.resources.find(
+      (r) => r.metadata.resourceType === "Microsoft.ContosoProviderHub/jobs"
+    );
+    ok(jobResource, "Job resource should be detected");
+
+    // The Job resource must have EXACTLY ONE List method (the real Jobs.list),
+    // not two. Before the fix, the @armResourceCollectionAction-decorated export
+    // op was falling through to a fallback that hard-coded kind=List on the Job
+    // resource, producing two List methods and overwriting the real one in the
+    // downstream C# collection generator.
+    const listMethods = jobResource.metadata.methods.filter(
+      (m: any) => m.kind === "List"
+    );
+    strictEqual(
+      listMethods.length,
+      1,
+      "Job resource must have exactly one List method (the real Jobs.list); the collection action must not be misclassified as List"
+    );
+    ok(
+      listMethods[0].methodId.endsWith(".list"),
+      `expected the surviving List method to be Jobs.list, got ${listMethods[0].methodId}`
+    );
+
+    // The export action must NOT be present on the Job resource as a List method.
+    const exportOnResource = jobResource.metadata.methods.find((m: any) =>
+      m.methodId.endsWith(".export")
+    );
+    strictEqual(
+      exportOnResource,
+      undefined,
+      "export must not be attached to the Job resource (its path has no {jobName}; it belongs at the provider/RG scope)"
+    );
+
+    // The export op should land in nonResourceMethods (RG-scoped provider action).
+    ok(armProviderSchema.nonResourceMethods);
+    const exportEntry = armProviderSchema.nonResourceMethods.find((m: any) =>
+      m.methodId.endsWith(".export")
+    );
+    ok(exportEntry, "export should be classified as a non-resource method");
+  });
+
   it("multiple resources sharing same model", async () => {
     // This test validates the scenario where the SAME model is used by two different
     // resource interfaces operating at different paths using LegacyOperations (similar to the legacy-operations example)

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/test-util.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/test-util.ts
@@ -165,6 +165,9 @@ export function normalizeSchemaForComparison(
   // Normalize resourceModelId on non-resource methods (known discrepancy between the two paths)
   for (const method of normalizedSchema.nonResourceMethods) {
     delete (method as any).resourceModelId;
+    // isCollectionAction is only set by buildArmProviderSchema (which inspects
+    // decorators), not by resolveArmResources (which uses ARM library data).
+    delete (method as any).isCollectionAction;
   }
 
   return normalizedSchema;


### PR DESCRIPTION
## Problem

 + "`" + ArmProviderAction[Sync|Async] + "`" +  templates apply `@armResourceCollectionAction` (not `@armResourceAction`) to POST actions whose path stops at a collection segment (no `{resourceName}`). The emitter had no case for this decorator in `parseResourceOperation`, so such operations fell through to `nonResourceMethods` and were then misclassified as `List` by the type-match fallback in `assignNonResourceMethodsToResources` — producing a second `List` on the type-matching resource which clobbered its real paginated list in the downstream C# collection generator.

### Concrete symptom (recoveryservices-siterecovery)

For `ReplicationJobsOperationGroup.export` declared as:

```tsp
@action("replicationJobs/export")
export is ArmProviderActionAsync<
  Request = JobQueryParameter,
  Response = Job,
  Scope = Extension.ResourceGroup,
  ...
>;
```

with path `.../vaults/{resourceName}/replicationJobs/export` (note: **no `{jobName}` segment**), the buggy emitter produced:

- `SiteRecoveryJobCollection.GetAll(WaitUntil, SiteRecoveryJobQueryContent, ...)` — an LRO-shaped method built from the export action
- The real paginated `Pageable<SiteRecoveryJobResource> GetAll(string filter, ...)` — **missing**
- `Export` — **missing entirely**

## Root cause

Two compounding issues, fixed together:

1. **Missing decorator case** in `parseResourceOperation` (`resource-detection.ts`). The function had no branch for `@armResourceCollectionAction`, so the operation got `kind=undefined` and was dropped into `nonResourceMethods`.
2. **Over-eager type-match fallback** in `assignNonResourceMethodsToResources` (`resource-metadata.ts`). When prefix-matching and resource-model-ID matching both fail, the fallback hard-codes `kind: List` for any non-resource method whose path `resourceType` matches a known resource. This is correct for unannotated list operations but wrong for POST collection actions.

## Fix

- Add `armResourceCollectionActionName` constant/regex in `sdk-context-options.ts` and register it under `additionalDecorators`.
- Add a case in `parseResourceOperation` returning `kind: Action` with no `modelId` (the decorator takes no resource-model argument, unlike `@armResourceAction`).
- Tag the resulting `NonResourceMethod` with `isCollectionAction: true` and short-circuit the resourceType-based List-coercion branch in `assignNonResourceMethodsToResources` for such methods.

## Verification

- New regression test `ArmProviderAction with @armResourceCollectionAction does not clobber resource list` in `resource-detection.test.ts` — asserts the Job resource has exactly one `List` method (the real `Jobs.list`) and that `export` lands in `nonResourceMethods`.
- Full emitter test suite still passes (125/125).
- Re-ran SDK generation for `recoveryservices-siterecovery`:
  - ✅ `SiteRecoveryJobCollection.GetAll(string filter = null, ...)` — real paginated list restored
  - ✅ `SiteRecoveryJobResource.Export(WaitUntil, SiteRecoveryJobQueryContent, ...)` — Export now emits correctly

## Notes

The new `isCollectionAction` field on `NonResourceMethod` is only set by `buildArmProviderSchema` (which inspects decorators), not by `resolveArmResources` (which uses the upstream ARM library's pre-classified provider operations). `normalizeSchemaForComparison` strips it before deep-equality, matching the existing pattern for `resourceModelId`.
