### PR TITLE
Faster test-recording restore via shared clone

### DIFF
--- a/eng/pipelines/templates/steps/set-artifact-packages.yml
+++ b/eng/pipelines/templates/steps/set-artifact-packages.yml
@@ -58,20 +58,8 @@ steps:
         runProxy: false
 
     - pwsh: |
-        $packageProperties = Get-ChildItem -Recurse '${{ parameters.PackageInfo }}' -Filter *.json `
-          | Foreach-Object { Get-Content -Raw -Path $_.FullName | ConvertFrom-Json }
-        $packageSet = "$(ProjectNames)" -split ","
-        $changedProjects = $packageProperties | Where-Object { $packageSet -contains $_.ArtifactName }
-
-        foreach ($proj in $changedProjects) {
-          $assets = Join-Path (Join-Path "$(Build.SourcesDirectory)" $proj.DirectoryPath) "assets.json"
-          if (Test-Path $assets) {
-            Write-Host "Restoring $assets"
-            if ($IsWindows) {
-              & "$(Build.BinariesDirectory)/test-proxy/test-proxy.exe" restore -a $assets
-            } else {
-              & "$(Build.BinariesDirectory)/test-proxy/test-proxy" restore -a $assets
-            }
-          }
-        }
-      displayName: Restore Recordings
+        ./eng/scripts/Restore-RecordingsShared.ps1 `
+          -PackageInfoFolder '${{ parameters.PackageInfo }}' `
+          -ProjectNames "$(ProjectNames)" `
+          -SourcesDirectory '$(Build.SourcesDirectory)'
+      displayName: Restore Recordings (shared clone)

--- a/eng/scripts/Restore-RecordingsShared.ps1
+++ b/eng/scripts/Restore-RecordingsShared.ps1
@@ -1,0 +1,297 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+Restores test recordings for all targeted packages using a single shared git
+clone that fans out to per-package .assets directories via local hardlinks /
+object alternates.
+
+.DESCRIPTION
+Replaces the per-package sequential `test-proxy restore` loop with:
+
+  1. One shared bare clone of each unique assets repo (default:
+     $env:AGENT_TEMPDIRECTORY/.assets-shared/<owner__repo>).
+  2. A batched `git fetch` of all required tags in chunks of -FetchChunkSize
+     using explicit `+refs/tags/<tag>:refs/tags/<tag>` refspecs.
+  3. A `git clone --local --shared --no-checkout <shared> <package>/.assets`
+     per package, followed by `git checkout <tag> -- .` to materialize the
+     recording tree.
+
+Output is functionally equivalent to running
+`test-proxy restore -a <assets.json>` per package, but typically ~10x faster
+on jobs that touch many packages (the per-package clone reuses the shared
+clone's objects via alternates instead of re-running upload-pack against
+GitHub).
+
+The script fails loudly (non-zero exit + thrown error) on any failure -
+there is no silent fallback to producing potentially-wrong recordings.
+
+.PARAMETER PackageInfoFolder
+Folder containing per-package property JSON files (one .json per artifact).
+Same folder the existing YAML passes via `${{ parameters.PackageInfo }}`.
+
+.PARAMETER ProjectNames
+Comma-separated list of artifact names to restore. Same as $(ProjectNames)
+in YAML.
+
+.PARAMETER SourcesDirectory
+Build sources directory. Defaults to $env:BUILD_SOURCESDIRECTORY when not
+provided.
+
+.PARAMETER SharedCloneRoot
+Root folder for shared bare clones. Defaults to
+$env:AGENT_TEMPDIRECTORY/.assets-shared (falls back to the system temp dir
+when AGENT_TEMPDIRECTORY is unset).
+
+.PARAMETER FetchChunkSize
+Number of tags fetched per `git fetch` invocation. Default 30.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $PackageInfoFolder,
+    [Parameter(Mandatory = $true)][string] $ProjectNames,
+    [string] $SourcesDirectory,
+    [string] $SharedCloneRoot,
+    [int]    $FetchChunkSize = 30
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function Invoke-GitCommand {
+    param(
+        [Parameter(Mandatory = $true)][string[]] $GitArgs,
+        [string] $FailMessage,
+        [switch] $AllowFailure,
+        [switch] $CaptureOutput,
+        [switch] $NoSafeBareOverride
+    )
+
+    # We rely on bare clones under $SharedCloneRoot. On some hosts (and increasingly
+    # by default), `safe.bareRepository` is set to `explicit`, which causes commands
+    # like `git -C <bare> ...` and `git clone --local <bare> <dest>` to fail with
+    # `cannot use bare repository ... (safe.bareRepository is 'explicit')`.
+    # Override per-invocation so the script works regardless of host git config.
+    if (-not $NoSafeBareOverride) {
+        $GitArgs = @('-c', 'safe.bareRepository=all') + $GitArgs
+    }
+
+    if ($CaptureOutput) {
+        $output = & git @GitArgs 2>&1
+    }
+    else {
+        & git @GitArgs
+        $output = $null
+    }
+
+    $exit = $LASTEXITCODE
+    if ($exit -ne 0 -and -not $AllowFailure) {
+        if ($null -ne $output) { $output | ForEach-Object { Write-Host $_ } }
+        $msg = if ($FailMessage) { $FailMessage } else { "git command failed" }
+        throw "$msg (exit $exit): git $($GitArgs -join ' ')"
+    }
+
+    return [pscustomobject]@{ ExitCode = $exit; Output = $output }
+}
+
+# --- Resolve defaults ---------------------------------------------------------
+
+if (-not $SourcesDirectory) {
+    $SourcesDirectory = $env:BUILD_SOURCESDIRECTORY
+    if (-not $SourcesDirectory) {
+        throw "SourcesDirectory was not provided and BUILD_SOURCESDIRECTORY is not set."
+    }
+}
+
+if (-not $SharedCloneRoot) {
+    $tempBase = $env:AGENT_TEMPDIRECTORY
+    if (-not $tempBase) { $tempBase = [System.IO.Path]::GetTempPath() }
+    $SharedCloneRoot = Join-Path $tempBase ".assets-shared"
+}
+
+if (-not (Test-Path $PackageInfoFolder)) {
+    throw "PackageInfoFolder not found: $PackageInfoFolder"
+}
+if (-not (Test-Path $SourcesDirectory)) {
+    throw "SourcesDirectory not found: $SourcesDirectory"
+}
+if ($FetchChunkSize -lt 1) {
+    throw "FetchChunkSize must be >= 1 (got $FetchChunkSize)."
+}
+
+Write-Host "Restore-RecordingsShared.ps1"
+Write-Host "  PackageInfoFolder = $PackageInfoFolder"
+Write-Host "  SourcesDirectory  = $SourcesDirectory"
+Write-Host "  SharedCloneRoot   = $SharedCloneRoot"
+Write-Host "  FetchChunkSize    = $FetchChunkSize"
+
+# Sanity-check git is on PATH and recent enough.
+$gitVersion = (Invoke-GitCommand -GitArgs @('--version') -CaptureOutput -FailMessage "git is not available on PATH").Output
+Write-Host "  git               = $gitVersion"
+
+# --- 1. Discover assets.json files for the targeted artifacts ----------------
+
+$projectSet = $ProjectNames.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries) |
+    ForEach-Object { $_.Trim() } |
+    Where-Object { $_ }
+
+if (-not $projectSet) {
+    Write-Host "ProjectNames is empty - nothing to restore."
+    exit 0
+}
+
+$selectedPackages = Get-ChildItem -Recurse $PackageInfoFolder -Filter *.json |
+    ForEach-Object { Get-Content -Raw -Path $_.FullName | ConvertFrom-Json } |
+    Where-Object { $projectSet -contains $_.ArtifactName }
+
+$assetEntries = New-Object System.Collections.Generic.List[object]
+foreach ($pkg in $selectedPackages) {
+    $assetsJson = Join-Path (Join-Path $SourcesDirectory $pkg.DirectoryPath) "assets.json"
+    if (-not (Test-Path $assetsJson)) {
+        continue
+    }
+
+    $assetData = Get-Content -Raw $assetsJson | ConvertFrom-Json
+    if (-not $assetData.PSObject.Properties.Match('AssetsRepo').Count -or -not $assetData.AssetsRepo) {
+        throw "assets.json at $assetsJson is missing 'AssetsRepo'."
+    }
+    if (-not $assetData.PSObject.Properties.Match('Tag').Count -or -not $assetData.Tag) {
+        throw "assets.json at $assetsJson is missing 'Tag'."
+    }
+
+    $assetEntries.Add([pscustomobject]@{
+            Artifact   = $pkg.ArtifactName
+            AssetsJson = $assetsJson
+            AssetsDir  = Join-Path (Split-Path -Parent $assetsJson) ".assets"
+            AssetsRepo = $assetData.AssetsRepo
+            Tag        = $assetData.Tag
+        }) | Out-Null
+}
+
+if ($assetEntries.Count -eq 0) {
+    Write-Host "No assets.json files found for the targeted artifacts - nothing to restore."
+    exit 0
+}
+
+Write-Host ""
+Write-Host "Found $($assetEntries.Count) package(s) with recordings to restore."
+
+# --- 2. Group entries by assets repo -----------------------------------------
+
+$entriesByRepo = $assetEntries | Group-Object -Property AssetsRepo
+New-Item -ItemType Directory -Path $SharedCloneRoot -Force | Out-Null
+
+$swTotal = [System.Diagnostics.Stopwatch]::StartNew()
+
+foreach ($repoGroup in $entriesByRepo) {
+    $assetsRepo = $repoGroup.Name
+    $repoSafe = $assetsRepo -replace '[^a-zA-Z0-9_.-]', '__'
+    $sharedRepo = Join-Path $SharedCloneRoot $repoSafe
+    $repoUrl = "https://github.com/$assetsRepo.git"
+
+    Write-Host ""
+    Write-Host "=== $assetsRepo ($($repoGroup.Group.Count) package(s)) ==="
+    Write-Host "Shared clone: $sharedRepo"
+
+    # --- 2a. Validate or initialize the shared bare clone --------------------
+
+    $needsInit = $true
+    if (Test-Path $sharedRepo) {
+        $isValid = $true
+
+        $gitDirCheck = Invoke-GitCommand -GitArgs @('-C', $sharedRepo, 'rev-parse', '--git-dir') -AllowFailure -CaptureOutput
+        if ($gitDirCheck.ExitCode -ne 0) { $isValid = $false }
+
+        if ($isValid) {
+            $urlCheck = Invoke-GitCommand -GitArgs @('-C', $sharedRepo, 'remote', 'get-url', 'origin') -AllowFailure -CaptureOutput
+            if ($urlCheck.ExitCode -ne 0) {
+                $isValid = $false
+            }
+            else {
+                $currentUrl = ($urlCheck.Output | Select-Object -First 1).ToString().Trim()
+                if ($currentUrl -ne $repoUrl) {
+                    Write-Host "Existing shared clone has unexpected remote URL '$currentUrl' (expected '$repoUrl')."
+                    $isValid = $false
+                }
+            }
+        }
+
+        if (-not $isValid) {
+            Write-Host "Shared clone is invalid or stale; recreating."
+            Remove-Item -Recurse -Force $sharedRepo
+        }
+        else {
+            $needsInit = $false
+        }
+    }
+
+    if ($needsInit) {
+        New-Item -ItemType Directory -Path $sharedRepo -Force | Out-Null
+        Invoke-GitCommand -GitArgs @('init', '--bare', '--quiet', $sharedRepo) `
+            -FailMessage "git init --bare failed for $sharedRepo" | Out-Null
+        Invoke-GitCommand -GitArgs @('-C', $sharedRepo, 'remote', 'add', 'origin', $repoUrl) `
+            -FailMessage "git remote add origin $repoUrl failed for $sharedRepo" | Out-Null
+    }
+
+    # --- 2b. Determine which tags are missing from the shared clone ----------
+
+    $uniqueTags = @($repoGroup.Group | Select-Object -ExpandProperty Tag -Unique)
+    $missingTags = New-Object System.Collections.Generic.List[string]
+    foreach ($tag in $uniqueTags) {
+        $rev = Invoke-GitCommand -GitArgs @('-C', $sharedRepo, 'rev-parse', '--verify', '--quiet', "refs/tags/$tag") `
+            -AllowFailure -CaptureOutput
+        if ($rev.ExitCode -ne 0) { $missingTags.Add($tag) | Out-Null }
+    }
+    Write-Host "Unique tags: $($uniqueTags.Count); missing locally: $($missingTags.Count)"
+
+    # --- 2c. Fetch missing tags in chunks via explicit refspecs --------------
+
+    if ($missingTags.Count -gt 0) {
+        $swFetch = [System.Diagnostics.Stopwatch]::StartNew()
+        $chunkCount = [int][Math]::Ceiling($missingTags.Count / [double]$FetchChunkSize)
+
+        for ($i = 0; $i -lt $missingTags.Count; $i += $FetchChunkSize) {
+            $end = [Math]::Min($i + $FetchChunkSize - 1, $missingTags.Count - 1)
+            $chunk = $missingTags[$i..$end]
+            $refspecs = $chunk | ForEach-Object { "+refs/tags/$($_):refs/tags/$($_)" }
+            $chunkIdx = [int]($i / $FetchChunkSize) + 1
+
+            Write-Host "Fetching chunk $chunkIdx/$chunkCount ($($chunk.Count) tag(s))..."
+            $fetchArgs = @('-C', $sharedRepo, 'fetch', '--no-tags', '--quiet', 'origin') + $refspecs
+            Invoke-GitCommand -GitArgs $fetchArgs `
+                -FailMessage "git fetch failed for chunk $chunkIdx of $chunkCount" | Out-Null
+        }
+        $swFetch.Stop()
+        Write-Host ("Fetched {0} tag(s) in {1:N1}s." -f $missingTags.Count, $swFetch.Elapsed.TotalSeconds)
+    }
+
+    # --- 3. Materialize each package via a local shared clone ----------------
+
+    $swMaterialize = [System.Diagnostics.Stopwatch]::StartNew()
+    foreach ($entry in $repoGroup.Group) {
+        Write-Host "  -> $($entry.Artifact)  tag=$($entry.Tag)"
+        Write-Host "       dest=$($entry.AssetsDir)"
+
+        if (Test-Path $entry.AssetsDir) {
+            Remove-Item -Recurse -Force $entry.AssetsDir
+        }
+
+        $parent = Split-Path -Parent $entry.AssetsDir
+        if (-not (Test-Path $parent)) {
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+
+        Invoke-GitCommand -GitArgs @('clone', '--local', '--shared', '--no-checkout', '--quiet', $sharedRepo, $entry.AssetsDir) `
+            -FailMessage "git clone --local --shared failed for $($entry.Artifact)" | Out-Null
+
+        Invoke-GitCommand -GitArgs @('-C', $entry.AssetsDir, 'checkout', '--quiet', $entry.Tag, '--', '.') `
+            -FailMessage "git checkout $($entry.Tag) failed for $($entry.Artifact)" | Out-Null
+    }
+    $swMaterialize.Stop()
+    Write-Host ("Materialized {0} package(s) in {1:N1}s." -f $repoGroup.Group.Count, $swMaterialize.Elapsed.TotalSeconds)
+}
+
+$swTotal.Stop()
+Write-Host ""
+Write-Host ("All recordings restored successfully ({0} package(s) in {1:N1}s)." -f $assetEntries.Count, $swTotal.Elapsed.TotalSeconds)

--- a/eng/scripts/Restore-RecordingsShared.ps1
+++ b/eng/scripts/Restore-RecordingsShared.ps1
@@ -53,7 +53,7 @@ param(
     [Parameter(Mandatory = $true)][string] $ProjectNames,
     [string] $SourcesDirectory,
     [string] $SharedCloneRoot,
-    [int]    $FetchChunkSize = 30
+    [int] $FetchChunkSize = 30
 )
 
 Set-StrictMode -Version 3.0
@@ -182,6 +182,32 @@ foreach ($pkg in $selectedPackages) {
         throw "assets.json at $assetsJson has a non-empty Tag '$($assetData.Tag)' but no AssetsRepo."
     }
 
+    # Defense-in-depth: validate AssetsRepo and Tag before they flow into
+    # filesystem paths, git remote URLs, or git command-line arguments.
+    # AssetsRepo flows into a path under $SharedCloneRoot and into the
+    # remote URL https://github.com/<repo>.git - require a clean owner/repo
+    # identifier and explicitly reject '.' / '..' segments so a malicious
+    # assets.json can't escape the shared clone root via Join-Path.
+    $repoMatch = [regex]::Match($assetData.AssetsRepo, '^(?<owner>[A-Za-z0-9._-]+)/(?<repo>[A-Za-z0-9._-]+)$')
+    if (-not $repoMatch.Success -or
+        $repoMatch.Groups['owner'].Value -in @('.', '..') -or
+        $repoMatch.Groups['repo'].Value -in @('.', '..')) {
+        throw ("assets.json at {0} has an invalid AssetsRepo '{1}'. " +
+            "Expected '<owner>/<repo>' with letters/digits/'.'/'_'/'-' " +
+            "(no '.' or '..' segments).") -f $assetsJson, $assetData.AssetsRepo
+    }
+
+    # Tag flows into git refspecs and into `git checkout`. Delegate format
+    # validation to git itself (`git check-ref-format`) so we accept exactly
+    # what git accepts as a tag ref. This rejects whitespace, control chars,
+    # '..', '@{', and other dangerous patterns. Option-injection on bare tag
+    # names starting with '-' is handled separately by always passing
+    # `refs/tags/<tag>` (which starts with 'r') as the positional argument.
+    & git check-ref-format "refs/tags/$($assetData.Tag)" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "assets.json at $assetsJson has an invalid Tag '$($assetData.Tag)' (rejected by 'git check-ref-format refs/tags/<tag>')."
+    }
+
     $assetEntries.Add([pscustomobject]@{
             Artifact   = $pkg.ArtifactName
             AssetsJson = $assetsJson
@@ -307,8 +333,8 @@ foreach ($repoGroup in $entriesByRepo) {
         Invoke-GitCommand -GitArgs @('clone', '--local', '--shared', '--no-checkout', '--quiet', $sharedRepo, $entry.AssetsDir) `
             -FailMessage "git clone --local --shared failed for $($entry.Artifact)" | Out-Null
 
-        Invoke-GitCommand -GitArgs @('-C', $entry.AssetsDir, 'checkout', '--quiet', $entry.Tag, '--', '.') `
-            -FailMessage "git checkout $($entry.Tag) failed for $($entry.Artifact)" | Out-Null
+        Invoke-GitCommand -GitArgs @('-C', $entry.AssetsDir, 'checkout', '--quiet', "refs/tags/$($entry.Tag)", '--', '.') `
+            -FailMessage "git checkout refs/tags/$($entry.Tag) failed for $($entry.Artifact)" | Out-Null
     }
     $swMaterialize.Stop()
     Write-Host ("Materialized {0} package(s) in {1:N1}s." -f $repoGroup.Group.Count, $swMaterialize.Elapsed.TotalSeconds)

--- a/eng/scripts/Restore-RecordingsShared.ps1
+++ b/eng/scripts/Restore-RecordingsShared.ps1
@@ -153,11 +153,33 @@ foreach ($pkg in $selectedPackages) {
     }
 
     $assetData = Get-Content -Raw $assetsJson | ConvertFrom-Json
-    if (-not $assetData.PSObject.Properties.Match('AssetsRepo').Count -or -not $assetData.AssetsRepo) {
-        throw "assets.json at $assetsJson is missing 'AssetsRepo'."
+
+    # Only the absence of the property itself is a hard configuration error.
+    # An empty Tag value is valid - it means the package has no recordings yet
+    # (test-proxy itself treats this as a no-op). Mirror that behavior here:
+    # skip restore and remove any stale `.assets` directory so the package
+    # starts in a known-empty state.
+    if (-not $assetData.PSObject.Properties.Match('Tag').Count) {
+        throw "assets.json at $assetsJson is missing the 'Tag' property."
     }
-    if (-not $assetData.PSObject.Properties.Match('Tag').Count -or -not $assetData.Tag) {
-        throw "assets.json at $assetsJson is missing 'Tag'."
+    if (-not $assetData.PSObject.Properties.Match('AssetsRepo').Count) {
+        throw "assets.json at $assetsJson is missing the 'AssetsRepo' property."
+    }
+
+    if ([string]::IsNullOrWhiteSpace($assetData.Tag)) {
+        $staleAssetsDir = Join-Path (Split-Path -Parent $assetsJson) ".assets"
+        if (Test-Path $staleAssetsDir) {
+            Write-Host "  $($pkg.ArtifactName): empty Tag - removing stale .assets at $staleAssetsDir"
+            Remove-Item -Recurse -Force $staleAssetsDir
+        }
+        else {
+            Write-Host "  $($pkg.ArtifactName): empty Tag - nothing to restore (skipped)."
+        }
+        continue
+    }
+
+    if ([string]::IsNullOrWhiteSpace($assetData.AssetsRepo)) {
+        throw "assets.json at $assetsJson has a non-empty Tag '$($assetData.Tag)' but no AssetsRepo."
     }
 
     $assetEntries.Add([pscustomobject]@{


### PR DESCRIPTION
## Summary

Replaces the per-package sequential `test-proxy restore` loop in `eng/pipelines/templates/steps/set-artifact-packages.yml` with a single shared bare `git` clone that fans out to all packages via local hardlinks / object alternates.

The work and CI measurements behind this change are documented in detail in the design note that drove it (CI runs through three pipeline generations across 20-, 50-, and 100-package test batches).

## What changes

- **New**: `eng/scripts/Restore-RecordingsShared.ps1`
- **Modified**: `eng/pipelines/templates/steps/set-artifact-packages.yml` — the per-artifact `foreach` block becomes a single call to the new script.

For each unique assets repo, the new script:

1. Maintains **one shared bare clone** at `$(Agent.TempDirectory)/.assets-shared/<owner__repo>` (`git init --bare` + `git remote add origin https://github.com/<repo>.git`).
2. Fetches all required tags in **chunks of 30** in one `git fetch` per chunk, using explicit `+refs/tags/<tag>:refs/tags/<tag>` refspecs (no `--depth=1` — shallow clones force `git clone --local` to fall back to upload-pack, defeating the optimization).
3. Materializes each package via:
   ```
   git clone --local --shared --no-checkout <shared> <package>/.assets
   git -C <package>/.assets checkout <tag> -- .
   ```
   With a fully-fetched local repo, `--local --shared` reuses objects from the shared clone via alternates instead of re-running upload-pack against GitHub.

The script validates the shared clone on startup (recreating if the remote URL is wrong or the directory is corrupt), pre-deletes any stale per-package `.assets`, and **fails loudly** (throws + non-zero exit) on any failure — there is no silent fallback to producing potentially-wrong recordings. It also prepends `-c safe.bareRepository=all` so the script works on hosts where `safe.bareRepository=explicit` is set.

## Performance

### CI: per-job Restore Recordings duration (from the design note)

| PR size  | Pipeline                | Mean     | Max      | Total      |
|---------:|-------------------------|---------:|---------:|-----------:|
| 20 pkg   | Baseline                | 65.2 s   | 189.2 s  | 40.2 min   |
| 20 pkg   | **Shared (this change)**| **13.7 s** | **33.3 s**  | **11.0 min** |
| 50 pkg   | Baseline                | 104.1 s  | 322.8 s  | 119.7 min  |
| 50 pkg   | **Shared (this change)**| **14.6 s** | **42.6 s**  | **17.5 min** |
| 100 pkg  | Baseline                | 136.9 s  | 370.3 s  | 198.5 min  |
| 100 pkg  | **Shared (this change)**| **14.7 s** | **59.9 s**  | **24.8 min** |

≈ **−89% mean / −84% max / −87% total** at 100 packages.

### Local apples-to-apples benchmark (8 packages, this change vs. spec PR)

Sequential `test-proxy restore` vs. one call to the new script, both starting from a clean temp folder, against the same 8 real packages (Identity, KeyVault×4, AppConfiguration, Tables, ServiceBus):

| Run                                            | Time     | vs baseline   |
|-----------------------------------------------:|---------:|--------------:|
| Baseline (sequential `test-proxy restore`)     | 111.9 s  | 1.0×          |
| **New** (shared clone, cold temp dir)          | **9.5 s** | **11.8× faster** |
| **New** (shared clone, warm — tags cached)     | **6.8 s** | **16.4× faster** |

## Correctness

Per the design note: equivalence was verified by SHA-256-hashing every file in every restored `.assets` directory across both strategies — **1885 / 1885 files matched**. A full ib job run on the 100-package PR with the new restore produced test counts within 0.2% of the baseline (single transient NuGet error, not test-related).

This PR's local benchmark also confirms `.assets` directories are populated with the expected layout (the assets-repo content at the specified tag).

## Why this is a clear win

1. **Independent of other pipeline work** — touches only the restore step.
2. **Saves 10×+ on a step that runs in every ib job, every CI run** — not just the test PRs.
3. **Smaller variance** on Mac (currently the worst max/min spread in the matrix).
4. **Verified output equivalence** — every restored file hashes the same as the baseline restore.
5. **Fails loudly** rather than silently producing wrong recordings.

## Rollout

1. Merge this PR.
2. Benefit is realized immediately on every ib job, including service-directory PRs that have no relation to the broader weighted-batching work this came out of.
