### PR TITLE
Phase 1.97: SCM resolveChild callback for chain-aware resolvers

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added experimental `FileBinaryContent` type for representing a file part within an HTTP request payload, typically as part of a `multipart/form-data` request.
 - Added experimental `MultiPartFormContent` type for building `multipart/form-data` request payloads.
+- Added a chain-aware `CredentialResolver.TryResolve(IConfigurationSection, Func<IConfigurationSection, AuthenticationTokenProvider?>, out AuthenticationTokenProvider?)` virtual overload. The callback lets a chain-owning resolver resolve child sections back through the active engine — preserving caching, normalization, and ordering — without needing to know about credential sources owned by other packages. The default implementation forwards to the existing two-arg overload (experimental `SCME0002`).
 
 ### Breaking Changes
 

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net10.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net10.0.cs
@@ -301,6 +301,7 @@ namespace System.ClientModel.Primitives
     {
         protected CredentialResolver() { }
         public abstract bool TryResolve(Microsoft.Extensions.Configuration.IConfigurationSection credentialSection, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.ClientModel.AuthenticationTokenProvider? provider);
+        public virtual bool TryResolve(Microsoft.Extensions.Configuration.IConfigurationSection credentialSection, System.Func<Microsoft.Extensions.Configuration.IConfigurationSection, System.ClientModel.AuthenticationTokenProvider?> resolveChild, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.ClientModel.AuthenticationTokenProvider? provider) { throw null; }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
     public sealed partial class CredentialSettings

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
@@ -301,6 +301,7 @@ namespace System.ClientModel.Primitives
     {
         protected CredentialResolver() { }
         public abstract bool TryResolve(Microsoft.Extensions.Configuration.IConfigurationSection credentialSection, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.ClientModel.AuthenticationTokenProvider? provider);
+        public virtual bool TryResolve(Microsoft.Extensions.Configuration.IConfigurationSection credentialSection, System.Func<Microsoft.Extensions.Configuration.IConfigurationSection, System.ClientModel.AuthenticationTokenProvider?> resolveChild, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.ClientModel.AuthenticationTokenProvider? provider) { throw null; }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
     public sealed partial class CredentialSettings

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net9.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net9.0.cs
@@ -301,6 +301,7 @@ namespace System.ClientModel.Primitives
     {
         protected CredentialResolver() { }
         public abstract bool TryResolve(Microsoft.Extensions.Configuration.IConfigurationSection credentialSection, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.ClientModel.AuthenticationTokenProvider? provider);
+        public virtual bool TryResolve(Microsoft.Extensions.Configuration.IConfigurationSection credentialSection, System.Func<Microsoft.Extensions.Configuration.IConfigurationSection, System.ClientModel.AuthenticationTokenProvider?> resolveChild, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.ClientModel.AuthenticationTokenProvider? provider) { throw null; }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
     public sealed partial class CredentialSettings

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -293,6 +293,7 @@ namespace System.ClientModel.Primitives
     {
         protected CredentialResolver() { }
         public abstract bool TryResolve(Microsoft.Extensions.Configuration.IConfigurationSection credentialSection, out System.ClientModel.AuthenticationTokenProvider? provider);
+        public virtual bool TryResolve(Microsoft.Extensions.Configuration.IConfigurationSection credentialSection, System.Func<Microsoft.Extensions.Configuration.IConfigurationSection, System.ClientModel.AuthenticationTokenProvider?> resolveChild, out System.ClientModel.AuthenticationTokenProvider? provider) { throw null; }
     }
     public sealed partial class CredentialSettings
     {

--- a/sdk/core/System.ClientModel/src/Auth/CredentialResolver.cs
+++ b/sdk/core/System.ClientModel/src/Auth/CredentialResolver.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
+using System.ClientModel.Internal;
 
 namespace System.ClientModel.Primitives;
 
@@ -64,5 +65,8 @@ public abstract class CredentialResolver
         IConfigurationSection credentialSection,
         Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild,
         [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
-        => TryResolve(credentialSection, out provider);
+    {
+        Argument.AssertNotNull(resolveChild, nameof(resolveChild));
+        return TryResolve(credentialSection, out provider);
+    }
 }

--- a/sdk/core/System.ClientModel/src/Auth/CredentialResolver.cs
+++ b/sdk/core/System.ClientModel/src/Auth/CredentialResolver.cs
@@ -29,4 +29,40 @@ public abstract class CredentialResolver
     public abstract bool TryResolve(
         IConfigurationSection credentialSection,
         [NotNullWhen(true)] out AuthenticationTokenProvider? provider);
+
+    /// <summary>
+    /// Attempts to construct an <see cref="AuthenticationTokenProvider"/> for
+    /// the supplied credential configuration section, with access to a callback
+    /// that recursively resolves child sections through the same active resolver
+    /// chain.
+    /// </summary>
+    /// <param name="credentialSection">The credential configuration section
+    /// (post-overlay if any overrides were applied by the caller).</param>
+    /// <param name="resolveChild">A callback that resolves a child
+    /// <see cref="IConfigurationSection"/> through the active resolver chain
+    /// (including caching, normalization, and ordering). Returns the resolved
+    /// <see cref="AuthenticationTokenProvider"/>, or <see langword="null"/> if
+    /// no resolver in the chain claims the child section. Always non-null;
+    /// resolvers that do not need the chain can ignore the callback.</param>
+    /// <param name="provider">When this method returns <see langword="true"/>,
+    /// contains the constructed provider; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if this resolver recognized and handled
+    /// the section; <see langword="false"/> to defer to the next resolver in the
+    /// chain.</returns>
+    /// <remarks>
+    /// This overload exists so chain-owning resolvers (e.g., a resolver that
+    /// builds a <c>ChainedTokenCredential</c> from child <c>Sources[]</c>
+    /// entries) can recurse back into the active engine for each child entry
+    /// without re-implementing the engine's caching, normalization, or
+    /// ordering logic — and without requiring the resolver to know about
+    /// credential sources owned by other packages. The default implementation
+    /// ignores <paramref name="resolveChild"/> and forwards to
+    /// <see cref="TryResolve(IConfigurationSection, out AuthenticationTokenProvider?)"/>,
+    /// so existing resolvers continue to work unchanged.
+    /// </remarks>
+    public virtual bool TryResolve(
+        IConfigurationSection credentialSection,
+        Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild,
+        [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        => TryResolve(credentialSection, out provider);
 }

--- a/sdk/core/System.ClientModel/src/Convenience/CredentialSettings.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/CredentialSettings.cs
@@ -48,27 +48,20 @@ public sealed class CredentialSettings
     /// </summary>
     /// <remarks>
     /// This value determines the type of authentication policy to use. For example, "ApiKeyCredential" creates an <see cref="ApiKeyAuthenticationPolicy"/>.
+    /// <para>
+    /// Matching is case-insensitive: values read from configuration are normalized to lowercase before storage,
+    /// so resolvers should compare against lowercase constants. Each resolver decides which forms it accepts
+    /// (for example, both short <c>"broker"</c> and long <c>"brokercredential"</c>).
+    /// </para>
     /// </remarks>
     public string? CredentialSource
     {
         get => field;
-        set => field = NormalizeCredentialSource(value);
-    }
-
-    private static string? NormalizeCredentialSource(string? value)
-    {
-        if (value is null)
+        set
         {
-            return null;
+            string? lower = value?.ToLowerInvariant();
+            field = lower == "apikey" ? "apikeycredential" : lower;
         }
-
-        string lower = value.ToLowerInvariant();
-
-        return lower switch
-        {
-            "apikey" => "apikeycredential",
-            _ => lower
-        };
     }
 
     /// <summary>

--- a/sdk/core/System.ClientModel/src/Internal/CredentialCache.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CredentialCache.cs
@@ -31,15 +31,25 @@ internal static class CredentialCache
     /// <summary>
     /// Look up a cached <see cref="CredentialSettings"/> for
     /// (<paramref name="mergedSection"/>, <paramref name="resolver"/>); on
-    /// miss, call <see cref="CredentialResolver.TryResolve"/>. If the
-    /// resolver matches and produces a non-null, non-disposable provider,
+    /// miss, call <see cref="CredentialResolver.TryResolve(IConfigurationSection, Func{IConfigurationSection, AuthenticationTokenProvider?}, out AuthenticationTokenProvider?)"/>.
+    /// If the resolver matches and produces a non-null, non-disposable provider,
     /// build and cache a <see cref="CredentialSettings"/> for it. Returns
     /// <see langword="null"/> when the resolver does not match (the no-match
     /// case is handled by <see cref="GetOrCreateInline"/>).
     /// </summary>
+    /// <param name="mergedSection">The credential section to resolve (already
+    /// merged with any overrides).</param>
+    /// <param name="resolver">The resolver to invoke on cache miss.</param>
+    /// <param name="resolveChild">A callback that recursively resolves child
+    /// sections through the active engine. Passed straight through to the
+    /// chain-aware <see cref="CredentialResolver.TryResolve(IConfigurationSection, Func{IConfigurationSection, AuthenticationTokenProvider?}, out AuthenticationTokenProvider?)"/>
+    /// overload so chain-owning resolvers can recurse without re-implementing
+    /// engine logic. Required — callers without a chain pass a no-op
+    /// (<c>static _ =&gt; null</c>) to honor the resolver's non-null contract.</param>
     public static CredentialSettings? GetOrTryResolve(
         IConfigurationSection mergedSection,
-        CredentialResolver resolver)
+        CredentialResolver resolver,
+        Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild)
     {
         string sectionKey = CredentialSectionHasher.ComputeKey(mergedSection);
         if (sectionKey.Length == 0)
@@ -63,7 +73,10 @@ internal static class CredentialCache
             return existing;
         }
 
-        if (!resolver.TryResolve(mergedSection, out AuthenticationTokenProvider? provider) || provider is null)
+        // Always invoke the chain-aware overload. Resolvers that don't override
+        // it inherit the default implementation, which forwards to the legacy
+        // (section, out provider) overload.
+        if (!resolver.TryResolve(mergedSection, resolveChild, out AuthenticationTokenProvider? provider) || provider is null)
         {
             return null;
         }

--- a/sdk/core/System.ClientModel/src/Internal/CredentialCache.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CredentialCache.cs
@@ -45,7 +45,7 @@ internal static class CredentialCache
     /// chain-aware <see cref="CredentialResolver.TryResolve(IConfigurationSection, Func{IConfigurationSection, AuthenticationTokenProvider?}, out AuthenticationTokenProvider?)"/>
     /// overload so chain-owning resolvers can recurse without re-implementing
     /// engine logic. Required — callers without a chain pass a no-op
-    /// (<c>static _ =&gt; null</c>) to honor the resolver's non-null contract.</param>
+    /// (<c><![CDATA[static _ => null]]></c>) to honor the resolver's non-null contract.</param>
     /// <param name="chainKey">Stable identifier for the active resolver chain
     /// composition. Used as a discriminator when the resolver actually invokes
     /// <paramref name="resolveChild"/> during <c>TryResolve</c> — the produced

--- a/sdk/core/System.ClientModel/src/Internal/CredentialCache.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CredentialCache.cs
@@ -46,10 +46,18 @@ internal static class CredentialCache
     /// overload so chain-owning resolvers can recurse without re-implementing
     /// engine logic. Required — callers without a chain pass a no-op
     /// (<c>static _ =&gt; null</c>) to honor the resolver's non-null contract.</param>
+    /// <param name="chainKey">Stable identifier for the active resolver chain
+    /// composition. Used as a discriminator when the resolver actually invokes
+    /// <paramref name="resolveChild"/> during <c>TryResolve</c> — the produced
+    /// provider then depends on the chain, so it must be cached per chain.
+    /// Resolvers that do not invoke <paramref name="resolveChild"/> get a
+    /// single shared cache entry (chain-independent), preserving cross-chain
+    /// sharing for the common non-chain case.</param>
     public static CredentialSettings? GetOrTryResolve(
         IConfigurationSection mergedSection,
         CredentialResolver resolver,
-        Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild)
+        Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild,
+        string chainKey)
     {
         string sectionKey = CredentialSectionHasher.ComputeKey(mergedSection);
         if (sectionKey.Length == 0)
@@ -66,17 +74,38 @@ internal static class CredentialCache
         // Reference-identity hash bypasses any user GetHashCode override on
         // the resolver and gives a stable identifier for the lifetime of the
         // resolver object.
-        string key = sectionKey + "::" + RuntimeHelpers.GetHashCode(resolver).ToString(Globalization.CultureInfo.InvariantCulture);
+        string resolverPart = sectionKey + "::" + RuntimeHelpers.GetHashCode(resolver).ToString(Globalization.CultureInfo.InvariantCulture);
+        string sharedKey = resolverPart;
+        string chainSpecificKey = resolverPart + "::" + chainKey;
 
-        if (s_cache.TryGetValue(key, out CredentialSettings? existing))
+        // Lookup order:
+        //   1. Shared slot — populated when a prior resolve completed without
+        //      invoking resolveChild. The cached provider is chain-independent
+        //      and safe to share across every chain composition.
+        //   2. Chain-specific slot — populated when a prior resolve DID invoke
+        //      resolveChild. Only valid for this exact chain composition.
+        if (s_cache.TryGetValue(sharedKey, out CredentialSettings? existing) ||
+            s_cache.TryGetValue(chainSpecificKey, out existing))
         {
             return existing;
         }
 
+        // Track whether the resolver consumes downstream chain results during
+        // this invocation. Wrap the engine-supplied resolveChild with a thin
+        // delegate that sets a local flag before forwarding; the flag drives
+        // which slot the result goes into below.
+        bool usedChild = false;
+        Func<IConfigurationSection, AuthenticationTokenProvider?> trackedResolveChild = section =>
+        {
+            usedChild = true;
+            return resolveChild(section);
+        };
+
         // Always invoke the chain-aware overload. Resolvers that don't override
         // it inherit the default implementation, which forwards to the legacy
-        // (section, out provider) overload.
-        if (!resolver.TryResolve(mergedSection, resolveChild, out AuthenticationTokenProvider? provider) || provider is null)
+        // (section, out provider) overload — and never touches resolveChild, so
+        // usedChild stays false and the result lands in the shared slot.
+        if (!resolver.TryResolve(mergedSection, trackedResolveChild, out AuthenticationTokenProvider? provider) || provider is null)
         {
             return null;
         }
@@ -98,7 +127,12 @@ internal static class CredentialCache
             return created;
         }
 
-        return s_cache.GetOrAdd(key, created);
+        // Slot selection: chain-independent results go to the shared slot
+        // (cross-chain reuse for the common case). Chain-dependent results
+        // go to the chain-specific slot so a future call with a different
+        // downstream chain re-resolves through the new chain.
+        string storeKey = usedChild ? chainSpecificKey : sharedKey;
+        return s_cache.GetOrAdd(storeKey, created);
     }
 
     /// <summary>

--- a/sdk/core/System.ClientModel/src/Internal/CredentialResolverEngine.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CredentialResolverEngine.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 
 namespace System.ClientModel.Primitives;
@@ -46,20 +47,34 @@ internal static class CredentialResolverEngine
             configureOverrides(workingSection);
         }
 
+        // Materialize the resolver chain once at the top of every Resolve
+        // call. The recursive resolveChild callback below re-enters this
+        // method with the same enumerable, so a non-reentrant /
+        // single-use IEnumerable (e.g., a custom iterator that throws on
+        // second GetEnumerator) would blow up when the outer foreach has
+        // already started walking it. Pass the materialized list through
+        // the recursion so every layer sees the same snapshot.
+        IReadOnlyList<CredentialResolver>? resolverList = resolvers switch
+        {
+            null => null,
+            IReadOnlyList<CredentialResolver> list => list,
+            _ => resolvers.ToArray()
+        };
+
         // Build the recursive callback once per Resolve invocation. Resolvers
         // that override the chain-aware TryResolve overload (e.g., a chain-
         // owning resolver that walks Sources[]) can invoke this to resolve a
         // child IConfigurationSection through the same active resolver chain.
-        // The callback re-enters this engine method with the same resolver
-        // list and no overrides — overrides only apply to the top-level
-        // section the caller passed in.
+        // The callback re-enters this engine method with the materialized
+        // resolver list and no overrides — overrides only apply to the
+        // top-level section the caller passed in.
         //
         // Note: the recursive Resolve call goes through the full pipeline
         // (cache lookup, normalization, ordering), so chain entries pick up
         // caching for free and a single shared engine remains the source of
         // truth for resolution semantics.
         Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild =
-            child => Resolve(child, resolvers, configureOverrides: null)?.TokenProvider;
+            child => Resolve(child, resolverList, configureOverrides: null)?.TokenProvider;
 
         // Per-resolver cache lookup: the cached settings depend on the
         // (section, resolver-that-actually-produced-it) pair, not on the whole
@@ -77,9 +92,9 @@ internal static class CredentialResolverEngine
         // Reference-identity (RuntimeHelpers.GetHashCode) is used so distinct
         // instances of the same type don't leak providers into each other,
         // and any GetHashCode override on the resolver is bypassed.
-        if (resolvers is not null)
+        if (resolverList is not null)
         {
-            foreach (CredentialResolver resolver in resolvers)
+            foreach (CredentialResolver resolver in resolverList)
             {
                 if (resolver is null)
                 {

--- a/sdk/core/System.ClientModel/src/Internal/CredentialResolverEngine.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CredentialResolverEngine.cs
@@ -56,9 +56,9 @@ internal static class CredentialResolverEngine
         // second GetEnumerator) would blow up when the outer foreach has
         // already started walking it. Pass the materialized list through
         // the recursion so every layer sees the same snapshot.
-        IReadOnlyList<CredentialResolver>? resolverList = resolvers switch
+        IReadOnlyList<CredentialResolver> resolverList = resolvers switch
         {
-            null => null,
+            null => Array.Empty<CredentialResolver>(),
             IReadOnlyList<CredentialResolver> list => list,
             _ => resolvers.ToArray()
         };
@@ -103,7 +103,7 @@ internal static class CredentialResolverEngine
         // Reference-identity (RuntimeHelpers.GetHashCode) is used so distinct
         // instances of the same type don't leak providers into each other,
         // and any GetHashCode override on the resolver is bypassed.
-        if (resolverList is not null)
+        if (resolverList.Count > 0)
         {
             string chainKey = ComputeChainKey(resolverList);
             foreach (CredentialResolver resolver in resolverList)

--- a/sdk/core/System.ClientModel/src/Internal/CredentialResolverEngine.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CredentialResolverEngine.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
 using Microsoft.Extensions.Configuration;
 
 namespace System.ClientModel.Primitives;
@@ -76,24 +78,34 @@ internal static class CredentialResolverEngine
         Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild =
             child => Resolve(child, resolverList, configureOverrides: null)?.TokenProvider;
 
-        // Per-resolver cache lookup: the cached settings depend on the
-        // (section, resolver-that-actually-produced-it) pair, not on the whole
-        // chain. So callers with overlapping chains share entries whenever the
-        // same resolver instance is the one that wins for a given section.
+        // Per-resolver cache lookup. The cache uses a dual-slot strategy:
         //
-        // For each resolver in order:
-        //   1. Look up cache by (sectionHash, RuntimeHelpers.GetHashCode(resolver)).
-        //      If hit, return — that resolver previously produced settings for
-        //      this exact section.
-        //   2. Otherwise call TryResolve. If it succeeds, store the produced
-        //      settings under that key and return.
-        //   3. If it doesn't match, continue to the next resolver.
+        //   * Shared slot — keyed by (sectionHash, resolverInstance). Populated
+        //     when a resolver's TryResolve does NOT invoke resolveChild — its
+        //     output is chain-independent, so one entry serves every chain
+        //     composition.
+        //   * Chain-specific slot — keyed by (sectionHash, resolverInstance,
+        //     chainKey). Populated when a resolver DOES invoke resolveChild —
+        //     its output depends on the downstream resolvers, so a different
+        //     chain composition must produce a fresh resolve.
+        //
+        // CredentialCache.GetOrTryResolve looks up the shared slot first then
+        // the chain-specific slot on miss. After invoking TryResolve it stores
+        // the result in whichever slot is correct based on whether resolveChild
+        // was used.
+        //
+        // chainKey is computed once per Resolve invocation from the materialized
+        // resolverList — stable identifier for the active chain composition
+        // (reference-identity hashes joined in order). All resolvers in this
+        // engine call share the same chainKey since they all see the same
+        // resolveChild closure capturing the same resolverList.
         //
         // Reference-identity (RuntimeHelpers.GetHashCode) is used so distinct
         // instances of the same type don't leak providers into each other,
         // and any GetHashCode override on the resolver is bypassed.
         if (resolverList is not null)
         {
+            string chainKey = ComputeChainKey(resolverList);
             foreach (CredentialResolver resolver in resolverList)
             {
                 if (resolver is null)
@@ -101,7 +113,7 @@ internal static class CredentialResolverEngine
                     continue;
                 }
 
-                CredentialSettings? matched = CredentialCache.GetOrTryResolve(workingSection, resolver, resolveChild);
+                CredentialSettings? matched = CredentialCache.GetOrTryResolve(workingSection, resolver, resolveChild, chainKey);
 
                 if (matched is not null)
                 {
@@ -115,5 +127,31 @@ internal static class CredentialResolverEngine
         // credential lives directly on the section as Key/CredentialSource
         // rather than through a token provider.
         return CredentialCache.GetOrCreateInline(workingSection);
+    }
+
+    // Compose a stable chain identifier from reference-identity hashes of
+    // the resolver instances in order. Two engine calls with the same
+    // resolver instances in the same order produce the same chainKey; any
+    // change (different instance, different order, added/removed resolver)
+    // produces a different one. Resolvers' own GetHashCode overrides are
+    // bypassed via RuntimeHelpers.GetHashCode.
+    private static string ComputeChainKey(IReadOnlyList<CredentialResolver> resolverList)
+    {
+        if (resolverList.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        StringBuilder sb = new();
+        for (int i = 0; i < resolverList.Count; i++)
+        {
+            CredentialResolver r = resolverList[i];
+            if (i > 0)
+            {
+                sb.Append('|');
+            }
+            sb.Append(r is null ? "_" : RuntimeHelpers.GetHashCode(r).ToString(Globalization.CultureInfo.InvariantCulture));
+        }
+        return sb.ToString();
     }
 }

--- a/sdk/core/System.ClientModel/src/Internal/CredentialResolverEngine.cs
+++ b/sdk/core/System.ClientModel/src/Internal/CredentialResolverEngine.cs
@@ -46,6 +46,21 @@ internal static class CredentialResolverEngine
             configureOverrides(workingSection);
         }
 
+        // Build the recursive callback once per Resolve invocation. Resolvers
+        // that override the chain-aware TryResolve overload (e.g., a chain-
+        // owning resolver that walks Sources[]) can invoke this to resolve a
+        // child IConfigurationSection through the same active resolver chain.
+        // The callback re-enters this engine method with the same resolver
+        // list and no overrides — overrides only apply to the top-level
+        // section the caller passed in.
+        //
+        // Note: the recursive Resolve call goes through the full pipeline
+        // (cache lookup, normalization, ordering), so chain entries pick up
+        // caching for free and a single shared engine remains the source of
+        // truth for resolution semantics.
+        Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild =
+            child => Resolve(child, resolvers, configureOverrides: null)?.TokenProvider;
+
         // Per-resolver cache lookup: the cached settings depend on the
         // (section, resolver-that-actually-produced-it) pair, not on the whole
         // chain. So callers with overlapping chains share entries whenever the
@@ -71,7 +86,7 @@ internal static class CredentialResolverEngine
                     continue;
                 }
 
-                CredentialSettings? matched = CredentialCache.GetOrTryResolve(workingSection, resolver);
+                CredentialSettings? matched = CredentialCache.GetOrTryResolve(workingSection, resolver, resolveChild);
 
                 if (matched is not null)
                 {

--- a/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
@@ -1281,7 +1281,7 @@ public class CredentialResolverTests
     }
 
     [Test]
-    public void Engine_ResolveChild_WalksFullChainAndShareCacheWithTopLevel()
+    public void Engine_ResolveChild_WalksFullChainAndSharesCacheWithTopLevel()
     {
         // A chain-owning resolver invokes resolveChild(childSection) on a child
         // section that another resolver in the same chain can claim.

--- a/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
@@ -111,14 +111,15 @@ public class CredentialResolverTests
 
         var resolver = new ScopedRecordingResolver("Anything", "x");
 
-        // GetOrTryResolve(IConfigurationSection, CredentialResolver, Func<...>) —
-        // the third param is required (non-nullable) so callers honor the resolver's
-        // chain-aware contract. Pass an explicit no-op since this test bypasses
-        // the engine and has no chain.
+        // GetOrTryResolve(IConfigurationSection, CredentialResolver, Func<...>, string chainKey) —
+        // the third and fourth params are required so callers honor the
+        // resolver's chain-aware contract and the cache's chain-discriminator
+        // contract. Pass an explicit no-op resolveChild and an empty chainKey
+        // since this test bypasses the engine and has no chain.
         Func<IConfigurationSection, AuthenticationTokenProvider?> noChain = static _ => null;
         var result = getOrTryResolve.Invoke(
             null,
-            new object?[] { null, resolver, noChain });
+            new object?[] { null, resolver, noChain, string.Empty });
 
         Assert.That(result, Is.Null);
         Assert.That(resolver.WasCalled, Is.False, "resolver must not run when the merged section is null");
@@ -1394,6 +1395,177 @@ public class CredentialResolverTests
             "resolveChild should have walked the chain and matched the child resolver.");
     }
 
+    [Test]
+    public void Engine_ChainCache_DifferentDownstream_ProducesDistinctEntries()
+    {
+        // Scenario from PR review: chain-owning resolver reused across two
+        // calls with the same parent section but different downstream resolvers
+        // for the inner section. The cache must NOT return the first call's
+        // wrapped provider for the second call — the second call's downstream
+        // resolver would otherwise be silently bypassed.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Cred:CredentialSource"] = "MyChain",
+            ["Cred:Inner:CredentialSource"] = "FooCred",
+            ["Cred:Inner:Bar"] = "false",
+        });
+
+        var chainOwner = new ChainWrapperResolver("MyChain", section => section.GetSection("Inner"));
+        var fooRespectsBar = new FooCredResolver("FooCred", respectsBar: true);
+        var fooIgnoresBar = new FooCredResolver("FooCred", respectsBar: false);
+
+        CredentialSettings? first = config.GetCredentialSettings(
+            "Cred", chainOwner, fooRespectsBar);
+        Assert.That(((ChainWrapperProvider)first!.TokenProvider!).Inner, Is.InstanceOf<FooTokenProvider>());
+        Assert.That(((FooTokenProvider)((ChainWrapperProvider)first.TokenProvider!).Inner!).RespectsBar, Is.True);
+
+        CredentialSettings? second = config.GetCredentialSettings(
+            "Cred", chainOwner, fooIgnoresBar);
+
+        Assert.That(second?.TokenProvider, Is.Not.SameAs(first.TokenProvider),
+            "Chain-aware result must NOT be served from cache when the downstream chain composition changed.");
+        Assert.That(((FooTokenProvider)((ChainWrapperProvider)second!.TokenProvider!).Inner!).RespectsBar, Is.False,
+            "Second call's inner provider must come from fooIgnoresBar — proves the new chain was actually walked.");
+    }
+
+    [Test]
+    public void Engine_ChainCache_SameDownstream_ReturnsCachedEntry()
+    {
+        // Same parent section + same chain composition = cache hit. Pins the
+        // happy path: chain-aware cache entries are reusable when nothing
+        // about the chain changes.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Cred:CredentialSource"] = "MyChain",
+            ["Cred:Inner:CredentialSource"] = "FooCred",
+        });
+
+        var chainOwner = new ChainWrapperResolver("MyChain", section => section.GetSection("Inner"));
+        var foo = new FooCredResolver("FooCred", respectsBar: true);
+
+        CredentialSettings? first = config.GetCredentialSettings("Cred", chainOwner, foo);
+        CredentialSettings? second = config.GetCredentialSettings("Cred", chainOwner, foo);
+
+        Assert.That(second?.TokenProvider, Is.SameAs(first?.TokenProvider),
+            "Same (section, resolver, chain composition) should hit the chain-specific cache slot.");
+    }
+
+    [Test]
+    public void Engine_NonChainCache_SharedAcrossDifferentChainCompositions()
+    {
+        // Non-chain-aware resolver: its TryResolve never invokes resolveChild,
+        // so its output is chain-independent. The cache stores it under the
+        // shared slot (chainKey=null) so subsequent calls with the same
+        // (section, resolver) but different chain compositions still hit.
+        // This pins the "1 entry for non-chains, N for chains" property.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Cred:CredentialSource"] = "Simple",
+        });
+
+        var simple = new ScopedRecordingResolver("Simple", "simple-provider");
+        var neverMatches = new ScopedRecordingResolver("Other", "other");
+        var alsoNeverMatches = new ScopedRecordingResolver("Yet-Another", "yet-another");
+
+        CredentialSettings? first = config.GetCredentialSettings("Cred", simple, neverMatches);
+        CredentialSettings? second = config.GetCredentialSettings("Cred", simple, alsoNeverMatches);
+
+        Assert.That(second?.TokenProvider, Is.SameAs(first?.TokenProvider),
+            "Non-chain-aware resolver output must be shared across different chain compositions (shared cache slot).");
+    }
+
+    [Test]
+    public void Engine_ChainCache_RespectsResolverOrderInChainKey()
+    {
+        // Two chains containing the same resolver instances but in different
+        // order produce distinct cache entries — the resolver order affects
+        // which resolver actually claims a given inner section, so it must
+        // affect the chain key.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Cred:CredentialSource"] = "MyChain",
+            ["Cred:Inner:CredentialSource"] = "FooCred",
+        });
+
+        var chainOwner = new ChainWrapperResolver("MyChain", section => section.GetSection("Inner"));
+        var fooA = new FooCredResolver("FooCred", respectsBar: true);
+        var fooB = new FooCredResolver("FooCred", respectsBar: false);
+
+        // Order: [chainOwner, fooA, fooB] — fooA wins for inner (first match).
+        CredentialSettings? first = config.GetCredentialSettings(
+            "Cred", chainOwner, fooA, fooB);
+        // Order: [chainOwner, fooB, fooA] — fooB wins for inner.
+        CredentialSettings? second = config.GetCredentialSettings(
+            "Cred", chainOwner, fooB, fooA);
+
+        Assert.That(second?.TokenProvider, Is.Not.SameAs(first?.TokenProvider),
+            "Different resolver order can change which downstream resolver wins — must produce a distinct cache entry.");
+        Assert.That(((FooTokenProvider)((ChainWrapperProvider)first!.TokenProvider!).Inner!).RespectsBar, Is.True,
+            "First call: fooA (respectsBar:true) wins the inner.");
+        Assert.That(((FooTokenProvider)((ChainWrapperProvider)second!.TokenProvider!).Inner!).RespectsBar, Is.False,
+            "Second call: fooB (respectsBar:false) wins the inner.");
+    }
+
+    [Test]
+    public void Engine_ChainCache_DistinctParentInstances_DoNotShareCache()
+    {
+        // Two different chainOwner instances of the same type must produce
+        // distinct cache entries even with identical downstream chain — the
+        // cache key uses resolver reference identity, not type identity, so
+        // resolver instance state cannot leak across instances.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Cred:CredentialSource"] = "MyChain",
+            ["Cred:Inner:CredentialSource"] = "FooCred",
+        });
+
+        var chainOwnerA = new ChainWrapperResolver("MyChain", section => section.GetSection("Inner"));
+        var chainOwnerB = new ChainWrapperResolver("MyChain", section => section.GetSection("Inner"));
+        var foo = new FooCredResolver("FooCred", respectsBar: true);
+
+        CredentialSettings? a = config.GetCredentialSettings("Cred", chainOwnerA, foo);
+        CredentialSettings? b = config.GetCredentialSettings("Cred", chainOwnerB, foo);
+
+        Assert.That(b?.TokenProvider, Is.Not.SameAs(a?.TokenProvider),
+            "Distinct resolver instances must get distinct cache entries even when types and downstream chain match.");
+    }
+
+    [Test]
+    public void Engine_ChainCache_ConditionalChainUse_ChoosesSlotPerSection()
+    {
+        // A resolver that calls resolveChild for some sections and not others
+        // must land its results in the appropriate slot per section: chain-
+        // specific when resolveChild was used, shared when it wasn't. Two
+        // calls with the same resolver against a non-chain section share
+        // their cached entry even across different chain compositions, while
+        // the same resolver against a chain section gets distinct entries
+        // per chain.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Plain:CredentialSource"] = "Conditional",
+            ["WithChild:CredentialSource"] = "Conditional",
+            ["WithChild:Child:CredentialSource"] = "FooCred",
+        });
+
+        var conditional = new ConditionalChainResolver("Conditional", "Child");
+        var fooA = new FooCredResolver("FooCred", respectsBar: true);
+        var fooB = new FooCredResolver("FooCred", respectsBar: false);
+
+        // Plain section (no child subsection) → resolveChild never called →
+        // shared slot. Same instance across different chain compositions.
+        CredentialSettings? plain1 = config.GetCredentialSettings("Plain", conditional, fooA);
+        CredentialSettings? plain2 = config.GetCredentialSettings("Plain", conditional, fooB);
+        Assert.That(plain2?.TokenProvider, Is.SameAs(plain1?.TokenProvider),
+            "Plain section: resolveChild not called → shared slot → same instance across chains.");
+
+        // WithChild section → resolveChild called → chain-specific slot.
+        // Different chain compositions → different entries.
+        CredentialSettings? chain1 = config.GetCredentialSettings("WithChild", conditional, fooA);
+        CredentialSettings? chain2 = config.GetCredentialSettings("WithChild", conditional, fooB);
+        Assert.That(chain2?.TokenProvider, Is.Not.SameAs(chain1?.TokenProvider),
+            "WithChild section: resolveChild called → chain-specific slot → different entries per chain.");
+    }
+
     private sealed class CapturingChainAwareResolver : CredentialResolver
     {
         private readonly string _matchSource;
@@ -1471,6 +1643,143 @@ public class CredentialResolverTests
             provider = new StubTokenProvider("parent");
             return true;
         }
+    }
+
+    // Chain-owning resolver that wraps the resolved child provider in a
+    // ChainWrapperProvider so tests can observe which inner provider was
+    // used. Models real chain-owning resolvers (e.g., AzureCredentialResolver
+    // for ChainedTokenCredential) that assemble their output from
+    // downstream provider instances.
+    // Resolver that conditionally invokes resolveChild based on whether the
+    // section has a named child subsection. Pins the conditional-chain-use
+    // scenario where the same resolver routes through both cache slots
+    // depending on the input section.
+    private sealed class ConditionalChainResolver : CredentialResolver
+    {
+        private readonly string _matchSource;
+        private readonly string _childKey;
+
+        public ConditionalChainResolver(string matchSource, string childKey)
+        {
+            _matchSource = matchSource;
+            _childKey = childKey;
+        }
+
+        public override bool TryResolve(IConfigurationSection credentialSection, [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            provider = null;
+            return false;
+        }
+
+        public override bool TryResolve(
+            IConfigurationSection credentialSection,
+            Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild,
+            [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            string? source = credentialSection["CredentialSource"];
+            if (!string.Equals(source, _matchSource, StringComparison.OrdinalIgnoreCase))
+            {
+                provider = null;
+                return false;
+            }
+
+            IConfigurationSection child = credentialSection.GetSection(_childKey);
+            if (child.Exists())
+            {
+                AuthenticationTokenProvider? inner = resolveChild(child);
+                provider = new ChainWrapperProvider(inner);
+            }
+            else
+            {
+                // Resolve produced a chain-independent provider — resolveChild
+                // was NOT called, so the cache should park us in the shared slot.
+                provider = new StubTokenProvider("conditional-no-child");
+            }
+            return true;
+        }
+    }
+
+    private sealed class ChainWrapperResolver : CredentialResolver
+    {
+        private readonly string _matchSource;
+        private readonly Func<IConfigurationSection, IConfigurationSection> _selectChild;
+
+        public ChainWrapperResolver(
+            string matchSource,
+            Func<IConfigurationSection, IConfigurationSection> selectChild)
+        {
+            _matchSource = matchSource;
+            _selectChild = selectChild;
+        }
+
+        public override bool TryResolve(IConfigurationSection credentialSection, [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            provider = null;
+            return false;
+        }
+
+        public override bool TryResolve(
+            IConfigurationSection credentialSection,
+            Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild,
+            [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            string? source = credentialSection["CredentialSource"];
+            if (!string.Equals(source, _matchSource, StringComparison.OrdinalIgnoreCase))
+            {
+                provider = null;
+                return false;
+            }
+
+            IConfigurationSection child = _selectChild(credentialSection);
+            AuthenticationTokenProvider? childProvider = resolveChild(child);
+            provider = new ChainWrapperProvider(childProvider);
+            return true;
+        }
+    }
+
+    private sealed class ChainWrapperProvider : AuthenticationTokenProvider
+    {
+        public ChainWrapperProvider(AuthenticationTokenProvider? inner) => Inner = inner;
+        public AuthenticationTokenProvider? Inner { get; }
+        public override GetTokenOptions? CreateTokenOptions(IReadOnlyDictionary<string, object> properties) => null;
+        public override AuthenticationToken GetToken(GetTokenOptions options, Threading.CancellationToken cancellationToken) => default!;
+        public override Threading.Tasks.ValueTask<AuthenticationToken> GetTokenAsync(GetTokenOptions options, Threading.CancellationToken cancellationToken) => default!;
+    }
+
+    // Two distinct FooCredResolver instances (respectsBar:true / :false)
+    // model the chain-swap scenario: same source name claimed by different
+    // resolver instances that produce semantically different providers.
+    private sealed class FooCredResolver : CredentialResolver
+    {
+        private readonly string _matchSource;
+        private readonly bool _respectsBar;
+
+        public FooCredResolver(string matchSource, bool respectsBar)
+        {
+            _matchSource = matchSource;
+            _respectsBar = respectsBar;
+        }
+
+        public override bool TryResolve(IConfigurationSection credentialSection, [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            string? source = credentialSection["CredentialSource"];
+            if (!string.Equals(source, _matchSource, StringComparison.OrdinalIgnoreCase))
+            {
+                provider = null;
+                return false;
+            }
+            provider = new FooTokenProvider(_respectsBar);
+            return true;
+        }
+    }
+
+    private sealed class FooTokenProvider : AuthenticationTokenProvider
+    {
+        public FooTokenProvider(bool respectsBar) => RespectsBar = respectsBar;
+        public bool RespectsBar { get; }
+        public override GetTokenOptions? CreateTokenOptions(IReadOnlyDictionary<string, object> properties) => null;
+        public override AuthenticationToken GetToken(GetTokenOptions options, Threading.CancellationToken cancellationToken) => default!;
+        public override Threading.Tasks.ValueTask<AuthenticationToken> GetTokenAsync(GetTokenOptions options, Threading.CancellationToken cancellationToken) => default!;
     }
 
     // Enumerable that throws if GetEnumerator() is called more than once.

--- a/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
@@ -111,9 +111,14 @@ public class CredentialResolverTests
 
         var resolver = new ScopedRecordingResolver("Anything", "x");
 
+        // GetOrTryResolve(IConfigurationSection, CredentialResolver, Func<...>) —
+        // the third param is required (non-nullable) so callers honor the resolver's
+        // chain-aware contract. Pass an explicit no-op since this test bypasses
+        // the engine and has no chain.
+        Func<IConfigurationSection, AuthenticationTokenProvider?> noChain = static _ => null;
         var result = getOrTryResolve.Invoke(
             null,
-            new object?[] { null, resolver });
+            new object?[] { null, resolver, noChain });
 
         Assert.That(result, Is.Null);
         Assert.That(resolver.WasCalled, Is.False, "resolver must not run when the merged section is null");
@@ -937,7 +942,8 @@ public class CredentialResolverTests
     {
         // SCM does not produce a built-in provider for inline ApiKey configs.
         // The standalone caller reads cred.Key directly when TokenProvider
-        // is null. The CredentialSource is normalized to "apikeycredential".
+        // is null. The CredentialSource is normalized to "apikeycredential"
+        // (the one back-compat alias preserved from 1.13.0).
         IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
         {
             ["TestClient:Credential:CredentialSource"] = "ApiKey",
@@ -1184,6 +1190,232 @@ public class CredentialResolverTests
         {
             CallCount++;
             provider = new AsyncDisposableStubTokenProvider();
+            return true;
+        }
+    }
+
+    // ---- Phase 1.97: chain-aware TryResolve overload + case-insensitive normalization ----
+
+    [Test]
+    public void CredentialSource_IsLowercasedOnAssignment()
+    {
+        // CredentialSettings normalizes by lowercasing. Resolvers are
+        // responsible for accepting whichever spellings they want (short and/or
+        // long form). The single exception is "apikey" → "apikeycredential",
+        // a back-compat alias preserved from SCM 1.13.0 because generated
+        // client code dispatches on the long form.
+        var settings = new CredentialSettings(null!);
+
+        settings.CredentialSource = "Broker";
+        Assert.That(settings.CredentialSource, Is.EqualTo("broker"));
+
+        settings.CredentialSource = "BrokerCredential";
+        Assert.That(settings.CredentialSource, Is.EqualTo("brokercredential"));
+
+        settings.CredentialSource = "BROKER";
+        Assert.That(settings.CredentialSource, Is.EqualTo("broker"));
+
+        settings.CredentialSource = "ApiKey";
+        Assert.That(settings.CredentialSource, Is.EqualTo("apikeycredential"),
+            "ApiKey is the one back-compat alias preserved from 1.13.0.");
+
+        settings.CredentialSource = null;
+        Assert.That(settings.CredentialSource, Is.Null);
+    }
+
+    [Test]
+    public void TryResolve_NewOverload_DefaultImplForwardsToLegacyOverload()
+    {
+        // A resolver that overrides only the legacy (section, out provider) overload
+        // must still be reachable through the new (section, resolveChild, out provider)
+        // overload — the default virtual forwards.
+        IConfigurationSection section = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Cred:CredentialSource"] = "Match"
+        }).GetSection("Cred");
+
+        var legacy = new ScopedRecordingResolver("Match", "legacy");
+
+        bool ok = legacy.TryResolve(section, static _ => null, out AuthenticationTokenProvider? provider);
+
+        Assert.That(ok, Is.True);
+        Assert.That(provider, Is.SameAs(legacy.LastProvider));
+    }
+
+    [Test]
+    public void Engine_PassesNonNullResolveChild_ToResolvers()
+    {
+        // Resolvers that override the chain-aware overload receive a non-null
+        // callback from the engine — even when no chain-style nesting is
+        // happening on the top-level call.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["TestClient:Credential:CredentialSource"] = "Match"
+        });
+
+        var capturing = new CapturingChainAwareResolver(matchSource: "Match");
+
+        CredentialSettings? cred = config.GetCredentialSettings("TestClient:Credential", capturing);
+
+        Assert.That(cred, Is.Not.Null);
+        Assert.That(capturing.LastResolveChild, Is.Not.Null,
+            "Engine must hand resolvers a non-null resolveChild callback so chain-owning resolvers can recurse without a null check.");
+    }
+
+    [Test]
+    public void Engine_ResolveChild_WalksFullChainAndShareCacheWithTopLevel()
+    {
+        // A chain-owning resolver invokes resolveChild(childSection) on a child
+        // section that another resolver in the same chain can claim.
+        // - The child resolver runs (chain walked correctly).
+        // - The returned provider matches what GetCredentialSettings would
+        //   return for that child section directly (cache shared, same key).
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Parent:CredentialSource"] = "Parent",
+            // child section content
+            ["Parent:Child:CredentialSource"] = "Child",
+            ["Parent:Child:TenantId"] = "t-child",
+        });
+
+        // ChainOwnerResolver: claims "Parent", uses resolveChild to resolve
+        // the child section and stores the returned provider on its stub.
+        var childResolver = new ScopedRecordingResolver("Child", "child-provider");
+        AuthenticationTokenProvider? recursivelyResolved = null;
+        var parentResolver = new InvokeChildResolver("Parent",
+            section => section.GetSection("Child"),
+            provider => recursivelyResolved = provider);
+
+        CredentialSettings? parentCred = config.GetCredentialSettings(
+            "Parent",
+            parentResolver,
+            childResolver);
+
+        Assert.That(parentCred, Is.Not.Null, "parent should resolve");
+        Assert.That(recursivelyResolved, Is.Not.Null, "resolveChild should have produced a provider for the Child section");
+        Assert.That(recursivelyResolved, Is.SameAs(childResolver.LastProvider),
+            "resolveChild should walk the same chain and surface the child resolver's provider");
+
+        // Independent direct call returns the cached child provider — proves
+        // cache identity is shared between recursive path and top-level path.
+        CredentialSettings? childCred = config.GetCredentialSettings(
+            "Parent:Child",
+            parentResolver,
+            childResolver);
+
+        Assert.That(childCred?.TokenProvider, Is.SameAs(recursivelyResolved),
+            "Top-level resolution of the child section must hit the same cache entry the recursive call produced.");
+    }
+
+    [Test]
+    public void Engine_ResolveChild_DoesNotReapplyConfigureOverridesOnRecursion()
+    {
+        // configureOverrides only applies to the top-level call; recursive
+        // resolveChild invocations re-enter the engine with configureOverrides
+        // == null. This is enforced structurally and pinned by an invocation
+        // count — running the override callback twice could double-apply state
+        // (e.g., a callback that increments a counter on the section) and break
+        // resolver caching keyed by merged content.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Parent:CredentialSource"] = "Parent",
+            ["Parent:Child:CredentialSource"] = "Child",
+        });
+
+        var childResolver = new ScopedRecordingResolver("Child", "child");
+        var parentResolver = new InvokeChildResolver("Parent",
+            section => section.GetSection("Child"),
+            _ => { });
+
+        int overrideInvocations = 0;
+        config.GetCredentialSettings(
+            "Parent",
+            new CredentialResolver[] { parentResolver, childResolver },
+            section =>
+            {
+                overrideInvocations++;
+                section["TenantId"] = "override-tenant";
+            });
+
+        Assert.That(overrideInvocations, Is.EqualTo(1),
+            "configureOverrides must be invoked exactly once — recursive resolveChild calls re-enter with null overrides.");
+    }
+
+    private sealed class CapturingChainAwareResolver : CredentialResolver
+    {
+        private readonly string _matchSource;
+
+        public CapturingChainAwareResolver(string matchSource) => _matchSource = matchSource;
+
+        public Func<IConfigurationSection, AuthenticationTokenProvider?>? LastResolveChild { get; private set; }
+
+        public override bool TryResolve(IConfigurationSection credentialSection, [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            // Should never be called by the engine — engine always invokes the
+            // chain-aware overload, which this class overrides.
+            provider = null;
+            return false;
+        }
+
+        public override bool TryResolve(
+            IConfigurationSection credentialSection,
+            Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild,
+            [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            LastResolveChild = resolveChild;
+            string? source = credentialSection["CredentialSource"];
+            if (string.Equals(source, _matchSource, StringComparison.OrdinalIgnoreCase))
+            {
+                provider = new StubTokenProvider("chain-aware");
+                return true;
+            }
+            provider = null;
+            return false;
+        }
+    }
+
+    private sealed class InvokeChildResolver : CredentialResolver
+    {
+        private readonly string _matchSource;
+        private readonly Func<IConfigurationSection, IConfigurationSection> _selectChild;
+        private readonly Action<AuthenticationTokenProvider?> _onChildResolved;
+
+        public InvokeChildResolver(
+            string matchSource,
+            Func<IConfigurationSection, IConfigurationSection> selectChild,
+            Action<AuthenticationTokenProvider?> onChildResolved)
+        {
+            _matchSource = matchSource;
+            _selectChild = selectChild;
+            _onChildResolved = onChildResolved;
+        }
+
+        public override bool TryResolve(IConfigurationSection credentialSection, [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            // Default forwards here from the chain-aware overload when no
+            // resolveChild is plumbed — but in this test the engine always
+            // calls the chain-aware overload, so this branch is unused.
+            provider = null;
+            return false;
+        }
+
+        public override bool TryResolve(
+            IConfigurationSection credentialSection,
+            Func<IConfigurationSection, AuthenticationTokenProvider?> resolveChild,
+            [NotNullWhen(true)] out AuthenticationTokenProvider? provider)
+        {
+            string? source = credentialSection["CredentialSource"];
+            if (!string.Equals(source, _matchSource, StringComparison.OrdinalIgnoreCase))
+            {
+                provider = null;
+                return false;
+            }
+
+            IConfigurationSection child = _selectChild(credentialSection);
+            AuthenticationTokenProvider? childProvider = resolveChild(child);
+            _onChildResolved(childProvider);
+
+            provider = new StubTokenProvider("parent");
             return true;
         }
     }

--- a/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
@@ -1359,6 +1359,41 @@ public class CredentialResolverTests
             "configureOverrides must be invoked exactly once — recursive resolveChild calls re-enter with null overrides.");
     }
 
+    [Test]
+    public void Engine_ResolveChild_HandlesSingleUseResolverEnumerable()
+    {
+        // Pinning the contract surfaced in PR review: when a chain-owning
+        // resolver invokes resolveChild, the engine re-enters Resolve with the
+        // same resolver enumerable while the outer foreach is still walking it.
+        // If the engine doesn't materialize the enumerable once per top-level
+        // call, a non-reentrant / single-use IEnumerable<CredentialResolver>
+        // (custom iterator, throws on second GetEnumerator) would blow up.
+        // The engine must enumerate it exactly once and reuse the materialized
+        // copy for the recursive call.
+        IConfigurationRoot config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Parent:CredentialSource"] = "Parent",
+            ["Parent:Child:CredentialSource"] = "Child",
+        });
+
+        var childResolver = new ScopedRecordingResolver("Child", "child");
+        var parentResolver = new InvokeChildResolver(
+            "Parent",
+            section => section.GetSection("Child"),
+            _ => { });
+
+        var singleUse = new SingleUseResolverList(parentResolver, childResolver);
+
+        CredentialSettings? cred = config.GetCredentialSettings("Parent", singleUse, _ => { });
+
+        Assert.That(cred, Is.Not.Null,
+            "Top-level resolution should succeed without the recursive call re-enumerating the single-use list.");
+        Assert.That(singleUse.EnumerateCount, Is.EqualTo(1),
+            "Engine must materialize resolvers once and reuse for recursion.");
+        Assert.That(childResolver.WasCalled, Is.True,
+            "resolveChild should have walked the chain and matched the child resolver.");
+    }
+
     private sealed class CapturingChainAwareResolver : CredentialResolver
     {
         private readonly string _matchSource;
@@ -1436,5 +1471,32 @@ public class CredentialResolverTests
             provider = new StubTokenProvider("parent");
             return true;
         }
+    }
+
+    // Enumerable that throws if GetEnumerator() is called more than once.
+    // Mirrors "non-reentrant / single-use" iterators a caller might pass.
+    private sealed class SingleUseResolverList : IEnumerable<CredentialResolver>
+    {
+        private readonly CredentialResolver[] _resolvers;
+        private int _enumerateCount;
+
+        public SingleUseResolverList(params CredentialResolver[] resolvers)
+        {
+            _resolvers = resolvers;
+        }
+
+        public int EnumerateCount => _enumerateCount;
+
+        public IEnumerator<CredentialResolver> GetEnumerator()
+        {
+            int n = System.Threading.Interlocked.Increment(ref _enumerateCount);
+            if (n > 1)
+            {
+                throw new InvalidOperationException("SingleUseResolverList enumerated more than once.");
+            }
+            return ((IEnumerable<CredentialResolver>)_resolvers).GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/CredentialResolverTests.cs
@@ -1243,6 +1243,24 @@ public class CredentialResolverTests
     }
 
     [Test]
+    public void TryResolve_NewOverload_DefaultImplThrowsOnNullResolveChild()
+    {
+        // The new overload documents resolveChild as non-null; the base virtual
+        // enforces that contract so derived resolvers (which may assume non-null)
+        // see a clear ArgumentNullException at the API boundary rather than an
+        // NRE deep in their override.
+        IConfigurationSection section = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Cred:CredentialSource"] = "Match"
+        }).GetSection("Cred");
+
+        var legacy = new ScopedRecordingResolver("Match", "legacy");
+
+        Assert.Throws<ArgumentNullException>(() =>
+            legacy.TryResolve(section, null!, out _));
+    }
+
+    [Test]
     public void Engine_PassesNonNullResolveChild_ToResolvers()
     {
         // Resolvers that override the chain-aware overload receive a non-null

--- a/sdk/core/System.ClientModel/tests/Convenience/CredentialSettingsTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/CredentialSettingsTests.cs
@@ -31,7 +31,7 @@ public class CredentialSettingsTests
     [TestCase("ManagedIdentity", "managedidentity")]
     [TestCase("ManagedIdentityCredential", "managedidentitycredential")]
     [TestCase("AzureCli", "azurecli")]
-    public void CredentialSource_NormalizesToLowercaseLongForm(string input, string expected)
+    public void CredentialSource_NormalizesToLowercase(string input, string expected)
     {
         CredentialSettings settings = new CredentialSettings(null!)
         {


### PR DESCRIPTION
## Phase 1.97 — SCM `resolveChild` callback for chain-aware resolvers

Foundation for Phase 3.5 (Azure.Core chain factory rewire). Lets a chain-owning resolver recurse back into the active engine for child sections, without re-implementing caching/ordering and without needing to know about credential sources owned by other packages.

### Changes

- **New virtual overload** `CredentialResolver.TryResolve(IConfigurationSection, Func<IConfigurationSection, AuthenticationTokenProvider?>, out AuthenticationTokenProvider?)`. Default forwards to the existing two-arg overload — fully back-compat for existing resolvers.
- `CredentialResolverEngine` binds `resolveChild` to a recursive callback that re-enters `Resolve` with the same chain and `configureOverrides: null` (top-level overrides apply once, never re-applied on recursion).
- `CredentialCache.GetOrTryResolve` requires `resolveChild` (non-nullable) and always invokes the new overload.
- `CredentialSettings.CredentialSource` doc updated to call out case-insensitive matching + per-resolver spelling responsibility. Storage behavior unchanged from 1.13.0.
- API baselines updated across all four TFMs.

### Tests

- New: chain-aware default-impl forwarding, engine passes non-null callback to resolvers, `resolveChild` walks the full chain and shares the cache with the top-level call, single-application of `configureOverrides` across recursion.
- Updated: `CredentialCache_NullMergedSection` reflection test now passes an explicit no-op for the required `resolveChild` arg.

Full SCM test run: **2140 / 2140 pass** on net8.0.

### Why this is its own PR

This SCM change ships in the next SCM beta and unblocks Phase 3.5 in Azure.Core (chain factory rewire, `AzureCredentialResolver.Default` public). The Azure.Core consumer work depends on the SCM beta landing on NuGet + the CPM pin bumping first.