### PR TITLE
Set release date for Azure.Security.ConfidentialLedger 1.4.1-beta.5

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.1-beta.5 (Unreleased)
+## 1.4.1-beta.5 (2026-05-26)
 
 ### Bugs Fixed
 


### PR DESCRIPTION
Update CHANGELOG.md to set release date to 2026-05-26 (from Unreleased). This fixes the Verify ChangeLogEntry task failure in the release pipeline (build 6351855).

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
