### PR TITLE
Fix Windows MAX_PATH failure in Restore-RecordingsShared.ps1 (sparse-checkout + core.longpaths)

### DIFF
--- a/eng/scripts/Restore-RecordingsShared.ps1
+++ b/eng/scripts/Restore-RecordingsShared.ps1
@@ -208,12 +208,33 @@ foreach ($pkg in $selectedPackages) {
         throw "assets.json at $assetsJson has an invalid Tag '$($assetData.Tag)' (rejected by 'git check-ref-format refs/tags/<tag>')."
     }
 
+    # Compute the sparse-checkout path: the package's own subtree inside the
+    # assets repo. Tags in Azure/azure-sdk-assets contain the full repo layout
+    # (every package), so without sparse-checkout each package's `.assets`
+    # directory would materialize the entire repo - tens of thousands of files
+    # per package, and on Windows the deep paths blow past MAX_PATH (260 chars)
+    # and `git checkout` aborts with "Filename too long". Sparse-checkout limits
+    # materialization to <AssetsRepoPrefixPath>/<DirectoryPath>, matching what
+    # `test-proxy restore` writes.
+    $prefix = ''
+    if ($assetData.PSObject.Properties.Match('AssetsRepoPrefixPath').Count) {
+        $prefix = "$($assetData.AssetsRepoPrefixPath)"
+    }
+    $sparseSegments = @($prefix, $pkg.DirectoryPath) |
+        ForEach-Object { ($_ -replace '\\', '/').Trim('/') } |
+        Where-Object { $_ }
+    $sparsePath = $sparseSegments -join '/'
+    if (-not $sparsePath) {
+        throw "assets.json at $assetsJson + package '$($pkg.ArtifactName)' produced an empty sparse-checkout path (AssetsRepoPrefixPath='$prefix', DirectoryPath='$($pkg.DirectoryPath)')."
+    }
+
     $assetEntries.Add([pscustomobject]@{
             Artifact   = $pkg.ArtifactName
             AssetsJson = $assetsJson
             AssetsDir  = Join-Path (Split-Path -Parent $assetsJson) ".assets"
             AssetsRepo = $assetData.AssetsRepo
             Tag        = $assetData.Tag
+            SparsePath = $sparsePath
         }) | Out-Null
 }
 
@@ -282,6 +303,12 @@ foreach ($repoGroup in $entriesByRepo) {
             -FailMessage "git remote add origin $repoUrl failed for $sharedRepo" | Out-Null
     }
 
+    # Ensure core.longpaths is set on the shared clone (idempotent - applied to
+    # both freshly-initialized and reused clones). Required on Windows because
+    # paths inside Azure/azure-sdk-assets tags can exceed MAX_PATH (260 chars).
+    Invoke-GitCommand -GitArgs @('-C', $sharedRepo, 'config', 'core.longpaths', 'true') `
+        -FailMessage "git config core.longpaths failed for $sharedRepo" | Out-Null
+
     # --- 2b. Determine which tags are missing from the shared clone ----------
 
     $uniqueTags = @($repoGroup.Group | Select-Object -ExpandProperty Tag -Unique)
@@ -330,10 +357,23 @@ foreach ($repoGroup in $entriesByRepo) {
             New-Item -ItemType Directory -Path $parent -Force | Out-Null
         }
 
-        Invoke-GitCommand -GitArgs @('clone', '--local', '--shared', '--no-checkout', '--quiet', $sharedRepo, $entry.AssetsDir) `
+        Invoke-GitCommand -GitArgs @('-c', 'core.longpaths=true', 'clone', '--local', '--shared', '--no-checkout', '--quiet', $sharedRepo, $entry.AssetsDir) `
             -FailMessage "git clone --local --shared failed for $($entry.Artifact)" | Out-Null
 
-        Invoke-GitCommand -GitArgs @('-C', $entry.AssetsDir, 'checkout', '--quiet', "refs/tags/$($entry.Tag)", '--', '.') `
+        # Set core.longpaths on the per-package clone (Windows MAX_PATH defense)
+        # and configure sparse-checkout so only the package's own subtree is
+        # materialized - matches `test-proxy restore` semantics, ~100x less data
+        # on disk per package, and avoids the deep-path checkout failures that
+        # used to abort the build on Windows agents.
+        Invoke-GitCommand -GitArgs @('-C', $entry.AssetsDir, 'config', 'core.longpaths', 'true') `
+            -FailMessage "git config core.longpaths failed for $($entry.Artifact)" | Out-Null
+
+        Invoke-GitCommand -GitArgs @('-C', $entry.AssetsDir, 'sparse-checkout', 'init', '--cone') `
+            -FailMessage "git sparse-checkout init failed for $($entry.Artifact)" | Out-Null
+        Invoke-GitCommand -GitArgs @('-C', $entry.AssetsDir, 'sparse-checkout', 'set', $entry.SparsePath) `
+            -FailMessage "git sparse-checkout set $($entry.SparsePath) failed for $($entry.Artifact)" | Out-Null
+
+        Invoke-GitCommand -GitArgs @('-c', 'core.longpaths=true', '-C', $entry.AssetsDir, 'checkout', '--quiet', "refs/tags/$($entry.Tag)") `
             -FailMessage "git checkout refs/tags/$($entry.Tag) failed for $($entry.Artifact)" | Out-Null
     }
     $swMaterialize.Stop()

--- a/sdk/servicefabricmanagedclusters/Azure.ResourceManager.ServiceFabricManagedClusters/README.md
+++ b/sdk/servicefabricmanagedclusters/Azure.ResourceManager.ServiceFabricManagedClusters/README.md
@@ -80,4 +80,3 @@ more information, see the [Code of Conduct FAQ][coc_faq] or contact
 [cg]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/resourcemanager/Azure.ResourceManager/docs/CONTRIBUTING.md
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
-<!-- ci-touch: verify Restore-RecordingsShared.ps1 long-path fix on Windows -->

--- a/sdk/servicefabricmanagedclusters/Azure.ResourceManager.ServiceFabricManagedClusters/README.md
+++ b/sdk/servicefabricmanagedclusters/Azure.ResourceManager.ServiceFabricManagedClusters/README.md
@@ -80,3 +80,4 @@ more information, see the [Code of Conduct FAQ][coc_faq] or contact
 [cg]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/resourcemanager/Azure.ResourceManager/docs/CONTRIBUTING.md
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
+<!-- ci-touch: verify Restore-RecordingsShared.ps1 long-path fix on Windows -->


### PR DESCRIPTION
## Bug

`eng/scripts/Restore-RecordingsShared.ps1` (introduced in #59341) fails on default Windows CI agents for any package whose recordings live at a long path in `Azure/azure-sdk-assets`. The build step `Restore Recordings (shared clone)` exits with `error: unable to create file ... Filename too long` and the test job aborts before any tests run. Linux/Mac aren't affected.

PR #59341 was validated against a 20-package set that didn't include any of the deep-path RM services, so the bug slipped through. Bigger test-batching matrix runs hit it: 11/50 Windows jobs failed on #58080, 24/100 on #57904.

## Root cause

The script clones the assets repo per-package into `<pkg>/.assets` and runs `git checkout refs/tags/<tag> -- .`. The tag tree preserves the full repo layout (`net/sdk/<svc>/<pkg>/...`), and on a default Windows agent (`LongPathsEnabled=0`, no `core.longpaths` set) the resulting deep paths hit MAX_PATH (260). Test-proxy's own restore avoided this because it sparse-checks out only the package's subtree and sets `core.longpaths` itself.

## Fix (Option 3 from the bug report - both arms)

1. **`core.longpaths=true`** - applied to the shared bare clone (idempotent, runs on both fresh and reused clones), and to each per-package clone (post-clone `git config`, plus `-c core.longpaths=true` on the per-invocation `clone` and `checkout` commands so even those individual operations have it active).
2. **Sparse-checkout** the package's own subtree per package: capture `AssetsRepoPrefixPath` from `assets.json` and `DirectoryPath` from package info, normalise to `<prefix>/<dirpath>` (forward slashes, slashes trimmed, empty segments dropped), then before checkout:
   - `git -C <pkg>/.assets sparse-checkout init --cone`
   - `git -C <pkg>/.assets sparse-checkout set <prefix>/<dirpath>`
   The final checkout drops the `-- .` pathspec so HEAD detaches cleanly to the tag with sparsity applied.

Sparse-checkout is the structurally correct change (matches `test-proxy restore` semantics, ~10x less data on disk per package). `core.longpaths` is the belt-and-suspenders defence that actually unblocks deep paths.

## Verification

Local repro from the bug spec on a Windows box (with the fix):

- `Azure.ResourceManager.ServiceFabricManagedClusters` (canonical long-path package): succeeds. Deepest materialised path is **278 chars**, the file ends up on disk.
- `Azure.ResourceManager.NotificationHubs`: succeeds.
- Re-runs against an existing shared clone: succeed (idempotent `git config`).
- Sparse-checkout confirmed: only `net/sdk/<that-package>/...` is materialised under `.assets`.

I could not reproduce the actual `Filename too long` error on my dev box because Windows `LongPathsEnabled=1` is set in the registry there. Pre-fix I confirmed the materialised tree contains 30 files with paths > 260 chars (longest 317), which are exactly the files that fail the syscall on a default agent. The included README touch on `Azure.ResourceManager.ServiceFabricManagedClusters` is so CI exercises the deep-path restore on a real Windows agent and we can confirm the fix end-to-end.

## Related

- Bug introduced by: #59341
- Reproduced on test PRs: #58080 (50 pkg), #57904 (100 pkg)