### PR TITLE
feat(EventHubs WebJobs): expose Identifier on EventHubOptions

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Exposed `Identifier` on `EventHubOptions` as a pass-through to `EventProcessorOptions.Identifier`. Hosts (e.g. Azure Functions) can now supply a stable per-instance identifier so the processor enters recovery mode immediately on restart instead of waiting for `PartitionOwnershipExpirationInterval` to elapse. ([#52057](https://github.com/Azure/azure-sdk-for-net/issues/52057))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.net10.0.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.net10.0.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         public Azure.Messaging.EventHubs.EventHubsRetryOptions ClientRetryOptions { get { throw null; } set { } }
         public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public bool EnableCheckpointing { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
         public Microsoft.Azure.WebJobs.EventHubs.InitialOffsetOptions InitialOffsetOptions { get { throw null; } }
         public System.TimeSpan LoadBalancingUpdateInterval { get { throw null; } set { } }
         public int MaxEventBatchSize { get { throw null; } set { } }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.net8.0.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.net8.0.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         public Azure.Messaging.EventHubs.EventHubsRetryOptions ClientRetryOptions { get { throw null; } set { } }
         public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public bool EnableCheckpointing { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
         public Microsoft.Azure.WebJobs.EventHubs.InitialOffsetOptions InitialOffsetOptions { get { throw null; } }
         public System.TimeSpan LoadBalancingUpdateInterval { get { throw null; } set { } }
         public int MaxEventBatchSize { get { throw null; } set { } }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.netstandard2.0.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         public Azure.Messaging.EventHubs.EventHubsRetryOptions ClientRetryOptions { get { throw null; } set { } }
         public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public bool EnableCheckpointing { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
         public Microsoft.Azure.WebJobs.EventHubs.InitialOffsetOptions InitialOffsetOptions { get { throw null; } }
         public System.TimeSpan LoadBalancingUpdateInterval { get { throw null; } set { } }
         public int MaxEventBatchSize { get { throw null; } set { } }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
@@ -265,6 +265,13 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             set => EventProcessorOptions.LoadBalancingUpdateInterval = value;
         }
 
+        /// <inheritdoc cref="EventProcessorOptions.Identifier"/>
+        public string Identifier
+        {
+            get => EventProcessorOptions.Identifier;
+            set => EventProcessorOptions.Identifier = value;
+        }
+
         /// <summary>
         /// Gets or sets the Azure Blobs container name that the event processor uses to coordinate load balancing listening on an event hub.
         /// </summary>
@@ -293,6 +300,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                     { nameof(PrefetchSizeInBytes), PrefetchSizeInBytes },
                     { nameof(PartitionOwnershipExpirationInterval), PartitionOwnershipExpirationInterval },
                     { nameof(LoadBalancingUpdateInterval), LoadBalancingUpdateInterval },
+                    { nameof(Identifier), Identifier },
                     { nameof(InitialOffsetOptions), ConstructInitialOffsetOptions() },
                     { nameof(EnableCheckpointing), EnableCheckpointing },
                 };

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubConfigurationTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubConfigurationTests.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(5, options.BatchCheckpointFrequency);
             Assert.AreEqual(31, options.EventProcessorOptions.PartitionOwnershipExpirationInterval.TotalSeconds);
             Assert.AreEqual(21, options.EventProcessorOptions.LoadBalancingUpdateInterval.TotalSeconds);
+            Assert.AreEqual("test-host-instance", options.Identifier);
+            Assert.AreEqual("test-host-instance", options.EventProcessorOptions.Identifier);
             Assert.AreEqual("FromEnqueuedTime", options.InitialOffsetOptions.Type.ToString());
             Assert.AreEqual("2020-09-13 12:00:00Z", options.InitialOffsetOptions.EnqueuedTimeUtc.Value.ToString("u"));
             Assert.AreEqual(5, options.ClientRetryOptions.MaximumRetries);
@@ -97,6 +99,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(123, result.PrefetchCount);
             Assert.AreEqual(TimeSpan.FromSeconds(31), result.PartitionOwnershipExpirationInterval);
             Assert.AreEqual(TimeSpan.FromSeconds(21), result.LoadBalancingUpdateInterval);
+            Assert.AreEqual("test-host-instance", result.Identifier);
             Assert.AreEqual("FromEnqueuedTime", result.InitialOffsetOptions.Type.ToString());
             Assert.AreEqual("2020-09-13 12:00:00Z", result.InitialOffsetOptions.EnqueuedTimeUtc.Value.ToString("u"));
             Assert.AreEqual(5, result.ClientRetryOptions.MaximumRetries);
@@ -272,6 +275,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 { $"{extensionPath}:BatchCheckpointFrequency", "5" },
                 { $"{extensionPath}:PartitionOwnershipExpirationInterval", "00:00:31" },
                 { $"{extensionPath}:LoadBalancingUpdateInterval", "00:00:21" },
+                { $"{extensionPath}:Identifier", "test-host-instance" },
                 { $"{extensionPath}:LoadBalancingStrategy", "greedy" },
                 { $"{extensionPath}:InitialOffsetOptions:Type", "FromEnqueuedTime" },
                 { $"{extensionPath}:InitialOffsetOptions:EnqueuedTimeUTC", "2020-09-13 12:00:00Z" },

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubConfigurationTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubConfigurationTests.cs
@@ -63,8 +63,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(5, options.BatchCheckpointFrequency);
             Assert.AreEqual(31, options.EventProcessorOptions.PartitionOwnershipExpirationInterval.TotalSeconds);
             Assert.AreEqual(21, options.EventProcessorOptions.LoadBalancingUpdateInterval.TotalSeconds);
-            Assert.AreEqual("test-host-instance", options.Identifier);
-            Assert.AreEqual("test-host-instance", options.EventProcessorOptions.Identifier);
+            Assert.AreEqual("webjobs-test-instance", options.Identifier);
+            Assert.AreEqual("webjobs-test-instance", options.EventProcessorOptions.Identifier);
             Assert.AreEqual("FromEnqueuedTime", options.InitialOffsetOptions.Type.ToString());
             Assert.AreEqual("2020-09-13 12:00:00Z", options.InitialOffsetOptions.EnqueuedTimeUtc.Value.ToString("u"));
             Assert.AreEqual(5, options.ClientRetryOptions.MaximumRetries);
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(123, result.PrefetchCount);
             Assert.AreEqual(TimeSpan.FromSeconds(31), result.PartitionOwnershipExpirationInterval);
             Assert.AreEqual(TimeSpan.FromSeconds(21), result.LoadBalancingUpdateInterval);
-            Assert.AreEqual("test-host-instance", result.Identifier);
+            Assert.AreEqual("webjobs-test-instance", result.Identifier);
             Assert.AreEqual("FromEnqueuedTime", result.InitialOffsetOptions.Type.ToString());
             Assert.AreEqual("2020-09-13 12:00:00Z", result.InitialOffsetOptions.EnqueuedTimeUtc.Value.ToString("u"));
             Assert.AreEqual(5, result.ClientRetryOptions.MaximumRetries);
@@ -275,7 +275,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 { $"{extensionPath}:BatchCheckpointFrequency", "5" },
                 { $"{extensionPath}:PartitionOwnershipExpirationInterval", "00:00:31" },
                 { $"{extensionPath}:LoadBalancingUpdateInterval", "00:00:21" },
-                { $"{extensionPath}:Identifier", "test-host-instance" },
+                { $"{extensionPath}:Identifier", "webjobs-test-instance" },
                 { $"{extensionPath}:LoadBalancingStrategy", "greedy" },
                 { $"{extensionPath}:InitialOffsetOptions:Type", "FromEnqueuedTime" },
                 { $"{extensionPath}:InitialOffsetOptions:EnqueuedTimeUTC", "2020-09-13 12:00:00Z" },


### PR DESCRIPTION
## Summary

The WebJobs/Functions Event Hubs trigger options do not expose `EventProcessorOptions.Identifier`, the unique name an Event Hubs processor uses to claim partition ownership. Today the SDK auto-generates a fresh `Guid` for this identifier each time the process starts, and there is no public knob for a host (most importantly the Azure Functions host) to set it explicitly.

Ownership semantics make this identifier load-bearing. An Event Hubs **partition** is one of N parallel streams of events on an Event Hub. When multiple workers (for example, the nodes of a Function App on a dedicated plan) read from the same Event Hub, they cooperate by writing **ownership records** to a checkpoint store (an Azure Blob Storage container). A record states, in effect, that worker `X` owns partition `3` as of timestamp `T`. Each ownership record carries the worker's **identifier**, which today is a `Guid` generated by the SDK when the processor starts up.

Periodically each worker scans those ownership records. A partition is treated as abandoned when no one has refreshed the partition's ownership record within `PartitionOwnershipExpirationInterval` (default: 2 minutes). Only after that interval has elapsed will another worker steal the partition.

## Motivation

When a Function App node restarts (graceful redeploy, portal-triggered restart, node migration, or a crash), the new process inside that node starts a fresh processor with a freshly generated `Guid`. From the checkpoint store's perspective, "worker `abc-123` owned partition `3`" and "worker `def-456` just started" are two unrelated workers. The new process has no way to signal that it is the same logical owner as before. It sees an unexpired ownership record, assumes the prior owner is still alive, and waits.

The new process therefore waits roughly `PartitionOwnershipExpirationInterval` (2 minutes, by default) before any partition becomes claimable. During that window the Function App consumes nothing from those partitions. This matches the symptom reported in #52057.

A **stable** identifier, one that is the same string for a given logical worker across restarts, lets the new process recognize its own prior ownership record on startup and resume processing immediately.

## Changes

Adds a new public property, `EventHubOptions.Identifier`, on the WebJobs/Functions Event Hubs trigger options. The property is a pass-through to `Azure.Messaging.EventHubs.Primitives.EventProcessorOptions.Identifier`. A host that runs the trigger can now set this name explicitly instead of letting the SDK auto-generate a fresh `Guid` each time the process starts.

This is the SDK-level knob only. It does not by itself fix the customer-facing symptom; it makes the fix possible from the host.

- `src/Config/EventHubOptions.cs`: a new public `Identifier { get; set; }` property that reads/writes `EventProcessorOptions.Identifier`. Same shape as the other pass-through properties already on this class (`PrefetchCount`, `PartitionOwnershipExpirationInterval`, etc.).
- `EventHubOptions.Format()`: the new property is included in the formatted output, so it round-trips through the `IOptionsFormatter` logging pipeline like every other option on this class.
- API reference snapshots updated for `net8.0`, `net10.0`, and `netstandard2.0`. These files are the public-surface contract the SDK build verifies against; any new public member has to appear here too.
- `tests/EventHubConfigurationTests.cs`: extended to set `Identifier` from configuration and assert it round-trips through `Format()`.
- `CHANGELOG.md`: entry under `6.6.0-beta.1 -> Features Added` linking to #52057.

When a host (or a self-hosted app) sets `Identifier` to a string that is stable across restarts of the same logical instance, the existing recovery logic in the SDK resumes processing immediately. When nothing sets it, behavior is identical to today: the SDK auto-generates a `Guid` each time, exactly as before this PR.

The Azure Functions host still needs to pick a stable per-instance value (a natural candidate is the `WEBSITE_INSTANCE_ID` environment variable, or a value derived from slot + site + function name) and pass it through `EventHubOptions.Identifier` when it configures the trigger. That work is tracked in Azure/azure-functions-host#11788 and is intentionally out of scope for this PR.

## Test plan

- [x] `dotnet build` of `Microsoft.Azure.WebJobs.Extensions.EventHubs.sln` succeeds with no warnings.
- [x] `dotnet test` on `EventHubConfigurationTests` passes locally on net10.0 (22/22).
- [x] CI matrix green across macOS, Ubuntu, and Windows test cells covering net462, net8.0, net9.0, and net10.0.

Refs #52057.