### PR TITLE
Fix single-page raw array resource lists

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -384,13 +384,13 @@ function getDirectResponseModelId(
 }
 
 /**
- * Returns the page-item model id for a pageable method, or undefined when the
- * method is not pageable or returns a non-model item type.
+ * Returns the item model id for a method that returns a resource collection.
+ * Some ARM single-page list templates are represented as basic GET methods
+ * returning T[], so list detection must not be limited to paging/lropaging.
  */
-function getPagingItemModelIdLocal(
+function getCollectionItemModelIdLocal(
   method: SdkMethod<SdkHttpOperation>
 ): string | undefined {
-  if (method.kind !== "paging" && method.kind !== "lropaging") return undefined;
   const r = method.response?.type;
   if (r?.kind === "array" && r.valueType.kind === "model") {
     return (r.valueType as SdkModelType).crossLanguageDefinitionId;
@@ -435,7 +435,7 @@ function assignRemainingOperations(
     const sdkMethod = serviceMethods.get(methodId);
     const itemModelId =
       sdkMethod?.operation?.verb === "get"
-        ? getPagingItemModelIdLocal(sdkMethod)
+        ? getCollectionItemModelIdLocal(sdkMethod)
         : undefined;
     const listTarget =
       itemModelId && identifiedResourceModelIds.has(itemModelId)

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -408,6 +408,112 @@ interface CurrentEmployees {
     // );
   });
 
+  it("legacy single-page raw array list is assigned to the listed resource", async () => {
+    const program = await typeSpecCompile(
+      `
+/** A parent resource */
+model ParentResource is TrackedResource<ParentResourceProperties> {
+  ...ResourceNameParameter<ParentResource>;
+}
+
+model ParentResourceProperties {
+  description?: string;
+}
+
+/** A child resource under the parent */
+@parentResource(ParentResource)
+model ChildResource is ProxyResource<ChildResourceProperties, false> {
+  ...ResourceNameParameter<
+    Resource = ChildResource,
+    KeyName = "childResourceName",
+    SegmentName = "childResources",
+    NamePattern = ""
+  >;
+}
+
+model ChildResourceProperties {
+  description?: string;
+}
+
+model ChildResourceList is ChildResource[];
+
+alias ChildResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+    ...ResourceGroupParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+
+    @path
+    @segment("parentResources")
+    parentResourceName: string;
+  },
+  {
+    @path
+    @segment("childResources")
+    childResourceName: string;
+  }
+>;
+
+@armResourceOperations
+interface ParentResources {
+  get is ArmResourceRead<ParentResource>;
+  createOrUpdate is ArmResourceCreateOrReplaceSync<ParentResource>;
+}
+
+@armResourceOperations
+interface ChildResources {
+  get is ChildResourceOps.Read<ChildResource>;
+  list is ChildResourceOps.ListSinglePage<
+    ChildResource,
+    Response = ArmResponse<ChildResourceList>
+  >;
+}
+`,
+      runner
+    );
+
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const [root] = createModel(sdkContext);
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+
+    const childResource = armProviderSchema.resources.find(
+      (r) =>
+        r.metadata.resourceType ===
+        "Microsoft.ContosoProviderHub/parentResources/childResources"
+    );
+    ok(childResource);
+
+    const listMethod = childResource.metadata.methods.find(
+      (m: any) => m.kind === "List"
+    );
+    ok(listMethod);
+    strictEqual(
+      listMethod.operationPath.path,
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContosoProviderHub/parentResources/{parentResourceName}/childResources"
+    );
+    strictEqual(
+      listMethod.scope.scopeIdPattern?.path,
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContosoProviderHub/parentResources/{parentResourceName}"
+    );
+
+    const parentResource = armProviderSchema.resources.find(
+      (r) =>
+        r.metadata.resourceType ===
+        "Microsoft.ContosoProviderHub/parentResources"
+    );
+    ok(parentResource);
+    strictEqual(
+      parentResource.metadata.methods.some(
+        (m: any) =>
+          m.kind === "Action" &&
+          m.operationPath.path.endsWith("/childResources")
+      ),
+      false
+    );
+  });
+
   it("resource with grand parent under a resource group", async () => {
     const program = await typeSpecCompile(
       `


### PR DESCRIPTION
## Summary
- Treat GET operations returning an array of a detected resource model as collection-list candidates.
- Keep the existing collection-path matching guard so only true resource collection paths become `List` operations.
- Add a regression test for legacy `ListSinglePage` raw-array resource lists.

## Validation
- `npx vitest run -c .\emitter\vitest.config.ts .\emitter\test\resource-detection.test.ts -t "legacy single-page raw array list" --hookTimeout=30000 --reporter=basic`
- `npm run prettier`
- `npm run lint`