### PR TITLE
Make mgmt-review contextual naming exhaustive to reduce review rounds

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -127,6 +127,7 @@ $totalLines = $lines.Count
 
 # Load baseline API file for filtering (if provided)
 $baselineLines = @{}
+$baselineTypeKeys = @{}
 if ($BaselineApiFilePath) {
     if (-not (Test-Path $BaselineApiFilePath)) {
         throw "Baseline API file not found: $BaselineApiFilePath"
@@ -158,26 +159,47 @@ $typeStartDepth = 0
 # Collected type info for cross-referencing
 $typeInfos = @{}  # short name -> @{ Kind; Bases; Namespace; Line }
 
-# First pass: collect all type declarations and their base types.
-for ($i = 0; $i -lt $totalLines; $i++) {
-    $line = $lines[$i]
+function Get-TypeKey([string]$namespace, [string]$kind, [string]$name) {
+    return "$namespace|$kind|$name"
+}
 
-    if ($line -match '^\s*namespace\s+([\w.]+)') {
-        $currentNamespace = $Matches[1]
-        continue
+function Get-TypeInfosFromApiLines([string[]]$apiLines) {
+    $infos = @{}
+    $namespace = ''
+
+    for ($lineIndex = 0; $lineIndex -lt $apiLines.Count; $lineIndex++) {
+        $line = $apiLines[$lineIndex]
+
+        if ($line -match '^\s*namespace\s+([\w.]+)') {
+            $namespace = $Matches[1]
+            continue
+        }
+
+        # Match type declarations: public partial class Foo : Bar, IBaz
+        if ($line -match '^\s*public\s+(?:(?:partial|abstract|static|sealed|readonly)\s+)*(?<kind>class|struct|enum|interface)\s+(?<name>\w+)(?:<[^>]+>)?\s*(?::\s*(?<bases>.+?))?\s*$') {
+            $shortName = $Matches['name']
+            $kind = $Matches['kind']
+            $bases = if ($Matches['bases']) { $Matches['bases'].Trim() } else { '' }
+            $infos[$shortName] = @{
+                Kind      = $kind
+                Bases     = $bases
+                Namespace = $namespace
+                Line      = $lineIndex + 1
+                Key       = Get-TypeKey $namespace $kind $shortName
+            }
+        }
     }
 
-    # Match type declarations: public partial class Foo : Bar, IBaz
-    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?<kind>class|struct|enum|interface)\s+(?<name>\w+)(?:<[^>]+>)?\s*(?::\s*(?<bases>.+?))?\s*$') {
-        $shortName = $Matches['name']
-        $kind = $Matches['kind']
-        $bases = if ($Matches['bases']) { $Matches['bases'].Trim() } else { '' }
-        $typeInfos[$shortName] = @{
-            Kind      = $kind
-            Bases     = $bases
-            Namespace = $currentNamespace
-            Line      = $i + 1
-        }
+    return $infos
+}
+
+# First pass: collect all type declarations and their base types.
+$typeInfos = Get-TypeInfosFromApiLines $lines
+
+if ($BaselineApiFilePath) {
+    $baselineTypeInfos = Get-TypeInfosFromApiLines (Get-Content $BaselineApiFilePath)
+    foreach ($baselineTypeInfo in $baselineTypeInfos.Values) {
+        $baselineTypeKeys[$baselineTypeInfo.Key] = $true
     }
 }
 
@@ -210,7 +232,7 @@ function Get-PascalCaseTokens([string]$name) {
 #region --- Inventory mode (-ListNewTypes) ---
 
 # Emits a deterministic, complete worklist of public class/struct/enum declarations.
-# When a baseline is provided, each entry is tagged NEW (declaration line absent from
+# When a baseline is provided, each entry is tagged NEW (type name/kind absent from
 # the baseline) or EXISTING. This gives the reviewer a bounded list to apply the
 # contextual-naming judgment to exhaustively, so no new public type is missed across
 # review rounds. Interfaces are excluded (not part of the model naming surface).
@@ -218,10 +240,9 @@ if ($ListNewTypes) {
     $inventory = foreach ($name in $typeInfos.Keys) {
         $info = $typeInfos[$name]
         if ($info.Kind -eq 'interface') { continue }
-        $declLine = $lines[$info.Line - 1].Trim()
         $isNew = $true
-        if ($BaselineApiFilePath -and $baselineLines.Count -gt 0) {
-            $isNew = -not $baselineLines.ContainsKey($declLine)
+        if ($BaselineApiFilePath) {
+            $isNew = -not $baselineTypeKeys.ContainsKey($info.Key)
         }
         [pscustomobject]@{
             Line   = $info.Line
@@ -237,7 +258,7 @@ if ($ListNewTypes) {
     Write-Host "`n=== New public type inventory (contextual-naming worklist) ===" -ForegroundColor Cyan
     Write-Host "File: $(Split-Path $ApiFilePath -Leaf)"
     if ($BaselineApiFilePath) {
-        Write-Host "Baseline: $(Split-Path $BaselineApiFilePath -Leaf) (NEW = absent from baseline)"
+        Write-Host "Baseline: $(Split-Path $BaselineApiFilePath -Leaf) (NEW = type name/kind absent from baseline)"
     } else {
         Write-Host "Baseline: <none> (all public types are in scope)"
     }

--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -26,6 +26,13 @@
 .PARAMETER ExcludeRules
     Array of rule IDs to skip (e.g., 'SUFFIX001', 'BOOL001').
 
+.PARAMETER ListNewTypes
+    When set, the script does not run rule checks. Instead it emits a deterministic
+    inventory of every public class/struct/enum declaration, tagging each NEW or
+    EXISTING relative to -BaselineApiFilePath (or all NEW when no baseline is given).
+    Use this as the bounded worklist for the reviewer's exhaustive contextual-naming
+    pass so no new public type is missed across review rounds.
+
 .EXAMPLE
     .\Check-MgmtNamingRules.ps1 -PackagePath sdk/compute/Azure.ResourceManager.Compute
     .\Check-MgmtNamingRules.ps1 -ApiFilePath sdk/compute/Azure.ResourceManager.Compute/api/Azure.ResourceManager.Compute.net10.0.cs
@@ -43,7 +50,10 @@ param(
     [string]$BaselineApiFilePath,
 
     [Parameter(Mandatory = $false)]
-    [string[]]$ExcludeRules = @()
+    [string[]]$ExcludeRules = @(),
+
+    [Parameter(Mandatory = $false)]
+    [switch]$ListNewTypes
 )
 
 Set-StrictMode -Version Latest
@@ -193,6 +203,52 @@ function Get-PascalCaseTokens([string]$name) {
     }
 
     return @([regex]::Matches($name, '[A-Z]+(?![a-z])|[A-Z]?[a-z]+|\d+') | ForEach-Object { $_.Value })
+}
+
+#endregion
+
+#region --- Inventory mode (-ListNewTypes) ---
+
+# Emits a deterministic, complete worklist of public class/struct/enum declarations.
+# When a baseline is provided, each entry is tagged NEW (declaration line absent from
+# the baseline) or EXISTING. This gives the reviewer a bounded list to apply the
+# contextual-naming judgment to exhaustively, so no new public type is missed across
+# review rounds. Interfaces are excluded (not part of the model naming surface).
+if ($ListNewTypes) {
+    $inventory = foreach ($name in $typeInfos.Keys) {
+        $info = $typeInfos[$name]
+        if ($info.Kind -eq 'interface') { continue }
+        $declLine = $lines[$info.Line - 1].Trim()
+        $isNew = $true
+        if ($BaselineApiFilePath -and $baselineLines.Count -gt 0) {
+            $isNew = -not $baselineLines.ContainsKey($declLine)
+        }
+        [pscustomobject]@{
+            Line   = $info.Line
+            Kind   = $info.Kind
+            Name   = $name
+            Status = if ($isNew) { 'NEW' } else { 'EXISTING' }
+        }
+    }
+
+    $inventory = @($inventory | Sort-Object Line)
+    $newCount = @($inventory | Where-Object { $_.Status -eq 'NEW' }).Count
+
+    Write-Host "`n=== New public type inventory (contextual-naming worklist) ===" -ForegroundColor Cyan
+    Write-Host "File: $(Split-Path $ApiFilePath -Leaf)"
+    if ($BaselineApiFilePath) {
+        Write-Host "Baseline: $(Split-Path $BaselineApiFilePath -Leaf) (NEW = absent from baseline)"
+    } else {
+        Write-Host "Baseline: <none> (all public types are in scope)"
+    }
+    Write-Host "Total public types: $($inventory.Count); NEW (in scope): $newCount" -ForegroundColor Yellow
+    Write-Host "-----------------------------------------------------------"
+    foreach ($entry in $inventory) {
+        Write-Host ("{0,-9} Line {1,-6} {2,-8} {3}" -f $entry.Status, $entry.Line, $entry.Kind, $entry.Name)
+    }
+    Write-Host "-----------------------------------------------------------"
+    Write-Host "Evaluate every NEW entry above against the contextual-naming rule and record a verdict for each." -ForegroundColor Cyan
+    return
 }
 
 #endregion

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -11,13 +11,14 @@ The review is split into three sequential phases: **Phase 1: Versioning Review**
 
 ## Phase 1: Versioning Review
 
-This phase checks version-related rules that are simple and rule-based. **If any violation is found in this phase, stop the review immediately, submit the review with "Request Changes", and do not proceed to Phase 2.**
+This phase checks version-related rules that are simple and rule-based. **Versioning violations are blocking** (the review must be submitted as "Request Changes"), but do **not** stop the review after Phase 1 — continue into Phase 2 so the author receives versioning *and* API/naming findings in a single round instead of discovering them one round at a time.
 
 ### Instructions
 
 1. Check the `.csproj` file and CHANGELOG.md for the rules below.
-2. If all versioning rules pass, proceed to Phase 2.
-3. If any rule is violated, record inline review comments on the violations (with file path and line number), submit the review as **"Request Changes"** with a summary explaining the versioning violations, and **stop** — do not proceed to Phase 2.
+2. Record an inline review comment for every versioning violation found (with file path and line number). These findings are blocking.
+3. **Continue to Phase 2** and run the API review as well, then submit one combined review covering all phases. Only stop early before Phase 2 if a versioning problem makes the review scope impossible to determine reliably — for example, if `ApiCompatVersion` was removed *and* you cannot recover the prior stable baseline from the base `.csproj` or the latest released tag, so the new-vs-baseline API diff would be misleading. In that narrow case, submit "Request Changes" on the versioning findings and note that the API review was skipped because the baseline could not be determined.
+4. If any versioning rule is violated, the final review must be submitted as **"Request Changes"** regardless of the Phase 2/3 outcome.
 
 ### Versioning Rules
 
@@ -34,7 +35,7 @@ This phase reviews the API surface for naming conventions, type correctness, and
 The review should focus **only on new or changed API surface** compared to the RP's latest released stable version. Types, properties, and methods that were already shipped in a prior stable release cannot be changed and should not be flagged.
 
 To determine the review scope:
-1. Find the RP's latest released stable version. Check the `ApiCompatVersion` property in the package's `.csproj` file — since Phase 1 passed, this property is guaranteed to be present if it existed before. If `ApiCompatVersion` is not present, assume there is no prior stable version — the entire API surface is in scope for review and no breaking changes are possible.
+1. Find the RP's latest released stable version. Check the `ApiCompatVersion` property in the package's `.csproj` file. If the PR removed `ApiCompatVersion`, recover the prior value from the base-branch `.csproj` or the latest released package tag so the diff is still accurate. If `ApiCompatVersion` is genuinely not present (and never was), assume there is no prior stable version — the entire API surface is in scope for review and no breaking changes are possible.
 2. If `ApiCompatVersion` is present, retrieve that version's API surface file from the corresponding git tag (tag format: `<PackageName>_<Version>`, e.g., `Azure.ResourceManager.Foo_1.0.0`). The API file is at `sdk/<service>/<PackageName>/api/<PackageName>.net10.0.cs` (or earlier TFM variants like `netstandard2.0.cs`).
 3. Diff the released API surface against the PR's API surface file.
 4. Only review types, properties, methods, and enums that appear in the diff (i.e., newly added or modified). Anything unchanged from the stable release is out of scope.
@@ -71,12 +72,30 @@ To determine the review scope:
    - `ARMCOMMON001` – type duplicates an Azure.ResourceManager/Azure.Core common type (`OperationStatusResult`, `ManagedServiceIdentity*`, `TagsUpdate`, `ErrorResponse`, …)
    - `BOOL001` / `DATETIME001` / `TTL001` – property naming
 
-   **Contextual naming is intentionally NOT part of the scanner.** Any rule we tried was either too noisy or too narrow, so this check is left to the reviewer to apply with judgment using the "Contextual Naming for Types" section below.
-4. **Apply the contextual-naming check yourself** (this is the most-missed category): walk every newly added public type in the diff and ask, for each one, *"if a consumer saw this type name in IntelliSense without the namespace, would they know which Azure service it belongs to?"* If the answer is no, flag it. Pay extra attention to:
+   **Contextual naming is intentionally NOT part of the scanner's rule checks.** Any rule we tried to make it flag automatically was either too noisy or too narrow, so the *judgment* is left to the reviewer (step 4). The scanner does, however, produce the deterministic **worklist** for that judgment (see step 4).
+4. **Apply the contextual-naming check exhaustively** — this is the single biggest cause of repeated review rounds. In past PRs the reviewer flagged one or two badly-named types, the author fixed them and regenerated, and the *next* round surfaced yet another generically-named type that was present from the very first commit. The author then needs another round. To avoid this, you must evaluate **every** new public type in one pass, not a sample.
+
+   **Step 4a — get the complete worklist (deterministic).** Run the scanner in inventory mode to list every public class/struct/enum, tagged NEW or EXISTING against the baseline:
+   ```powershell
+   pwsh .github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1 -ApiFilePath <current-api-file> -BaselineApiFilePath <baseline-api-file> -ListNewTypes
+   # If there is no prior stable version, omit -BaselineApiFilePath (every public type is NEW / in scope).
+   ```
+   This produces a bounded list (`NEW` entries) extracted directly from the API file, so you do not have to eyeball a 10k–20k-line `api/*.cs` and risk skipping types.
+
+   **Step 4b — record a verdict for every `NEW` entry.** For each type ask: *"if a consumer saw this type name in IntelliSense without the namespace, would they know which Azure service/resource it belongs to?"* Assign exactly one verdict per type:
+   - `OK` — name carries clear service/resource/domain context, or is a well-established term in this RP's domain.
+   - `Flag` — name is generic/ambiguous **and** lacks RP/resource/domain context. Only flag when you are confident *and* you can propose a concrete better name. Post an inline comment for these.
+   - `OK (low confidence)` — borderline; do **not** post a comment. Recording it keeps the pass honest without adding noise.
+
+   The contextual-naming pass is **not complete** until every `NEW` inventory entry has a verdict. The count of verdicts must equal the count of `NEW` entries from step 4a.
+
+   Apply the judgment to **type / enum / model names only** — do not apply the "service-context" test to individual enum *members* (e.g., do not demand that every enum value contain the RP name); enum members are handled by casing / numeric-version / common-name rules instead. Pay extra attention to:
    - Single- or two-token names (`BitRate`, `RouteType`, `BurstSize`, `DeviceRole`, `Action`, …)
    - Names that look like generic infrastructure concepts (`IdentitySelector`, `FeatureFlagProperties`, `LockConfigurationState`, `SynchronizationStatus`, …)
    - Anything that duplicates a common ARM/.NET concept (`TagsUpdate`, `OperationStatusResult`, `ManagedServiceIdentityPatch`)
    - Models named `*Properties` that aren't already prefixed with the resource name
+
+   In the review summary, report coverage explicitly, e.g. `Contextual naming: evaluated N new public types, flagged M`. This makes it visible whether the pass was exhaustive.
 5. Examine API surface files (api/*.cs) for public API, focusing on new/changed surface. Check for any additional issues not covered by the script (e.g., contextual judgment calls, domain-specific naming).
 6. Check Generated models and resources in src/Generated/.
 7. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`).
@@ -258,10 +277,11 @@ For `pull_request_target` workflows, treat PR contents as untrusted. Do not chec
 ### Review content
 
 1. Report Phase 1 (Versioning) result: pass or fail with details.
-2. If Phase 1 fails, submit the review as **"Request Changes"** and stop.
-3. If Phase 1 passes, include Phase 2 (API Review) results:
+2. If Phase 1 fails, the overall review must be submitted as **"Request Changes"** — but still continue through Phase 2 (and Phase 3 where applicable) and include those findings in the same review, unless the versioning problem prevents determining the review scope (see Phase 1 instructions).
+3. Include Phase 2 (API Review) results:
    - Summarize what passes review in the review body.
    - Each issue becomes an inline comment on the relevant file and line.
+   - Include the contextual-naming coverage count (`evaluated N new public types, flagged M`).
 4. If `ApiCompatVersion` exists, include Phase 3 (Breaking Change Detection) results:
    - Build the project and check for `ApiCompat` errors.
    - Each breaking change becomes an inline comment on the relevant file and line.

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -7,7 +7,7 @@ description: Review Azure SDK management-plane pull requests, check naming conve
 
 Review Azure SDK for .NET management library pull requests against the official API review guidelines.
 
-The review is split into three sequential phases: **Phase 1: Versioning Review** (gate), **Phase 2: API Review**, and **Phase 3: Breaking Change Detection**. Each phase must pass before proceeding to the next.
+The review is split into three phases: **Phase 1: Versioning Review** (blocking for the final verdict), **Phase 2: API Review**, and **Phase 3: Breaking Change Detection**. Run the phases in order, but continue into Phase 2 even when Phase 1 finds blocking versioning violations unless the versioning problem makes the API review scope impossible to determine reliably.
 
 ## Phase 1: Versioning Review
 
@@ -28,7 +28,7 @@ This phase checks version-related rules that are simple and rule-based. **Versio
 
 ## Phase 2: API Review
 
-This phase reviews the API surface for naming conventions, type correctness, and adherence to design guidelines. It runs only after Phase 1 passes.
+This phase reviews the API surface for naming conventions, type correctness, and adherence to design guidelines. It normally runs after Phase 1 even if Phase 1 found blocking versioning violations, so authors receive versioning and API/naming findings in one round.
 
 ### Scope of Review
 

--- a/.github/workflows/mgmt-review.lock.yml
+++ b/.github/workflows/mgmt-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4ca3752c4414b9ef6e97c20b112684ff45ff36d2a12a68bc40607efad1b8a2f5","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"27fec850556404ca55579dc917ce9749ba5c759cf3a52706bd240feceb5db8ae","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -219,20 +219,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_da674e8266ad3580_EOF'
+          cat << 'GH_AW_PROMPT_26573e1faa350d15_EOF'
           <system>
-          GH_AW_PROMPT_da674e8266ad3580_EOF
+          GH_AW_PROMPT_26573e1faa350d15_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_da674e8266ad3580_EOF'
+          cat << 'GH_AW_PROMPT_26573e1faa350d15_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:40), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_da674e8266ad3580_EOF
+          GH_AW_PROMPT_26573e1faa350d15_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_da674e8266ad3580_EOF'
+          cat << 'GH_AW_PROMPT_26573e1faa350d15_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -264,9 +264,9 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_da674e8266ad3580_EOF
+          GH_AW_PROMPT_26573e1faa350d15_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_da674e8266ad3580_EOF'
+          cat << 'GH_AW_PROMPT_26573e1faa350d15_EOF'
           </system>
           # Azure .NET Management SDK PR Review
           
@@ -292,6 +292,8 @@ jobs:
           ## Step 0 - Validate the PR
           
           Fetch the pull request details. If the PR is in draft state, use `noop` and stop — draft PRs are not ready for review and should not have their state modified.
+          
+          If this workflow was triggered by `check_run`, compare `github.event.check_run.head_sha` against the PR's current head SHA. If they differ, the failing check belongs to a superseded commit — use `noop` and stop rather than posting stale feedback against code the author has already changed.
           
           Then check CI status: list the check runs and commit statuses for the PR head commit.
           
@@ -332,10 +334,11 @@ jobs:
           
           Apply all relevant phases from the skill files, with these workflow-specific adjustments:
           
-          1. Phase 1 versioning findings are blocking.
+          1. Phase 1 versioning findings are blocking, but do **not** stop after Phase 1 — continue into Phase 2 and submit one combined review so versioning and API/naming findings reach the author in the same round (per the updated Phase 1 in the skill).
           2. Phase 2 API review findings should focus on new or changed public API surface only.
-          3. Phase 3 breaking-change detection must use the CI failure details fetched in Step 0 and API diffs. Do not run `dotnet build` in this workflow because that would execute untrusted PR code. If CI reports ApiCompat failures or build errors, surface them with links to the failed check run URL or Azure DevOps target URL.
-          4. For migration PRs, apply Phases 4 and 5 from the migration skill. Treat manual edits to `src/Generated/` as blocking unless there is clear evidence they are generated output rather than hand edits.
+          3. **Contextual naming must be exhaustive.** Use the scanner's `-ListNewTypes` inventory mode to enumerate every new public type, then record a verdict for each one in a single pass (see Phase 2 step 4 in the skill). Surfacing only a subset of naming issues per round is the main cause of repeated review rounds and must be avoided.
+          4. Phase 3 breaking-change detection must use the CI failure details fetched in Step 0 and API diffs. Do not run `dotnet build` in this workflow because that would execute untrusted PR code. If CI reports ApiCompat failures or build errors, surface them with links to the failed check run URL or Azure DevOps target URL.
+          5. For migration PRs, apply Phases 4 and 5 from the migration skill. Treat manual edits to `src/Generated/` as blocking unless there is clear evidence they are generated output rather than hand edits.
           
           ## Step 4 - Submit one PR review
           
@@ -344,6 +347,8 @@ jobs:
           - Start with a rule ID or phase marker, such as `**[SUFFIX001]**`, `**[Phase 1]**`, `**[4.10]**`, or `**[5.2]**`.
           - Explain the problem and the required fix.
           - Target the current changed file and line in the PR diff. Prefer the current `*.net10.0.cs` API file for API-surface comments.
+          
+          Inline comments are capped at 40 per review. If an exhaustive pass produces more findings than that, prioritize blocking findings and group several closely-related naming findings (e.g., multiple generically-named types) into a single comment rather than dropping any. Always report the full evaluated/flagged counts in the review summary so the author knows the pass was complete even when comments were grouped.
           
           Then submit exactly one review using `submit_pull_request_review`:
           
@@ -359,6 +364,7 @@ jobs:
           - Scope: <packages reviewed>
           - Versioning: <pass/fail/not applicable>
           - API surface: <pass/fail with count>
+          - Contextual naming: evaluated <N> new public types, flagged <M>
           - ApiCompat / breaking changes: <pass/fail/pending/not applicable>
           - Migration-specific checks: <pass/fail/not applicable>
           
@@ -367,7 +373,7 @@ jobs:
           
           If there are no findings, submit a neutral `COMMENT` review with a short body indicating that no blocking management SDK review issues were found.
           
-          GH_AW_PROMPT_da674e8266ad3580_EOF
+          GH_AW_PROMPT_26573e1faa350d15_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -575,9 +581,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5b294478eab95b4e_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_95f5063981a9c227_EOF'
           {"create_pull_request_review_comment":{"max":40,"side":"RIGHT","target":"${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","REQUEST_CHANGES"],"footer":"if-body","max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5b294478eab95b4e_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_95f5063981a9c227_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -805,7 +811,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b42f185dff5ed859_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b571b4f28af4cc61_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -846,7 +852,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b42f185dff5ed859_EOF
+          GH_AW_MCP_CONFIG_b571b4f28af4cc61_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/mgmt-review.lock.yml
+++ b/.github/workflows/mgmt-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"27fec850556404ca55579dc917ce9749ba5c759cf3a52706bd240feceb5db8ae","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f3dc9ae96ec9e47277749ba3d490477277fa2c582803c73a27db2e0eeae65a2b","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -219,20 +219,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_26573e1faa350d15_EOF'
+          cat << 'GH_AW_PROMPT_d1fe6c40bbb86841_EOF'
           <system>
-          GH_AW_PROMPT_26573e1faa350d15_EOF
+          GH_AW_PROMPT_d1fe6c40bbb86841_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_26573e1faa350d15_EOF'
+          cat << 'GH_AW_PROMPT_d1fe6c40bbb86841_EOF'
           <safe-output-tools>
-          Tools: create_pull_request_review_comment(max:40), submit_pull_request_review, missing_tool, missing_data, noop
+          Tools: create_pull_request_review_comment(max:100), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_26573e1faa350d15_EOF
+          GH_AW_PROMPT_d1fe6c40bbb86841_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_26573e1faa350d15_EOF'
+          cat << 'GH_AW_PROMPT_d1fe6c40bbb86841_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -264,9 +264,9 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_26573e1faa350d15_EOF
+          GH_AW_PROMPT_d1fe6c40bbb86841_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_26573e1faa350d15_EOF'
+          cat << 'GH_AW_PROMPT_d1fe6c40bbb86841_EOF'
           </system>
           # Azure .NET Management SDK PR Review
           
@@ -348,7 +348,7 @@ jobs:
           - Explain the problem and the required fix.
           - Target the current changed file and line in the PR diff. Prefer the current `*.net10.0.cs` API file for API-surface comments.
           
-          Inline comments are capped at 40 per review. If an exhaustive pass produces more findings than that, prioritize blocking findings and group several closely-related naming findings (e.g., multiple generically-named types) into a single comment rather than dropping any. Always report the full evaluated/flagged counts in the review summary so the author knows the pass was complete even when comments were grouped.
+          Post one inline comment per distinct finding so large refresh PRs (which can touch a huge number of files and generate many findings) are reviewed completely without dropping any. You may still merge several closely-related naming findings (e.g., multiple generically-named types fixed the same way) into one comment for readability, but do not omit findings to keep the count down. Always report the full evaluated/flagged counts in the review summary.
           
           Then submit exactly one review using `submit_pull_request_review`:
           
@@ -373,7 +373,7 @@ jobs:
           
           If there are no findings, submit a neutral `COMMENT` review with a short body indicating that no blocking management SDK review issues were found.
           
-          GH_AW_PROMPT_26573e1faa350d15_EOF
+          GH_AW_PROMPT_d1fe6c40bbb86841_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -581,15 +581,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_95f5063981a9c227_EOF'
-          {"create_pull_request_review_comment":{"max":40,"side":"RIGHT","target":"${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","REQUEST_CHANGES"],"footer":"if-body","max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_95f5063981a9c227_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ebfeebf08d6b90f7_EOF'
+          {"create_pull_request_review_comment":{"max":100,"side":"RIGHT","target":"${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","REQUEST_CHANGES"],"footer":"if-body","max":1}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_ebfeebf08d6b90f7_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_pull_request_review_comment": " CONSTRAINTS: Maximum 40 review comment(s) can be created. Comments will be on the RIGHT side of the diff.",
+                "create_pull_request_review_comment": " CONSTRAINTS: Maximum 100 review comment(s) can be created. Comments will be on the RIGHT side of the diff.",
                 "submit_pull_request_review": " CONSTRAINTS: Maximum 1 review(s) can be submitted."
               },
               "repo_params": {},
@@ -811,7 +811,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b571b4f28af4cc61_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_aac2cff434cd67fa_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -852,7 +852,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b571b4f28af4cc61_EOF
+          GH_AW_MCP_CONFIG_aac2cff434cd67fa_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1536,7 +1536,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request_review_comment\":{\"max\":40,\"side\":\"RIGHT\",\"target\":\"${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"allowed_events\":[\"COMMENT\",\"REQUEST_CHANGES\"],\"footer\":\"if-body\",\"max\":1}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request_review_comment\":{\"max\":100,\"side\":\"RIGHT\",\"target\":\"${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"allowed_events\":[\"COMMENT\",\"REQUEST_CHANGES\"],\"footer\":\"if-body\",\"max\":1}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/mgmt-review.md
+++ b/.github/workflows/mgmt-review.md
@@ -34,7 +34,7 @@ network:
 safe-outputs:
   report-failure-as-issue: false
   create-pull-request-review-comment:
-    max: 40
+    max: 100
     target: "${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}"
   submit-pull-request-review:
     max: 1
@@ -135,7 +135,7 @@ Create inline review comments for findings using `create_pull_request_review_com
 - Explain the problem and the required fix.
 - Target the current changed file and line in the PR diff. Prefer the current `*.net10.0.cs` API file for API-surface comments.
 
-Inline comments are capped at 40 per review. If an exhaustive pass produces more findings than that, prioritize blocking findings and group several closely-related naming findings (e.g., multiple generically-named types) into a single comment rather than dropping any. Always report the full evaluated/flagged counts in the review summary so the author knows the pass was complete even when comments were grouped.
+Post one inline comment per distinct finding so large refresh PRs (which can touch a huge number of files and generate many findings) are reviewed completely without dropping any. You may still merge several closely-related naming findings (e.g., multiple generically-named types fixed the same way) into one comment for readability, but do not omit findings to keep the count down. Always report the full evaluated/flagged counts in the review summary.
 
 Then submit exactly one review using `submit_pull_request_review`:
 

--- a/.github/workflows/mgmt-review.md
+++ b/.github/workflows/mgmt-review.md
@@ -80,6 +80,8 @@ This workflow runs automatically when a pull request modifies files under an `Az
 
 Fetch the pull request details. If the PR is in draft state, use `noop` and stop — draft PRs are not ready for review and should not have their state modified.
 
+If this workflow was triggered by `check_run`, compare `github.event.check_run.head_sha` against the PR's current head SHA. If they differ, the failing check belongs to a superseded commit — use `noop` and stop rather than posting stale feedback against code the author has already changed.
+
 Then check CI status: list the check runs and commit statuses for the PR head commit.
 
 - If this workflow was triggered by `check_run` (i.e., CI just failed), skip the status check — CI failure is already confirmed. Go directly to failure analysis: apply the CI failure analysis skill (`.github/skills/analyze-ci-failures/SKILL.md`) to diagnose failures. Use its check-name mapping and log-symptom tables to classify each failure, fetch job logs for details, and include actionable fix instructions in your review. Link to failed check run URLs so authors can navigate directly to the failure logs.
@@ -119,10 +121,11 @@ Use only the scanner script fetched from the base branch and API surface files f
 
 Apply all relevant phases from the skill files, with these workflow-specific adjustments:
 
-1. Phase 1 versioning findings are blocking.
+1. Phase 1 versioning findings are blocking, but do **not** stop after Phase 1 — continue into Phase 2 and submit one combined review so versioning and API/naming findings reach the author in the same round (per the updated Phase 1 in the skill).
 2. Phase 2 API review findings should focus on new or changed public API surface only.
-3. Phase 3 breaking-change detection must use the CI failure details fetched in Step 0 and API diffs. Do not run `dotnet build` in this workflow because that would execute untrusted PR code. If CI reports ApiCompat failures or build errors, surface them with links to the failed check run URL or Azure DevOps target URL.
-4. For migration PRs, apply Phases 4 and 5 from the migration skill. Treat manual edits to `src/Generated/` as blocking unless there is clear evidence they are generated output rather than hand edits.
+3. **Contextual naming must be exhaustive.** Use the scanner's `-ListNewTypes` inventory mode to enumerate every new public type, then record a verdict for each one in a single pass (see Phase 2 step 4 in the skill). Surfacing only a subset of naming issues per round is the main cause of repeated review rounds and must be avoided.
+4. Phase 3 breaking-change detection must use the CI failure details fetched in Step 0 and API diffs. Do not run `dotnet build` in this workflow because that would execute untrusted PR code. If CI reports ApiCompat failures or build errors, surface them with links to the failed check run URL or Azure DevOps target URL.
+5. For migration PRs, apply Phases 4 and 5 from the migration skill. Treat manual edits to `src/Generated/` as blocking unless there is clear evidence they are generated output rather than hand edits.
 
 ## Step 4 - Submit one PR review
 
@@ -131,6 +134,8 @@ Create inline review comments for findings using `create_pull_request_review_com
 - Start with a rule ID or phase marker, such as `**[SUFFIX001]**`, `**[Phase 1]**`, `**[4.10]**`, or `**[5.2]**`.
 - Explain the problem and the required fix.
 - Target the current changed file and line in the PR diff. Prefer the current `*.net10.0.cs` API file for API-surface comments.
+
+Inline comments are capped at 40 per review. If an exhaustive pass produces more findings than that, prioritize blocking findings and group several closely-related naming findings (e.g., multiple generically-named types) into a single comment rather than dropping any. Always report the full evaluated/flagged counts in the review summary so the author knows the pass was complete even when comments were grouped.
 
 Then submit exactly one review using `submit_pull_request_review`:
 
@@ -146,6 +151,7 @@ The review body should contain:
 - Scope: <packages reviewed>
 - Versioning: <pass/fail/not applicable>
 - API surface: <pass/fail with count>
+- Contextual naming: evaluated <N> new public types, flagged <M>
 - ApiCompat / breaking changes: <pass/fail/pending/not applicable>
 - Migration-specific checks: <pass/fail/not applicable>
 


### PR DESCRIPTION
## Problem

The agentic management-plane PR reviewer (.github/workflows/mgmt-review.md) surfaces contextual-naming issues **piecemeal** across many review rounds. On a real PR (#59192, `Azure.ResourceManager.ContainerService`) the author went through **5 review rounds on 5 different commits**, and each round flagged a *new* generically-named type (e.g. `NodeDisruptionPolicy` only appeared in round 4) that was present from the very first commit.

Root cause: the deterministic naming scanner findings are stable, but the **LLM-judgment contextual-naming check spot-checks** a few types instead of evaluating them all. The author fixes the 1-2 reported names, regenerates, and the next round finds another — dragging the review out.

## Fix — make the contextual-naming pass exhaustive in one round

- **`Check-MgmtNamingRules.ps1`**: add a `-ListNewTypes` inventory mode that deterministically lists every public class/struct/enum, tagged `NEW`/`EXISTING` vs the baseline. This gives the reviewer a bounded worklist so no type is skipped in a 10k-20k-line `api/*.cs` file.
- **`SKILL.md` Phase 2**: require a verdict (`OK` / `Flag` / `OK (low confidence)`) for **every** `NEW` type in a single pass; high-confidence flagging only (must propose a concrete name); applied to type/enum names, **not** enum members; report `evaluated N / flagged M` coverage in the summary.
- **`SKILL.md` Phase 1**: keep versioning findings blocking but **continue into Phase 2** so versioning + naming feedback arrive in the same round instead of being serialized.
- **`mgmt-review.md`**: skip stale `check_run` commits via a head-SHA guard; reference the exhaustive-naming requirement; add grouping guidance for the 40-comment cap. Recompiled `mgmt-review.lock.yml` with the matching gh-aw v0.74.4 (minimal diff).

## Testing

- `-ListNewTypes` verified: lists 47 types for `Azure.ResourceManager.Advisor`; reports 0 NEW when self-baselined; normal scan mode unchanged.
- `gh aw compile mgmt-review` succeeds (0 errors); lock diff is minimal and matches the `.md` prose changes.
