### PR TITLE
Prepare 1.0.0-beta.25 release notes

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed the blueprint attribute key from `blueprint_id` to `microsoft.a365.agent.blueprint.id` to align telemetry attributes with A365 schema.
+- Fixed the blueprint telemetry attribute key from `gen_ai.agent.blueprint.id` to `microsoft.a365.agent.blueprint.id` to align with A365 schema.
 
 ### Other Changes
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Release History
 
-## 1.0.0-beta.25 (Unreleased)
+## 1.0.0-beta.25 (2026-05-23)
 
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Fixed the blueprint attribute key from `blueprint_id` to `microsoft.a365.agent.blueprint.id` to align telemetry attributes with A365 schema.
 
 ### Other Changes
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed the blueprint telemetry attribute key from `gen_ai.agent.blueprint.id` to `microsoft.a365.agent.blueprint.id` to align with A365 schema.
+- Corrected `FoundryEnrichmentProcessor` to emit the Agent365 blueprint telemetry key as `microsoft.a365.agent.blueprint.id` (previously emitted as `gen_ai.agent.blueprint.id` in this code path).
 
 ### Other Changes
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.25 (2026-05-23)
+## 1.0.0-beta.25 (2026-05-25)
 
 ### Features Added
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -2,15 +2,9 @@
 
 ## 1.0.0-beta.25 (2026-05-25)
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Corrected `FoundryEnrichmentProcessor` to emit the Agent365 blueprint telemetry key as `microsoft.a365.agent.blueprint.id` (previously emitted as `gen_ai.agent.blueprint.id` in this code path).
-
-### Other Changes
 
 ## 1.0.0-beta.24 (2026-05-21)
 


### PR DESCRIPTION

# Description

This PR prepares Azure.AI.AgentServer.Core 1.0.0-beta.25 release notes by:
- Finalizing the beta.25 changelog date as 2026-05-23.
- Adding the bug-fix note for telemetry attribute key migration from gen_ai.agent.blueprint.id to microsoft.a365.agent.blueprint.id.

Relevant PRs:
- .NET fix: https://github.com/Azure/azure-sdk-for-net/pull/59422
- Python parity reference: https://github.com/Azure/azure-sdk-for-python/pull/47094

No API spec regeneration is included in this PR.

# All SDK Contribution checklist:
- [x] The pull request does not introduce breaking changes.
- [x] CHANGELOG is updated for new features, bug fixes or other significant changes.
- [x] I have read the contribution guidelines.

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.

Testing note:
This is a changelog-only release preparation PR. Functional validation is covered in PR #59422.