### PR TITLE
[Core] Prepare Azure.Core 1.56.0 release (2026-05-14)

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.56.0-beta.1 (Unreleased)
+## 1.56.0 (2026-05-14)
 
 ### Features Added
 
 - Added experimental `TokenRequestCallback` property and `TokenRequestCallbackContext` type to MSAL-backed credential options to allow customizing token request body parameters before they are sent to the identity provider.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.55.0 (2026-05-05)
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.56.0-beta.1</Version>
+    <Version>1.56.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.55.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>


### PR DESCRIPTION
## Azure.Core 1.56.0 Release Preparation

This PR prepares the Azure.Core 1.56.0 release:

- **Version**: `1.56.0-beta.1` → `1.56.0`
- **Release Date**: May 14, 2026
- **Changelog**: Finalized with release date and cleaned up empty sections

### Changes
- Updated version in `Azure.Core.csproj`
- Finalized `CHANGELOG.md` entry

---
🤖 Created by JonathanCrd's copilot