### PR TITLE
Emit derived discriminated provisioning resources

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
@@ -147,9 +147,13 @@ namespace Azure.Generator.Provisioning
             foreach (var inputModel in reachableModels)
             {
                 var model = ProvisioningGenerator.Instance.TypeFactory.CreateModel(inputModel);
-                if (model is not null && model is not ProvisioningResourceProvider)
+                if (model is not null)
                 {
                     providers.Add(model);
+                    if (model is ProvisioningResourceProvider resource)
+                    {
+                        ProvisioningGenerator.Instance.AddTypeToKeep(resource.Name);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Emit derived provisioning resource providers discovered through reachable discriminator models
- Fixes missing concrete provisioning resource types for discriminated ARM resources

## Validation
- dotnet test .\\eng\\packages\\http-client-csharp-provisioning\\generator\\Azure.Generator.Provisioning\\test\\Azure.Generator.Provisioning.Tests.csproj --no-restore --verbosity minimal