### PR TITLE
Remove unused @typespec/openapi3 from http-client-csharp emitter-package.json

### DIFF
--- a/eng/http-client-csharp-emitter-package.json
+++ b/eng/http-client-csharp-emitter-package.json
@@ -9,7 +9,6 @@
     "@typespec/compiler": "1.11.0",
     "@typespec/http": "1.11.0",
     "@typespec/openapi": "1.11.0",
-    "@typespec/openapi3": "1.11.0",
     "@typespec/rest": "0.81.0",
     "@typespec/streams": "0.81.0",
     "@typespec/versioning": "0.81.0",


### PR DESCRIPTION
## What

Removes the unused `@typespec/openapi3` devDependency from `eng/http-client-csharp-emitter-package.json`.

## Why

The `@typespec/openapi3` entry has been carried on this file since #56699 ("Nirovins/split packages") but is **not referenced anywhere in the unbranded http-client-csharp emitter source** (verified by grepping `microsoft/typespec packages/http-client-csharp/`). It's dead weight.

Because `tsp-client generate-config-files` preserves unknown devDependencies as-is when merging in the source emitter's pinned peerDeps, this entry just sits at `1.11.0` across regens.

This is about to bite us when the source emitter bumps typespec to `1.12.0` / `0.82.0`. The leftover `@typespec/openapi3@1.11.0` (peerOptional `@typespec/streams@^0.81.0`) will conflict with the freshly merged `@typespec/streams@0.82.0` and break `tsp-client`'s internal `npm install` with `ERESOLVE`:

```
npm error ERESOLVE unable to resolve dependency tree
npm error Found: @typespec/streams@0.82.0
npm error   peerOptional @typespec/streams@"^0.82.0" from @typespec/http@1.12.0
npm error Could not resolve dependency:
npm error   peerOptional @typespec/streams@"^0.81.0" from @typespec/openapi3@1.11.0
```

## Verification

Reproduced and validated the fix locally with `npm install` against simulated `package.json`:

| Scenario | Result |
|---|---|
| bumped 1.12.0/0.82.0 + leftover `openapi3@1.11.0` | ❌ ERESOLVE (reproduces the failure) |
| bumped 1.12.0/0.82.0, `openapi3` removed | ✅ `added 76 packages in 3s` |
| current 1.11.0/0.81.0, `openapi3` removed | ✅ `added 150 packages in 12s` |

Removing it today is safe (no current ERESOLVE) and prevents the impending failure on the next typespec bump.
