### PR TITLE
[Mgmt Generator] Avoid emitting unused REST client fields on collection classes

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -76,7 +76,7 @@ namespace Azure.Generator.Management.Providers
             ResourceData = ManagementClientGenerator.Instance.TypeFactory.CreateModel(model)!;
 
             // Initialize client info dictionary using extension method
-            _clientInfos = resourceMetadata.CreateClientInfosMap(this);
+            _clientInfos = resourceMetadata.CreateClientInfosMap(this, resourceMethods);
 
             _dataField = new FieldProvider(FieldModifiers.Private | FieldModifiers.ReadOnly, ResourceData.Type, "_data", this);
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -56,7 +56,7 @@ namespace Azure.Generator.Management.Providers
             _resource = resource;
 
             // Initialize client info dictionary using extension method
-            _clientInfos = resourceMetadata.CreateClientInfosMap(this);
+            _clientInfos = resourceMetadata.CreateClientInfosMap(this, resourceMethods);
 
             _resourceTypeExpression = Static(_resource.Type).As<ArmResource>().ResourceType();
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ArmResourceMetadataExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ArmResourceMetadataExtensions.cs
@@ -15,18 +15,37 @@ namespace Azure.Generator.Management.Utilities
         extension(ArmResourceMetadata resourceMetadata)
         {
             /// <summary>
-            /// Creates a dictionary mapping InputClient to RestClientInfo for all distinct clients used by the resource.
+            /// Creates a dictionary mapping InputClient to RestClientInfo for the distinct clients
+            /// actually used by the supplied <paramref name="methods"/>.
             /// </summary>
             /// <param name="clientProvider">The client provider that will own the fields.</param>
+            /// <param name="methods">The subset of resource methods that will be emitted on the
+            /// owning client provider (e.g. only the methods placed on the collection class).
+            /// Passing all of <c>resourceMetadata.Methods</c> here causes unused diagnostics/REST
+            /// client fields to be emitted for operation groups whose operations are not actually
+            /// referenced by the owning class. See https://github.com/Azure/azure-sdk-for-net/issues/59242.</param>
             /// <returns>A dictionary mapping InputClient to RestClientInfo.</returns>
-            internal Dictionary<InputClient, RestClientInfo> CreateClientInfosMap(TypeProvider clientProvider)
+            internal Dictionary<InputClient, RestClientInfo> CreateClientInfosMap(TypeProvider clientProvider, IEnumerable<ResourceMethod> methods)
             {
                 var clientInfos = new Dictionary<InputClient, RestClientInfo>();
 
-                // Create rest client providers and fields for each unique InputClient
+                // Determine the set of InputClients actually referenced by the supplied methods.
+                var referencedClients = new HashSet<InputClient>();
+                foreach (var method in methods)
+                {
+                    referencedClients.Add(method.InputClient);
+                }
+
+                // Iterate resourceMetadata.Methods (rather than `methods`) to preserve the original
+                // declaration order of REST client fields, which keeps regenerated SDK diffs minimal
+                // when this filter is introduced.
                 foreach (var resourceMethod in resourceMetadata.Methods)
                 {
                     var inputClient = resourceMethod.InputClient;
+                    if (!referencedClients.Contains(inputClient))
+                    {
+                        continue; // Skip clients not referenced by any emitted method on the owning class
+                    }
                     if (clientInfos.ContainsKey(inputClient))
                     {
                         continue; // Skip if the client is already processed

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
@@ -619,6 +619,78 @@ namespace Azure.Generator.Management.Tests.Common
             return (parentClient, childClient, [parentModel, childModel, childPageModel]);
         }
 
+        /// <summary>
+        /// Two-client fixture used to reproduce https://github.com/Azure/azure-sdk-for-net/issues/59242.
+        /// MainClient contains the CRUD methods that go on the collection (Read/Create) and the
+        /// resource (Read). ActionClient contains a single Action method that only goes on the
+        /// resource. The bug being guarded against is that the collection would otherwise emit a
+        /// private REST client field for ActionClient even though no method on the collection uses
+        /// it.
+        /// </summary>
+        public static (InputClient MainClient, InputClient ActionClient, IReadOnlyList<InputModelType> InputModels) ClientWithResourceActionInDifferentClient()
+        {
+            const string MainClientName = "MainClient";
+            const string ActionClientName = "ActionClient";
+            const string ResourceModelName = "ResponseType";
+
+            var responseModel = InputFactory.Model(ResourceModelName,
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("tags", new InputDictionaryType("dict", InputPrimitiveType.String, InputPrimitiveType.String), isReadOnly: false),
+                ],
+                decorators: []);
+            var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: responseModel);
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+
+            // CRUD operation parameters
+            var subsIdOpParameter = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var rgOpParameter = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var testNameOpParameter = InputFactory.PathParameter("testName", InputPrimitiveType.String, isRequired: true);
+            var dataOpParameter = InputFactory.BodyParameter("data", responseModel, isRequired: true);
+
+            var resourcePath = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}";
+            var actionPath = resourcePath + "/doAction";
+
+            var getOperation = InputFactory.Operation(name: "get", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: resourcePath);
+            var createOperation = InputFactory.Operation(name: "createTest", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: resourcePath, httpMethod: "PUT");
+            // The action lives at a sub-path on the resource and belongs to a separate InputClient.
+            var actionOperation = InputFactory.Operation(name: "doAction", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: actionPath, httpMethod: "POST");
+
+            var subscriptionIdParameter = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var resourceGroupParameter = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var testNameParameter = InputFactory.MethodParameter("testName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var dataParameter = InputFactory.MethodParameter("data", responseModel, location: InputRequestLocation.Body, isRequired: true);
+
+            var getMethod = InputFactory.BasicServiceMethod("get", getOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var createMethod = InputFactory.BasicServiceMethod("createTest", createOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var actionMethod = InputFactory.BasicServiceMethod("doAction", actionOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+
+            var resourceIdPattern = new RequestPathPattern(resourcePath);
+            var armProviderDecorator = BuildArmProviderSchema(responseModel, [
+                new ResourceMethod(ResourceOperationKind.Read, getMethod, new RequestPathPattern(getMethod.Operation.Path), new ArmScopeInfo(ResourceScope.ResourceGroup, resourceIdPattern, null), null!),
+                new ResourceMethod(ResourceOperationKind.Create, createMethod, new RequestPathPattern(createMethod.Operation.Path), new ArmScopeInfo(ResourceScope.ResourceGroup, resourceIdPattern, null), null!),
+                new ResourceMethod(ResourceOperationKind.Action, actionMethod, new RequestPathPattern(actionMethod.Operation.Path), new ArmScopeInfo(ResourceScope.ResourceGroup, resourceIdPattern, null), null!)
+            ], resourceIdPattern, "Microsoft.Tests/tests", null, ResourceScope.ResourceGroup, "ResponseType");
+
+            var mainClient = InputFactory.Client(
+                MainClientName,
+                methods: [getMethod, createMethod],
+                decorators: [armProviderDecorator],
+                crossLanguageDefinitionId: $"Test.{MainClientName}");
+
+            var actionClient = InputFactory.Client(
+                ActionClientName,
+                methods: [actionMethod],
+                decorators: [],
+                crossLanguageDefinitionId: $"Test.{ActionClientName}");
+
+            return (mainClient, actionClient, [responseModel]);
+        }
+
         private static InputDecoratorInfo BuildArmProviderSchema(InputModelType resourceModel, IReadOnlyList<ResourceMethod> methods, RequestPathPattern resourceIdPattern, string resourceType, string? singletonResourceName, ResourceScope resourceScope, string? resourceName)
         {
             return BuildArmProviderSchemaMultiResource([

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
@@ -326,5 +326,49 @@ namespace Azure.Generator.Management.Tests.Providers
             Assert.That(signature.Parameters.Any(p => p.Type.Equals(typeof(WaitUntil))), Is.False,
                 "GetIfExistsAsync should not have a WaitUntil parameter even when Get is an LRO");
         }
+
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/issues/59242
+        // The collection class must only declare REST client / diagnostics fields for operation
+        // groups whose methods are actually emitted on the collection. Methods whose operation
+        // group only contributes to the resource class (e.g. Actions) must not leak fields onto
+        // the collection.
+        [TestCase]
+        public void CollectionDoesNotEmitFieldsForActionOnlyOperationGroup()
+        {
+            var (mainClient, actionClient, models) = InputResourceData.ClientWithResourceActionInDifferentClient();
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => models, clients: () => [mainClient, actionClient]);
+
+            var collection = plugin.Object.OutputLibrary.TypeProviders.OfType<ResourceCollectionClientProvider>().FirstOrDefault();
+            Assert.That(collection, Is.Not.Null);
+
+            // ActionClient's REST client type is named "ActionClient" -> field name "_actionClientRestClient".
+            // The bug being guarded against would have emitted this field on the collection because
+            // CreateClientInfosMap iterated the full resource metadata methods list, including the
+            // action method.
+            var fieldNames = collection!.Fields.Select(f => f.Name).ToArray();
+            Assert.That(fieldNames, Does.Not.Contain("_actionClientRestClient"),
+                "Collection must not declare a REST client field for an operation group whose methods are only emitted on the resource class.");
+            Assert.That(fieldNames, Does.Not.Contain("_actionClientClientDiagnostics"),
+                "Collection must not declare a diagnostics field for an operation group whose methods are only emitted on the resource class.");
+        }
+
+        [TestCase]
+        public void ResourceStillEmitsFieldsForActionOnlyOperationGroup()
+        {
+            // Companion to CollectionDoesNotEmitFieldsForActionOnlyOperationGroup: the resource
+            // class IS allowed (and required) to keep the ActionClient field, since the action
+            // method is emitted on the resource.
+            var (mainClient, actionClient, models) = InputResourceData.ClientWithResourceActionInDifferentClient();
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => models, clients: () => [mainClient, actionClient]);
+
+            var resource = plugin.Object.OutputLibrary.TypeProviders.OfType<ResourceClientProvider>().FirstOrDefault();
+            Assert.That(resource, Is.Not.Null);
+
+            var fieldNames = resource!.Fields.Select(f => f.Name).ToArray();
+            Assert.That(fieldNames, Does.Contain("_actionClientRestClient"),
+                "Resource must declare a REST client field for the action's operation group.");
+            Assert.That(fieldNames, Does.Contain("_actionClientClientDiagnostics"),
+                "Resource must declare a diagnostics field for the action's operation group.");
+        }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarCollection.cs
@@ -29,8 +29,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         private readonly Bars _barsRestClient;
         private readonly ClientDiagnostics _barClientDiagnostics;
         private readonly Bar _barRestClient;
-        private readonly ClientDiagnostics _employeesClientDiagnostics;
-        private readonly Employees _employeesRestClient;
 
         /// <summary> Initializes a new instance of BarCollection for mocking. </summary>
         protected BarCollection()
@@ -47,8 +45,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             _barsRestClient = new Bars(_barsClientDiagnostics, Pipeline, Endpoint, barApiVersion ?? "2024-05-01");
             _barClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", BarResource.ResourceType.Namespace, Diagnostics);
             _barRestClient = new Bar(_barClientDiagnostics, Pipeline, Endpoint, barApiVersion ?? "2024-05-01");
-            _employeesClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", BarResource.ResourceType.Namespace, Diagnostics);
-            _employeesRestClient = new Employees(_employeesClientDiagnostics, Pipeline, Endpoint, barApiVersion ?? "2024-05-01");
             ValidateResourceId(id);
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/FooCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/FooCollection.cs
@@ -28,12 +28,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
     {
         private readonly ClientDiagnostics _foosClientDiagnostics;
         private readonly Foos _foosRestClient;
-        private readonly ClientDiagnostics _entityResourceReproClientDiagnostics;
-        private readonly EntityResourceRepro _entityResourceReproRestClient;
-        private readonly ClientDiagnostics _grandparentFlattenReproClientDiagnostics;
-        private readonly GrandparentFlattenRepro _grandparentFlattenReproRestClient;
-        private readonly ClientDiagnostics _sharedParamReproClientDiagnostics;
-        private readonly SharedParamRepro _sharedParamReproRestClient;
 
         /// <summary> Initializes a new instance of FooCollection for mocking. </summary>
         protected FooCollection()
@@ -48,12 +42,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             TryGetApiVersion(FooResource.ResourceType, out string fooApiVersion);
             _foosClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", FooResource.ResourceType.Namespace, Diagnostics);
             _foosRestClient = new Foos(_foosClientDiagnostics, Pipeline, Endpoint, fooApiVersion ?? "2024-05-01");
-            _entityResourceReproClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", FooResource.ResourceType.Namespace, Diagnostics);
-            _entityResourceReproRestClient = new EntityResourceRepro(_entityResourceReproClientDiagnostics, Pipeline, Endpoint, fooApiVersion ?? "2024-05-01");
-            _grandparentFlattenReproClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", FooResource.ResourceType.Namespace, Diagnostics);
-            _grandparentFlattenReproRestClient = new GrandparentFlattenRepro(_grandparentFlattenReproClientDiagnostics, Pipeline, Endpoint, fooApiVersion ?? "2024-05-01");
-            _sharedParamReproClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", FooResource.ResourceType.Namespace, Diagnostics);
-            _sharedParamReproRestClient = new SharedParamRepro(_sharedParamReproClientDiagnostics, Pipeline, Endpoint, fooApiVersion ?? "2024-05-01");
             ValidateResourceId(id);
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZooCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZooCollection.cs
@@ -28,8 +28,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
     {
         private readonly ClientDiagnostics _zoosClientDiagnostics;
         private readonly Zoos _zoosRestClient;
-        private readonly ClientDiagnostics _zooRecommendationClientDiagnostics;
-        private readonly ZooRecommendation _zooRecommendationRestClient;
 
         /// <summary> Initializes a new instance of ZooCollection for mocking. </summary>
         protected ZooCollection()
@@ -44,8 +42,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             TryGetApiVersion(ZooResource.ResourceType, out string zooApiVersion);
             _zoosClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", ZooResource.ResourceType.Namespace, Diagnostics);
             _zoosRestClient = new Zoos(_zoosClientDiagnostics, Pipeline, Endpoint, zooApiVersion ?? "2024-05-01");
-            _zooRecommendationClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", ZooResource.ResourceType.Namespace, Diagnostics);
-            _zooRecommendationRestClient = new ZooRecommendation(_zooRecommendationClientDiagnostics, Pipeline, Endpoint, zooApiVersion ?? "2024-05-01");
             ValidateResourceId(id);
         }
 


### PR DESCRIPTION
Fixes #59242

## Root cause

`ArmResourceMetadataExtensions.CreateClientInfosMap` iterated **every** method on the resource metadata and emitted a private `ClientDiagnostics` + REST client field per distinct `InputClient`. Both `ResourceClientProvider` and `ResourceCollectionClientProvider` consumed that map unconditionally, so a collection class ended up declaring **and constructor-initializing** fields for operation groups whose methods are never emitted on that collection (e.g. resource-only Actions, child operation groups owned by the parent resource).

Notably, `CategorizeMethods` in the very same file already split methods into `methodsInResource` / `methodsInCollection` / `methodsInExtension` buckets — `CreateClientInfosMap` just ignored that split.

## Impact in shipped SDKs

A scan of the 156 TypeSpec-based `Azure.ResourceManager.*` packages on `main` found **120 unused-field occurrences across 46 packages**, e.g.

| Package | Collection | Unused fields |
|---|---|---|
| `Azure.ResourceManager.ApiCenter` | `ApiCenterApiCollection.cs` | `_apiVersionsRestClient`, `_deploymentsRestClient` |
| `Azure.ResourceManager.DesktopVirtualization` | `HostPoolCollection.cs` | 6 (`_scalingPlansRestClient`, `_userSessionsRestClient`, ...) |
| `Azure.ResourceManager.DataBoxEdge` | `DataBoxEdgeDeviceCollection.cs` | 3 |

For example `ApiCenterApiCollection` only emits the standard CRUD methods, but still allocates `_apiVersionsClientDiagnostics`/`_apiVersionsRestClient` and `_deploymentsClientDiagnostics`/`_deploymentsRestClient`. Those operation groups belong to `ApiCenterApiResource` (`HEAD apiVersion` / `HEAD deployment`), not the collection.

## Fix

- `CreateClientInfosMap` now accepts the filtered methods bucket and skips `InputClient`s not referenced by it.
- Iteration order continues to follow `resourceMetadata.Methods` (not the filtered subset) so regenerated SDK diffs stay minimal — only the unused field declarations and their ctor initialization are removed, no incidental reordering.
- Both call sites (`ResourceClientProvider`, `ResourceCollectionClientProvider`) pass their already-categorized `resourceMethods`.

## Verification

- ✅ Generator builds clean
- ✅ Test projects regenerate; regenerated code compiles
- ✅ All 5 previously-unused fields removed from `Mgmt-TypeSpec` test project (BarCollection, FooCollection, ZooCollection)
- ✅ No incidental reordering or other unintended diffs in the regenerated code
- ✅ Full mgmt generator unit test suite: 202 pass (was 200; +2 new regression tests). The 1 remaining failure (`WriteAdditionalFilesSkipsNonSdkDirectory`) is pre-existing on `main`, unrelated to this change.

## Regression tests

Added a two-client fixture `InputResourceData.ClientWithResourceActionInDifferentClient` (CRUD on `MainClient`, action on `ActionClient`) and two tests in `ResourceCollectionClientProviderTests`:

- `CollectionDoesNotEmitFieldsForActionOnlyOperationGroup` — asserts the collection does **not** declare `_actionClientRestClient` / `_actionClientClientDiagnostics`. Verified to fail on the broken pre-fix code and pass with the fix.
- `ResourceStillEmitsFieldsForActionOnlyOperationGroup` — companion assertion that the resource class still gets those fields (since the action method is emitted there).
