### PR TITLE
Fix blueprint_id attribute key to microsoft.a365.agent.blueprint.id

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Added Agent365 tracing export support with managed identity token acquisition when `FOUNDRY_AGENT365_TRACING_ENABLED` is set.
 - Added `AgentInstanceClientId`, `AgentBlueprintClientId`, `AgentTenantId`, and `IsAgent365TracingEnabled` properties to `FoundryEnvironment`.
-- Added `FoundryEnrichmentProcessor` attributes: `gen_ai.agent.blueprint.id`, `microsoft.tenant.id`, and `microsoft.foundry.agent.type` on telemetry spans.
+- Added `FoundryEnrichmentProcessor` attributes: `microsoft.a365.agent.blueprint.id`, `microsoft.tenant.id`, and `microsoft.foundry.agent.type` on telemetry spans.
 - Added `W3CBaggagePropagator` middleware that parses the W3C `baggage` header into `Activity.Baggage` on all target frameworks (net8.0, net9.0, net10.0).
 - Configured W3C Trace Context and Baggage propagators via `Sdk.SetDefaultTextMapPropagator` for outgoing request propagation.
 - Added conditional exporter registration: Azure Monitor, OTLP, and Agent365 exporters activate only when their respective environment variables are set.

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Platform/FoundryEnvironment.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Platform/FoundryEnvironment.cs
@@ -97,7 +97,7 @@ public static class FoundryEnvironment
     /// <summary>
     /// The managed identity client ID of the agent blueprint.
     /// Sourced from the <c>FOUNDRY_AGENT_BLUEPRINT_CLIENT_ID</c> environment variable.
-    /// Stamped as <c>gen_ai.agent.blueprint.id</c> on telemetry spans.
+    /// Stamped as <c>microsoft.a365.agent.blueprint.id</c> on telemetry spans.
     /// </summary>
     public static string? AgentBlueprintClientId { get; private set; }
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/FoundryEnrichmentProcessor.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/FoundryEnrichmentProcessor.cs
@@ -103,7 +103,7 @@ internal sealed class FoundryEnrichmentProcessor : BaseProcessor<Activity>
 
         if (!string.IsNullOrEmpty(_blueprintId))
         {
-            activity.SetTag("gen_ai.agent.blueprint.id", _blueprintId);
+            activity.SetTag("microsoft.a365.agent.blueprint.id", _blueprintId);
         }
 
         if (!string.IsNullOrEmpty(_tenantId))

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnrichmentProcessorTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnrichmentProcessorTests.cs
@@ -342,7 +342,7 @@ public class FoundryEnrichmentProcessorTests
         using var activity = _activitySource.StartActivity("test")!;
         activity.Stop();
 
-        Assert.That(activity.GetTagItem("gen_ai.agent.blueprint.id"), Is.EqualTo("blueprint-xyz"));
+        Assert.That(activity.GetTagItem("microsoft.a365.agent.blueprint.id"), Is.EqualTo("blueprint-xyz"));
     }
 
     [Test]
@@ -354,7 +354,7 @@ public class FoundryEnrichmentProcessorTests
         using var activity = _activitySource.StartActivity("test")!;
         activity.Stop();
 
-        Assert.That(activity.GetTagItem("gen_ai.agent.blueprint.id"), Is.Null);
+        Assert.That(activity.GetTagItem("microsoft.a365.agent.blueprint.id"), Is.Null);
     }
 
     [Test]
@@ -393,7 +393,7 @@ public class FoundryEnrichmentProcessorTests
         Assert.That(activity.GetTagItem("gen_ai.agent.id"), Is.EqualTo("instance-id"));
         Assert.That(activity.GetTagItem("gen_ai.agent.name"), Is.EqualTo("my-agent"));
         Assert.That(activity.GetTagItem("gen_ai.agent.version"), Is.EqualTo("1.0"));
-        Assert.That(activity.GetTagItem("gen_ai.agent.blueprint.id"), Is.EqualTo("blueprint-id"));
+        Assert.That(activity.GetTagItem("microsoft.a365.agent.blueprint.id"), Is.EqualTo("blueprint-id"));
         Assert.That(activity.GetTagItem("microsoft.tenant.id"), Is.EqualTo("tenant-id"));
         Assert.That(activity.GetTagItem("microsoft.foundry.project.id"), Is.EqualTo("/sub/rg/proj"));
     }


### PR DESCRIPTION
Update blueprint attribute tag from gen_ai.agent.blueprint.id to microsoft.a365.agent.blueprint.id and update corresponding tests.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
