### PR TITLE
Fix mgmt SDK package resolution

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -282,6 +282,22 @@ function Update-DataPlanePackageFolder() {
   return $projectFolder
 }
 
+function Get-MgmtPackageFolderCandidates() {
+    param(
+        [string]$sdkPath,
+        [string]$packageName,
+        [string]$AUTOREST_CONFIG_FILE = "autorest.md"
+    )
+
+    $serviceFolder = Join-Path $sdkPath "sdk" $packageName
+    if (!(Test-Path -Path $serviceFolder)) {
+        return @()
+    }
+
+    $packageFolders = @(Get-ChildItem -Path $serviceFolder -Directory -Filter "Azure.ResourceManager.*" -ErrorAction SilentlyContinue)
+    return @($packageFolders | Where-Object { Test-Path -Path (Join-Path $_.FullName "src" $AUTOREST_CONFIG_FILE) })
+}
+
 <#
 .SYNOPSIS
 Prepare the SDK pacakge for mangement-plane.
@@ -302,16 +318,17 @@ function Update-MgmtPackageFolder() {
         $packageName = $service
     }
 
-    $projectFolder = (Join-Path $sdkPath "sdk" $packageName "Azure.ResourceManager.*")
-    $mgmtPackageName = ""
-    $projectFolder = $projectFolder -replace "\\", "/"
-    if (Test-Path -Path $projectFolder) {
+    $projectFolders = @(Get-MgmtPackageFolderCandidates -sdkPath $sdkPath -packageName $packageName -AUTOREST_CONFIG_FILE $AUTOREST_CONFIG_FILE)
+    if ($projectFolders.Count -eq 1) {
       Write-Host "Path exists!"
-      $folderinfo = Get-ChildItem -Path $projectFolder
-      $mgmtPackageName = $folderinfo.Name
-      $projectFolder = "$sdkPath/sdk/$packageName/$mgmtPackageName"
+      $projectFolder = $projectFolders[0].FullName -replace "\\", "/"
+      $mgmtPackageName = $projectFolders[0].Name
+    } elseif ($projectFolders.Count -gt 1) {
+      $candidateNames = $projectFolders.Name -join ", "
+      Write-Host "[ERROR] Found multiple management SDK package folders with src/$AUTOREST_CONFIG_FILE under sdk/${packageName}: $candidateNames. Cannot determine which package to generate from swagger."
+      exit 1
     } else {
-      Write-Host "[ERROR] Project directory doesn't exist. It is a new .NET SDK. We will not support onboard a new service SDK from swagger. Please contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+      Write-Host "[ERROR] Project directory doesn't exist. It is a new .NET SDK or does not contain a swagger-based $AUTOREST_CONFIG_FILE. We will not support onboard a new service SDK from swagger. Please contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
       exit 1
     }
 
@@ -572,8 +589,8 @@ function Invoke-GenerateAndBuildSDK () {
             $package = $packageNameHash[$service]
             Write-Host "rename package name to $package"
         }
-        $projectFolder = (Join-Path $sdkRootPath "sdk" $package "Azure.ResourceManager.*")
-        if (Test-Path -Path $projectFolder) {
+        $serviceFolder = Join-Path $sdkRootPath "sdk" $package
+        if (Test-Path -Path $serviceFolder) {
             Update-MgmtPackageFolder -service $service -packageName $package -sdkPath $sdkRootPath -commitid $commitid -readme $readmeFile -outputJsonFile $newpackageoutput
             if ( !$?) {
                 Write-Host "[ERROR] Failed to create sdk project folder.service:$service,package:$package, sdkPath:$sdkRootPath,readme:$readmeFile.exit code: $?. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."

--- a/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
+++ b/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
@@ -124,6 +124,58 @@ Describe "Generate and Build SDK" -Tag "Unit" {
     }
 }
 
+Describe "Update-MgmtPackageFolder function" -Tag "UnitTest" {
+    BeforeEach {
+        $script:mgmtTestRootDir = Join-Path ([System.IO.Path]::GetTempPath()) "mgmt-package-folder-test-$(Get-Random)"
+        $script:mgmtSdkRoot = Join-Path $script:mgmtTestRootDir "sdk-root"
+        $script:mgmtServiceDir = Join-Path $script:mgmtSdkRoot "sdk" "resources"
+        $script:mgmtProjectDir = Join-Path $script:mgmtServiceDir "Azure.ResourceManager.Resources"
+        $script:mgmtSrcDir = Join-Path $script:mgmtProjectDir "src"
+
+        New-Item -ItemType Directory -Path $script:mgmtSrcDir -Force | Out-Null
+        foreach ($package in @("Azure.ResourceManager.Resources.Bicep", "Azure.ResourceManager.Resources.Deployments", "Azure.ResourceManager.Resources.Policy")) {
+            New-Item -ItemType Directory -Path (Join-Path $script:mgmtServiceDir $package "src") -Force | Out-Null
+        }
+
+        $autorestContent = @"
+# Generated code configuration
+
+``` yaml
+require: https://github.com/Azure/azure-rest-api-specs/blob/old/specification/resources/resource-manager/readme.md
+```
+"@
+        Set-Content -Path (Join-Path $script:mgmtSrcDir "autorest.md") -Value $autorestContent
+    }
+
+    AfterEach {
+        if (Test-Path $script:mgmtTestRootDir) {
+            Remove-Item -Recurse -Force $script:mgmtTestRootDir
+        }
+    }
+
+    It "should select the swagger package when the service folder has multiple management packages" {
+        $outputJsonFile = Join-Path $script:mgmtTestRootDir "output.json"
+        $readme = "https://github.com/Azure/azure-rest-api-specs/blob/new/specification/resources/resource-manager/Microsoft.Resources/resources/readme.md"
+        $expectedProjectFolder = $script:mgmtProjectDir -replace "\\", "/"
+
+        $projectFolder = Update-MgmtPackageFolder `
+            -service "resources" `
+            -packageName "resources" `
+            -sdkPath $script:mgmtSdkRoot `
+            -readme $readme `
+            -outputJsonFile $outputJsonFile
+
+        $projectFolder | Should -Be $expectedProjectFolder
+
+        $output = Get-Content $outputJsonFile -Raw | ConvertFrom-Json
+        $output.packageName | Should -Be "Azure.ResourceManager.Resources"
+        $output.projectFolder | Should -Be $expectedProjectFolder
+
+        $autorestContent = Get-Content (Join-Path $script:mgmtSrcDir "autorest.md") -Raw
+        $autorestContent | Should -Match ([regex]::Escape("require: $readme"))
+    }
+}
+
 Describe "GetSDKProjectFolder function" -Tag "UnitTest" {
     BeforeAll {
         $testTspConfigDir = Join-Path $PSScriptRoot "test-data"


### PR DESCRIPTION
## Summary

Fix management-plane swagger generation package resolution when a service directory contains multiple `Azure.ResourceManager.*` packages.

The script now resolves swagger/readme-based management SDK generation to the package folder that contains `src/autorest.md` instead of treating every `Azure.ResourceManager.*` directory under the service folder as the target package.

## Problem this solves

The .NET SDK generation pipeline can still run the legacy swagger/readme generation path for management-plane specs when the input resolves to a `readme.md` configuration instead of a TypeSpec C# emitter output path. In the failing pipeline, the generation request was for:

```text
specification/resources/resource-manager/Microsoft.Resources/resources/tspconfig.yaml
specification/resources/resource-manager/Microsoft.Resources/resources/readme.md
```

That run fell back to swagger/readme generation for the `resources` management-plane service. The `sdk/resources` directory already contains several management SDK packages:

```text
Azure.ResourceManager.Resources
Azure.ResourceManager.Resources.Bicep
Azure.ResourceManager.Resources.Deployments
Azure.ResourceManager.Resources.DeploymentStacks
Azure.ResourceManager.Resources.Policy
```

Only `Azure.ResourceManager.Resources` is the swagger/readme-based package in this scenario; the sibling packages are TypeSpec-based packages and do not have `src/autorest.md`.

Before this change, the automation script built the package path with this pattern:

```text
sdk/<service>/Azure.ResourceManager.*
```

PowerShell expanded that wildcard to all matching package folders. The script then assigned the matched names into a scalar string, which converted the array into a single space-separated value. That produced the invalid path shown in the pipeline log:

```text
sdk/resources/Azure.ResourceManager.Resources Azure.ResourceManager.Resources.Bicep Azure.ResourceManager.Resources.Deployments Azure.ResourceManager.Resources.DeploymentStacks Azure.ResourceManager.Resources.Policy
```

The next generation step tried to read `src/autorest.md` and run `dotnet build` under that combined path. Since that path does not exist, the pipeline failed with errors like:

```text
Cannot find path .../src/autorest.md
MSBUILD : error MSB1009: Project file does not exist.
```

## Where the issue came from

This issue is in the SDK automation script, not in the generated SDK code. The script assumed that a management service folder contains only one `Azure.ResourceManager.*` package. That assumption is no longer safe for services such as `resources`, where one service directory can contain a legacy swagger/readme package alongside multiple TypeSpec-generated management packages.

Because the resolver did not distinguish swagger packages from TypeSpec packages, any service folder with more than one `Azure.ResourceManager.*` child could be resolved incorrectly.

## Fix

This PR adds a helper that finds management package candidates by looking for `src/autorest.md`:

```text
sdk/<service>/Azure.ResourceManager.*/src/autorest.md
```

For the failing `resources` case, that selects only:

```text
sdk/resources/Azure.ResourceManager.Resources
```

The TypeSpec packages are ignored by this legacy swagger/readme path because they use `tsp-location.yaml` instead of `src/autorest.md`.

The script also now fails with a clear error if multiple swagger/readme-based management packages are found, instead of silently constructing a malformed space-joined path.

## Validation

- Added a regression test for a service folder that contains one swagger/readme management package plus multiple TypeSpec management packages.
- Parsed the changed PowerShell files.
- Verified the real `sdk/resources` layout resolves to `Azure.ResourceManager.Resources`.
- Ran a direct resolver regression against a mocked multi-package `sdk/resources` layout.