### PR TITLE
Update TypeSpec spec repo pins

### DIFF
--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tsp-location.yaml
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration
-commit: 9c3e7f9d855fd6be125b7140864d0a630aa46f7f
+commit: 6299a048dbae22bada10309e3f045d98b14bac4f
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 
 

--- a/sdk/cognitiveservices/Azure.ResourceManager.CognitiveServices/tsp-location.yaml
+++ b/sdk/cognitiveservices/Azure.ResourceManager.CognitiveServices/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/cognitiveservices/CognitiveServices.Management
-commit: 9c3e7f9d855fd6be125b7140864d0a630aa46f7f
+commit: 6299a048dbae22bada10309e3f045d98b14bac4f
 repo: Azure/azure-rest-api-specs
 emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"

--- a/sdk/resources/Azure.ResourceManager.Resources.Policy/tsp-location.yaml
+++ b/sdk/resources/Azure.ResourceManager.Resources.Policy/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/resources/resource-manager/Microsoft.Authorization/policy
-commit: 9c3e7f9d855fd6be125b7140864d0a630aa46f7f
+commit: 6299a048dbae22bada10309e3f045d98b14bac4f
 repo: Azure/azure-rest-api-specs
 emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json

--- a/sdk/storage/Azure.ResourceManager.Storage/tsp-location.yaml
+++ b/sdk/storage/Azure.ResourceManager.Storage/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Storage.Management
 repo: Azure/azure-rest-api-specs
-commit: 9c3e7f9d855fd6be125b7140864d0a630aa46f7f
+commit: 6299a048dbae22bada10309e3f045d98b14bac4f
 emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"


### PR DESCRIPTION
This updates the tsp-location files touched by #59331 to use the current latest commit on Azure/azure-rest-api-specs main:

`6299a048dbae22bada10309e3f045d98b14bac4f`