### PR TITLE
Yakumar/msrc 116673 cts redirect trust

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.9 (Unreleased)
+## 1.0.0-beta.9 (2026-05-26)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Improved redirect performance for write operations by caching the latest primary node URL from redirect responses and reusing it for subsequent non-GET requests. The cache is lazily populated and refreshed whenever the service redirects to a different primary node.
 
+### Other Changes
+
+- Hardened redirect handling in the Code Transparency client. Credentials and request bodies are now only forwarded on HTTPS redirects whose target hostname matches the configured service endpoint or one of its subdomains, with the same port. Redirects to any other target are refused. Write-URL cache writes are now staged per-call and only committed after a successful trusted redirect chain.
+
 ## 1.0.0-beta.8 (2026-03-02)
 
 ### Bugs Fixed

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -63,7 +63,7 @@ namespace Azure.Security.CodeTransparency
             ClientDiagnostics = new ClientDiagnostics(options, true);
             Pipeline = HttpPipelineBuilder.Build(
                 options,
-                new HttpPipelinePolicy[] { new CodeTransparencyRedirectPolicy() },
+                new HttpPipelinePolicy[] { new CodeTransparencyRedirectPolicy(endpoint) },
                 credential == null ?
                     Array.Empty<HttpPipelinePolicy>() :
                     new HttpPipelinePolicy[] { new AzureKeyCredentialPolicy(credential, AuthorizationHeader, AuthorizationApiKeyPrefix) },

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -11,20 +12,60 @@ namespace Azure.Security.CodeTransparency
 {
     /// <summary>
     /// An <see cref="HttpPipelinePolicy"/> that follows HTTP 307 and 308 redirect responses
-    /// while preserving the Authorization header.
+    /// while preserving the Authorization header, but only when the redirect target stays
+    /// within the configured endpoint's trust boundary.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Code Transparency Service nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect)
     /// responses to route write operations to the primary node. The standard redirect behavior in .NET
-    /// strips the Authorization header on cross-domain redirects for security reasons. However, CTS
-    /// redirects occur between trusted nodes within the same ledger, so the Authorization header must
-    /// be preserved for the redirected request to succeed.
+    /// strips the Authorization header on cross-domain redirects for security reasons. This policy
+    /// preserves the Authorization header for redirects to trusted targets — the configured endpoint
+    /// host or a subdomain of it on HTTPS with the same port.
+    /// </para>
+    /// <para>
+    /// Redirects to untrusted targets are refused by throwing <see cref="InvalidOperationException"/>
+    /// to prevent credential and request-body leakage (MSRC #116673).
+    /// </para>
+    /// <para>
+    /// Cache writes are staged per-call and only committed after a successful trusted chain
+    /// to prevent write-URL cache poisoning.
+    /// </para>
     /// </remarks>
     internal sealed class CodeTransparencyRedirectPolicy : HttpPipelinePolicy
     {
         private const int MaxRedirects = 5;
+
+        /// <summary>
+        /// Status codes that must never cause a cache commit. Broader than
+        /// <see cref="IsRedirectResponse"/> so a future widening of followed
+        /// codes cannot poison the cache.
+        /// </summary>
+        private static readonly HashSet<int> s_redirectStatusCodes =
+            new HashSet<int> { 300, 301, 302, 303, 307, 308 };
+
         private readonly object _primaryNodeLock = new object();
+        private readonly string _ledgerHostname;
+        private readonly int _ledgerPort;
         private Uri _primaryNodeBaseUri;
+
+        /// <summary>
+        /// Creates a new redirect policy anchored on the specified endpoint.
+        /// </summary>
+        /// <param name="endpoint">The configured service endpoint used as the trust anchor.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="endpoint"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="endpoint"/> is not an absolute URI.</exception>
+        public CodeTransparencyRedirectPolicy(Uri endpoint)
+        {
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
+            if (!endpoint.IsAbsoluteUri)
+            {
+                throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
+            }
+
+            _ledgerHostname = CanonicalHostname(endpoint.IdnHost);
+            _ledgerPort = endpoint.IsDefaultPort ? GetDefaultPort(endpoint.Scheme) : endpoint.Port;
+        }
 
         /// <inheritdoc/>
         public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
@@ -41,6 +82,9 @@ namespace Azure.Security.CodeTransparency
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
             bool appliedCache = TryApplyCachedPrimaryNode(message.Request);
+
+            // Per-call staged cache candidate. Committed only after a successful trusted chain.
+            Uri pendingCacheUri = null;
 
             try
             {
@@ -92,39 +136,138 @@ namespace Azure.Security.CodeTransparency
 
                 Uri redirectUri = BuildRedirectUri(message.Request.Uri.ToUri(), location);
 
-                // Only cache the redirect target as the primary node for non-GET (write) requests.
-                // GET requests may be redirected for other reasons (e.g., historical queries routed
-                // to backup nodes), so their redirect targets should not be assumed to be the primary.
+                // SECURITY: validate trust BEFORE touching request URI or cache.
+                // Untrusted targets are refused to prevent credential and request-body
+                // leakage to attacker-controlled hosts (MSRC #116673).
+                if (!IsTrustedRedirectTarget(redirectUri))
+                {
+                    string origin = FormatOrigin(redirectUri);
+                    message.Response.Dispose();
+                    throw new InvalidOperationException(
+                        $"Confidential Ledger refused to follow redirect to untrusted target origin: {origin}");
+                }
+
+                // Stage (do not commit) cache candidate for non-GET trusted hops.
+                // GET requests may be redirected for other reasons (e.g., historical queries
+                // routed to backup nodes), so their redirect targets should not be cached.
                 if (message.Request.Method != RequestMethod.Get)
                 {
-                    CachePrimaryNode(redirectUri);
+                    pendingCacheUri = GetPrimaryNodeBaseUri(redirectUri);
                 }
 
-                // Disallow redirect from HTTPS to HTTP.
-                if (string.Equals(message.Request.Uri.Scheme, "https", StringComparison.OrdinalIgnoreCase) &&
-                    !string.Equals(redirectUri.Scheme, "https", StringComparison.OrdinalIgnoreCase))
-                {
-                    break;
-                }
-
-                // Update the request URI to the redirect target.
+                // Update the request URI to the trusted redirect target.
                 // The Authorization header is intentionally preserved because CTS redirects
-                // are between trusted nodes within the same ledger.
+                // within the trust boundary are between nodes of the same ledger.
                 message.Request.Uri.Reset(redirectUri);
 
                 // Dispose of the redirect response before re-sending.
                 message.Response.Dispose();
 
-                if (async)
+                try
                 {
-                    await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+                    if (async)
+                    {
+                        await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        ProcessNext(message, pipeline);
+                    }
                 }
-                else
+                catch
                 {
-                    ProcessNext(message, pipeline);
+                    // Transport error mid-chain: discard staged cache and invalidate any
+                    // prior cached value as a safety net.
+                    InvalidateCachedPrimaryNode();
+                    throw;
                 }
             }
+
+            // Commit the staged cache only when the redirect chain reached a terminal
+            // non-redirect, non-5xx response. If the chain ended on a 3xx (e.g., max-retries
+            // exhausted, malformed Location, or no Location header), we do not know the
+            // staged URL is reachable, so the cache is discarded.
+            if (pendingCacheUri != null
+                && !s_redirectStatusCodes.Contains(message.Response.Status)
+                && message.Response.Status < 500)
+            {
+                CommitPrimaryNode(pendingCacheUri);
+            }
+            else if (message.Response.Status >= 500)
+            {
+                // Trusted chain ended in 5xx — invalidate any previously cached value.
+                InvalidateCachedPrimaryNode();
+            }
         }
+
+        // ---------- Trust check ----------
+
+        private static string CanonicalHostname(string host)
+        {
+            if (string.IsNullOrEmpty(host))
+            {
+                return string.Empty;
+            }
+
+            if (host[host.Length - 1] == '.')
+            {
+                host = host.Substring(0, host.Length - 1);
+            }
+
+            return host.ToLowerInvariant();
+        }
+
+        private bool IsTrustedRedirectTarget(Uri target)
+        {
+            if (target == null || !target.IsAbsoluteUri)
+            {
+                return false;
+            }
+
+            if (!string.Equals(target.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            int targetPort = target.IsDefaultPort ? GetDefaultPort(target.Scheme) : target.Port;
+            if (targetPort != _ledgerPort)
+            {
+                return false;
+            }
+
+            string targetHost = CanonicalHostname(target.IdnHost);
+            return targetHost.Equals(_ledgerHostname, StringComparison.Ordinal)
+                || targetHost.EndsWith("." + _ledgerHostname, StringComparison.Ordinal);
+        }
+
+        private static int GetDefaultPort(string scheme)
+        {
+            if (string.Equals(scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                return 443;
+            }
+
+            if (string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+            {
+                return 80;
+            }
+
+            return -1;
+        }
+
+        private static string FormatOrigin(Uri uri)
+        {
+            if (uri == null || !uri.IsAbsoluteUri)
+            {
+                return "<invalid>";
+            }
+
+            return uri.IsDefaultPort
+                ? $"{uri.Scheme}://{uri.Host}"
+                : $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+        }
+
+        // ---------- Redirect helpers ----------
 
         private static bool IsRedirectResponse(int statusCode)
         {
@@ -143,6 +286,8 @@ namespace Azure.Security.CodeTransparency
             return redirectUri;
         }
 
+        // ---------- Cache helpers ----------
+
         private bool TryApplyCachedPrimaryNode(Request request)
         {
             if (request.Method == RequestMethod.Get)
@@ -160,17 +305,16 @@ namespace Azure.Security.CodeTransparency
             return true;
         }
 
-        private void CachePrimaryNode(Uri redirectUri)
+        private void CommitPrimaryNode(Uri primaryBase)
         {
-            Uri candidatePrimary = GetPrimaryNodeBaseUri(redirectUri);
-            if (candidatePrimary == null)
+            if (primaryBase == null)
             {
                 return;
             }
 
             lock (_primaryNodeLock)
             {
-                Volatile.Write(ref _primaryNodeBaseUri, candidatePrimary);
+                Volatile.Write(ref _primaryNodeBaseUri, primaryBase);
             }
         }
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -25,7 +25,7 @@ namespace Azure.Security.CodeTransparency
     /// </para>
     /// <para>
     /// Redirects to untrusted targets are refused by throwing <see cref="InvalidOperationException"/>
-    /// to prevent credential and request-body leakage (MSRC #116673).
+    /// to prevent credential and request-body leakage to attacker-controlled hosts.
     /// </para>
     /// <para>
     /// Cache writes are staged per-call and only committed after a successful trusted chain
@@ -136,34 +136,25 @@ namespace Azure.Security.CodeTransparency
 
                 Uri redirectUri = BuildRedirectUri(message.Request.Uri.ToUri(), location);
 
-                // SECURITY: validate trust BEFORE touching request URI or cache.
-                // Untrusted targets are refused to prevent credential and request-body
-                // leakage to attacker-controlled hosts (MSRC #116673).
+                // Validate trust before modifying the request URI or staging a cache write.
                 if (!IsTrustedRedirectTarget(redirectUri))
                 {
                     string origin = FormatOrigin(redirectUri);
-                    // Invalidate any existing cached primary — the node that issued this
-                    // untrusted redirect is misbehaving and must not receive further traffic.
                     InvalidateCachedPrimaryNode();
                     message.Response.Dispose();
                     throw new InvalidOperationException(
                         $"Confidential Ledger refused to follow redirect to untrusted target origin: {origin}");
                 }
 
-                // Stage (do not commit) cache candidate for non-GET trusted hops.
-                // GET requests may be redirected for other reasons (e.g., historical queries
-                // routed to backup nodes), so their redirect targets should not be cached.
+                // Stage cache candidate for non-GET trusted hops.
                 if (message.Request.Method != RequestMethod.Get)
                 {
                     pendingCacheUri = GetPrimaryNodeBaseUri(redirectUri);
                 }
 
-                // Update the request URI to the trusted redirect target.
-                // The Authorization header is intentionally preserved because CTS redirects
-                // within the trust boundary are between nodes of the same ledger.
+                // Preserve the Authorization header on trusted redirects.
                 message.Request.Uri.Reset(redirectUri);
 
-                // Dispose of the redirect response before re-sending.
                 message.Response.Dispose();
 
                 try
@@ -179,17 +170,13 @@ namespace Azure.Security.CodeTransparency
                 }
                 catch
                 {
-                    // Transport error mid-chain: discard staged cache and invalidate any
-                    // prior cached value as a safety net.
+                    // Transport error mid-chain: invalidate cache for clean retry.
                     InvalidateCachedPrimaryNode();
                     throw;
                 }
             }
 
-            // Commit the staged cache only when the redirect chain reached a terminal
-            // non-redirect, non-5xx response. If the chain ended on a 3xx (e.g., max-retries
-            // exhausted, malformed Location, or no Location header), we do not know the
-            // staged URL is reachable, so the cache is discarded.
+            // Commit staged cache only on a terminal non-redirect, non-5xx response.
             if (pendingCacheUri != null
                 && !s_redirectStatusCodes.Contains(message.Response.Status)
                 && message.Response.Status < 500)
@@ -202,8 +189,6 @@ namespace Azure.Security.CodeTransparency
                 InvalidateCachedPrimaryNode();
             }
         }
-
-        // ---------- Trust check ----------
 
         private static string CanonicalHostname(string host)
         {
@@ -270,8 +255,6 @@ namespace Azure.Security.CodeTransparency
                 : $"{uri.Scheme}://{uri.Host}:{uri.Port}";
         }
 
-        // ---------- Redirect helpers ----------
-
         private static bool IsRedirectResponse(int statusCode)
         {
             return statusCode == 307 || statusCode == 308;
@@ -288,8 +271,6 @@ namespace Azure.Security.CodeTransparency
 
             return redirectUri;
         }
-
-        // ---------- Cache helpers ----------
 
         private bool TryApplyCachedPrimaryNode(Request request)
         {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -142,6 +142,9 @@ namespace Azure.Security.CodeTransparency
                 if (!IsTrustedRedirectTarget(redirectUri))
                 {
                     string origin = FormatOrigin(redirectUri);
+                    // Invalidate any existing cached primary — the node that issued this
+                    // untrusted redirect is misbehaving and must not receive further traffic.
+                    InvalidateCachedPrimaryNode();
                     message.Response.Dispose();
                     throw new InvalidOperationException(
                         $"Confidential Ledger refused to follow redirect to untrusted target origin: {origin}");

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
@@ -368,7 +368,7 @@ namespace Azure.Security.CodeTransparency.Tests
             Assert.AreEqual("https://myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
         }
 
-        // ==================== Security regression tests (MSRC #116673) ====================
+        // ==================== Security regression tests ====================
 
         [Test]
         public async Task ThrowsOnCrossOriginHttpsRedirect()

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
@@ -12,6 +12,8 @@ namespace Azure.Security.CodeTransparency.Tests
 {
     public class CodeTransparencyRedirectPolicyTests : SyncAsyncPolicyTestBase
     {
+        private static readonly Uri s_endpoint = new Uri("https://myledger.confidential-ledger.azure.com");
+
         public CodeTransparencyRedirectPolicyTests(bool isAsync) : base(isAsync)
         {
         }
@@ -20,48 +22,48 @@ namespace Azure.Security.CodeTransparency.Tests
         public async Task Follows307RedirectToNewLocation()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
-            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
+            Assert.AreEqual("https://primary-node.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
         }
 
         [Test]
         public async Task Follows308RedirectToNewLocation()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(308).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(308).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
-            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
+            Assert.AreEqual("https://primary-node.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
         }
 
         [Test]
         public async Task PreservesAuthorizationHeaderOnRedirect()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
                 message.Request.Headers.SetValue("Authorization", "Bearer test-token");
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
@@ -73,14 +75,14 @@ namespace Azure.Security.CodeTransparency.Tests
         public async Task PreservesHttpMethodOnRedirect()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Method = RequestMethod.Post;
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
@@ -97,7 +99,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://example.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(new Uri("https://example.confidential-ledger.azure.com")));
 
             Assert.AreEqual(statusCode, response.Status);
             Assert.AreEqual(1, mockTransport.Requests.Count);
@@ -108,12 +110,12 @@ namespace Azure.Security.CodeTransparency.Tests
         {
             // The policy allows up to 5 redirects; after that it returns the redirect response.
             var mockTransport = new MockTransport(_ =>
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"));
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(307, response.Status);
             // 1 original + 5 redirects = 6 total requests
@@ -130,26 +132,28 @@ namespace Azure.Security.CodeTransparency.Tests
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(307, response.Status);
             Assert.AreEqual(1, mockTransport.Requests.Count);
         }
 
         [Test]
-        public async Task BlocksHttpsToHttpRedirect()
+        public async Task ThrowsOnHttpsToHttpRedirect()
         {
             var mockTransport = new MockTransport(
                 new MockResponse(307).AddHeader("Location", "http://insecure-node.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
-            var response = await SendRequestAsync(mockTransport, message =>
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
+                }, new CodeTransparencyRedirectPolicy(s_endpoint));
+            });
 
-            // Should NOT follow the redirect (HTTPS → HTTP downgrade)
-            Assert.AreEqual(307, response.Status);
+            // Untrusted redirect must not be followed
             Assert.AreEqual(1, mockTransport.Requests.Count);
         }
 
@@ -163,7 +167,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
@@ -174,25 +178,25 @@ namespace Azure.Security.CodeTransparency.Tests
         public async Task FollowsMultipleRedirectsWithinLimit()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://node-1.confidential-ledger.azure.com/ledger"),
-                new MockResponse(307).AddHeader("Location", "https://node-2.confidential-ledger.azure.com/ledger"),
-                new MockResponse(307).AddHeader("Location", "https://primary.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://node-2.myledger.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(4, mockTransport.Requests.Count);
-            Assert.AreEqual("https://primary.confidential-ledger.azure.com/ledger", mockTransport.Requests[3].Uri.ToString());
+            Assert.AreEqual("https://primary.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[3].Uri.ToString());
         }
 
         [Test]
         public async Task DisposesIntermediateRedirectResponses()
         {
-            var redirectResponse = new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger");
+            var redirectResponse = new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger");
             var mockTransport = new MockTransport(
                 redirectResponse,
                 new MockResponse(200));
@@ -200,7 +204,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new CodeTransparencyRedirectPolicy());
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.IsTrue(redirectResponse.IsDisposed);
@@ -209,9 +213,9 @@ namespace Azure.Security.CodeTransparency.Tests
         [Test]
         public async Task CachesPrimaryNodeForSubsequentNonGetRequests()
         {
-            var policy = new CodeTransparencyRedirectPolicy();
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 new MockResponse(200));
 
@@ -228,15 +232,15 @@ namespace Azure.Security.CodeTransparency.Tests
             }, policy);
 
             Assert.AreEqual(3, mockTransport.Requests.Count);
-            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
+            Assert.AreEqual("https://primary-node.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
         }
 
         [Test]
         public async Task UsesCachedPrimaryOnlyForNonGetRequests()
         {
-            var policy = new CodeTransparencyRedirectPolicy();
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 new MockResponse(200));
 
@@ -259,11 +263,11 @@ namespace Azure.Security.CodeTransparency.Tests
         [Test]
         public async Task RefreshesCachedPrimaryWhenRedirectTargetChanges()
         {
-            var policy = new CodeTransparencyRedirectPolicy();
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-a.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-a.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
-                new MockResponse(307).AddHeader("Location", "https://primary-b.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-b.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 new MockResponse(200));
 
@@ -289,7 +293,7 @@ namespace Azure.Security.CodeTransparency.Tests
             bool sawPrimaryA = false;
             foreach (MockRequest request in mockTransport.Requests)
             {
-                if (request.Uri.ToString() == "https://primary-a.confidential-ledger.azure.com/ledger")
+                if (request.Uri.ToString() == "https://primary-a.myledger.confidential-ledger.azure.com/ledger")
                 {
                     sawPrimaryA = true;
                     break;
@@ -297,21 +301,21 @@ namespace Azure.Security.CodeTransparency.Tests
             }
 
             Assert.IsTrue(sawPrimaryA, "Expected at least one request to the previously cached primary node.");
-            Assert.AreEqual("https://primary-b.confidential-ledger.azure.com/ledger", mockTransport.Requests[4].Uri.ToString());
+            Assert.AreEqual("https://primary-b.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[4].Uri.ToString());
         }
 
         [Test]
         public async Task InvalidatesCacheOnServerErrorFromCachedPrimary()
         {
-            var policy = new CodeTransparencyRedirectPolicy();
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
                 // First write: 307 → primary, 200 (cache warmed)
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 // Second write: goes directly to cached primary, gets 503 (invalidates cache)
                 new MockResponse(503),
                 // Third write: cache was cleared, goes back through load balancer, 307 → primary, 200
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             await SendRequestAsync(mockTransport, message =>
@@ -332,23 +336,17 @@ namespace Azure.Security.CodeTransparency.Tests
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
             }, policy);
 
-            // Write #1: LB → 307 → primary = 2 requests
-            // Write #2: cached primary → 503 = 1 request
-            // Write #3: cache invalidated, back through LB → 307 → primary = 2 requests
-            // Total = 5 proves the cache was cleared after the 503.
-            // (If cache were still active, write #3 would go directly to primary = 4 total.)
             Assert.AreEqual(5, mockTransport.Requests.Count);
-            // Write #2 was sent directly to cached primary
-            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
+            Assert.AreEqual("https://primary-node.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
         }
 
         [Test]
         public async Task DoesNotCacheRedirectTargetForGetRequests()
         {
-            var policy = new CodeTransparencyRedirectPolicy();
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
                 // GET is redirected (e.g., to a backup/historical node)
-                new MockResponse(307).AddHeader("Location", "https://backup-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://backup-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 // Subsequent POST should NOT go to backup-node
                 new MockResponse(200));
@@ -368,6 +366,353 @@ namespace Azure.Security.CodeTransparency.Tests
             Assert.AreEqual(3, mockTransport.Requests.Count);
             // POST should go to the common URL (cache not populated from GET redirect)
             Assert.AreEqual("https://myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
+        }
+
+        // ==================== Security regression tests (MSRC #116673) ====================
+
+        [Test]
+        public async Task ThrowsOnCrossOriginHttpsRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com/steal"),
+                new MockResponse(200));
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                    message.Request.Headers.SetValue("Authorization", "Bearer SECRET");
+                }, new CodeTransparencyRedirectPolicy(s_endpoint));
+            });
+
+            StringAssert.Contains("untrusted target origin", ex.Message);
+            StringAssert.Contains("https://attacker.example.com", ex.Message);
+            // Path must NOT appear in error message
+            Assert.IsFalse(ex.Message.Contains("/steal"));
+            // Attacker must never have been contacted
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ThrowsOnSiblingDomainRedirect()
+        {
+            // test-ledger-primary.confidential-ledger.azure.com is NOT a subdomain of
+            // myledger.confidential-ledger.azure.com
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://test-ledger-primary.confidential-ledger.azure.com/app/entries"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new CodeTransparencyRedirectPolicy(s_endpoint));
+            });
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ThrowsOnPrefixCollisionRedirect()
+        {
+            // evilmyledger.confidential-ledger.azure.com must NOT match
+            // myledger.confidential-ledger.azure.com (leading-dot boundary check)
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://evilmyledger.confidential-ledger.azure.com/x"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new CodeTransparencyRedirectPolicy(s_endpoint));
+            });
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ThrowsOnDifferentPortRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com:8443/app/entries"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new CodeTransparencyRedirectPolicy(s_endpoint));
+            });
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ThrowsOnProtocolRelativeUntrustedRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "//attacker.example.com/app/entries"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new CodeTransparencyRedirectPolicy(s_endpoint));
+            });
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task FollowsTrustedSubdomainRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com/app/entries"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                message.Request.Headers.SetValue("Authorization", "Bearer SECRET");
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.IsTrue(mockTransport.Requests[1].Headers.TryGetValue("Authorization", out string authValue));
+            Assert.AreEqual("Bearer SECRET", authValue);
+        }
+
+        [Test]
+        public async Task FollowsTrustedUppercaseHostRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://NODE-1.MYLEDGER.CONFIDENTIAL-LEDGER.AZURE.COM/app/entries"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task UntrustedRedirectDoesNotPoisonCache()
+        {
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
+
+            // First write: 307 to attacker, must throw and not cache.
+            var mockTransport1 = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com/x"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport1, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, policy);
+            });
+
+            // Second write should still go to the load balancer URL — cache must be empty.
+            var mockTransport2 = new MockTransport(new MockResponse(200));
+
+            await SendRequestAsync(mockTransport2, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", mockTransport2.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public async Task MidChainUntrustedHopThrowsAndDiscardsStagedCache()
+        {
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
+
+            // Hop 1: trusted subdomain; Hop 2: attacker — must throw.
+            var mockTransport1 = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com/app/entries"),
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com/app/entries"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport1, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, policy);
+            });
+
+            // We sent to original + first trusted redirect, but NOT to attacker
+            Assert.AreEqual(2, mockTransport1.Requests.Count);
+
+            // Cache must be cold — staged entry from hop 1 must be discarded.
+            var mockTransport2 = new MockTransport(new MockResponse(200));
+            await SendRequestAsync(mockTransport2, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", mockTransport2.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public async Task DoesNotCommitCacheWhenMaxRedirectsExhausted()
+        {
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
+
+            // 6 trusted 307 responses — MaxRedirects=5 so chain bottoms out on a 307.
+            var mockTransport1 = new MockTransport(_ =>
+                new MockResponse(307).AddHeader("Location", "https://node.myledger.confidential-ledger.azure.com/x"));
+
+            await SendRequestAsync(mockTransport1, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            // Cache must NOT be committed — chain ended on 3xx.
+            var mockTransport2 = new MockTransport(new MockResponse(200));
+            await SendRequestAsync(mockTransport2, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", mockTransport2.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public async Task DoesNotCommitCacheWhenChainEndsIn5xx()
+        {
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
+            var mockTransport1 = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node.myledger.confidential-ledger.azure.com/x"),
+                new MockResponse(500));
+
+            await SendRequestAsync(mockTransport1, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            // Cache must NOT be committed because final response was 5xx.
+            var mockTransport2 = new MockTransport(new MockResponse(200));
+            await SendRequestAsync(mockTransport2, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", mockTransport2.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public async Task CachedNodeReturnsUntrustedRedirect_InvalidatesCache()
+        {
+            var policy = new CodeTransparencyRedirectPolicy(s_endpoint);
+
+            // Warm the cache legitimately.
+            var warmTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com/x"),
+                new MockResponse(200));
+            await SendRequestAsync(warmTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            // Cached node returns a malicious redirect — must throw.
+            var maliciousTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com/x"));
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(maliciousTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, policy);
+            });
+
+            // Cache must be invalidated. Next write goes through the load balancer.
+            var followUpTransport = new MockTransport(new MockResponse(200));
+            await SendRequestAsync(followUpTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", followUpTransport.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public void ConstructorThrowsOnNullEndpoint()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CodeTransparencyRedirectPolicy(null));
+        }
+
+        [Test]
+        public void ConstructorThrowsOnRelativeEndpoint()
+        {
+            Assert.Throws<ArgumentException>(() => new CodeTransparencyRedirectPolicy(new Uri("/relative", UriKind.Relative)));
+        }
+
+        [Test]
+        public async Task ExceptionMessageContainsOnlyOrigin()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com:9443/secret/path?token=abc"),
+                new MockResponse(200));
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new CodeTransparencyRedirectPolicy(s_endpoint));
+            });
+
+            StringAssert.Contains("https://attacker.example.com:9443", ex.Message);
+            Assert.IsFalse(ex.Message.Contains("/secret/path"), "Path must not appear in error");
+            Assert.IsFalse(ex.Message.Contains("token=abc"), "Query must not appear in error");
+        }
+
+        [Test]
+        public async Task FollowsTrustedExplicitDefaultPort443()
+        {
+            // Endpoint has no explicit port (default 443); redirect target has explicit :443
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com:443/app/entries"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
         }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - Improved redirect performance for write operations by caching the latest primary node URL from redirect responses and reusing it for subsequent non-GET requests. The cache is lazily populated and refreshed whenever the service redirects to a different primary node.
+- Hardened redirect handling so credential-preserving redirects are only followed when the target remains within the configured ledger endpoint's trust boundary.
 
 ## 1.4.1-beta.4 (2026-02-27)
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
@@ -73,7 +73,7 @@ namespace Azure.Security.ConfidentialLedger
             _tokenCredential = credential;
             _pipeline = HttpPipelineBuilder.Build(
                 actualOptions,
-                new HttpPipelinePolicy[] { new ConfidentialLedgerRedirectPolicy() },
+                new HttpPipelinePolicy[] { new ConfidentialLedgerRedirectPolicy(ledgerEndpoint) },
                 _tokenCredential == null ?
                     Array.Empty<HttpPipelinePolicy>() :
                     new HttpPipelinePolicy[] { new BearerTokenAuthenticationPolicy(_tokenCredential, AuthorizationScopes) },

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerRedirectPolicy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -11,20 +12,45 @@ namespace Azure.Security.ConfidentialLedger
 {
     /// <summary>
     /// An <see cref="HttpPipelinePolicy"/> that follows HTTP 307 and 308 redirect responses
-    /// while preserving the Authorization header.
+    /// while preserving the Authorization header, but only when the redirect target stays
+    /// within the configured ledger endpoint's trust boundary.
     /// </summary>
     /// <remarks>
     /// Azure Confidential Ledger nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect)
     /// responses to route write operations to the primary node. The standard redirect behavior in .NET
-    /// strips the Authorization header on cross-domain redirects for security reasons. However, ACL
-    /// redirects occur between trusted nodes within the same ledger, so the Authorization header must
-    /// be preserved for the redirected request to succeed.
+    /// strips the Authorization header on cross-domain redirects for security reasons. This policy
+    /// preserves the Authorization header for redirects to trusted targets - the configured ledger
+    /// endpoint host or a subdomain of it on HTTPS with the same port.
     /// </remarks>
     internal sealed class ConfidentialLedgerRedirectPolicy : HttpPipelinePolicy
     {
         private const int MaxRedirects = 5;
+
+        private static readonly HashSet<int> s_redirectStatusCodes =
+            new HashSet<int> { 300, 301, 302, 303, 307, 308 };
+
         private readonly object _primaryNodeLock = new object();
+        private readonly string _ledgerHostname;
+        private readonly int _ledgerPort;
         private Uri _primaryNodeBaseUri;
+
+        /// <summary>
+        /// Creates a new redirect policy anchored on the configured ledger endpoint.
+        /// </summary>
+        /// <param name="endpoint">The configured ledger endpoint used as the trust anchor.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="endpoint"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="endpoint"/> is not an absolute URI.</exception>
+        public ConfidentialLedgerRedirectPolicy(Uri endpoint)
+        {
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
+            if (!endpoint.IsAbsoluteUri)
+            {
+                throw new ArgumentException("Endpoint must be an absolute URI.", nameof(endpoint));
+            }
+
+            _ledgerHostname = CanonicalHostname(endpoint.IdnHost);
+            _ledgerPort = endpoint.IsDefaultPort ? GetDefaultPort(endpoint.Scheme) : endpoint.Port;
+        }
 
         /// <inheritdoc/>
         public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
@@ -41,6 +67,7 @@ namespace Azure.Security.ConfidentialLedger
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
             bool appliedCache = TryApplyCachedPrimaryNode(message.Request);
+            Uri pendingCacheUri = null;
 
             try
             {
@@ -55,9 +82,6 @@ namespace Azure.Security.ConfidentialLedger
             }
             catch
             {
-                // Transport failure (connection refused, timeout, DNS, etc.) while targeting
-                // the cached primary — invalidate so the next request goes through the load
-                // balancer and can discover the new primary via redirect.
                 if (appliedCache)
                 {
                     InvalidateCachedPrimaryNode();
@@ -66,9 +90,6 @@ namespace Azure.Security.ConfidentialLedger
                 throw;
             }
 
-            // If we sent to the cached primary and got a server error, the node may be
-            // unhealthy or no longer primary (e.g., DR failover). Invalidate the cache so
-            // the next write goes through the load balancer to re-discover the primary.
             if (appliedCache && message.Response.Status >= 500)
             {
                 InvalidateCachedPrimaryNode();
@@ -80,50 +101,126 @@ namespace Azure.Security.ConfidentialLedger
             {
                 if (++redirectCount > MaxRedirects)
                 {
-                    // Too many redirects; return the last redirect response as-is.
                     break;
                 }
 
                 if (!message.Response.Headers.TryGetValue("Location", out string location))
                 {
-                    // No Location header; return the redirect response as-is.
                     break;
                 }
 
                 Uri redirectUri = BuildRedirectUri(message.Request.Uri.ToUri(), location);
 
-                // Only cache the redirect target as the primary node for non-GET (write) requests.
-                // GET requests may be redirected for other reasons (e.g., historical queries routed
-                // to backup nodes), so their redirect targets should not be assumed to be the primary.
+                if (!IsTrustedRedirectTarget(redirectUri))
+                {
+                    string origin = FormatOrigin(redirectUri);
+                    InvalidateCachedPrimaryNode();
+                    message.Response.Dispose();
+                    throw new InvalidOperationException(
+                        $"Confidential Ledger refused to follow redirect to untrusted target origin: {origin}");
+                }
+
                 if (message.Request.Method != RequestMethod.Get)
                 {
-                    CachePrimaryNode(redirectUri);
+                    pendingCacheUri = GetPrimaryNodeBaseUri(redirectUri);
                 }
 
-                // Disallow redirect from HTTPS to HTTP.
-                if (string.Equals(message.Request.Uri.Scheme, "https", StringComparison.OrdinalIgnoreCase) &&
-                    !string.Equals(redirectUri.Scheme, "https", StringComparison.OrdinalIgnoreCase))
-                {
-                    break;
-                }
-
-                // Update the request URI to the redirect target.
-                // The Authorization header is intentionally preserved because ACL redirects
-                // are between trusted nodes within the same ledger.
                 message.Request.Uri.Reset(redirectUri);
-
-                // Dispose of the redirect response before re-sending.
                 message.Response.Dispose();
 
-                if (async)
+                try
                 {
-                    await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+                    if (async)
+                    {
+                        await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        ProcessNext(message, pipeline);
+                    }
                 }
-                else
+                catch
                 {
-                    ProcessNext(message, pipeline);
+                    InvalidateCachedPrimaryNode();
+                    throw;
                 }
             }
+
+            if (pendingCacheUri != null
+                && !s_redirectStatusCodes.Contains(message.Response.Status)
+                && message.Response.Status < 500)
+            {
+                CommitPrimaryNode(pendingCacheUri);
+            }
+            else if (message.Response.Status >= 500)
+            {
+                InvalidateCachedPrimaryNode();
+            }
+        }
+
+        private static string CanonicalHostname(string host)
+        {
+            if (string.IsNullOrEmpty(host))
+            {
+                return string.Empty;
+            }
+
+            if (host[host.Length - 1] == '.')
+            {
+                host = host.Substring(0, host.Length - 1);
+            }
+
+            return host.ToLowerInvariant();
+        }
+
+        private bool IsTrustedRedirectTarget(Uri target)
+        {
+            if (target == null || !target.IsAbsoluteUri)
+            {
+                return false;
+            }
+
+            if (!string.Equals(target.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            int targetPort = target.IsDefaultPort ? GetDefaultPort(target.Scheme) : target.Port;
+            if (targetPort != _ledgerPort)
+            {
+                return false;
+            }
+
+            string targetHost = CanonicalHostname(target.IdnHost);
+            return targetHost.Equals(_ledgerHostname, StringComparison.Ordinal)
+                || targetHost.EndsWith("." + _ledgerHostname, StringComparison.Ordinal);
+        }
+
+        private static int GetDefaultPort(string scheme)
+        {
+            if (string.Equals(scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                return 443;
+            }
+
+            if (string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+            {
+                return 80;
+            }
+
+            return -1;
+        }
+
+        private static string FormatOrigin(Uri uri)
+        {
+            if (uri == null || !uri.IsAbsoluteUri)
+            {
+                return "<invalid>";
+            }
+
+            return uri.IsDefaultPort
+                ? $"{uri.Scheme}://{uri.Host}"
+                : $"{uri.Scheme}://{uri.Host}:{uri.Port}";
         }
 
         private static bool IsRedirectResponse(int statusCode)
@@ -160,17 +257,16 @@ namespace Azure.Security.ConfidentialLedger
             return true;
         }
 
-        private void CachePrimaryNode(Uri redirectUri)
+        private void CommitPrimaryNode(Uri primaryBase)
         {
-            Uri candidatePrimary = GetPrimaryNodeBaseUri(redirectUri);
-            if (candidatePrimary == null)
+            if (primaryBase == null)
             {
                 return;
             }
 
             lock (_primaryNodeLock)
             {
-                Volatile.Write(ref _primaryNodeBaseUri, candidatePrimary);
+                Volatile.Write(ref _primaryNodeBaseUri, primaryBase);
             }
         }
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerRedirectPolicyTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerRedirectPolicyTests.cs
@@ -12,6 +12,8 @@ namespace Azure.Security.ConfidentialLedger.Tests
 {
     public class ConfidentialLedgerRedirectPolicyTests : SyncAsyncPolicyTestBase
     {
+        private static readonly Uri s_endpoint = new Uri("https://myledger.confidential-ledger.azure.com");
+
         public ConfidentialLedgerRedirectPolicyTests(bool isAsync) : base(isAsync)
         {
         }
@@ -20,48 +22,48 @@ namespace Azure.Security.ConfidentialLedger.Tests
         public async Task Follows307RedirectToNewLocation()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
-            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
+            Assert.AreEqual("https://primary-node.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
         }
 
         [Test]
         public async Task Follows308RedirectToNewLocation()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(308).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(308).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
-            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
+            Assert.AreEqual("https://primary-node.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
         }
 
         [Test]
         public async Task PreservesAuthorizationHeaderOnRedirect()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
                 message.Request.Headers.SetValue("Authorization", "Bearer test-token");
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
@@ -73,14 +75,14 @@ namespace Azure.Security.ConfidentialLedger.Tests
         public async Task PreservesHttpMethodOnRedirect()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Method = RequestMethod.Post;
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
@@ -97,7 +99,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://example.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(statusCode, response.Status);
             Assert.AreEqual(1, mockTransport.Requests.Count);
@@ -108,12 +110,12 @@ namespace Azure.Security.ConfidentialLedger.Tests
         {
             // The policy allows up to 5 redirects; after that it returns the redirect response.
             var mockTransport = new MockTransport(_ =>
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"));
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(307, response.Status);
             // 1 original + 5 redirects = 6 total requests
@@ -130,26 +132,27 @@ namespace Azure.Security.ConfidentialLedger.Tests
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(307, response.Status);
             Assert.AreEqual(1, mockTransport.Requests.Count);
         }
 
         [Test]
-        public async Task BlocksHttpsToHttpRedirect()
+        public async Task ThrowsOnHttpsToHttpRedirect()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "http://insecure-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "http://insecure-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
-            var response = await SendRequestAsync(mockTransport, message =>
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
+                }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+            });
 
-            // Should NOT follow the redirect (HTTPS → HTTP downgrade)
-            Assert.AreEqual(307, response.Status);
             Assert.AreEqual(1, mockTransport.Requests.Count);
         }
 
@@ -163,7 +166,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(2, mockTransport.Requests.Count);
@@ -174,25 +177,25 @@ namespace Azure.Security.ConfidentialLedger.Tests
         public async Task FollowsMultipleRedirectsWithinLimit()
         {
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://node-1.confidential-ledger.azure.com/ledger"),
-                new MockResponse(307).AddHeader("Location", "https://node-2.confidential-ledger.azure.com/ledger"),
-                new MockResponse(307).AddHeader("Location", "https://primary.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://node-2.myledger.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.AreEqual(4, mockTransport.Requests.Count);
-            Assert.AreEqual("https://primary.confidential-ledger.azure.com/ledger", mockTransport.Requests[3].Uri.ToString());
+            Assert.AreEqual("https://primary.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[3].Uri.ToString());
         }
 
         [Test]
         public async Task DisposesIntermediateRedirectResponses()
         {
-            var redirectResponse = new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger");
+            var redirectResponse = new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger");
             var mockTransport = new MockTransport(
                 redirectResponse,
                 new MockResponse(200));
@@ -200,7 +203,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
             var response = await SendRequestAsync(mockTransport, message =>
             {
                 message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/ledger"));
-            }, new ConfidentialLedgerRedirectPolicy());
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
 
             Assert.AreEqual(200, response.Status);
             Assert.IsTrue(redirectResponse.IsDisposed);
@@ -209,9 +212,9 @@ namespace Azure.Security.ConfidentialLedger.Tests
         [Test]
         public async Task CachesPrimaryNodeForSubsequentNonGetRequests()
         {
-            var policy = new ConfidentialLedgerRedirectPolicy();
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 new MockResponse(200));
 
@@ -228,15 +231,15 @@ namespace Azure.Security.ConfidentialLedger.Tests
             }, policy);
 
             Assert.AreEqual(3, mockTransport.Requests.Count);
-            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
+            Assert.AreEqual("https://primary-node.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
         }
 
         [Test]
         public async Task UsesCachedPrimaryOnlyForNonGetRequests()
         {
-            var policy = new ConfidentialLedgerRedirectPolicy();
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 new MockResponse(200));
 
@@ -259,11 +262,11 @@ namespace Azure.Security.ConfidentialLedger.Tests
         [Test]
         public async Task RefreshesCachedPrimaryWhenRedirectTargetChanges()
         {
-            var policy = new ConfidentialLedgerRedirectPolicy();
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
-                new MockResponse(307).AddHeader("Location", "https://primary-a.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-a.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
-                new MockResponse(307).AddHeader("Location", "https://primary-b.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-b.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 new MockResponse(200));
 
@@ -289,7 +292,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
             bool sawPrimaryA = false;
             foreach (MockRequest request in mockTransport.Requests)
             {
-                if (request.Uri.ToString() == "https://primary-a.confidential-ledger.azure.com/ledger")
+                if (request.Uri.ToString() == "https://primary-a.myledger.confidential-ledger.azure.com/ledger")
                 {
                     sawPrimaryA = true;
                     break;
@@ -297,21 +300,21 @@ namespace Azure.Security.ConfidentialLedger.Tests
             }
 
             Assert.IsTrue(sawPrimaryA, "Expected at least one request to the previously cached primary node.");
-            Assert.AreEqual("https://primary-b.confidential-ledger.azure.com/ledger", mockTransport.Requests[4].Uri.ToString());
+            Assert.AreEqual("https://primary-b.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[4].Uri.ToString());
         }
 
         [Test]
         public async Task InvalidatesCacheOnServerErrorFromCachedPrimary()
         {
-            var policy = new ConfidentialLedgerRedirectPolicy();
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
                 // First write: 307 → primary, 200 (cache warmed)
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 // Second write: goes directly to cached primary, gets 503 (invalidates cache)
                 new MockResponse(503),
                 // Third write: cache was cleared, goes back through load balancer, 307 → primary, 200
-                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200));
 
             await SendRequestAsync(mockTransport, message =>
@@ -339,16 +342,16 @@ namespace Azure.Security.ConfidentialLedger.Tests
             // (If cache were still active, write #3 would go directly to primary = 4 total.)
             Assert.AreEqual(5, mockTransport.Requests.Count);
             // Write #2 was sent directly to cached primary
-            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
+            Assert.AreEqual("https://primary-node.myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
         }
 
         [Test]
         public async Task DoesNotCacheRedirectTargetForGetRequests()
         {
-            var policy = new ConfidentialLedgerRedirectPolicy();
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
             var mockTransport = new MockTransport(
                 // GET is redirected (e.g., to a backup/historical node)
-                new MockResponse(307).AddHeader("Location", "https://backup-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://backup-node.myledger.confidential-ledger.azure.com/ledger"),
                 new MockResponse(200),
                 // Subsequent POST should NOT go to backup-node
                 new MockResponse(200));
@@ -368,6 +371,333 @@ namespace Azure.Security.ConfidentialLedger.Tests
             Assert.AreEqual(3, mockTransport.Requests.Count);
             // POST should go to the common URL (cache not populated from GET redirect)
             Assert.AreEqual("https://myledger.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
+        }
+
+        [Test]
+        public async Task ThrowsOnCrossOriginHttpsRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com/steal"),
+                new MockResponse(200));
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                    message.Request.Headers.SetValue("Authorization", "Bearer SECRET");
+                }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+            });
+
+            StringAssert.Contains("untrusted target origin", ex.Message);
+            StringAssert.Contains("https://attacker.example.com", ex.Message);
+            Assert.IsFalse(ex.Message.Contains("/steal"));
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ThrowsOnSiblingDomainRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://test-ledger-primary.confidential-ledger.azure.com/app/entries"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+            });
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ThrowsOnPrefixCollisionRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://evilmyledger.confidential-ledger.azure.com/x"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+            });
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ThrowsOnDifferentPortRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com:8443/app/entries"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+            });
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ThrowsOnProtocolRelativeUntrustedRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "//attacker.example.com/app/entries"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+            });
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task FollowsTrustedSubdomainRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com/app/entries"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                message.Request.Headers.SetValue("Authorization", "Bearer SECRET");
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.IsTrue(mockTransport.Requests[1].Headers.TryGetValue("Authorization", out string authValue));
+            Assert.AreEqual("Bearer SECRET", authValue);
+        }
+
+        [Test]
+        public async Task FollowsTrustedUppercaseHostRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://NODE-1.MYLEDGER.CONFIDENTIAL-LEDGER.AZURE.COM/app/entries"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task UntrustedRedirectDoesNotPoisonCache()
+        {
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
+
+            var mockTransport1 = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com/x"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport1, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, policy);
+            });
+
+            var mockTransport2 = new MockTransport(new MockResponse(200));
+
+            await SendRequestAsync(mockTransport2, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", mockTransport2.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public async Task MidChainUntrustedHopThrowsAndDiscardsStagedCache()
+        {
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
+
+            var mockTransport1 = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com/app/entries"),
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com/app/entries"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport1, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, policy);
+            });
+
+            Assert.AreEqual(2, mockTransport1.Requests.Count);
+
+            var mockTransport2 = new MockTransport(new MockResponse(200));
+            await SendRequestAsync(mockTransport2, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", mockTransport2.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public async Task DoesNotCommitCacheWhenMaxRedirectsExhausted()
+        {
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
+
+            var mockTransport1 = new MockTransport(_ =>
+                new MockResponse(307).AddHeader("Location", "https://node.myledger.confidential-ledger.azure.com/x"));
+
+            await SendRequestAsync(mockTransport1, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            var mockTransport2 = new MockTransport(new MockResponse(200));
+            await SendRequestAsync(mockTransport2, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", mockTransport2.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public async Task DoesNotCommitCacheWhenChainEndsIn5xx()
+        {
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
+            var mockTransport1 = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node.myledger.confidential-ledger.azure.com/x"),
+                new MockResponse(500));
+
+            await SendRequestAsync(mockTransport1, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            var mockTransport2 = new MockTransport(new MockResponse(200));
+            await SendRequestAsync(mockTransport2, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", mockTransport2.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public async Task CachedNodeReturnsUntrustedRedirect_InvalidatesCache()
+        {
+            var policy = new ConfidentialLedgerRedirectPolicy(s_endpoint);
+
+            var warmTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com/x"),
+                new MockResponse(200));
+            await SendRequestAsync(warmTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            var maliciousTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com/x"));
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(maliciousTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, policy);
+            });
+
+            var followUpTransport = new MockTransport(new MockResponse(200));
+            await SendRequestAsync(followUpTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, policy);
+
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/app/entries", followUpTransport.Requests[0].Uri.ToString());
+        }
+
+        [Test]
+        public void ConstructorThrowsOnNullEndpoint()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ConfidentialLedgerRedirectPolicy(null));
+        }
+
+        [Test]
+        public void ConstructorThrowsOnRelativeEndpoint()
+        {
+            Assert.Throws<ArgumentException>(() => new ConfidentialLedgerRedirectPolicy(new Uri("/relative", UriKind.Relative)));
+        }
+
+        [Test]
+        public async Task ExceptionMessageContainsOnlyOrigin()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://attacker.example.com:9443/secret/path?token=abc"),
+                new MockResponse(200));
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+                }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+            });
+
+            StringAssert.Contains("https://attacker.example.com:9443", ex.Message);
+            Assert.IsFalse(ex.Message.Contains("/secret/path"), "Path must not appear in error");
+            Assert.IsFalse(ex.Message.Contains("token=abc"), "Query must not appear in error");
+        }
+
+        [Test]
+        public async Task FollowsTrustedExplicitDefaultPort443()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.myledger.confidential-ledger.azure.com:443/app/entries"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/app/entries"));
+            }, new ConfidentialLedgerRedirectPolicy(s_endpoint));
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
         }
     }
 }


### PR DESCRIPTION

### Packages impacted by this PR

`Azure.Security.CodeTransparency` (1.0.0-beta.9)  
`Azure.Security.ConfidentialLedger` (1.4.1-beta.5)

### Issues associated with this PR

MSRC #116673 (IcM #31000000604457)  
MSRC #119290 / IcM #31000000622297 follow-up context  
ADO Feature #37442109 (SDK redirect caching for ACL & CTS)

### Describe the problem that is addressed by this PR

`CodeTransparencyRedirectPolicy` and `ConfidentialLedgerRedirectPolicy` preserve credential headers when following 307/308 redirects from the service load balancer to the primary node. Previously, they did not verify that the redirect target stayed within the configured endpoint’s trust boundary. A bad redirect could send credentials and request body to an untrusted host, and the write-URL cache could persist that bad target for later writes.

### What are the possible designs available to address the problem?

**Strip-and-follow on cross-origin** — rejected because 307/308 can still send the request body.  
**Disable redirects entirely** — rejected because legitimate LB → primary-node redirects are required.  
**Trust-anchor + refuse-on-mismatch** — chosen. Redirects are followed only when the target is HTTPS, same effective port, and the configured endpoint host or subdomain.

### Describe the solution

Both redirect policies now take the configured endpoint as a trust anchor:

- `CodeTransparencyRedirectPolicy(Uri endpoint)`
- `ConfidentialLedgerRedirectPolicy(Uri endpoint)`

Redirects outside HTTPS + same port + same host/subdomain are refused with `InvalidOperationException` before the request URI is changed or resent. Error messages include only the target origin.

Cache updates are staged per request and committed only after a trusted redirect chain ends on a non-3xx, non-5xx response.

### Are there test cases added in this PR?

Yes. Redirect policy tests were updated for both packages and run in sync and async modes.

Coverage includes cross-origin redirects, HTTP downgrade, sibling/prefix domains, different port, protocol-relative redirects, trusted subdomains, uppercase host canonicalization, explicit `:443`, cache-poison prevention, mid-chain untrusted hops, max-redirect exhaustion, 5xx terminal responses, cached-node malicious redirect, constructor guards, and sanitized exception messages.

### Validation

- CodeTransparency redirect tests: 78/78 passed
- ConfidentialLedger redirect tests: 78/78 passed
- Full ConfidentialLedger net10.0 test project: 115 passed, 143 skipped, 0 failed
- Format and diff checks passed
- Independent Opus 4.8 review found no significant issues

### Provide a list of related PRs

- azure-sdk-for-js#38569 — JS ACL fix, same trust-boundary pattern
- azure-sdk-for-js#38259 — JS redirect-caching context
- Python fix is tracked separately; no Python fix PR identified yet for the custom `RedirectCachingPolicy`

### Checklists

- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? — N/A, hand-authored code only
- [x] Added a changelog