### PR TITLE
Fix NullReferenceException in perf framework due to CommandLineParser 2.9.1 constructor change

### DIFF
--- a/common/Perf/Azure.Test.Perf/PerfUtilities.cs
+++ b/common/Perf/Azure.Test.Perf/PerfUtilities.cs
@@ -52,10 +52,10 @@ namespace Azure.Test.PerfStress
                 var baseOptionsType = t.GetConstructors().First().GetParameters()[0].ParameterType;
                 var tb = mb.DefineType(t.Name + "Options", TypeAttributes.Public, baseOptionsType);
 
-                var attrCtor = typeof(VerbAttribute).GetConstructor(new Type[] { typeof(string), typeof(bool) });
+                var attrCtor = typeof(VerbAttribute).GetConstructor(new Type[] { typeof(string), typeof(bool), typeof(string[]) });
                 var verbName = GetVerbName(t.Name);
                 tb.SetCustomAttribute(new CustomAttributeBuilder(attrCtor,
-                    new object[] { verbName, attrCtor.GetParameters()[1].DefaultValue }));
+                    new object[] { verbName, false, null }));
 
                 optionTypes.Add(tb.CreateType());
             }


### PR DESCRIPTION
# Problem

The perf test framework throws a NullReferenceException at PerfUtilities.GetOptionTypes when running any perf test:

> System.NullReferenceException: Object reference not set to an instance of an object.
    at Azure.Test.PerfStress.PerfUtilities.GetOptionTypes(IEnumerable`1 testTypes)
      in common/Perf/Azure.Test.Perf/PerfUtilities.cs:line 57

This regressed after PR #55609 bumped CommandLineParser from 2.8.0 to 2.9.1.

# Root Cause

In CommandLineParser 2.8.0, VerbAttribute had a 2-parameter constructor:

 `public VerbAttribute(string name, bool isDefault = false)`

In 2.9.1, an `aliases` parameter was added:

 `public VerbAttribute(string name, bool isDefault = false, string[] aliases = null)`

The code used `GetConstructor(new Type[] { typeof(string), typeof(bool) })` which matches by exact parameter count — it no longer finds a match with the 3-parameter constructor and returns null.

# Fix

Updated the reflection call to use the correct 3-parameter signature and pass explicit default values for `isDefault` and `aliases`.