### PR TITLE
[Monitor OTel] Add/expose controls for optimizing short-lived processes

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net10.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net10.0.cs
@@ -13,13 +13,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.v2_1) { }
         public string ConnectionString { get { throw null; } set { } }
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
+        public bool DisableNetworkTransmission { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
         public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
+        public bool EnableStatsbeat { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }
         public string StorageDirectory { get { throw null; } set { } }
+        public System.TimeSpan StorageTransmitInterval { get { throw null; } set { } }
         public double? TracesPerSecond { get { throw null; } set { } }
         public Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion Version { get { throw null; } set { } }
         public enum ServiceVersion
@@ -32,12 +35,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public sealed partial class AzureMonitorMetricExporter : OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
     {
         public AzureMonitorMetricExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public partial class AzureMonitorOpenTelemetryExporterContext : System.ClientModel.Primitives.ModelReaderWriterContext
     {
@@ -50,6 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorTraceExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public static partial class OpenTelemetryBuilderExtensions
     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net8.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net8.0.cs
@@ -13,13 +13,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.v2_1) { }
         public string ConnectionString { get { throw null; } set { } }
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
+        public bool DisableNetworkTransmission { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
         public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
+        public bool EnableStatsbeat { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }
         public string StorageDirectory { get { throw null; } set { } }
+        public System.TimeSpan StorageTransmitInterval { get { throw null; } set { } }
         public double? TracesPerSecond { get { throw null; } set { } }
         public Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion Version { get { throw null; } set { } }
         public enum ServiceVersion
@@ -32,12 +35,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public sealed partial class AzureMonitorMetricExporter : OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
     {
         public AzureMonitorMetricExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public partial class AzureMonitorOpenTelemetryExporterContext : System.ClientModel.Primitives.ModelReaderWriterContext
     {
@@ -50,6 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorTraceExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public static partial class OpenTelemetryBuilderExtensions
     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -13,13 +13,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.v2_1) { }
         public string ConnectionString { get { throw null; } set { } }
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
+        public bool DisableNetworkTransmission { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
         public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
+        public bool EnableStatsbeat { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }
         public string StorageDirectory { get { throw null; } set { } }
+        public System.TimeSpan StorageTransmitInterval { get { throw null; } set { } }
         public double? TracesPerSecond { get { throw null; } set { } }
         public Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion Version { get { throw null; } set { } }
         public enum ServiceVersion
@@ -32,12 +35,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorLogExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public sealed partial class AzureMonitorMetricExporter : OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
     {
         public AzureMonitorMetricExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public partial class AzureMonitorOpenTelemetryExporterContext : System.ClientModel.Primitives.ModelReaderWriterContext
     {
@@ -50,6 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorTraceExporter(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions options) { }
         protected override void Dispose(bool disposing) { }
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) { throw null; }
+        public void FlushOfflineStorage() { }
     }
     public static partial class OpenTelemetryBuilderExtensions
     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 using Azure.Core;
@@ -93,6 +94,54 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public bool DisableOfflineStorage { get; set; }
 
         /// <summary>
+        /// When enabled, the exporter persists telemetry directly to offline storage
+        /// without attempting network transmission during <c>Export()</c> calls.
+        /// </summary>
+        /// <remarks>
+        /// This is intended for short-lived processes (e.g., CLI tools) where the
+        /// latency of an HTTP round-trip on every invocation would exceed the runtime budget.
+        /// Use in combination with <see cref="AzureMonitorTraceExporter.FlushOfflineStorage"/> or an external
+        /// drain process to periodically upload the accumulated blobs.
+        /// This setting does not affect Statsbeat (SDK health telemetry); use
+        /// <see cref="EnableStatsbeat"/> to control that independently.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown during exporter construction if both this and <see cref="DisableOfflineStorage"/>
+        /// are set to <c>true</c>, as there would be no destination for telemetry.
+        /// </exception>
+        public bool DisableNetworkTransmission { get; set; }
+
+        /// <summary>
+        /// The interval at which accumulated offline storage blobs are retransmitted.
+        /// Default is 120 seconds. Set to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
+        /// to disable automatic retransmission (manual control via <see cref="AzureMonitorTraceExporter.FlushOfflineStorage"/>).
+        /// </summary>
+        /// <remarks>
+        /// Has no effect if <see cref="DisableOfflineStorage"/> is <c>true</c>.
+        /// Must be a positive value or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
+        /// </remarks>
+        public TimeSpan StorageTransmitInterval
+        {
+            get => _storageTransmitInterval;
+            set
+            {
+                if (value != System.Threading.Timeout.InfiniteTimeSpan && value <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "StorageTransmitInterval must be a positive value or Timeout.InfiniteTimeSpan.");
+                }
+
+                if (value.TotalMilliseconds > int.MaxValue)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "StorageTransmitInterval must not exceed Int32.MaxValue milliseconds.");
+                }
+
+                _storageTransmitInterval = value;
+            }
+        }
+
+        private TimeSpan _storageTransmitInterval = TimeSpan.FromSeconds(120);
+
+        /// <summary>
         /// Enables or disables the Live Metrics feature. This property is enabled by default.
         /// Note: Enabling Live Metrics incurs no additional billing or costs. However, it does introduce
         /// a performance overhead due to extra data collection, processing, and networking calls. This overhead
@@ -116,9 +165,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public bool EnableTraceBasedLogsSampler { get; set; } = true;
 
         /// <summary>
-        /// Internal flag to control if Statsbeat is enabled.
+        /// Gets or sets a value indicating whether Statsbeat (SDK health telemetry
+        /// and environment detection via IMDS metadata probes) is enabled.
+        /// Default is <c>true</c>.
         /// </summary>
-        internal bool EnableStatsbeat { get; set; } = true;
+        /// <remarks>
+        /// When disabled, no IMDS metadata probes or SDK usage metrics are sent.
+        /// Can also be disabled via the <c>APPLICATIONINSIGHTS_STATSBEAT_DISABLED</c>
+        /// environment variable.
+        /// For short-lived CLI processes, disabling this avoids a 150-200ms IMDS probe
+        /// on each invocation.
+        /// </remarks>
+        public bool EnableStatsbeat { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether standard metrics should be collected.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -61,6 +61,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return exportResult;
         }
 
+        /// <summary>
+        /// Immediately attempts to transmit any telemetry accumulated in offline storage.
+        /// This is intended for use with <see cref="AzureMonitorExporterOptions.DisableNetworkTransmission"/>
+        /// where the caller controls when network uploads occur.
+        /// </summary>
+        public void FlushOfflineStorage()
+        {
+            _transmitter.FlushOfflineStorage();
+        }
+
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -70,6 +70,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return exportResult;
         }
 
+        /// <summary>
+        /// Immediately attempts to transmit any telemetry accumulated in offline storage.
+        /// This is intended for use with <see cref="AzureMonitorExporterOptions.DisableNetworkTransmission"/>
+        /// where the caller controls when network uploads occur.
+        /// </summary>
+        public void FlushOfflineStorage()
+        {
+            _transmitter.FlushOfflineStorage();
+        }
+
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -63,6 +63,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return exportResult;
         }
 
+        /// <summary>
+        /// Immediately attempts to transmit any telemetry accumulated in offline storage.
+        /// This is intended for use with <see cref="AzureMonitorExporterOptions.DisableNetworkTransmission"/>
+        /// where the caller controls when network uploads occur.
+        /// </summary>
+        public void FlushOfflineStorage()
+        {
+            _transmitter.FlushOfflineStorage();
+        }
+
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -32,6 +32,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal readonly TransmissionStateManager _transmissionStateManager;
         internal readonly TransmitFromStorageHandler? _transmitFromStorageHandler;
         private readonly bool _isAadEnabled;
+        private readonly bool _disableNetworkTransmission;
         private bool _disposed;
 
         public AzureMonitorTransmitter(AzureMonitorExporterOptions options, IPlatform platform)
@@ -41,9 +42,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 throw new ArgumentNullException(nameof(options));
             }
 
+            if (options.DisableNetworkTransmission && options.DisableOfflineStorage)
+            {
+                throw new InvalidOperationException("DisableNetworkTransmission and DisableOfflineStorage cannot both be true. Telemetry would have no destination.");
+            }
+
             options.Retry.MaxRetries = 0;
 
             _connectionVars = InitializeConnectionVars(options, platform);
+            _disableNetworkTransmission = options.DisableNetworkTransmission;
 
             _transmissionStateManager = new TransmissionStateManager();
 
@@ -53,7 +60,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             if (_fileBlobProvider != null)
             {
-                _transmitFromStorageHandler = new TransmitFromStorageHandler(_applicationInsightsRestClient, _fileBlobProvider, _transmissionStateManager, _connectionVars, _isAadEnabled);
+                var interval = _disableNetworkTransmission
+                    ? System.Threading.Timeout.InfiniteTimeSpan
+                    : options.StorageTransmitInterval;
+                _transmitFromStorageHandler = new TransmitFromStorageHandler(_applicationInsightsRestClient, _fileBlobProvider, _transmissionStateManager, _connectionVars, _isAadEnabled, interval);
             }
 
             _statsbeat = InitializeStatsbeat(options, _connectionVars, platform);
@@ -159,6 +169,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         public string InstrumentationKey => _connectionVars.InstrumentationKey;
 
+        /// <inheritdoc/>
+        public void FlushOfflineStorage()
+        {
+            _transmitFromStorageHandler?.DrainAll();
+        }
+
         public async ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, TelemetrySchemaTypeCounter telemetrySchemaTypeCounter, TelemetryItemOrigin origin, bool async, CancellationToken cancellationToken)
         {
             ExportResult result = ExportResult.Failure;
@@ -169,6 +185,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             try
             {
+                // In offline-only mode, bypass network entirely and persist to disk.
+                if (_disableNetworkTransmission)
+                {
+                    if (_fileBlobProvider != null)
+                    {
+                        byte[] requestContent = HttpPipelineHelper.GetSerializedContent(telemetryItems);
+                        result = _fileBlobProvider.SaveTelemetry(requestContent);
+                    }
+
+                    return result;
+                }
+
                 if (_transmissionStateManager.State == TransmissionState.Closed)
                 {
                     using var httpMessage = async ?

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ITransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ITransmitter.cs
@@ -20,6 +20,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// </summary>
         ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, TelemetrySchemaTypeCounter telemetrySchemaTypeCounter, TelemetryItemOrigin origin, bool async, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Immediately transmits any telemetry accumulated in offline storage.
+        /// </summary>
+        void FlushOfflineStorage();
+
         string InstrumentationKey { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -23,7 +23,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private readonly bool _isAadEnabled;
         private bool _disposed;
 
-        internal TransmitFromStorageHandler(ApplicationInsightsRestClient applicationInsightsRestClient, PersistentBlobProvider blobProvider, TransmissionStateManager transmissionStateManager, ConnectionVars connectionVars, bool isAadEnabled)
+        internal TransmitFromStorageHandler(ApplicationInsightsRestClient applicationInsightsRestClient, PersistentBlobProvider blobProvider, TransmissionStateManager transmissionStateManager, ConnectionVars connectionVars, bool isAadEnabled, TimeSpan? transmitInterval = null)
         {
             _applicationInsightsRestClient = applicationInsightsRestClient;
             _connectionVars = connectionVars;
@@ -33,9 +33,83 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             _transmitFromStorageTimer = new System.Timers.Timer();
             _transmitFromStorageTimer.Elapsed += TransmitFromStorage;
             _transmitFromStorageTimer.AutoReset = true;
-            _transmitFromStorageTimer.Interval = 120000;
-            _transmitFromStorageTimer.Start();
-            _isAadEnabled = isAadEnabled;
+
+            var interval = transmitInterval ?? TimeSpan.FromSeconds(120);
+            if (interval != System.Threading.Timeout.InfiniteTimeSpan)
+            {
+                _transmitFromStorageTimer.Interval = interval.TotalMilliseconds;
+                _transmitFromStorageTimer.Start();
+            }
+        }
+
+        /// <summary>
+        /// Drains all accumulated blobs from offline storage. Unlike <see cref="TransmitFromStorage"/>
+        /// which caps at 10 files per tick, this method loops until all blobs are uploaded
+        /// or a transmission failure occurs.
+        /// </summary>
+        internal void DrainAll()
+        {
+            while (true)
+            {
+                if (_transmissionStateManager.State != TransmissionState.Closed)
+                {
+                    break;
+                }
+
+                if (!_blobProvider.TryGetBlob(out var blob) || !blob.TryLease(120000))
+                {
+                    break;
+                }
+
+                TelemetrySchemaTypeCounter? telemetrySchemaTypeCounter = new TelemetrySchemaTypeCounter();
+
+                try
+                {
+                    blob.TryRead(out var data);
+
+                    if (data == null)
+                    {
+                        // Unreadable blob — delete it to avoid spinning on the same blob forever.
+                        blob.TryDelete();
+                        continue;
+                    }
+
+                    try
+                    {
+                        var telemetryItems = Encoding.UTF8.GetString(data).Split('\n');
+                        for (int i = 0; i < telemetryItems.Length; i++)
+                        {
+                            var telemetryType = HttpPipelineHelper.GetTelemetryTypeFromJson(telemetryItems[i]);
+                            HttpPipelineHelper.IncrementCounterByType(telemetrySchemaTypeCounter, telemetryType);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // Best-effort counter population; proceed with transmission regardless.
+                    }
+
+                    using var httpMessage = _applicationInsightsRestClient.InternalTrackAsync(data, CancellationToken.None).Result;
+                    var result = HttpPipelineHelper.IsSuccess(httpMessage, telemetrySchemaTypeCounter);
+
+                    if (result == ExportResult.Success)
+                    {
+                        _transmissionStateManager.ResetConsecutiveErrors();
+                        _transmissionStateManager.CloseTransmission();
+                        blob.TryDelete();
+                    }
+                    else
+                    {
+                        _transmissionStateManager.EnableBackOff(httpMessage.HasResponse ? httpMessage.Response : null);
+                        HttpPipelineHelper.ProcessTransmissionResult(httpMessage, _blobProvider, blob, _connectionVars, TelemetryItemOrigin.Storage, _isAadEnabled, telemetrySchemaTypeCounter);
+                        break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    AzureMonitorExporterEventSource.Log.FailedToTransmitFromStorage(_isAadEnabled, _connectionVars.InstrumentationKey, ex);
+                    break;
+                }
+            }
         }
 
         internal void TransmitFromStorage(object? sender, ElapsedEventArgs? e)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
@@ -43,6 +43,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             throw new System.NotImplementedException();
         }
 
+        public void FlushOfflineStorage()
+        {
+        }
+
         public void Dispose()
         {
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineOnlyModeTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineOnlyModeTests.cs
@@ -1,0 +1,360 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+using OpenTelemetry;
+using OpenTelemetry.PersistentStorage.Abstractions;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public class OfflineOnlyModeTests
+    {
+        private static readonly ActivitySource activitySource = new ActivitySource("OTel.OfflineOnlyMode");
+
+        private const string testIkey = "test_ikey";
+        private const string testEndpoint = "http://localhost:5050";
+
+        static OfflineOnlyModeTests()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+            };
+
+            ActivitySource.AddActivityListener(listener);
+        }
+
+        [Fact]
+        public void OfflineOnlyMode_PersistsToStorageWithoutNetwork()
+        {
+            // Arrange: configure offline-only mode — network is bypassed entirely
+            using var activity = CreateActivity("TestActivity");
+            var telemetryItem = CreateTelemetryItem(activity);
+            var telemetryItems = new List<TelemetryItem> { telemetryItem };
+
+            using var transmitter = GetTransmitter(enableOfflineOnlyMode: true);
+            var telemetrySchemaTypeCounter = new TelemetrySchemaTypeCounter();
+
+            // Act
+            var result = transmitter.TrackAsync(telemetryItems, telemetrySchemaTypeCounter, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
+
+            // Assert: telemetry was saved to offline storage (not sent via network)
+            Assert.Equal(ExportResult.Success, result);
+            Assert.NotNull(transmitter._fileBlobProvider);
+            Assert.Single(transmitter._fileBlobProvider.GetBlobs());
+        }
+
+        [Fact]
+        public void OfflineOnlyMode_DoesNotAttemptNetworkTransmission()
+        {
+            // Arrange: use offline-only mode — even with a transport configured,
+            // no network call should be made. We verify this by checking that
+            // TransmissionState remains Closed (not set to Open from a failure).
+            using var activity = CreateActivity("TestActivity");
+            var telemetryItem = CreateTelemetryItem(activity);
+            var telemetryItems = new List<TelemetryItem> { telemetryItem };
+
+            // Configure with a transport that returns 500 — if network were called,
+            // transmission state would go to Open.
+            var mockTransport = new MockTransport(new MockResponse(500).SetContent("Error"));
+            using var transmitter = GetTransmitter(enableOfflineOnlyMode: true, transport: mockTransport);
+            var telemetrySchemaTypeCounter = new TelemetrySchemaTypeCounter();
+
+            // Act
+            transmitter.TrackAsync(telemetryItems, telemetrySchemaTypeCounter, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
+
+            // Assert: transmission state is still Closed (network was never called)
+            Assert.Equal(TransmissionState.Closed, transmitter._transmissionStateManager.State);
+            // And telemetry was persisted
+            Assert.NotNull(transmitter._fileBlobProvider);
+            Assert.Single(transmitter._fileBlobProvider.GetBlobs());
+        }
+
+        [Fact]
+        public void OfflineOnlyMode_MultipleTelemetryItemsAllPersisted()
+        {
+            // Arrange
+            using var activity1 = CreateActivity("Activity1");
+            using var activity2 = CreateActivity("Activity2");
+            using var activity3 = CreateActivity("Activity3");
+            var telemetryItems = new List<TelemetryItem>
+            {
+                CreateTelemetryItem(activity1),
+                CreateTelemetryItem(activity2),
+                CreateTelemetryItem(activity3),
+            };
+
+            using var transmitter = GetTransmitter(enableOfflineOnlyMode: true);
+            var telemetrySchemaTypeCounter = new TelemetrySchemaTypeCounter();
+
+            // Act
+            var result = transmitter.TrackAsync(telemetryItems, telemetrySchemaTypeCounter, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
+
+            // Assert: all items persisted in a single blob
+            Assert.Equal(ExportResult.Success, result);
+            Assert.NotNull(transmitter._fileBlobProvider);
+            Assert.Single(transmitter._fileBlobProvider.GetBlobs());
+        }
+
+        [Fact]
+        public void OfflineOnlyMode_ThrowsWhenStorageDisabled()
+        {
+            // Arrange & Act & Assert: cannot have both disabled — no destination for telemetry
+            Assert.Throws<InvalidOperationException>(() =>
+                GetTransmitter(enableOfflineOnlyMode: true, disableStorage: true));
+        }
+
+        [Fact]
+        public void FlushOfflineStorage_UploadsPersistedTelemetry()
+        {
+            // Arrange: simulate a failed transmission that persists to storage,
+            // then flush it via DrainAll with a successful response configured.
+            using var activity = CreateActivity("TestActivity");
+            var telemetryItem = CreateTelemetryItem(activity);
+            var telemetryItems = new List<TelemetryItem> { telemetryItem };
+
+            var mockResponseSuccess = new MockResponse(200).SetContent("{\"itemsReceived\": 1,\"itemsAccepted\": 1,\"errors\":[]}");
+            var transmitter = GetTransmitter(enableOfflineOnlyMode: false, mockResponses: mockResponseSuccess);
+            var telemetrySchemaTypeCounter = new TelemetrySchemaTypeCounter();
+
+            // First, simulate a failed transmission that persists to storage
+            transmitter._transmissionStateManager.OpenTransmission();
+            transmitter.TrackAsync(telemetryItems, telemetrySchemaTypeCounter, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
+
+            Assert.NotNull(transmitter._fileBlobProvider);
+            Assert.Single(transmitter._fileBlobProvider.GetBlobs());
+
+            // Reset state so flush can succeed
+            transmitter._transmissionStateManager.ResetConsecutiveErrors();
+            transmitter._transmissionStateManager.CloseTransmission();
+
+            // Act: call FlushOfflineStorage
+            transmitter.FlushOfflineStorage();
+
+            // Assert: blob was uploaded and deleted
+            Assert.Empty(transmitter._fileBlobProvider.GetBlobs());
+
+            transmitter.Dispose();
+        }
+
+        [Fact]
+        public void FlushOfflineStorage_NoOpWhenNoStorageHandler()
+        {
+            // Arrange: transmitter with no storage handler (DisableOfflineStorage=true)
+            var options = new AzureMonitorExporterOptions
+            {
+                ConnectionString = $"InstrumentationKey={testIkey};IngestionEndpoint={testEndpoint}",
+                DisableOfflineStorage = true,
+                EnableStatsbeat = false,
+            };
+
+            var transmitter = new AzureMonitorTransmitter(options, new MockPlatform());
+
+            // Act & Assert: should not throw
+            transmitter.FlushOfflineStorage();
+
+            transmitter.Dispose();
+        }
+
+        [Fact]
+        public void StorageTransmitInterval_DisablesTimerWithInfiniteTimeSpan()
+        {
+            // Arrange
+            var options = new AzureMonitorExporterOptions
+            {
+                ConnectionString = $"InstrumentationKey={testIkey};IngestionEndpoint={testEndpoint}",
+                StorageDirectory = "C:\\test",
+                StorageTransmitInterval = Timeout.InfiniteTimeSpan,
+                EnableStatsbeat = false,
+            };
+
+            var transmitter = new AzureMonitorTransmitter(options, new MockPlatform());
+
+            // Overwrite with mock storage
+            transmitter._fileBlobProvider = new MockFileProvider();
+            if (transmitter._transmitFromStorageHandler != null)
+            {
+                transmitter._transmitFromStorageHandler._blobProvider = transmitter._fileBlobProvider;
+            }
+
+            // Assert: transmitter was created successfully and handler exists
+            // (timer just won't fire automatically)
+            Assert.NotNull(transmitter._transmitFromStorageHandler);
+
+            transmitter.Dispose();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-2)]
+        [InlineData(-5000)]
+        public void StorageTransmitInterval_ThrowsOnInvalidValues(int milliseconds)
+        {
+            var options = new AzureMonitorExporterOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                options.StorageTransmitInterval = TimeSpan.FromMilliseconds(milliseconds));
+        }
+
+        [Fact]
+        public void StorageTransmitInterval_ThrowsOnExcessiveValues()
+        {
+            var options = new AzureMonitorExporterOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                options.StorageTransmitInterval = TimeSpan.MaxValue);
+        }
+
+        private static AzureMonitorTransmitter GetTransmitter(
+            bool enableOfflineOnlyMode = false,
+            bool disableStorage = false,
+            MockTransport? transport = null,
+            params MockResponse[] mockResponses)
+        {
+            MockTransport? mockTransport = transport;
+            if (mockTransport == null && mockResponses.Length > 0)
+            {
+                mockTransport = new MockTransport(mockResponses);
+            }
+
+            var options = new AzureMonitorExporterOptions
+            {
+                ConnectionString = $"InstrumentationKey={testIkey};IngestionEndpoint={testEndpoint}",
+                StorageDirectory = disableStorage ? null : "C:\\test",
+                DisableOfflineStorage = disableStorage,
+                DisableNetworkTransmission = enableOfflineOnlyMode,
+                EnableStatsbeat = false,
+            };
+
+            if (mockTransport != null)
+            {
+                options.Transport = mockTransport;
+            }
+
+            var transmitter = new AzureMonitorTransmitter(options, new MockPlatform());
+
+            if (!disableStorage)
+            {
+                // Overwrite storage with mock
+                transmitter._fileBlobProvider = new MockFileProvider();
+                if (transmitter._transmitFromStorageHandler != null)
+                {
+                    transmitter._transmitFromStorageHandler._blobProvider = transmitter._fileBlobProvider;
+                }
+            }
+
+            return transmitter;
+        }
+
+        private static Activity CreateActivity(string activityName)
+        {
+            var activity = activitySource.StartActivity(
+                activityName,
+                ActivityKind.Client,
+                parentContext: default,
+                startTime: DateTime.UtcNow);
+
+            Assert.NotNull(activity);
+            return activity;
+        }
+
+        private static TelemetryItem CreateTelemetryItem(Activity activity)
+        {
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            return new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty, 1.0f);
+        }
+
+        private class MockFileProvider : PersistentBlobProvider
+        {
+            private readonly List<PersistentBlob> _mockStorage = new();
+
+            protected override IEnumerable<PersistentBlob> OnGetBlobs()
+            {
+                return this._mockStorage.AsEnumerable();
+            }
+
+            protected override bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out PersistentBlob blob)
+            {
+                blob = new MockFileBlob(_mockStorage);
+                return blob.TryWrite(buffer);
+            }
+
+            protected override bool OnTryCreateBlob(byte[] buffer, out PersistentBlob blob)
+            {
+                blob = new MockFileBlob(_mockStorage);
+                return blob.TryWrite(buffer);
+            }
+
+            protected override bool OnTryGetBlob(out PersistentBlob blob)
+            {
+                if (_mockStorage.Any())
+                {
+                    blob = _mockStorage.First();
+                    return true;
+                }
+
+                blob = null!;
+                return false;
+            }
+        }
+
+        private class MockFileBlob : PersistentBlob
+        {
+            private byte[] _buffer = Array.Empty<byte>();
+            private readonly List<PersistentBlob> _mockStorage;
+
+            public MockFileBlob(List<PersistentBlob> mockStorage)
+            {
+                _mockStorage = mockStorage;
+            }
+
+            protected override bool OnTryRead(out byte[] buffer)
+            {
+                buffer = this._buffer;
+                return true;
+            }
+
+            protected override bool OnTryWrite(byte[] buffer, int leasePeriodMilliseconds = 0)
+            {
+                this._buffer = buffer;
+                _mockStorage.Add(this);
+                return true;
+            }
+
+            protected override bool OnTryLease(int leasePeriodMilliseconds)
+            {
+                return true;
+            }
+
+            protected override bool OnTryDelete()
+            {
+                try
+                {
+                    _mockStorage.Remove(this);
+                }
+                catch
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Short-lived processes (CLI tools, build scripts) can have a very different invocation pattern from typical services, which requires some differences in handling. Notably, what may be acceptable overhead for a long-running cloud service may double or more the runtime of local app, particularly if the app is run many times as part of a larger pipeline.

The current design requires a network round-trip on every Export() call, adding 300-500ms of latency that is unacceptable for tools where total invocation time must stay under 50ms. Those tools can batch telemetry to keep the amorized time low, but to do so with the A.M.OT.E tooling requires that we expose tighter control over the network transmission and file storage mechanisms.

This change adds:

1. DisableNetworkTransmission option: bypasses network transmission entirely, persisting telemetry directly to offline storage via the existing PersistentBlobProvider. No HTTP connections are made during Export(). Throws InvalidOperationException if combined with DisableOfflineStorage (no destination for telemetry).

2. FlushOfflineStorage() method on all three exporters: drains all accumulated blobs from offline storage. Unlike the internal timer which processes 10 files per tick, this method loops until all blobs are uploaded or a failure occurs.

3. StorageTransmitInterval option: makes the internal 120s retransmit timer configurable. Set to Timeout.InfiniteTimeSpan for fully manual control via FlushOfflineStorage(). Validates that value is positive.

4. EnableStatsbeat promoted from internal to public: gives users explicit control over IMDS metadata probes and SDK health metrics without relying on environment variables. Documented that disabling avoids 150-200ms IMDS probe per invocation for CLI scenarios.

In DisableNetworkTransmission mode, the automatic retransmit timer is disabled (set to InfiniteTimeSpan) so no background network activity occurs from the telemetry pipeline. The caller is responsible for periodically calling FlushOfflineStorage(). Statsbeat is controlled independently via EnableStatsbeat.

Fixes #59397

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
