### PR TITLE
Add provisioning resource projection collapse

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/docs/bicep-types-az-reference.md
+++ b/eng/packages/http-client-csharp-provisioning/docs/bicep-types-az-reference.md
@@ -1,0 +1,731 @@
+# Bicep Types Azure Reference
+
+This document summarizes useful information from the `Azure/bicep-types-az`
+repository, with emphasis on the `src/autorest.bicep` tool that generates the
+official Bicep resource type references from ARM Swagger.
+
+The purpose of this document is to record how the Bicep reference generator
+models resources, scopes, bodies, names, property flags, and discriminators so
+that provisioning generator design can use the same concepts where they apply.
+
+---
+
+## Source files
+
+The relevant code is concentrated in these files:
+
+| File | Purpose |
+| --- | --- |
+| `src/autorest.bicep/src/main.ts` | AutoRest plugin entry point. Reads CodeModel, builds provider definitions, and writes `types.json`, `types.md`, and optionally `schema.json`. |
+| `src/autorest.bicep/src/resources.ts` | Detects resource definitions from Swagger operations and paths. Produces provider/resource descriptors. |
+| `src/autorest.bicep/src/type-generator.ts` | Converts provider/resource definitions into Bicep type definitions. This is the closest analogue to provisioning type generation. |
+| `src/autorest.bicep/src/schema-generator.ts` | Converts provider/resource definitions into ARM template JSON schema. Useful for understanding child-resource schema and writable body behavior. |
+| `src/bicep-types/src/types.ts` in `Azure/bicep-types` | Defines the serialized Bicep type model: resource types, object types, discriminated object types, scopes, and property flags. |
+| `src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs` in `Azure/template-reference-generator` | Renders the public Bicep sample shown on Microsoft Learn. This is where language-level `parent` and `scope` declaration properties are added to examples. |
+| `src/TemplateRefGenerator/Generators/MarkdownGenerator.cs` in `Azure/template-reference-generator` | Renders the public property table shown on Microsoft Learn. This is where language-level `parent` and `scope` metadata rows are added. |
+
+The `autorest.bicep` plugin is Swagger/AutoRest based, not TypeSpec based, but
+the concepts it emits are the same concepts visible in the official Bicep
+reference.
+
+---
+
+## Overall flow
+
+The plugin flow is:
+
+1. AutoRest provides a CodeModel.
+2. `resources.ts` groups operations by API version.
+3. `resources.ts` identifies resources and list actions for each provider and
+   API version.
+4. `type-generator.ts` converts each provider definition into Bicep type
+   definitions.
+5. `main.ts` writes `types.json` and `types.md`.
+6. When configured for ARM schema generation, `schema-generator.ts` writes
+   `schema.json` instead.
+
+The central boundary is `ProviderDefinition`:
+
+- `namespace`
+- `apiVersion`
+- `resourcesByType`
+- `resourceActions`
+
+Each `ResourceDefinition` contains:
+
+- a `ResourceDescriptor`;
+- optional `putOperation`;
+- optional `getOperation`;
+- optional examples.
+
+This separation is important. Resource identity is carried by the descriptor,
+while body shape is carried by the PUT and GET operations.
+
+---
+
+## Resource descriptors
+
+`ResourceDescriptor` records the resource facts needed by the Bicep type
+system:
+
+- provider namespace;
+- resource type segments;
+- API version;
+- readable scopes;
+- writable scopes;
+- optional constant name.
+
+The fully qualified Bicep resource type is:
+
+```text
+<namespace>/<typeSegment1>/.../<typeSegmentN>
+```
+
+The final emitted resource name includes the API version:
+
+```text
+<namespace>/<typeSegment1>/.../<typeSegmentN>@<apiVersion>
+```
+
+The descriptor does not contain the resource body. It identifies a resource
+type and the scopes where it can be read or written.
+
+---
+
+## Resource path parsing
+
+Resource paths are parsed around the final `/providers/` segment.
+
+Everything before the final `/providers/` is treated as the parent scope.
+Everything after it is treated as the provider namespace and alternating
+resource type/name segments.
+
+The resource-group path is special-cased. A Swagger path like:
+
+```text
+/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}
+```
+
+is normalized as if it were:
+
+```text
+/subscriptions/{subscriptionId}/providers/Microsoft.Resources/resourceGroups/{resourceGroupName}
+```
+
+This lets resource groups fit the same provider/type/name pattern as other
+resources.
+
+The parser requires:
+
+- a provider namespace;
+- matching counts of type segments and name segments;
+- literal provider namespace;
+- literal type segments, unless a type segment is parameterized by an enum;
+- a final name segment that is either a path parameter or a literal singleton
+  name.
+
+When a type segment is a parameterized enum, the tool expands it into one
+resource descriptor per enum value. After expansion, resource type strings are
+constant.
+
+---
+
+## Scope classification
+
+Scopes are derived from the path prefix before the final `/providers/`.
+
+The tool recognizes:
+
+| Path prefix | Scope |
+| --- | --- |
+| `/` | Tenant |
+| `/subscriptions/{...}/` | Subscription |
+| `/subscriptions/{...}/resourceGroups/{...}/` | ResourceGroup |
+| `/providers/Microsoft.Management/managementGroups/{...}/` | ManagementGroup |
+| another resource path ending before the final provider | Extension |
+
+If the prefix is ambiguous, the AutoRest tool can fall back to all scopes. The
+newer TypeSpec management resource-detection design is stricter and treats the
+read path as the source of truth.
+
+The important Bicep concept is that readability and writability have separate
+scope sets:
+
+- `readableScopes`
+- `writableScopes`
+
+These are not the same as a single boolean saying whether a resource is
+readable or writable. They are sets of deployment scopes where the resource can
+be read or written.
+
+For example:
+
+```text
+readableScopes = ResourceGroup | Subscription
+writableScopes = ResourceGroup
+```
+
+means the resource can be read at resource-group or subscription scope, but can
+be written only at resource-group scope.
+
+The path prefix determines the scope value. The operation kind determines which
+scope set receives that value:
+
+- GET contributes the derived path scope to `readableScopes`;
+- PUT contributes the derived path scope to `writableScopes`.
+
+A resource may therefore be readable but not writable, or readable at different
+scopes than it is writable.
+
+---
+
+## GET and PUT drive resource definitions
+
+For each API version, `resources.ts` first gathers GET and PUT operations by
+path.
+
+A resource definition is created from:
+
+- a PUT operation, if one exists for the path; or
+- a GET operation, if it returns a schema marked as an Azure resource.
+
+The descriptor's readable and writable scopes are set independently:
+
+- GET contributes readable scope;
+- PUT contributes writable scope.
+
+For the common case where the same resource path has both PUT and GET, the tool
+creates one resource definition for that path and API version. The PUT operation
+provides the deployable/writable side, while the GET operation provides the
+readable/reference side.
+
+The resulting body is synthesized from both shapes:
+
+- PUT says what can be authored in a Bicep declaration;
+- GET says what can be read back from the resource;
+- the path says the resource identity, type, and scope.
+
+This means Bicep can represent resources such as read-only resources whose
+`Writable Scope(s)` are `None`.
+
+The provisioning generator should take the same distinction seriously. A
+resource type can be valid for reference/read output even if it is not
+deployable through a normal declaration.
+
+The AutoRest Bicep tool therefore determines ARM resources mostly from
+operation path and operation shape:
+
+1. If a path has a valid PUT operation, the path is treated as a deployable
+   resource path.
+2. If a path has no PUT but has a GET whose response schema is marked with
+   `x-ms-azure-resource`, the path is treated as a readable resource path.
+3. If a GET has no matching PUT and does not return an Azure resource schema,
+   it is treated as a collection or utility endpoint and no resource type is
+   generated from it.
+4. Required parameters outside accepted ARM locations can cause the operation
+   to be skipped.
+
+This is different from the TypeSpec management resource-detection design,
+which uses Read existence as the primary signal for .NET management resources.
+The official Bicep reference can contain PUT-only or GET-only resources because
+it models deployability and readability separately.
+
+---
+
+## Resource type determination
+
+The resource type is derived from the resource path, not from the model name.
+
+After the final `/providers/` segment, the first segment is the provider
+namespace. The remaining segments are interpreted as alternating
+`type/name/type/name` pairs. The resource type is:
+
+```text
+<namespace>/<type1>/<type2>/.../<typeN>
+```
+
+For example:
+
+```text
+/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Web/sites/{site}
+```
+
+becomes:
+
+```text
+Microsoft.Web/sites
+```
+
+and:
+
+```text
+/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Web/sites/{site}/slots/{slot}
+```
+
+becomes:
+
+```text
+Microsoft.Web/sites/slots
+```
+
+If a type segment is parameterized, the parameter must be an enum. The tool
+expands the resource into one descriptor per enum value. This means the final
+resource type emitted by Bicep is always concrete.
+
+The generated Bicep type name adds the API version:
+
+```text
+Microsoft.Web/sites@2024-04-01
+```
+
+---
+
+## Multiple operations with the same resource type
+
+`resources.ts` groups resource definitions by fully qualified resource type.
+Several paths can therefore produce definitions for the same resource type.
+
+The tool has two collapse phases:
+
+1. It groups definitions by resource type and tries to collapse partially
+   constant-name resources at the same normalized path.
+2. It collapses definitions with the same constant name by merging readable and
+   writable scope flags.
+
+The partially constant-name collapse handles a common pattern where several
+constant-name resources and one parameterized-name resource share the same
+path prefix and comparable request/response schemata. In that case the tool
+keeps the parameterized definition and merges the scopes from all variants.
+
+If multiple definitions remain for the same resource type, both
+`type-generator.ts` and `schema-generator.ts` require every remaining
+definition to have a constant name. When that is true, the resource type is
+represented as a name-discriminated resource body. The discriminator is `name`.
+
+Conceptually:
+
+```text
+Microsoft.Web/sites/basicPublishingCredentialsPolicies
+  name = 'ftp'
+  name = 'scm'
+```
+
+becomes one Bicep resource type with multiple body variants keyed by `name`.
+
+If multiple definitions remain for the same resource type and any definition
+does not have a constant name, the tool skips that resource type and emits a
+warning. This protects the Bicep reference from ambiguous resource bodies for a
+single type.
+
+This behavior is important for provisioning because "different GET operations
+produce the same resource type" does not always mean separate resource
+classes. If the resource type is the same and the variants are distinguished
+by constant names, Bicep models them as variants of one resource type.
+
+---
+
+## Resource name handling
+
+The resource name is extracted from the final path segment.
+
+If the final segment is a path parameter, the tool finds the corresponding
+parameter and uses its schema as the name type. If the final segment is a
+literal string, it is treated as a constant singleton name.
+
+There are different details for `types.json`/`types.md` and JSON schema output:
+
+- In `type-generator.ts`, a path name parameter becomes a fixed string literal
+  only when it is a constant. A single-value sealed enum is often converted to a
+  constant earlier by modelerfour. A single-value extensible enum remains an
+  open enum, so the Bicep type is the listed literal plus `string`.
+- In `schema-generator.ts`, `tryGetConstantName` treats both `ChoiceSchema` and
+  `SealedChoiceSchema` with exactly one string choice as a constant name. This
+  behavior applies even when the enum is extensible.
+- For a multi-value enum name parameter, the JSON schema `name` property is
+  emitted as `type: string` with an `enum` array. The JSON schema generator has
+  a TODO for open enums and does not preserve `modelAsString: true` by adding
+  arbitrary `string`.
+
+`type-generator.ts` also reconciles PUT and GET name shapes because they can
+differ. For example, PUT may restrict names with an enum while GET may return a
+plain string. The generated Bicep name type is the union of the useful literal
+and schema information from both sides.
+
+This is why singleton or constrained names in the Bicep reference are visible
+as literal name types such as:
+
+```text
+name: 'default'
+name: 'web'
+```
+
+---
+
+## Standard resource properties
+
+Every Bicep resource body gets standardized resource properties:
+
+| Property | Bicep flags |
+| --- | --- |
+| `id` | `ReadOnly`, `DeployTimeConstant` |
+| `name` | `Required`, `DeployTimeConstant` |
+| `type` | `ReadOnly`, `DeployTimeConstant` |
+| `apiVersion` | `ReadOnly`, `DeployTimeConstant` |
+
+The `type` property is a string literal for the fully qualified resource type.
+The `apiVersion` property is a string literal for the API version.
+
+These properties are added by the Bicep type generator independently of the
+Swagger body model. They are resource metadata, not ordinary model properties.
+
+---
+
+## Parent determination
+
+The AutoRest Bicep type model does not store an explicit parent resource
+reference in `ResourceDescriptor`.
+
+Parent information is implicit in the resource type segments and in the path
+shape. A resource whose type has multiple type segments is structurally a child
+resource type:
+
+```text
+Microsoft.Web/sites/slots
+```
+
+has the structural parent type:
+
+```text
+Microsoft.Web/sites
+```
+
+For `types.json` and `types.md`, the generated `ResourceType` records only:
+
+- resource type name;
+- body type;
+- readable scopes;
+- writable scopes;
+- resource functions.
+
+It does not record a parent pointer.
+
+The public Microsoft Learn Bicep reference can still show a `parent` property.
+For example, `Microsoft.KeyVault/vaults/secrets` is shown as:
+
+```bicep
+resource symbolicname 'Microsoft.KeyVault/vaults/secrets@2025-05-01' = {
+  parent: resourceSymbolicName
+  name: 'string'
+  ...
+}
+```
+
+That `parent` row is not emitted from the provider resource body in
+`types.json` or `types.md`. It is added by `Azure/template-reference-generator`
+when rendering public documentation. The docs generator checks whether the
+unqualified resource type contains `/`. If so, the resource is treated as a
+child resource and the Bicep sample/property table receives a language-level
+`parent` declaration property.
+
+So:
+
+- `types.json` / `types.md` do not contain a provider body `parent` property;
+- public Bicep reference docs show `parent` for structural child resources;
+- ARM template reference does not show `parent`, because parentage is expressed
+  by resource type/name structure.
+
+For ARM JSON schema generation, `schema-generator.ts` processes resources in
+parent-before-child order. When a resource has more than one type segment, it
+drops the final type segment to compute the immediate structural parent type.
+If that parent schema has already been generated, it adds the child schema
+under the parent's `resources` property.
+
+For a nested child-resource schema, the emitted `type` property is only the
+final child segment. For a top-level resource schema, the emitted `type`
+property is the full resource type.
+
+This parent behavior is structural and immediate. The AutoRest schema
+generator does not walk upward through skipped intermediate resource types. If
+the immediate structural parent is not generated, the child is still a
+resource type, but it is not nested under that missing parent in the generated
+JSON schema.
+
+This differs from the TypeSpec management resource-detection design, which
+explicitly resolves parent relationships by matching instance paths and can
+skip missing intermediate resources.
+
+---
+
+## Scope in generated schemas
+
+There are two different notions of scope in the Bicep outputs.
+
+In `types.json` / `types.md`, scope is represented as readable and writable
+scope flags on the resource type:
+
+- `readableScopes`
+- `writableScopes`
+
+These flags are displayed in `types.md` as:
+
+```text
+Readable Scope(s): ResourceGroup
+Writable Scope(s): ResourceGroup
+```
+
+In ARM JSON schema output, `schema-generator.ts` does not add a `scope`
+property to each generated resource schema. Instead, it classifies resource
+definitions into top-level schema buckets according to writable scope:
+
+| Writable scope | JSON schema bucket |
+| --- | --- |
+| ResourceGroup | `resourceDefinitions` |
+| Subscription | `subscription_resourceDefinitions` |
+| ManagementGroup | `managementGroup_resourceDefinitions` |
+| Tenant | `tenant_resourceDefinitions` |
+| Extension | `extension_resourceDefinitions` |
+| None | `unknown_resourceDefinitions` |
+
+So, in the AutoRest Bicep schema generator, a resource does not gain a
+provider-specific `scope` property because it is an extension resource. It is
+placed in the extension-resource bucket. Any language-level `scope` property
+used by Bicep source is handled outside these provider-specific schemas.
+
+Child resource schemas are also not scoped by a `scope` property. They are
+nested under a parent's `resources` array when the immediate parent schema is
+available.
+
+The public Microsoft Learn Bicep reference can still show a `scope` property.
+This is also added by `Azure/template-reference-generator`, not by the
+provider-specific resource body in `types.json` or `types.md`.
+
+The docs generator uses this rule for the Bicep sample and property table:
+
+1. If the unqualified resource type is a child resource, show `parent`.
+2. Otherwise, if `writableScopes` contains `ScopeType.Extension`, show `scope`.
+
+The generated sample value is:
+
+```bicep
+scope: resourceSymbolicName or scope
+```
+
+and the property table text says to use it when creating a resource at a scope
+different than the deployment scope, especially for extension resources.
+
+This means the `scope` declaration property in the public Bicep reference is
+specifically tied to writable extension-resource scope. It is not shown merely
+because a resource has multiple writable deployment scopes. The deployment
+target list at the top of the page uses all writable scopes, but the actual
+`scope:` property row follows the extension-resource rule above.
+
+---
+
+## Property flags
+
+The Bicep type system has these object property flags:
+
+- `Required`
+- `ReadOnly`
+- `WriteOnly`
+- `DeployTimeConstant`
+- `Identifier`
+
+`type-generator.ts` computes property flags from PUT and GET property
+presence, requiredness, `readOnly`, and `x-ms-mutability`.
+
+The core rules are:
+
+- property required in PUT means `Required`;
+- property missing from PUT, or marked read-only in PUT, means `ReadOnly`;
+- property missing from GET means `WriteOnly`;
+- `x-ms-mutability` can override read/write interpretation;
+- standard resource metadata gets `DeployTimeConstant`.
+
+This is more precise than using only a read response model. A property can be
+writable, read-only, or write-only depending on how it appears across request
+and response shapes.
+
+---
+
+## Body model synthesis
+
+`type-generator.ts` synthesizes the resource body from PUT and GET schemas.
+
+The generator starts with standardized resource properties, then adds
+properties from the union of PUT and GET object properties. Each property's
+type is parsed from the available schema. Each property's flags are computed
+from the PUT/GET comparison.
+
+When only one schema is available, that schema is used for both sides unless
+the object is synthetic or is being generated as a discriminator subtype. This
+prevents reused shared models from accidentally becoming read-only or
+write-only simply because one resource uses only one side of the shape.
+
+This is a useful distinction for provisioning:
+
+- resource bodies need request/response semantics;
+- reusable supporting models should not inherit incorrect read/write semantics
+  from one usage.
+
+---
+
+## Object and primitive type conversion
+
+The Bicep type generator maps Swagger schemas into Bicep type references:
+
+| Swagger schema | Bicep type concept |
+| --- | --- |
+| object | object type |
+| dictionary | object type with additional properties |
+| array | array type |
+| choice / sealed choice | union of string literals, with open enum adding `string` |
+| constant | string literal |
+| string / uri / date / uuid / arm-id | string type with constraints where available |
+| integer / number | integer type with min/max where possible |
+| boolean | boolean type |
+| any | any type |
+
+String constraints such as minimum length, maximum length, pattern, and secret
+metadata are preserved when available. Integer bounds are preserved where
+possible.
+
+This is relevant because official Bicep references are richer than a plain
+C#-type projection. They carry literal values, unions, string constraints, and
+array length constraints.
+
+---
+
+## Discriminated object types
+
+The Bicep type model has an explicit `DiscriminatedObjectType`:
+
+- name;
+- discriminator property name;
+- base properties;
+- map from discriminator value to subtype body.
+
+`type-generator.ts` handles polymorphic object schemas by flattening all
+discriminator subtypes. Nested discriminators are flattened only when they use
+the same discriminator property. If a subtype has a discriminator value, the
+generator adds the discriminator property to that subtype as a required string
+literal.
+
+This means a discriminator value is represented as part of the serialized
+object body, not just as a C# inheritance detail.
+
+For resource bodies, this can produce Bicep reference sections where the
+resource type is discriminated by a property such as `name`.
+
+---
+
+## Multiple definitions for the same resource type
+
+The AutoRest tool can produce multiple `ResourceDefinition` entries for the
+same fully qualified resource type.
+
+This happens most visibly for singleton variants that share the same resource
+type but have different constant names or different bodies.
+
+When all definitions for the same resource type have constant names, the Bicep
+generator represents them as a discriminated body keyed by `name`. The
+generated reference then shows a single resource type with a discriminator and
+multiple variant bodies.
+
+This is useful for provisioning because a resource variant may be a body
+variant of one detected resource type rather than a separate ARM resource type.
+
+---
+
+## Child resource schema
+
+`schema-generator.ts` contains logic that is useful for understanding how
+Bicep ARM schema represents child resources.
+
+Resources are processed in parent-before-child order. When a resource type has
+more than one type segment, the schema generator looks for the parent resource
+type by dropping the final type segment. If the parent has already been
+generated, the child is added under the parent's `resources` property as a
+nested child-resource schema definition.
+
+For nested child definitions, the emitted child `type` property uses only the
+final child type segment. For top-level definitions, the emitted `type`
+property uses the full resource type.
+
+This distinction is schema-specific, but it reinforces the Bicep concept that
+resource type and parent relationship are path-derived.
+
+---
+
+## Resource actions
+
+`resources.ts` recognizes POST operations whose final path segment starts with
+`list` as resource list actions.
+
+These are emitted as Bicep resource functions by `type-generator.ts` through
+`factory.addResourceFunctionType`. A resource function has:
+
+- action name;
+- resource type;
+- API version;
+- output type;
+- optional input type.
+
+This is not the same as a deployable resource property. Actions are callable
+functions associated with resource types.
+
+The current provisioning resource design may not need to expose all Bicep
+resource functions immediately, but the distinction is important when deciding
+whether a method contributes to body shape, resource identity, or auxiliary
+resource functionality.
+
+---
+
+## Generated reference shape
+
+The generated `types.md` reference shows resource information in this shape:
+
+```text
+## Resource Microsoft.Web/sites@2024-04-01
+* Readable Scope(s): ResourceGroup
+* Writable Scope(s): ResourceGroup
+### Properties
+* apiVersion: '2024-04-01' (ReadOnly, DeployTimeConstant)
+* id: string (ReadOnly, DeployTimeConstant)
+* name: string (Required, DeployTimeConstant)
+* type: 'Microsoft.Web/sites' (ReadOnly, DeployTimeConstant)
+```
+
+For read-only resources, writable scopes can be `None`.
+
+For singleton resources, `name` can be a string literal.
+
+For discriminated resource bodies, the reference shows a discriminator section
+and one body per discriminator value.
+
+These are the visible outcomes that provisioning generation should align with
+where the C# provisioning model has equivalent concepts.
+
+---
+
+## Useful concepts for provisioning
+
+The most useful concepts to carry into provisioning design are:
+
+1. Resource identity is descriptor-based: provider namespace, type segments,
+   API version, scope, and name.
+2. Resource body shape is operation-based: PUT and GET shapes are compared.
+3. Readable and writable scopes are separate capabilities.
+4. Standard resource metadata has fixed semantics independent of body models.
+5. Property flags require more information than `readOnly` on one model.
+6. Constant names should become fixed identity values; single-value enum
+   handling differs between Bicep type output and JSON schema output.
+7. Discriminators are serialized body semantics, not just type inheritance.
+8. Multiple definitions for one resource type can become a name-discriminated
+   resource body.
+9. Child resources and extension resources are path-derived.
+10. Resource actions are separate from resource bodies.
+
+The provisioning generator does not need to copy the AutoRest implementation,
+but these concepts explain why the official Bicep reference differs from a
+simple management-model projection.

--- a/eng/packages/http-client-csharp-provisioning/docs/resource-detection-design.md
+++ b/eng/packages/http-client-csharp-provisioning/docs/resource-detection-design.md
@@ -1,0 +1,372 @@
+# Provisioning Resource Detection — Design
+
+This document defines how the provisioning generator should decide which ARM
+resources to project into provisioning resource types, and how those resource
+types should align with the official Bicep reference.
+
+It is a design document, not an implementation plan. It describes desired
+behavior and invariants. Any implementation that satisfies these invariants is a
+correct implementation.
+
+---
+
+## Goal
+
+The provisioning generator should produce resources that are valid Bicep
+resources with aligned Bicep schemas.
+
+The design intentionally favors precision over coverage:
+
+- It is acceptable to miss an ARM resource that exists in Bicep.
+- It is not acceptable to generate a provisioning resource that does not
+  correspond to a Bicep resource.
+- It is not acceptable for a generated provisioning resource to emit a body
+  shape that disagrees with the Bicep resource schema for the same resource type
+  and API version.
+
+This means provisioning resource detection is conservative. A resource candidate
+is generated only when its identity and deployable shape can be tied to the same
+resource concept used by Bicep.
+
+---
+
+## Sources of truth
+
+Provisioning generation should generate resources from the TypeSpec management
+resource-detection result. The semantic target is Bicep.
+
+The TypeSpec management resource-detection result is the authoritative local
+input for:
+
+- resource type;
+- resource path;
+- resource scope;
+- parent relationship;
+- resource operations;
+- API versions;
+- request and response models.
+
+The official Bicep reference is the semantic compatibility target for generated
+provisioning resources:
+
+- resource type identity;
+- resource name shape;
+- parent and scope declaration behavior;
+- writable body shape;
+- readable output shape;
+- required, read-only, and write-only property semantics.
+
+The provisioning generator should not infer resource identity directly from
+model names, model inheritance, or the presence of common ARM properties such as
+`id`, `name`, and `type`. Those details may help describe a body, but they are
+not sufficient to prove that a model is a deployable resource.
+
+---
+
+## Detection boundary
+
+Provisioning resource generation should start from resource entries already
+detected by management resource detection.
+
+A detected resource entry can become a generated provisioning resource only if
+the entry has enough information to define a concrete Bicep resource identity:
+
+- a concrete resource type string;
+- a concrete API version;
+- a resource path with a known name position;
+- a known deployment scope or extension scope;
+- a deployable or referenceable body associated with the resource path.
+
+If any of these facts are missing or ambiguous, the implementation should skip
+the resource. Skipping preserves the main guarantee: generated resources should
+be Bicep resources.
+
+This differs from management SDK generation. Management libraries may expose
+resource-like client objects for operational convenience. Provisioning libraries
+should expose resource declarations and references that correspond to template
+authoring concepts.
+
+---
+
+## Resource identity
+
+Each generated provisioning resource represents one concrete ARM resource type
+at one concrete resource path shape.
+
+The identity is path based:
+
+- the final provider segment determines the provider namespace and resource
+  type segments;
+- the path prefix before that provider segment determines scope;
+- the alternating type/name segments determine the resource name tuple;
+- literal name segments determine singleton identity values;
+- parent relationships are derived from path structure.
+
+The identity is not model based. If the same model appears at multiple resource
+paths, those paths are distinct resource identities. If multiple models
+contribute to the same path and resource type, they are body-shape inputs for
+the same resource identity.
+
+Generated resource type strings must be concrete. A provisioning resource should
+not expose a variable resource type segment in its emitted Bicep `type`.
+Parameterized type segments must be resolved into concrete resource types before
+they can be generated.
+
+---
+
+## Relationship to Bicep resource identity
+
+The generated provisioning resource should match Bicep by resource type and API
+version.
+
+For a resource candidate:
+
+- if Bicep has no resource type with the same type string and API version, the
+  candidate should not be generated;
+- if Bicep models the resource type as multiple name-discriminated variants, the
+  provisioning surface should preserve that name distinction;
+- if Bicep treats several paths as one resource type with fixed-name body
+  variants, provisioning should not invent unrelated resource identities for
+  those variants.
+
+Different operations producing the same resource type do not automatically imply
+different provisioning resource classes. The deciding concept is the Bicep
+resource type. Distinct fixed-name variants may be represented as variants of
+that resource type; ambiguous same-type candidates should be skipped rather than
+projected as conflicting resources.
+
+The same resource type can also be discovered at different scopes. Bicep treats
+readable and writable scopes as capabilities of the resource type, not as
+separate resource types. Provisioning should collapse multiple detected resource
+entries only when their resource type is the same and their resource model is
+the same. The collapsed resource concept should preserve the union of confirmed
+readable and writable scopes. If the resource type is the same but the resource
+models differ, the implementation should not collapse them merely because the
+Bicep type string matches.
+
+---
+
+## Resource body
+
+A provisioning resource's public properties represent the Bicep body for that
+resource.
+
+The writable body comes from create and update request shapes. The readable body
+comes from read response shapes. The generated body is the union of these
+perspectives, with property semantics that preserve whether each value can be
+authored, read back, or both.
+
+For the common case where a resource has both PUT and GET:
+
+- PUT defines what can be declared;
+- GET defines what can be observed;
+- the path defines resource identity, name, parent, and scope.
+
+The generated provisioning schema should not be a direct copy of the management
+read model. Management SDK models are optimized for service clients. Bicep
+schemas are optimized for template declarations and references.
+
+---
+
+## Property semantics
+
+Each generated property has independent concepts of:
+
+- Bicep path;
+- CLR type;
+- requiredness;
+- writability;
+- output-ness;
+- fixed value, if any.
+
+The Bicep path is the serialized location in the emitted template. It may be a
+top-level resource property such as `location`, or a nested path such as
+`properties.sku`.
+
+A property is writable when it is accepted by a create or update request shape
+and is not read-only in that request shape. A property is output-only when it is
+present only in read responses, is marked read-only, or is resource metadata
+that Bicep treats as computed.
+
+A property is required when the deployable Bicep body requires it. A resource
+identity value can be required even if the service response model marks it as
+read-only.
+
+The standard resource metadata properties have fixed provisioning semantics:
+
+| ARM property | Provisioning meaning |
+| --- | --- |
+| `name` | Required identity value, or a fixed singleton value. |
+| `id` | Output-only resource identifier. |
+| `type` | Resource type metadata implied by the generated resource class. |
+| `apiVersion` | Resource version metadata controlled by the resource version surface. |
+| `systemData` | Output-only service metadata. |
+
+The `properties` object is not a separate resource boundary. It is part of the
+Bicep body. The C# surface may flatten or project nested values, but the emitted
+Bicep path must remain aligned with the Bicep schema.
+
+---
+
+## Name semantics
+
+Resource names are identity values, not ordinary body properties.
+
+The generated resource should preserve the name shape used by Bicep:
+
+- a path parameter name is customer supplied unless constrained by the path
+  schema;
+- a literal final path segment is a fixed singleton name;
+- a constant name schema is a fixed name;
+- a constrained enum name should preserve its allowed values where Bicep exposes
+  those values;
+- a multi-segment relative name should remain a tuple of identity values rather
+  than being collapsed into an opaque string when the parent path requires
+  multiple names.
+
+Single-value enum handling should follow the Bicep-visible shape. Bicep type
+output and JSON schema output differ in how they treat extensible single-value
+enums, so provisioning should align with the Bicep reference shape that users
+observe for the resource rather than assuming every single-value enum is a
+closed singleton.
+
+---
+
+## Parent and scope
+
+Parentage and scope are path-derived.
+
+Scope detection comes from the resource path prefix before the final provider
+segment. The prefix identifies whether the resource is tenant, management-group,
+subscription, resource-group, or extension scoped. The operation then determines
+which capability set receives that detected scope: read operations contribute to
+readable scopes, and write operations contribute to writable scopes.
+
+Provisioning should preserve this distinction. Scope is part of resource
+capability and declaration context; it is not an ordinary model property and
+should not be inferred from CLR model hierarchy.
+
+A child resource is identified by structural resource type segments and path
+position. The public Bicep reference shows a language-level `parent` property
+for structural child resources, but that property is not part of the provider
+body. Provisioning should model parent as a resource relationship, not as an
+ordinary serialized body property.
+
+Some ARM paths skip intermediate resources. Therefore, a child resource may be
+addressed by a relative name tuple instead of a single relative name. The design
+must allow that identity shape.
+
+Extension resources are scoped by the path prefix before the final provider
+segment. The public Bicep reference shows a language-level `scope` property for
+writable extension resources, unless the resource is already treated as a
+structural child resource. Provisioning should model this as a scope
+relationship, not as a provider body property.
+
+Readable and writable scopes are sets of deployment scopes, not simple
+read/write booleans. GET contributes the path-derived scope to readable scopes.
+PUT contributes the path-derived scope to writable scopes. A resource may be
+readable at scopes where it is not writable.
+
+---
+
+## Readable and writable resources
+
+Readable and writable capabilities are separate.
+
+A resource with create or update support is deployable. It may expose normal
+construction paths for declarations.
+
+A resource with read support but no create or update support is referenceable,
+but not deployable through a normal declaration. If such a resource is generated
+at all, the surface should make the distinction clear.
+
+A resource with no reliable read or write resource operation should not be
+generated from model shape alone.
+
+Bicep can contain resources whose writable scope is `None`. Provisioning may
+choose not to generate those resources, or may represent them only as existing
+resource references. It should not accidentally expose them as normal deployable
+resources.
+
+---
+
+## Supporting models
+
+Supporting model types represent reusable Bicep object shapes that are reachable
+from accepted resources.
+
+A model should be generated as a supporting construct when it is used by an
+accepted resource body and is not itself an accepted resource identity. Model
+classification therefore follows role in the accepted resource graph, not only
+TypeSpec inheritance.
+
+Shared models may be used by multiple resources or by both input and output
+shapes. Their generated semantics should preserve usage context. A property
+should not become globally writable or globally read-only simply because the
+same model appears in one request or one response.
+
+Known provisioning framework types, such as common identity and system metadata
+constructs, should remain framework types when they accurately represent the
+Bicep shape.
+
+---
+
+## Discriminators and variants
+
+Discriminators describe serialized body variants.
+
+A discriminated data model should be represented as a discriminated construct
+shape when the discriminator is part of the Bicep body. The discriminator value
+selects the body variant and should be emitted when Bicep requires it.
+
+A discriminated resource body should create provisioning variants only when
+Bicep models the resource body as variants for the same resource type. Fixed
+discriminator values should be generated as fixed emitted values, not ordinary
+customer-settable properties.
+
+Variants do not create new ARM resource identities unless the detected resource
+identity differs. A variant is a body shape for a resource identity.
+
+---
+
+## API versions
+
+API version is a resource identity dimension.
+
+Generated resource version surfaces should come from accepted resource metadata
+and should match the Bicep resource versions that exist for that resource type.
+The default version should follow the provisioning library's version policy,
+including preview filtering when a stable default is available.
+
+If a candidate's body shape cannot be matched to the Bicep shape for its API
+version, the safer result is to skip that candidate or that version.
+
+---
+
+## Alignment invariants
+
+The provisioning generator should satisfy these invariants for every generated
+resource:
+
+1. The emitted resource type and API version exist in the Bicep reference.
+2. The emitted name shape matches Bicep identity semantics.
+3. Parent and scope are represented as provisioning relationships, not provider
+   body properties.
+4. Detected scopes are derived from resource paths and preserved as readable and
+   writable scope capabilities.
+5. Detected entries are collapsed only when both resource type and resource model
+   are the same; compatible scopes are then unioned on that resource concept.
+6. Writable properties correspond to Bicep-authorable properties.
+7. Output-only properties correspond to Bicep-readable or computed properties.
+8. Required properties match the deployable request shape and identity
+   requirements.
+9. Fixed names and discriminator values are emitted as fixed values.
+10. Same-type fixed-name variants preserve Bicep's variant semantics.
+11. Read-only/reference-only resources are not exposed as ordinary deployable
+   resources.
+12. If confidence is insufficient, the resource is skipped.
+
+These invariants intentionally allow incomplete resource coverage. The
+provisioning generator should first be correct for the resources it produces.
+Broader coverage can be added only when it preserves the same Bicep-alignment
+guarantees.

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -3,6 +3,7 @@
 
 using Azure.Generator.Management.Models;
 using Microsoft.TypeSpec.Generator.Input;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,24 +18,43 @@ namespace Azure.Generator.Provisioning.Primitives
         private ProvisioningResourceProjection(IReadOnlyList<ArmResourceMetadata> metadata)
         {
             Metadata = metadata;
-            PrimaryMetadata = metadata[0];
-            ResourceModel = PrimaryMetadata.ResourceModel;
-            ResourceType = PrimaryMetadata.ResourceType;
+            ResourceModel = GetSameResourceModel(metadata);
+            ResourceType = GetSameResourceType(metadata);
+            ResourceName = GetSameValueOrDefault(metadata.Select(resource => resource.ResourceName), ResourceModel.Name, StringComparer.Ordinal);
+            SingletonResourceName = GetSameNullableValueOrDefault(metadata.Select(resource => resource.SingletonResourceName), null, StringComparer.Ordinal);
+            // TODO: Revisit parent merging in the parent/scope PR. For now, preserve
+            // the previous behavior by using the first detected parent.
+            ParentResourceId = metadata[0].ParentResourceId;
+            NameConstraints = GetSameValueOrDefault(
+                metadata.Select(resource => resource.NameConstraints),
+                new ArmResourceNameConstraints(null, null, null));
             ResourceIdPatterns = [.. CollectResourceIdPatterns(metadata)];
             ApiVersions = [.. CollectApiVersions(metadata)];
+            Methods = [.. CollectMethods(metadata)];
+            RbacRoles = [.. CollectRbacRoles(metadata)];
         }
-
-        internal ArmResourceMetadata PrimaryMetadata { get; }
 
         internal IReadOnlyList<ArmResourceMetadata> Metadata { get; }
 
         internal InputModelType ResourceModel { get; }
 
+        internal string ResourceName { get; }
+
         internal string ResourceType { get; }
+
+        internal string? SingletonResourceName { get; }
+
+        internal RequestPathPattern? ParentResourceId { get; }
+
+        internal ArmResourceNameConstraints NameConstraints { get; }
 
         internal IReadOnlyList<RequestPathPattern> ResourceIdPatterns { get; }
 
         internal IReadOnlyList<string> ApiVersions { get; }
+
+        internal IReadOnlyList<ResourceMethod> Methods { get; }
+
+        internal IReadOnlyList<ArmResourceRbacRole> RbacRoles { get; }
 
         internal static IReadOnlyList<ProvisioningResourceProjection> Create(IReadOnlyList<ArmResourceMetadata> metadata)
         {
@@ -54,6 +74,67 @@ namespace Azure.Generator.Provisioning.Primitives
             }
 
             return [.. orderedGroups.Select(group => new ProvisioningResourceProjection(group))];
+        }
+
+        private static InputModelType GetSameResourceModel(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var resourceModel = metadata[0].ResourceModel;
+            if (metadata.Any(resource => !ReferenceEquals(resource.ResourceModel, resourceModel)))
+            {
+                throw new InvalidOperationException("Collapsed provisioning resources must share the same resource model.");
+            }
+            return resourceModel;
+        }
+
+        private static string GetSameResourceType(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var resourceType = metadata[0].ResourceType;
+            if (metadata.Any(resource => !string.Equals(resource.ResourceType, resourceType, StringComparison.Ordinal)))
+            {
+                throw new InvalidOperationException("Collapsed provisioning resources must share the same resource type.");
+            }
+            return resourceType;
+        }
+
+        private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)
+            where T : notnull
+        {
+            comparer ??= EqualityComparer<T>.Default;
+            using var enumerator = values.GetEnumerator();
+            if (!enumerator.MoveNext())
+            {
+                return defaultValue;
+            }
+
+            var first = enumerator.Current;
+            while (enumerator.MoveNext())
+            {
+                if (!comparer.Equals(first, enumerator.Current))
+                {
+                    return defaultValue;
+                }
+            }
+            return first;
+        }
+
+        private static T? GetSameNullableValueOrDefault<T>(IEnumerable<T?> values, T? defaultValue, IEqualityComparer<T?>? comparer = null)
+        {
+            comparer ??= EqualityComparer<T?>.Default;
+            using var enumerator = values.GetEnumerator();
+            if (!enumerator.MoveNext())
+            {
+                return defaultValue;
+            }
+
+            var first = enumerator.Current;
+            while (enumerator.MoveNext())
+            {
+                if (!comparer.Equals(first, enumerator.Current))
+                {
+                    return defaultValue;
+                }
+            }
+            return first;
         }
 
         private static IEnumerable<RequestPathPattern> CollectResourceIdPatterns(IReadOnlyList<ArmResourceMetadata> metadata)
@@ -78,6 +159,36 @@ namespace Azure.Generator.Provisioning.Primitives
                     if (seen.Add(apiVersion))
                     {
                         yield return apiVersion;
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<ResourceMethod> CollectMethods(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var seen = new HashSet<ResourceMethod>();
+            foreach (var resource in metadata)
+            {
+                foreach (var method in resource.Methods)
+                {
+                    if (seen.Add(method))
+                    {
+                        yield return method;
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<ArmResourceRbacRole> CollectRbacRoles(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var seen = new HashSet<ArmResourceRbacRole>();
+            foreach (var resource in metadata)
+            {
+                foreach (var role in resource.RbacRoles)
+                {
+                    if (seen.Add(role))
+                    {
+                        yield return role;
                     }
                 }
             }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management.Models;
+using Microsoft.TypeSpec.Generator.Input;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Azure.Generator.Provisioning.Primitives
+{
+    /// <summary>
+    /// Provisioning-specific view over one or more compatible management resource
+    /// metadata entries that should emit as one provisioning resource type.
+    /// </summary>
+    internal sealed class ProvisioningResourceProjection
+    {
+        private ProvisioningResourceProjection(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            Metadata = metadata;
+            PrimaryMetadata = metadata[0];
+            ResourceModel = PrimaryMetadata.ResourceModel;
+            ResourceType = PrimaryMetadata.ResourceType;
+            ResourceIdPatterns = [.. CollectResourceIdPatterns(metadata)];
+            ApiVersions = [.. CollectApiVersions(metadata)];
+        }
+
+        internal ArmResourceMetadata PrimaryMetadata { get; }
+
+        internal IReadOnlyList<ArmResourceMetadata> Metadata { get; }
+
+        internal InputModelType ResourceModel { get; }
+
+        internal string ResourceType { get; }
+
+        internal IReadOnlyList<RequestPathPattern> ResourceIdPatterns { get; }
+
+        internal IReadOnlyList<string> ApiVersions { get; }
+
+        internal static IReadOnlyList<ProvisioningResourceProjection> Create(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var groups = new Dictionary<(string ResourceType, InputModelType ResourceModel), List<ArmResourceMetadata>>();
+            var orderedGroups = new List<List<ArmResourceMetadata>>();
+
+            foreach (var resource in metadata)
+            {
+                var key = (resource.ResourceType, resource.ResourceModel);
+                if (!groups.TryGetValue(key, out var group))
+                {
+                    group = [];
+                    groups.Add(key, group);
+                    orderedGroups.Add(group);
+                }
+                group.Add(resource);
+            }
+
+            return [.. orderedGroups.Select(group => new ProvisioningResourceProjection(group))];
+        }
+
+        private static IEnumerable<RequestPathPattern> CollectResourceIdPatterns(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var seen = new HashSet<RequestPathPattern>();
+            foreach (var resource in metadata)
+            {
+                if (seen.Add(resource.ResourceIdPattern))
+                {
+                    yield return resource.ResourceIdPattern;
+                }
+            }
+        }
+
+        private static IEnumerable<string> CollectApiVersions(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var seen = new HashSet<string>();
+            foreach (var resource in metadata)
+            {
+                foreach (var apiVersion in resource.ApiVersions)
+                {
+                    if (seen.Add(apiVersion))
+                    {
+                        yield return apiVersion;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Properties/AssemblyInfo.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Azure.Generator.Provisioning.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -28,7 +28,7 @@ using BicepIdentifierExpression = Azure.Provisioning.Expressions.IdentifierExpre
 namespace Azure.Generator.Provisioning.Providers
 {
     /// <summary>
-    /// Generates a ProvisionableResource subclass from an InputModelType + ArmResourceMetadata.
+    /// Generates a ProvisionableResource subclass from a provisioning resource projection.
     /// Flattens the ARM "properties" bag, includes system properties from the base model chain,
     /// and generates ResourceVersions, FromExisting, and the resource constructor.
     /// </summary>
@@ -54,8 +54,6 @@ namespace Azure.Generator.Provisioning.Providers
 
         private readonly InputModelType _inputModel;
         private readonly ProvisioningResourceProjection? _resourceProjection;
-        private readonly ArmResourceMetadata? _resourceMetadata;
-        private readonly IReadOnlyList<string> _apiVersions;
         private readonly string? _defaultApiVersion;
         /// <summary>
         /// All collected properties for the resource, including flattened and inherited ones,
@@ -82,11 +80,6 @@ namespace Azure.Generator.Provisioning.Providers
         private CSharpType? _parentType;
 
         /// <summary>
-        /// Gets the resource metadata, if this is a base resource type.
-        /// </summary>
-        internal ArmResourceMetadata? ResourceMetadata => _resourceMetadata;
-
-        /// <summary>
         /// Gets the provisioning resource projection, if this is a base resource type.
         /// </summary>
         internal ProvisioningResourceProjection? ResourceProjection => _resourceProjection;
@@ -95,7 +88,7 @@ namespace Azure.Generator.Provisioning.Providers
         /// Gets the parent resource's CSharpType via the output library, or null for top-level resources.
         /// </summary>
         private CSharpType? ParentResourceType
-            => _resourceMetadata?.ParentResourceId is { } parentId
+            => _resourceProjection?.ParentResourceId is { } parentId
                 ? ProvisioningGenerator.Instance.OutputLibrary.GetResourceByIdPattern(parentId)?.Type
                 : null;
 
@@ -121,10 +114,8 @@ namespace Azure.Generator.Provisioning.Providers
         {
             _inputModel = projection.ResourceModel;
             _resourceProjection = projection;
-            _resourceMetadata = projection.PrimaryMetadata;
-            _apiVersions = projection.ApiVersions;
-            _defaultApiVersion = _apiVersions.Count > 0
-                ? _apiVersions.Last()
+            _defaultApiVersion = projection.ApiVersions.Count > 0
+                ? projection.ApiVersions.Last()
                 : null;
             _createBodyWritableProperties = BuildCreateBodyWritableProperties();
             _allProperties = CollectAllProperties();
@@ -139,8 +130,6 @@ namespace Azure.Generator.Provisioning.Providers
         {
             _inputModel = inputModel;
             _resourceProjection = null;
-            _resourceMetadata = null;
-            _apiVersions = [];
             _defaultApiVersion = null;
             _createBodyWritableProperties = [];
             _allProperties = CollectAllProperties();
@@ -162,8 +151,8 @@ namespace Azure.Generator.Provisioning.Providers
         {
             // When the same input model is shared by multiple resources (e.g. parent +
             // child views like ContainerGroupProfile + ContainerGroupProfileRevision),
-            // fall back to the metadata's ResourceName to avoid file/type collisions.
-            return _resourceMetadata?.ResourceName ?? base.BuildName();
+            // fall back to the projection's ResourceName to avoid file/type collisions.
+            return _resourceProjection?.ResourceName ?? base.BuildName();
         }
 
         protected override string BuildRelativeFilePath()
@@ -273,7 +262,7 @@ namespace Azure.Generator.Provisioning.Providers
                 true,
                 [
                     bicepIdentifierParam,
-                    Literal(_resourceMetadata!.ResourceType),
+                    Literal(_resourceProjection!.ResourceType),
                     resourceVersionArg
                 ]);
 
@@ -305,14 +294,14 @@ namespace Azure.Generator.Provisioning.Providers
             methods.Add(BuildDefineAdditionalPropertiesMethod());
 
             // GetResourceNameRequirements() override — only for base resource types
-            var nameRequirementsMethod = BuildGetResourceNameRequirementsMethod(_resourceMetadata, this);
+            var nameRequirementsMethod = BuildGetResourceNameRequirementsMethod(_resourceProjection, this);
             if (nameRequirementsMethod != null)
             {
                 methods.Add(nameRequirementsMethod);
             }
 
             // CreateRoleAssignment() overloads — only for resources that have RBAC roles
-            if (_inputModel.DiscriminatorValue == null && _resourceMetadata?.RbacRoles?.Count > 0)
+            if (_inputModel.DiscriminatorValue == null && _resourceProjection?.RbacRoles.Count > 0)
             {
                 var outputLibrary = (ProvisioningOutputLibrary)ProvisioningGenerator.Instance.OutputLibrary;
                 var builtInRole = outputLibrary.BuiltInRole;
@@ -332,10 +321,9 @@ namespace Azure.Generator.Provisioning.Providers
             if (_inputModel.DiscriminatorValue != null)
                 return [];
 
-            if (_apiVersions.Count == 0)
+            var apiVersions = _resourceProjection?.ApiVersions;
+            if (apiVersions == null || apiVersions.Count == 0)
                 return [];
-
-            var apiVersions = _apiVersions;
 
             // When the current (default) API version is GA, exclude preview versions.
             // Preview versions are only included when the current version is itself a preview.
@@ -364,9 +352,9 @@ namespace Azure.Generator.Provisioning.Providers
         private HashSet<string> BuildCreateBodyWritableProperties()
         {
             var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (_resourceMetadata == null) return result;
+            if (_resourceProjection == null) return result;
 
-            var createMethod = _resourceMetadata.Methods
+            var createMethod = _resourceProjection.Methods
                 .FirstOrDefault(m => m.Kind == ResourceOperationKind.Create)?.InputMethod;
             if (createMethod == null) return result;
 
@@ -461,9 +449,9 @@ namespace Azure.Generator.Provisioning.Providers
                 // For singleton resources, the "name" property is output-only with a default value
                 string? defaultValue = null;
                 if (serializedName == "name"
-                    && _resourceMetadata?.SingletonResourceName is not null)
+                    && _resourceProjection?.SingletonResourceName is not null)
                 {
-                    defaultValue = _resourceMetadata.SingletonResourceName;
+                    defaultValue = _resourceProjection.SingletonResourceName;
                     isOutput = true;
                 }
                 // Ensure "location" at the resource level always uses AzureLocation,
@@ -614,14 +602,14 @@ namespace Azure.Generator.Provisioning.Providers
             return new MethodProvider(sig, this);
         }
 
-        private static MethodProvider? BuildGetResourceNameRequirementsMethod(ArmResourceMetadata? resourceMetadata, TypeProvider enclosingType)
+        private static MethodProvider? BuildGetResourceNameRequirementsMethod(ProvisioningResourceProjection? resourceProjection, TypeProvider enclosingType)
         {
-            if (resourceMetadata is null)
+            if (resourceProjection is null)
             {
                 return null;
             }
 
-            var constraints = resourceMetadata.NameConstraints;
+            var constraints = resourceProjection.NameConstraints;
 
             // Only generate the override when the spec actually specifies name constraints
             if (constraints.Pattern is null && constraints.MinLength is null && constraints.MaxLength is null)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -53,7 +53,9 @@ namespace Azure.Generator.Provisioning.Providers
         };
 
         private readonly InputModelType _inputModel;
+        private readonly ProvisioningResourceProjection? _resourceProjection;
         private readonly ArmResourceMetadata? _resourceMetadata;
+        private readonly IReadOnlyList<string> _apiVersions;
         private readonly string? _defaultApiVersion;
         /// <summary>
         /// All collected properties for the resource, including flattened and inherited ones,
@@ -85,6 +87,11 @@ namespace Azure.Generator.Provisioning.Providers
         internal ArmResourceMetadata? ResourceMetadata => _resourceMetadata;
 
         /// <summary>
+        /// Gets the provisioning resource projection, if this is a base resource type.
+        /// </summary>
+        internal ProvisioningResourceProjection? ResourceProjection => _resourceProjection;
+
+        /// <summary>
         /// Gets the parent resource's CSharpType via the output library, or null for top-level resources.
         /// </summary>
         private CSharpType? ParentResourceType
@@ -109,13 +116,15 @@ namespace Azure.Generator.Provisioning.Providers
         /// <summary>
         /// Constructor for base resource types (with metadata from ARM provider schema).
         /// </summary>
-        public ProvisioningResourceProvider(InputModelType inputModel, ArmResourceMetadata metadata)
-            : base(inputModel)
+        public ProvisioningResourceProvider(ProvisioningResourceProjection projection)
+            : base(projection.ResourceModel)
         {
-            _inputModel = inputModel;
-            _resourceMetadata = metadata;
-            _defaultApiVersion = metadata.ApiVersions.Count > 0
-                ? metadata.ApiVersions.Last()
+            _inputModel = projection.ResourceModel;
+            _resourceProjection = projection;
+            _resourceMetadata = projection.PrimaryMetadata;
+            _apiVersions = projection.ApiVersions;
+            _defaultApiVersion = _apiVersions.Count > 0
+                ? _apiVersions.Last()
                 : null;
             _createBodyWritableProperties = BuildCreateBodyWritableProperties();
             _allProperties = CollectAllProperties();
@@ -129,7 +138,9 @@ namespace Azure.Generator.Provisioning.Providers
             : base(inputModel)
         {
             _inputModel = inputModel;
+            _resourceProjection = null;
             _resourceMetadata = null;
+            _apiVersions = [];
             _defaultApiVersion = null;
             _createBodyWritableProperties = [];
             _allProperties = CollectAllProperties();
@@ -321,9 +332,10 @@ namespace Azure.Generator.Provisioning.Providers
             if (_inputModel.DiscriminatorValue != null)
                 return [];
 
-            var apiVersions = _resourceMetadata?.ApiVersions;
-            if (apiVersions == null || apiVersions.Count == 0)
+            if (_apiVersions.Count == 0)
                 return [];
+
+            var apiVersions = _apiVersions;
 
             // When the current (default) API version is GA, exclude preview versions.
             // Preview versions are only included when the current version is itself a preview.

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Reflection;
 using Azure.Generator.Management;
+using Azure.Generator.Management.Models;
+using Azure.Generator.Provisioning.Primitives;
 using Azure.Generator.Provisioning.Providers;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Providers;
@@ -58,19 +60,20 @@ namespace Azure.Generator.Provisioning
             var byModel = new Dictionary<InputModelType, List<ProvisioningResourceProvider>>();
 
             var allMetadata = ProvisioningGenerator.Instance.InputLibrary.ArmProviderSchema.Resources;
-            foreach (var metadata in allMetadata)
+            var projections = ProvisioningResourceProjection.Create(allMetadata);
+            foreach (var projection in projections)
             {
-                if (metadata.ResourceModel == null)
-                    continue;
-
-                var resource = new ProvisioningResourceProvider(metadata.ResourceModel, metadata);
+                var resource = new ProvisioningResourceProvider(projection);
                 list.Add(resource);
-                byIdPattern[metadata.ResourceIdPattern] = resource;
+                foreach (var resourceIdPattern in projection.ResourceIdPatterns)
+                {
+                    byIdPattern[resourceIdPattern.SerializedPath] = resource;
+                }
 
-                if (!byModel.TryGetValue(metadata.ResourceModel, out var modelList))
+                if (!byModel.TryGetValue(projection.ResourceModel, out var modelList))
                 {
                     modelList = new List<ProvisioningResourceProvider>();
-                    byModel[metadata.ResourceModel] = modelList;
+                    byModel[projection.ResourceModel] = modelList;
                 }
                 modelList.Add(resource);
             }
@@ -105,9 +108,9 @@ namespace Azure.Generator.Provisioning
         /// Gets a resource provider by its ARM resource ID pattern.
         /// Returns null if not found.
         /// </summary>
-        internal ProvisioningResourceProvider? GetResourceByIdPattern(string resourceIdPattern)
+        internal ProvisioningResourceProvider? GetResourceByIdPattern(RequestPathPattern resourceIdPattern)
         {
-            GetValue(ref _resourcesByIdPattern).TryGetValue(resourceIdPattern, out var resource);
+            GetValue(ref _resourcesByIdPattern).TryGetValue(resourceIdPattern.SerializedPath, out var resource);
             return resource;
         }
 
@@ -201,12 +204,9 @@ namespace Azure.Generator.Provisioning
             var enums = new List<InputEnumType>();
             var queue = new Queue<InputType>();
 
-            foreach (var metadata in ProvisioningGenerator.Instance.InputLibrary.ArmProviderSchema.Resources)
+            foreach (var resource in Resources)
             {
-                if (metadata.ResourceModel != null)
-                {
-                    queue.Enqueue(metadata.ResourceModel);
-                }
+                queue.Enqueue(resource.ResourceProjection!.ResourceModel);
             }
 
             while (queue.Count > 0)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
@@ -119,12 +119,12 @@ namespace Azure.Generator.Provisioning
                 ProvisioningResourceProvider? canonical = null;
                 foreach (var candidate in resources)
                 {
-                    if (string.Equals(candidate.ResourceMetadata?.ResourceName, model.Name, StringComparison.Ordinal))
+                    if (string.Equals(candidate.ResourceProjection?.ResourceName, model.Name, StringComparison.Ordinal))
                     {
                         return candidate;
                     }
                     if (canonical == null
-                        || string.CompareOrdinal(candidate.ResourceMetadata?.ResourceName, canonical.ResourceMetadata?.ResourceName) < 0)
+                        || string.CompareOrdinal(candidate.ResourceProjection?.ResourceName, canonical.ResourceProjection?.ResourceName) < 0)
                     {
                         canonical = candidate;
                     }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management.Models;
+using Azure.Generator.Provisioning.Primitives;
+using Microsoft.TypeSpec.Generator.Input;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Azure.Generator.Provisioning.Tests
+{
+    public class ProvisioningResourceProjectionTests
+    {
+        [Test]
+        public void SameResourceTypeAndModelCollapse()
+        {
+            var model = CreateModel("TestResourceData");
+            var resourceGroupResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+                "Microsoft.Test/widgets",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"]);
+            var subscriptionResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/providers/Microsoft.Test/widgets/{widgetName}",
+                "Microsoft.Test/widgets",
+                ResourceScope.Subscription,
+                ["2024-02-01"]);
+
+            var projections = ProvisioningResourceProjection.Create([resourceGroupResource, subscriptionResource]);
+
+            Assert.That(projections, Has.Count.EqualTo(1));
+            Assert.That(projections[0].PrimaryMetadata, Is.SameAs(resourceGroupResource));
+            Assert.That(projections[0].Metadata, Is.EqualTo(new[] { resourceGroupResource, subscriptionResource }));
+            Assert.That(projections[0].ResourceIdPatterns.Select(p => p.SerializedPath), Is.EqualTo(new[]
+            {
+                resourceGroupResource.ResourceIdPattern.SerializedPath,
+                subscriptionResource.ResourceIdPattern.SerializedPath
+            }));
+            Assert.That(projections[0].ApiVersions, Is.EqualTo(new[] { "2024-01-01", "2024-02-01" }));
+        }
+
+        [Test]
+        public void SameResourceTypeWithDifferentModelsDoesNotCollapse()
+        {
+            var firstModel = CreateModel("FirstResourceData");
+            var secondModel = CreateModel("SecondResourceData");
+            var firstResource = CreateMetadata(
+                firstModel,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+                "Microsoft.Test/widgets",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"]);
+            var secondResource = CreateMetadata(
+                secondModel,
+                "/subscriptions/{subscriptionId}/providers/Microsoft.Test/widgets/{widgetName}",
+                "Microsoft.Test/widgets",
+                ResourceScope.Subscription,
+                ["2024-01-01"]);
+
+            var projections = ProvisioningResourceProjection.Create([firstResource, secondResource]);
+
+            Assert.That(projections, Has.Count.EqualTo(2));
+            Assert.That(projections[0].ResourceModel, Is.SameAs(firstModel));
+            Assert.That(projections[1].ResourceModel, Is.SameAs(secondModel));
+        }
+
+        private static ArmResourceMetadata CreateMetadata(
+            InputModelType model,
+            string resourceIdPattern,
+            string resourceType,
+            ResourceScope scope,
+            IReadOnlyList<string> apiVersions)
+        {
+            var path = new RequestPathPattern(resourceIdPattern);
+            return new ArmResourceMetadata(
+                path,
+                model.Name,
+                resourceType,
+                model,
+                new ArmScopeInfo(scope, RequestPathPattern.GetFromScope(scope, path), null),
+                [],
+                null,
+                null,
+                [],
+                new ArmResourceNameConstraints(null, null, null),
+                apiVersions,
+                []);
+        }
+
+        private static InputModelType CreateModel(string name)
+            => new(
+                name,
+                "Sample.Models",
+                $"Sample.Models.{name}",
+                "public",
+                null,
+                string.Empty,
+                "Test model.",
+                InputModelTypeUsage.Input | InputModelTypeUsage.Output,
+                [],
+                null,
+                [],
+                null,
+                null,
+                new Dictionary<string, InputModelType>(),
+                null,
+                false,
+                new InputSerializationOptions(),
+                false);
+    }
+}

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -27,19 +27,23 @@ namespace Azure.Generator.Provisioning.Tests
                 "/subscriptions/{subscriptionId}/providers/Microsoft.Test/widgets/{widgetName}",
                 "Microsoft.Test/widgets",
                 ResourceScope.Subscription,
-                ["2024-02-01"]);
+                ["2024-02-01"],
+                [new ArmResourceRbacRole("SecondRole", "22222222-2222-2222-2222-222222222222")]);
 
             var projections = ProvisioningResourceProjection.Create([resourceGroupResource, subscriptionResource]);
 
             Assert.That(projections, Has.Count.EqualTo(1));
-            Assert.That(projections[0].PrimaryMetadata, Is.SameAs(resourceGroupResource));
             Assert.That(projections[0].Metadata, Is.EqualTo(new[] { resourceGroupResource, subscriptionResource }));
+            Assert.That(projections[0].ResourceName, Is.EqualTo(resourceGroupResource.ResourceName));
+            Assert.That(projections[0].ResourceType, Is.EqualTo("Microsoft.Test/widgets"));
+            Assert.That(projections[0].ResourceModel, Is.SameAs(model));
             Assert.That(projections[0].ResourceIdPatterns.Select(p => p.SerializedPath), Is.EqualTo(new[]
             {
                 resourceGroupResource.ResourceIdPattern.SerializedPath,
                 subscriptionResource.ResourceIdPattern.SerializedPath
             }));
             Assert.That(projections[0].ApiVersions, Is.EqualTo(new[] { "2024-01-01", "2024-02-01" }));
+            Assert.That(projections[0].RbacRoles.Select(r => r.Name), Is.EqualTo(new[] { "FirstRole", "SecondRole" }));
         }
 
         [Test]
@@ -67,27 +71,97 @@ namespace Azure.Generator.Provisioning.Tests
             Assert.That(projections[1].ResourceModel, Is.SameAs(secondModel));
         }
 
+        [Test]
+        public void CollapsedProjectionDropsInconsistentPerEntryValues()
+        {
+            var model = CreateModel("TestResourceData");
+            var firstResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/default",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                resourceName: "FirstResource",
+                singletonResourceName: "default",
+                parentResourceId: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+                nameConstraints: new ArmResourceNameConstraints("[a-z]+", 1, 24));
+            var secondResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/current",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                resourceName: "SecondResource",
+                singletonResourceName: "current",
+                parentResourceId: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/otherWidgets/{widgetName}",
+                nameConstraints: new ArmResourceNameConstraints("[0-9]+", 1, 24));
+
+            var projection = ProvisioningResourceProjection.Create([firstResource, secondResource])[0];
+
+            Assert.That(projection.ResourceName, Is.EqualTo(model.Name));
+            Assert.That(projection.SingletonResourceName, Is.Null);
+            Assert.That(projection.ParentResourceId, Is.EqualTo(firstResource.ParentResourceId));
+            Assert.That(projection.NameConstraints, Is.EqualTo(new ArmResourceNameConstraints(null, null, null)));
+        }
+
+        [Test]
+        public void CollapsedProjectionKeepsOnlyConsistentSingletonResourceName()
+        {
+            var model = CreateModel("TestResourceData");
+            var firstResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/default",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                singletonResourceName: "default");
+            var secondResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/providers/Microsoft.Test/widgets/{widgetName}/children/default",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.Subscription,
+                ["2024-01-01"],
+                singletonResourceName: "default");
+            var mixedNullResource = CreateMetadata(
+                model,
+                "/providers/Microsoft.Test/widgets/{widgetName}/children/default",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.Tenant,
+                ["2024-01-01"]);
+
+            var consistentProjection = ProvisioningResourceProjection.Create([firstResource, secondResource])[0];
+            var mixedNullProjection = ProvisioningResourceProjection.Create([firstResource, mixedNullResource])[0];
+
+            Assert.That(consistentProjection.SingletonResourceName, Is.EqualTo("default"));
+            Assert.That(mixedNullProjection.SingletonResourceName, Is.Null);
+        }
+
         private static ArmResourceMetadata CreateMetadata(
             InputModelType model,
             string resourceIdPattern,
             string resourceType,
             ResourceScope scope,
-            IReadOnlyList<string> apiVersions)
+            IReadOnlyList<string> apiVersions,
+            IReadOnlyList<ArmResourceRbacRole>? rbacRoles = null,
+            string? resourceName = null,
+            string? singletonResourceName = null,
+            string? parentResourceId = null,
+            ArmResourceNameConstraints? nameConstraints = null)
         {
             var path = new RequestPathPattern(resourceIdPattern);
             return new ArmResourceMetadata(
                 path,
-                model.Name,
+                resourceName ?? model.Name,
                 resourceType,
                 model,
                 new ArmScopeInfo(scope, RequestPathPattern.GetFromScope(scope, path), null),
                 [],
-                null,
-                null,
+                singletonResourceName,
+                parentResourceId is null ? null : new RequestPathPattern(parentResourceId),
                 [],
-                new ArmResourceNameConstraints(null, null, null),
+                nameConstraints ?? new ArmResourceNameConstraints(null, null, null),
                 apiVersions,
-                []);
+                rbacRoles ?? [new ArmResourceRbacRole("FirstRole", "11111111-1111-1111-1111-111111111111")]);
         }
 
         private static InputModelType CreateModel(string name)


### PR DESCRIPTION
## Summary
- add a provisioning resource projection layer over management resource detection metadata
- collapse detected resource entries only when both resource type and resource model match
- build provisioning resource providers from projections while preserving all resource ID patterns and API versions
- aggregate RBAC roles across collapsed resource entries
- add focused projection collapse and non-collapse tests
- add design/reference docs for provisioning resource detection and relevant `bicep-types-az` behavior

## Plan
This PR is the first step in the provisioning resource-detection cleanup. The goal is to make provisioning generation consume a provisioning-specific resource definition instead of using raw management resource entries directly.

The staged plan is:
1. **Introduce a projection layer and collapse only safe duplicates: same resource type and same resource model. This PR covers that step.**
2. Add explicit readable/writable scope capability modeling from detected resource paths and operations.
3. Use the scope and parent metadata to correct child-resource and extension-resource generation.
4. Revisit discriminated resource handling so derived models are not promoted to resources unless backed by detected resource identity.
5. Improve body synthesis from create/update/read shapes and add Bicep-alignment validation boundaries.

This PR intentionally keeps parent merging behavior mostly unchanged; there is a TODO for the parent/scope follow-up PR.

## Validation
- `dotnet test eng\packages\http-client-csharp-provisioning\generator\Azure.Generator.Provisioning\test\Azure.Generator.Provisioning.Tests.csproj --no-restore`
- `eng\packages\http-client-csharp-provisioning\eng\scripts\Generate.ps1` was run; generation completed, but the script's final parallel build hit a SourceLink file-write race. The generated local test project then built successfully single-threaded with `dotnet build eng\packages\http-client-csharp-provisioning\generator\TestProjects\Local\Provisioning-TypeSpec\src\Azure.Provisioning.ProvisioningTypeSpec.csproj -m:1 --no-restore`.