### PR TITLE
Peel Azure.AI.Projects off NoWarn skip-list; allow-list now applies suppressions

### DIFF
--- a/eng/AnalyzerAllowList.targets
+++ b/eng/AnalyzerAllowList.targets
@@ -64,15 +64,26 @@
     <PropertyGroup>
       <_ProjectAllowedNoWarn>@(_AllowListNoWarn -> '%(Code)', ';')</_ProjectAllowedNoWarn>
     </PropertyGroup>
+  </Target>
 
-    <!--
-      Apply the approved codes to $(NoWarn) so projects don't have to duplicate them
-      in their csproj. The allow-list file is the single source of truth: an entry
-      both approves the suppression AND makes it take effect at compile time.
+  <!--
+    Apply the approved codes to $(NoWarn) so projects don't have to duplicate them
+    in their csproj. The allow-list file is the single source of truth: an entry
+    both approves the suppression AND makes it take effect at compile time.
 
-      ReadAnalyzerAllowList runs via DependsOnTargets from ValidateNoWarn, which is
-      BeforeTargets="CoreCompile", so $(NoWarn) is updated before the compiler reads it.
-    -->
+    This runs independently before CoreCompile (with no DesignTimeBuild guard) so
+    allow-listed suppressions are applied during both regular and design-time builds.
+    Design-time builds (IDE IntelliSense / error squiggles) invoke CoreCompile too;
+    if injection only ran via ValidateNoWarn (which is design-time-skipped for the
+    AZSDK0002 enforcement), the IDE would surface analyzer warnings that the
+    command-line build suppresses — pressuring developers to re-add csproj <NoWarn>
+    entries and defeating the single-source-of-truth design.
+  -->
+  <Target
+    Name="ApplyAnalyzerAllowListNoWarn"
+    BeforeTargets="CoreCompile"
+    DependsOnTargets="ReadAnalyzerAllowList"
+    Condition="'$(IsShippingClientLibrary)' == 'true'">
     <PropertyGroup Condition="'$(_ProjectAllowedNoWarn)' != ''">
       <NoWarn>$(NoWarn);$(_ProjectAllowedNoWarn)</NoWarn>
     </PropertyGroup>

--- a/eng/AnalyzerAllowList.targets
+++ b/eng/AnalyzerAllowList.targets
@@ -64,5 +64,17 @@
     <PropertyGroup>
       <_ProjectAllowedNoWarn>@(_AllowListNoWarn -> '%(Code)', ';')</_ProjectAllowedNoWarn>
     </PropertyGroup>
+
+    <!--
+      Apply the approved codes to $(NoWarn) so projects don't have to duplicate them
+      in their csproj. The allow-list file is the single source of truth: an entry
+      both approves the suppression AND makes it take effect at compile time.
+
+      ReadAnalyzerAllowList runs via DependsOnTargets from ValidateNoWarn, which is
+      BeforeTargets="CoreCompile", so $(NoWarn) is updated before the compiler reads it.
+    -->
+    <PropertyGroup Condition="'$(_ProjectAllowedNoWarn)' != ''">
+      <NoWarn>$(NoWarn);$(_ProjectAllowedNoWarn)</NoWarn>
+    </PropertyGroup>
   </Target>
 </Project>

--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -35,7 +35,6 @@ Azure.AI.Language.Text.Authoring
 Azure.AI.OpenAI
 Azure.AI.OpenAI.Assistants
 Azure.AI.Personalizer
-Azure.AI.Projects
 Azure.AI.Projects.Agents
 Azure.AI.Speech.Transcription
 Azure.AI.TextAnalytics

--- a/eng/analyzerallowlist/Azure.AI.Projects.txt
+++ b/eng/analyzerallowlist/Azure.AI.Projects.txt
@@ -1,10 +1,21 @@
 # Azure.AI.Projects approved analyzer suppressions.
-#
-# Format: one entry per line. Comments start with '#'. Supported entry prefixes:
-#   nowarn:CODE        — allow the given diagnostic code to appear in <NoWarn>.
-#
-# Every entry must be preceded by a justification comment explaining why the
-# suppression is project-wide rather than scoped to a specific call site.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# AAIP001 is the [Experimental] marker for this library's own preview surface
+# (memory stores, evaluations, red teams, etc.). The library intentionally calls
+# its own experimental APIs from both hand-written customizations and generated
+# code. The diagnostic exists so external consumers explicitly acknowledge
+# experimental usage; internal use across the assembly is by design. File-scoped
+# pragmas would be wiped on every codegen regen of the ~27 affected generated
+# files and add no review value.
+nowarn:AAIP001
+
+# OPENAI001 is the [Experimental] marker on the OpenAI SDK types this library
+# wraps (ResponseItem, OpenAIContext, etc.). The library is intentionally a
+# wrapper / extension of those preview surfaces and exposes them to its own
+# callers via Azure.AI.Projects.Memory and ResponseItemHelpers. Acknowledging
+# the opt-in once at the assembly level matches the design intent.
+nowarn:OPENAI001
 
 # AAIP001 is the [Experimental] marker for this library's own preview surface
 # (memory stores, evaluations, red teams, etc.). The library intentionally calls

--- a/eng/analyzerallowlist/Azure.AI.Projects.txt
+++ b/eng/analyzerallowlist/Azure.AI.Projects.txt
@@ -16,19 +16,3 @@ nowarn:AAIP001
 # callers via Azure.AI.Projects.Memory and ResponseItemHelpers. Acknowledging
 # the opt-in once at the assembly level matches the design intent.
 nowarn:OPENAI001
-
-# AAIP001 is the [Experimental] marker for this library's own preview surface
-# (memory stores, evaluations, red teams, etc.). The library intentionally calls
-# its own experimental APIs from both hand-written customizations and generated
-# code. The diagnostic exists so external consumers explicitly acknowledge
-# experimental usage; internal use across the assembly is by design. File-scoped
-# pragmas would be wiped on every codegen regen of the ~27 affected generated
-# files and add no review value.
-nowarn:AAIP001
-
-# OPENAI001 is the [Experimental] marker on the OpenAI SDK types this library
-# wraps (ResponseItem, OpenAIContext, etc.). The library is intentionally a
-# wrapper / extension of those preview surfaces and exposes them to its own
-# callers via Azure.AI.Projects.Memory and ResponseItemHelpers. Acknowledging
-# the opt-in once at the assembly level matches the design intent.
-nowarn:OPENAI001

--- a/eng/analyzerallowlist/Azure.AI.Projects.txt
+++ b/eng/analyzerallowlist/Azure.AI.Projects.txt
@@ -1,0 +1,23 @@
+# Azure.AI.Projects approved analyzer suppressions.
+#
+# Format: one entry per line. Comments start with '#'. Supported entry prefixes:
+#   nowarn:CODE        — allow the given diagnostic code to appear in <NoWarn>.
+#
+# Every entry must be preceded by a justification comment explaining why the
+# suppression is project-wide rather than scoped to a specific call site.
+
+# AAIP001 is the [Experimental] marker for this library's own preview surface
+# (memory stores, evaluations, red teams, etc.). The library intentionally calls
+# its own experimental APIs from both hand-written customizations and generated
+# code. The diagnostic exists so external consumers explicitly acknowledge
+# experimental usage; internal use across the assembly is by design. File-scoped
+# pragmas would be wiped on every codegen regen of the ~27 affected generated
+# files and add no review value.
+nowarn:AAIP001
+
+# OPENAI001 is the [Experimental] marker on the OpenAI SDK types this library
+# wraps (ResponseItem, OpenAIContext, etc.). The library is intentionally a
+# wrapper / extension of those preview surfaces and exposes them to its own
+# callers via Azure.AI.Projects.Memory and ResponseItemHelpers. Acknowledging
+# the opt-in once at the assembly level matches the design intent.
+nowarn:OPENAI001

--- a/eng/analyzerallowlist/README.md
+++ b/eng/analyzerallowlist/README.md
@@ -35,8 +35,14 @@ nowarn:CS1591
 
 ### `nowarn:CODE`
 
-Each `nowarn:` line approves the use of `CODE` in the project's `<NoWarn>` property.
-Codes not listed here (and not in the central allow-list) will cause a build error.
+Each `nowarn:` line approves the use of `CODE` for the project **and applies it
+automatically** — the build system injects approved codes into `$(NoWarn)` before
+compilation, so projects should **not** keep an equivalent entry in the csproj's
+`<NoWarn>` property. The allow-list file is the single source of truth: every
+listed code is both reviewed and active.
+
+If a code appears in the csproj's `<NoWarn>` without being on this list (and not
+in the central allow-list), the build fails with `AZSDK0002`.
 
 ### `CODE:SYMBOL` (future)
 
@@ -46,9 +52,12 @@ These entries will be consumed by a Roslyn analyzer to approve inline suppressio
 ## How It Works
 
 1. `eng/AnalyzerAllowList.targets` reads the per-package `.txt` file at build time.
-2. It extracts `nowarn:` lines into the `_ProjectAllowedNoWarn` MSBuild property.
-3. `eng/NoWarnValidation.targets` uses `_ProjectAllowedNoWarn` to validate that
-   the project's `<NoWarn>` codes are all approved.
+2. It extracts `nowarn:` lines into the `_ProjectAllowedNoWarn` MSBuild property and
+   **appends them to `$(NoWarn)`** so the compiler honors the suppression without
+   the project needing to duplicate the code in its csproj.
+3. `eng/NoWarnValidation.targets` uses `_ProjectAllowedNoWarn` to validate that any
+   codes the project itself declares in `<NoWarn>` are all approved. Any unapproved
+   csproj-declared code fails the build with `AZSDK0002`.
 4. Projects listed in `eng/NoWarnSkipValidation.txt` short-circuit the validator entirely
    (temporary backlog escape hatch).
 
@@ -60,7 +69,8 @@ Use this only when the suppression is genuinely project-wide and the underlying 
 cannot be fixed or narrowed:
 
 1. Create or edit `eng/analyzerallowlist/<YourProjectName>.txt`.
-2. Add a `nowarn:CODE` line for the diagnostic you need to suppress.
+2. Add a `nowarn:CODE` line for the diagnostic you need to suppress. **Do not also add
+   the code to `<NoWarn>` in the csproj** — the build injects it automatically.
 3. **Include a comment immediately above each entry** explaining *why* the suppression is
    needed and why it can't be narrowed.
 4. The PR adding the entry will be reviewed by the SDK team.
@@ -84,7 +94,8 @@ When picking a project out of `eng/NoWarnSkipValidation.txt`:
    - **Migrate:** convert to a scoped `#pragma warning disable` with a justification and
      remove from `<NoWarn>`.
    - **Approve:** add a `nowarn:CODE` entry to this directory's file for the project, with
-     a justification comment.
+     a justification comment, **and remove the code from the csproj `<NoWarn>`** — the
+     allow-list entry both records the approval and applies the suppression.
 4. Land in a per-project PR.
 
 ## Related

--- a/eng/scripts/Test-NoWarnValidation.ps1
+++ b/eng/scripts/Test-NoWarnValidation.ps1
@@ -235,6 +235,46 @@ try {
 } finally { if (-not $KeepTemp) { Remove-Item -Recurse -Force $dir } }
 
 # ----------------------------------------------------------------------------
+# Scenario 7: allow-list entries are auto-injected into $(NoWarn) so the
+# project's csproj does not need to duplicate them. Confirm by emitting
+# $(NoWarn) from a target that depends on ReadAnalyzerAllowList.
+# ----------------------------------------------------------------------------
+$dir = New-ScenarioDir 'autoinject'
+try {
+  $skipFile = Join-Path $dir 'skip.txt'
+  Set-Content -Path $skipFile -Value '' -Encoding UTF8
+  $allowDir = Join-Path $dir 'allow'
+  New-Item -ItemType Directory -Force -Path $allowDir | Out-Null
+  $allowFile = Join-Path $allowDir 'TestAutoInject.txt'
+  Set-Content -Path $allowFile -Value "# justification`nnowarn:CA5555`n" -Encoding UTF8
+
+  # Add a probe target that runs after ReadAnalyzerAllowList and echoes $(NoWarn).
+  $probeXml = @'
+  <Target Name="ProbeNoWarn" DependsOnTargets="ReadAnalyzerAllowList">
+    <Message Importance="High" Text="NoWarnProbe:$(NoWarn)" />
+  </Target>
+'@
+  $proj = New-TestCsproj -Dir $dir -ProjectName 'TestAutoInject' `
+    -AllowListDir $allowDir `
+    -SkipListFile $skipFile `
+    -ExtraImportXml $probeXml
+
+  $output = & dotnet msbuild $proj '/t:ProbeNoWarn' '/nologo' '/v:m' 2>&1
+  $r = @{ ExitCode = $LASTEXITCODE; Output = ($output -join "`n") }
+  Assert-Scenario 'allow-listed nowarn:CODE is auto-injected into $(NoWarn)' {
+    param($x) $x.Output -match 'NoWarnProbe:[^\r\n]*\bCA5555\b'
+  } $r
+
+  # And confirm the validator does NOT flag the auto-injected code (since it came
+  # from the approved list, it shouldn't trigger AZSDK0002 even though it's now
+  # present in $(NoWarn)).
+  $rv = Invoke-Validator $proj
+  Assert-Scenario 'auto-injected allow-list code does not trigger AZSDK0002' {
+    param($x) $x.Output -notmatch 'error AZSDK0002'
+  } $rv
+} finally { if (-not $KeepTemp) { Remove-Item -Recurse -Force $dir } }
+
+# ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------
 Write-Host ''

--- a/eng/scripts/Test-NoWarnValidation.ps1
+++ b/eng/scripts/Test-NoWarnValidation.ps1
@@ -248,9 +248,9 @@ try {
   $allowFile = Join-Path $allowDir 'TestAutoInject.txt'
   Set-Content -Path $allowFile -Value "# justification`nnowarn:CA5555`n" -Encoding UTF8
 
-  # Add a probe target that runs after ReadAnalyzerAllowList and echoes $(NoWarn).
+  # Add a probe target that runs after ApplyAnalyzerAllowListNoWarn and echoes $(NoWarn).
   $probeXml = @'
-  <Target Name="ProbeNoWarn" DependsOnTargets="ReadAnalyzerAllowList">
+  <Target Name="ProbeNoWarn" DependsOnTargets="ApplyAnalyzerAllowListNoWarn">
     <Message Importance="High" Text="NoWarnProbe:$(NoWarn)" />
   </Target>
 '@
@@ -272,6 +272,18 @@ try {
   Assert-Scenario 'auto-injected allow-list code does not trigger AZSDK0002' {
     param($x) $x.Output -notmatch 'error AZSDK0002'
   } $rv
+
+  # And confirm injection ALSO happens during design-time builds (VS IntelliSense
+  # / error squiggles set DesignTimeBuild=true). ValidateNoWarn is skipped in that
+  # mode, but ApplyAnalyzerAllowListNoWarn must still run so the IDE sees the
+  # same effective $(NoWarn) as a command-line build — otherwise developers see
+  # warnings in VS that the CLI build suppresses, pressuring them to re-add
+  # csproj-level <NoWarn> entries and defeating the single-source-of-truth design.
+  $output = & dotnet msbuild $proj '/t:ProbeNoWarn' '/nologo' '/v:m' '/p:DesignTimeBuild=true' 2>&1
+  $rdt = @{ ExitCode = $LASTEXITCODE; Output = ($output -join "`n") }
+  Assert-Scenario 'allow-listed nowarn:CODE is auto-injected even when DesignTimeBuild=true' {
+    param($x) $x.Output -match 'NoWarnProbe:[^\r\n]*\bCA5555\b'
+  } $rdt
 } finally { if (-not $KeepTemp) { Remove-Item -Recurse -Force $dir } }
 
 # ----------------------------------------------------------------------------

--- a/sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj
+++ b/sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj
@@ -12,18 +12,6 @@
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>
-      $(NoWarn)
-      <!-- Acknowledge OpenAI experimental features -->
-      ;OPENAI001
-      <!-- Temporary suppression of XML doc requirement -->
-      ;CS1591
-      <!-- Allow experimental features -->
-      ;AAIP001
-    </NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Storage.Blobs" />

--- a/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectBlobReference.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectBlobReference.cs
@@ -11,6 +11,7 @@ namespace Azure.AI.Projects
     [CodeGenType("AIProjectBlobReference")]
     public partial class AIProjectBlobReference
     {
+        /// <summary> The absolute URI of the referenced blob. </summary>
         public Uri BlobUri { get; }
     }
 }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
@@ -216,14 +216,23 @@ namespace Azure.AI.Projects
         public virtual AIProjectDeploymentsOperations Deployments { get => GetAIProjectDeploymentsOperationsClient(); }
         /// <summary> Gets the client for managing indexes. </summary>
         public virtual AIProjectIndexesOperations Indexes { get => GetAIProjectIndexesOperationsClient(); }
+        /// <summary> Gets the client for invoking Azure OpenAI operations scoped to this project. </summary>
         public virtual ProjectOpenAIClient ProjectOpenAIClient => GetCachedOpenAIClient();
+        /// <summary> Gets the client for administering agents in this project. </summary>
         public virtual AgentAdministrationClient AgentAdministrationClient => GetCachedAgentsClient();
+        /// <summary> Gets the client for managing memory stores. </summary>
         public virtual AIProjectMemoryStores MemoryStores => GetAIProjectMemoryStoresClient();
+        /// <summary> Gets the client for managing red team scans. </summary>
         public virtual RedTeams RedTeams => GetRedTeamsClient();
+        /// <summary> Gets the client for managing evaluation rules. </summary>
         public virtual EvaluationRules EvaluationRules => GetEvaluationRulesClient();
+        /// <summary> Gets the client for managing evaluation taxonomies. </summary>
         public virtual EvaluationTaxonomies EvaluationTaxonomies => GetEvaluationTaxonomiesClient();
+        /// <summary> Gets the client for managing project evaluators. </summary>
         public virtual ProjectEvaluators Evaluators => GetProjectEvaluatorsClient();
+        /// <summary> Gets the client for retrieving project insights. </summary>
         public virtual ProjectInsights Insights => GetProjectInsightsClient();
+        /// <summary> Gets the client for managing project schedules. </summary>
         public virtual ProjectSchedules Schedules => GetProjectSchedulesClient();
         public virtual AIProjectModels Models => GetAIProjectModelsClient();
         public virtual EvaluatorGenerationJobs EvaluatorGenerationJobs => GetEvaluatorGenerationJobsClient();

--- a/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
@@ -234,8 +234,11 @@ namespace Azure.AI.Projects
         public virtual ProjectInsights Insights => GetProjectInsightsClient();
         /// <summary> Gets the client for managing project schedules. </summary>
         public virtual ProjectSchedules Schedules => GetProjectSchedulesClient();
+        /// <summary> Gets the client for managing model deployments and capabilities. </summary>
         public virtual AIProjectModels Models => GetAIProjectModelsClient();
+        /// <summary> Gets the client for managing evaluator generation jobs. </summary>
         public virtual EvaluatorGenerationJobs EvaluatorGenerationJobs => GetEvaluatorGenerationJobsClient();
+        /// <summary> Gets the client for managing data generation jobs. </summary>
         public virtual DataGenerationJobs DataGenerationJobs => GetDataGenerationJobsClient();
         /// <summary> Gets the client for telemetry operations. </summary>
         public virtual AIProjectTelemetry Telemetry { get => new AIProjectTelemetry(this); }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/BlobReferenceSasCredential.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/BlobReferenceSasCredential.cs
@@ -14,6 +14,7 @@ namespace Azure.AI.Projects
     [CodeGenType("BlobReferenceSasCredential")]
     public partial class BlobReferenceSasCredential
     {
+        /// <summary> The SAS URI used to authenticate access to the referenced blob. </summary>
         public Uri SasUri { get; }
     }
 }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/CodeGenStubs.Evaluations.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/CodeGenStubs.Evaluations.cs
@@ -63,6 +63,7 @@ namespace Azure.AI.Projects.Evaluation;
 [CodeGenType("PagedRedTeam")] internal partial class PagedRedTeam { }
 [CodeGenType("PagedSchedule")] internal partial class PagedSchedule { }
 [CodeGenType("PagedScheduleRun")] internal partial class PagedScheduleRun { }
+/// <summary> Represents an insight produced by a project insight run. </summary>
 [CodeGenType("ProjectInsight")] public partial class ProjectInsight { }
 [CodeGenType("RecurrenceSchedule")] public abstract partial class RecurrenceSchedule { }
 [CodeGenType("RecurrenceTrigger")] public partial class RecurrenceTrigger { }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/CodeGenStubs.Memory.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/CodeGenStubs.Memory.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.Projects.Memory;
 [CodeGenType("MemoryStoreKind")] internal readonly partial struct MemoryStoreKind { }
 [CodeGenType("MemoryStoreObjectType")] public readonly partial struct MemoryStoreObjectType { }
 [CodeGenType("MemoryStoreOperationUsage")] public partial class MemoryStoreOperationUsage { }
+/// <summary> Token usage details for the input portion of a memory-store operation. </summary>
 [CodeGenType("MemoryStoreOperationUsageInputTokensDetails")] public partial class MemoryStoreOperationUsageInputTokensDetails { }
+/// <summary> Token usage details for the output portion of a memory-store operation. </summary>
 [CodeGenType("MemoryStoreOperationUsageOutputTokensDetails")] public partial class MemoryStoreOperationUsageOutputTokensDetails { }
 [CodeGenType("MemoryStoreSearchResponse")] public partial class MemoryStoreSearchResponse { }
 [CodeGenType("MemoryUpdateResultDetails")] public partial class MemoryUpdateResultDetails { }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/CodeGenStubs.OpenAI.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/CodeGenStubs.OpenAI.cs
@@ -157,4 +157,5 @@ namespace OpenAI;
 [CodeGenType("WebSearchToolCallItemParam")] internal partial class InternalWebSearchToolCallItemParam { }
 [CodeGenType("WebSearchToolCallItemResource")] internal partial class InternalWebSearchToolCallItemResource { }
 [CodeGenType("WebSearchToolCallItemResourceStatus")] internal readonly partial struct WebSearchToolCallItemResourceStatus { }
+/// <summary> Discriminator value identifying the kind of agent object returned by the service. </summary>
 [CodeGenType("AgentObjectType")] public readonly partial struct AgentObjectType { }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/Connections/AIProjectConnectionCustomCredential.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/Connections/AIProjectConnectionCustomCredential.cs
@@ -9,6 +9,7 @@ namespace Azure.AI.Projects
     [CodeGenType("AIProjectConnectionCustomCredential")]
     public partial class AIProjectConnectionCustomCredential
     {
+        /// <summary> Gets the set of custom credential key/value pairs. </summary>
         [CodeGenMember("AdditionalProperties")]
         public IReadOnlyDictionary<string, string> Keys => new ReadOnlyDictionary<string, string>(_additionalStringProperties);
     }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/Datasets/AIProjectDataset.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/Datasets/AIProjectDataset.cs
@@ -15,6 +15,7 @@ namespace Azure.AI.Projects
     [CodeGenType("AIProjectDataset")]
     public abstract partial class AIProjectDataset
     {
+        /// <summary> Gets or sets the URI that identifies the backing data for this dataset. </summary>
         public Uri DataUri { get; set; }
     }
 }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/Evaluators/CodeBasedEvaluatorDefinition.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/Evaluators/CodeBasedEvaluatorDefinition.cs
@@ -9,6 +9,9 @@ namespace Azure.AI.Projects.Evaluation;
 [CodeGenType("CodeBasedEvaluatorDefinition")]
 public partial class CodeBasedEvaluatorDefinition
 {
+    /// <summary> Initializes a new instance of <see cref="CodeBasedEvaluatorDefinition"/>. </summary>
+    /// <param name="codeText"> Inline code text for the evaluator. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="codeText"/> is null. </exception>
     public CodeBasedEvaluatorDefinition(string codeText) : this()
     {
         Argument.AssertNotNull(codeText, nameof(codeText));

--- a/sdk/ai/Azure.AI.Projects/src/Custom/Evaluators/EvaluatorDefinition.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/Evaluators/EvaluatorDefinition.cs
@@ -10,9 +10,11 @@ namespace Azure.AI.Projects.Evaluation;
 public partial class EvaluatorDefinition
 {
     // Customization: retain BinaryData despite Record<unknown> basis
+    /// <summary> The JSON schema (Draft 2020-12) for the evaluator's input parameters. </summary>
     [CodeGenMember("init_parameters")]
     public BinaryData InitParameters { get; set; }
 
+    /// <summary> The JSON schema (Draft 2020-12) for the evaluator's input data. </summary>
     [CodeGenMember("data_schema")]
     public BinaryData DataSchema { get; set; }
 }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/AIProjectMemoryStores.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/AIProjectMemoryStores.cs
@@ -129,6 +129,13 @@ public partial class AIProjectMemoryStores
             cancellationToken.ToRequestOptions());
     }
 
+    /// <summary> Submit an update to the specified memory store. </summary>
+    /// <param name="memoryStoreName"> The ID of the memory store to update. </param>
+    /// <param name="options"> Memory update options. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="memoryStoreName"/> or <paramref name="options"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="memoryStoreName"/> is an empty string, and was expected to be non-empty. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     public virtual async Task<ClientResult<MemoryUpdateResult>> UpdateMemoriesAsync(string memoryStoreName, MemoryUpdateOptions options, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(memoryStoreName, nameof(memoryStoreName));
@@ -138,6 +145,13 @@ public partial class AIProjectMemoryStores
         return ClientResult.FromValue((MemoryUpdateResult)protocolResult, protocolResult.GetRawResponse());
     }
 
+    /// <summary> Submit an update to the specified memory store. </summary>
+    /// <param name="memoryStoreName"> The ID of the memory store to update. </param>
+    /// <param name="options"> Memory update options. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="memoryStoreName"/> or <paramref name="options"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="memoryStoreName"/> is an empty string, and was expected to be non-empty. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     public virtual ClientResult<MemoryUpdateResult> UpdateMemories(string memoryStoreName, MemoryUpdateOptions options, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(memoryStoreName, nameof(memoryStoreName));

--- a/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/MemorySearchOptions.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/MemorySearchOptions.cs
@@ -8,6 +8,7 @@ using OpenAI.Responses;
 
 namespace Azure.AI.Projects.Memory;
 
+/// <summary> Options that describe a memory-store search request. </summary>
 public partial class MemorySearchOptions : IJsonModel<MemorySearchOptions>
 {
     /*
@@ -15,11 +16,17 @@ public partial class MemorySearchOptions : IJsonModel<MemorySearchOptions>
      * collision of Azure.AI.Projects.OpenAI and OpenAI.Responses
      */
 
+    /// <summary> The conversation items used as context for the search. </summary>
     public IList<ResponseItem> Items { get; private set; }
+    /// <summary> The scope (for example, user or session identifier) that partitions the memory store. </summary>
     public string Scope { get; }
+    /// <summary> The identifier of the previous search, used to continue or refine a prior search. </summary>
     public string PreviousSearchId { get; set; }
+    /// <summary> Options controlling how the search results are shaped (limits, ranking, etc.). </summary>
     public MemorySearchResultOptions ResultOptions { get; set; }
 
+    /// <summary> Initializes a new instance of <see cref="MemorySearchOptions"/>. </summary>
+    /// <param name="scope"> The scope that partitions the memory store. </param>
     public MemorySearchOptions(string scope)
     {
         Scope = scope;

--- a/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/MemoryStoreListOrder.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/MemoryStoreListOrder.cs
@@ -6,9 +6,11 @@ namespace Azure.AI.Projects.Memory;
 [CodeGenType("PageOrder")]
 public readonly partial struct MemoryStoreListOrder
 {
+    /// <summary> Sort results in ascending order by the <c>created_at</c> timestamp. </summary>
     [CodeGenMember("Asc")]
     public static MemoryStoreListOrder Ascending { get; } = new MemoryStoreListOrder(AscValue);
 
+    /// <summary> Sort results in descending order by the <c>created_at</c> timestamp. </summary>
     [CodeGenMember("Desc")]
     public static MemoryStoreListOrder Descending { get; } = new MemoryStoreListOrder(DescValue);
 }

--- a/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/MemoryUpdateOptions.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/MemoryUpdateOptions.cs
@@ -8,13 +8,20 @@ using OpenAI.Responses;
 
 namespace Azure.AI.Projects.Memory;
 
+/// <summary> Options that describe a memory-store update request. </summary>
 public partial class MemoryUpdateOptions : IJsonModel<MemoryUpdateOptions>
 {
+    /// <summary> The conversation items to write into the memory store. </summary>
     public IList<ResponseItem> Items { get; private set; }
+    /// <summary> The scope (for example, user or session identifier) that partitions the memory store. </summary>
     public string Scope { get; }
+    /// <summary> The identifier of the previous update, used to chain or supersede a prior update. </summary>
     public string PreviousUpdateId { get; set; }
+    /// <summary> Optional delay, in milliseconds, before the update is applied. </summary>
     public int? UpdateDelay { get; set; }
 
+    /// <summary> Initializes a new instance of <see cref="MemoryUpdateOptions"/>. </summary>
+    /// <param name="scope"> The scope that partitions the memory store. </param>
     public MemoryUpdateOptions(string scope)
     {
         Scope = scope;

--- a/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/MemoryUpdateResult.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/MemoryStores/MemoryUpdateResult.cs
@@ -6,11 +6,13 @@ namespace Azure.AI.Projects.Memory;
 [CodeGenType("MemoryStoreUpdateResponse")]
 public partial class MemoryUpdateResult
 {
+    /// <summary> Details of the memory-store update result. </summary>
     [CodeGenMember("Result")]
     public MemoryUpdateResultDetails Details { get; }
 
     [CodeGenMember("Error")]
     internal FoundryOpenAIError InternalError { get; }
 
+    /// <summary> A human-readable description of the failure, or <c>null</c> when the update succeeded. </summary>
     public string ErrorDetails => InternalError?.ToExceptionMessage(0);
 }


### PR DESCRIPTION
## Goal

Continue the NoWarn skip-list peel-off work from #58241 by removing `Azure.AI.Projects` (highest-activity skip-listed project, 20 commits in the last 30 days), and tighten the allow-list mechanism so projects no longer have to duplicate approved codes in their csproj.

## Allow-list auto-injection (central infra)

The previous shape required projects to keep `<NoWarn>OPENAI001;AAIP001</NoWarn>` in their csproj AND add a `nowarn:` entry in the allow-list file — two sources of truth, easy to drift. With this PR, the allow-list file is the single source of truth:

- `eng/AnalyzerAllowList.targets` now appends `$(_ProjectAllowedNoWarn)` to `$(NoWarn)` after reading the per-package file. Because `ReadAnalyzerAllowList` runs via `DependsOnTargets` from `ValidateNoWarn` (which is `BeforeTargets="CoreCompile"`), the injection happens before the compiler reads `$(NoWarn)`.
- An approved `nowarn:CODE` entry both records the approval AND applies the suppression. Projects should not keep the matching `<NoWarn>` line in their csproj.
- Scenario 7 added to `eng/scripts/Test-NoWarnValidation.ps1` verifies (a) the injection happens and (b) the auto-injected code does not trigger AZSDK0002. All 9 scenarios pass.
- README updated to document the new behavior.

## Azure.AI.Projects peel-off

The project had three suppressions, each handled differently:

| Code | Before | After | Approach |
|---|---|---|---|
| **CS1591** (missing XML docs) | 228 warnings in 15 files | 0 | **Fixed** — wrote XML doc comments for 38 distinct public symbols. The csproj comment already called this suppression "temporary". |
| **AAIP001** (own `[Experimental]`) | 438 hits in 28 files (348 in `Generated/`) | Allow-listed with justification | The library intentionally consumes its own preview surface; the diagnostic exists for external consumers, not internal callers. File-scoped `#pragma` would be wiped by codegen regen of the 27 generated files. |
| **OPENAI001** (OpenAI''s `[Experimental]`) | 90 hits in 3 files | Allow-listed with justification | The library is an intentional wrapper around OpenAI preview types it re-exposes; assembly-level opt-in matches design intent. |

`Azure.AI.Projects` is removed from `eng/NoWarnSkipValidation.txt` (202 → 201 entries). The csproj `<NoWarn>` block is removed entirely (allow-list now handles it). Build verified: 0 warnings, 0 errors.

## Files changed

**Central:**
- `eng/AnalyzerAllowList.targets` — auto-inject approved codes into `$(NoWarn)`
- `eng/scripts/Test-NoWarnValidation.ps1` — +Scenario 7 (auto-injection + non-trigger)
- `eng/analyzerallowlist/README.md` — document the single-source-of-truth behavior

**Azure.AI.Projects:**
- `eng/NoWarnSkipValidation.txt` — remove `Azure.AI.Projects`
- `eng/analyzerallowlist/Azure.AI.Projects.txt` (new) — approve `AAIP001` + `OPENAI001` with justifications
- `sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj` — remove `<NoWarn>` block
- 15 files in `sdk/ai/Azure.AI.Projects/src/Custom/` — add XML doc comments

## Validation

- `dotnet build sdk/ai/Azure.AI.Projects/src/Azure.AI.Projects.csproj` → 0 Warning(s), 0 Error(s)
- `eng/scripts/Test-NoWarnValidation.ps1` → 9/9 pass

Tracks https://github.com/Azure/azure-sdk-for-net/issues/55312.