### PR TITLE
Remove scottaddie from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1237,7 +1237,7 @@
 /.config/1espt/                                                    @benbp @weshaggard
 /.vscode/                                                          @jsquire @m-redding
 /.devcontainer/                                                    @jsquire @m-redding
-/doc/                                                              @jsquire @scottaddie
+/doc/                                                              @jsquire
 /samples/                                                          @jsquire @m-redding
 
 # Repository configuration that should not be overridden


### PR DESCRIPTION
This removes a stale CODEOWNERS mention so documentation ownership no longer requests review from `@scottaddie`.

The `/doc/` entry is preserved with `@jsquire` as the remaining owner.