### PR TITLE
Refactor StringUtility to simplify lock token and sequence number formatting

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/StringUtility.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/StringUtility.cs
@@ -13,12 +13,12 @@ namespace Azure.Messaging.ServiceBus.Primitives
         public static string GetFormattedLockTokens(IEnumerable<Guid> lockTokens)
         {
             // ReceiveAndDelete messages have empty lock tokens, so skip them to avoid noisy logs.
-            return string.Join(", ", lockTokens.Where(static token => token != Guid.Empty));
+            return $"[{string.Join(", ", lockTokens.Where(static token => token != Guid.Empty))}]";
         }
 
         public static string GetFormattedSequenceNumbers(IEnumerable<long> sequenceNumbers)
         {
-            return string.Join(", ", sequenceNumbers);
+            return $"[{string.Join(", ", sequenceNumbers)}]";
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/StringUtility.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/StringUtility.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 
 namespace Azure.Messaging.ServiceBus.Primitives
 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/StringUtility.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/StringUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 
 namespace Azure.Messaging.ServiceBus.Primitives
@@ -12,24 +13,13 @@ namespace Azure.Messaging.ServiceBus.Primitives
     {
         public static string GetFormattedLockTokens(IEnumerable<Guid> lockTokens)
         {
-            var lockTokenBuilder = new StringBuilder();
-            foreach (var lockToken in lockTokens)
-            {
-                lockTokenBuilder.AppendFormat(CultureInfo.InvariantCulture, "<LockToken>{0}</LockToken>", lockToken.ToString());
-            }
-
-            return lockTokenBuilder.ToString();
+            // ReceiveAndDelete messages have empty lock tokens, so skip them to avoid noisy logs.
+            return string.Join(", ", lockTokens.Where(static token => token != Guid.Empty));
         }
 
         public static string GetFormattedSequenceNumbers(IEnumerable<long> sequenceNumbers)
         {
-            var sequenceNumberBuilder = new StringBuilder();
-            foreach (var sequenceNumber in sequenceNumbers)
-            {
-                sequenceNumberBuilder.AppendFormat(CultureInfo.InvariantCulture, "<SequenceNumber>{0}</SequenceNumber>", sequenceNumber);
-            }
-
-            return sequenceNumberBuilder.ToString();
+            return string.Join(", ", sequenceNumbers);
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -208,7 +208,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
                 var msg = await sessionReceiver.ReceiveMessageAsync();
                 _listener.SingleEventById(ServiceBusEventSource.ReceiveMessageStartEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
-                _listener.SingleEventById(ServiceBusEventSource.ReceiveMessageCompleteEvent, e => e.Payload.Contains(sessionReceiver.Identifier) && e.Payload.Contains($"<LockToken>{msg.LockToken}</LockToken>"));
+                _listener.SingleEventById(ServiceBusEventSource.ReceiveMessageCompleteEvent, e => e.Payload.Contains(sessionReceiver.Identifier) && e.Payload.Contains($"{msg.LockToken}"));
 
                 msg = await sessionReceiver.PeekMessageAsync();
                 _listener.SingleEventById(ServiceBusEventSource.CreateManagementLinkStartEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
@@ -242,7 +242,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
-                await using var client = new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace, TestEnvironment.Credential);
+                await using var client = CreateClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
                 ServiceBusMessage message = ServiceBusTestUtilities.GetMessage();
@@ -299,7 +299,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     e => e.Payload.Contains($"{processor.Identifier}-Receiver"));
                 _listener.SingleEventById(
                     ServiceBusEventSource.ReceiveMessageCompleteEvent,
-                    e => e.Payload.Contains($"{processor.Identifier}-Receiver") && e.Payload.Contains($"<LockToken>{lockToken}</LockToken>"));
+                    e => e.Payload.Contains($"{processor.Identifier}-Receiver") && e.Payload.Contains($"{lockToken}"));
                 _listener.SingleEventById(
                     ServiceBusEventSource.ProcessorMessageHandlerStartEvent,
                     e => e.Payload.Contains(processor.Identifier) && e.Payload.Contains(lockToken));
@@ -603,7 +603,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
-                await using var client = new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace, TestEnvironment.Credential,
+                await using var client = CreateClientWithOptions(
                     new ServiceBusClientOptions { EnableCrossEntityTransactions = true });
                 var sender = client.CreateSender(scope.QueueName);
                 var receiver = client.CreateReceiver(scope.QueueName);
@@ -625,8 +625,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
-                await using var client = new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace,
-                    TestEnvironment.Credential,
+                await using var client = CreateClientWithOptions(
                     new ServiceBusClientOptions { EnableCrossEntityTransactions = true });
                 var sender = client.CreateSender(scope.QueueName);
                 var receiver = client.CreateReceiver(scope.QueueName);
@@ -648,7 +647,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
-                await using var client = new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace, TestEnvironment.Credential);
+                await using var client = CreateClient();
                 var receiver = client.CreateReceiver(scope.QueueName);
 
                 var cts = new CancellationTokenSource();
@@ -664,7 +663,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         [Test]
         public async Task ReceiveFromNonExistentQueueLogsErrorEvent()
         {
-            await using var client = new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace, TestEnvironment.Credential);
+            await using var client = CreateClient();
             var receiver = client.CreateReceiver("nonexistentqueue");
 
             await AsyncAssert.ThrowsAsync<ServiceBusException>(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -30,6 +30,19 @@ namespace Azure.Messaging.ServiceBus.Tests
                         MaxRetries = maxRetries
                     }
                 };
+            return CreateClientWithOptions(options);
+        }
+
+        protected ServiceBusClient CreateClientWithOptions(ServiceBusClientOptions options = null)
+        {
+            options ??= new ServiceBusClientOptions
+            {
+                RetryOptions = new ServiceBusRetryOptions
+                {
+                    TryTimeout = TimeSpan.FromSeconds(DefaultTryTimeout),
+                    MaxRetries = 3
+                }
+            };
             return new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace, TestEnvironment.Credential, options);
         }
 


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-net/issues/59040

I have looked into the issue and concluded the string serialization is necessary because of the way Event Sources WriteEvent works. Otherwise we'd have to use WriteEventCore and serialize the GUIDs in the binary form, which makes it hard for consumers and defeats the point. Using `string.Join` in a comma-separated list reduces the unnecessary wrapping as discussed in the issue and moves things closer to how modern .NET structured logging would work. It is also in numerous instances more efficient compared to using a StringBuilder since string.Join has been purposefully optimized in modern .NET

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
