### PR TITLE
Fix culture-sensitive timeout formatting in Azure.Core and System.ClientModel

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -174,7 +175,7 @@ namespace Azure.Core.Pipeline
                 throw CancellationHelper.CreateOperationCanceledException(
                     inner,
                     timeoutToken,
-                    $"The operation was cancelled because it exceeded the configured timeout of {timeout:g}. " +
+                    $"The operation was cancelled because it exceeded the configured timeout of {timeout.ToString("g", CultureInfo.InvariantCulture)}. " +
                     $"Network timeout can be adjusted in {nameof(ClientOptions)}.{nameof(ClientOptions.Retry)}.{nameof(RetryOptions.NetworkTimeout)}.");
             }
         }

--- a/sdk/core/System.ClientModel/src/Internal/CancellationHelper.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CancellationHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ClientModel.Primitives;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -67,7 +68,7 @@ internal static class CancellationHelper
             throw CreateOperationCanceledException(
                 innerException,
                 timeoutToken,
-                $"The operation was cancelled because it exceeded the configured timeout of {timeout:g}. " +
+                $"The operation was cancelled because it exceeded the configured timeout of {timeout.ToString("g", CultureInfo.InvariantCulture)}. " +
                     $"The default timeout can be adjusted by passing a custom {nameof(ClientPipelineOptions)}.{nameof(ClientPipelineOptions.NetworkTimeout)} value to the client's constructor. See https://aka.ms/net/scm/configure/networktimeout for more information.");
         }
     }


### PR DESCRIPTION
## Description

Fixes #58678

`TimeSpan` formatted with `{timeout:g}` is culture-sensitive,  on locales like `l-NL` the decimal separator is `,` producing errors