### PR TITLE
Fix mgmt SDK generation when a service has multiple Azure.ResourceManager.* packages

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -307,8 +307,22 @@ function Update-MgmtPackageFolder() {
     $projectFolder = $projectFolder -replace "\\", "/"
     if (Test-Path -Path $projectFolder) {
       Write-Host "Path exists!"
-      $folderinfo = Get-ChildItem -Path $projectFolder
-      $mgmtPackageName = $folderinfo.Name
+      # A service folder may contain multiple Azure.ResourceManager.* packages where only
+      # some are still generated from swagger. Swagger-based packages have a src autorest
+      # config file, while TypeSpec-migrated packages do not, so narrow to the swagger one.
+      $folderinfo = @(Get-ChildItem -Path $projectFolder -Directory | Where-Object {
+        Test-Path -Path (Join-Path $_.FullName "src" $AUTOREST_CONFIG_FILE)
+      })
+      if ($folderinfo.Count -eq 0) {
+        Write-Host "[ERROR] No existing swagger-based management package was found under sdk/$packageName (expected exactly one Azure.ResourceManager.* folder containing src/$AUTOREST_CONFIG_FILE). It may be a new .NET SDK or already migrated to TypeSpec. We will not support onboarding a new service SDK from swagger. Please contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+        exit 1
+      }
+      if ($folderinfo.Count -gt 1) {
+        $candidateNames = ($folderinfo.Name -join ", ")
+        Write-Host "[ERROR] Multiple swagger-based management packages were found under sdk/$packageName ($candidateNames). Cannot determine which package to generate from this swagger readme. Please contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+        exit 1
+      }
+      $mgmtPackageName = $folderinfo[0].Name
       $projectFolder = "$sdkPath/sdk/$packageName/$mgmtPackageName"
     } else {
       Write-Host "[ERROR] Project directory doesn't exist. It is a new .NET SDK. We will not support onboard a new service SDK from swagger. Please contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."


### PR DESCRIPTION
## Problem

The `SDK Validation - .NET` check on spec PR [Azure/azure-rest-api-specs#43120](https://github.com/Azure/azure-rest-api-specs/pull/43120) fails during mgmt SDK generation with:

```
MSBUILD : error MSB1009: Project file does not exist.
Switch: .../sdk/resources/Azure.ResourceManager.Resources Azure.ResourceManager.Resources.Bicep Azure.ResourceManager.Resources.Deployments Azure.ResourceManager.Resources.DeploymentStacks Azure.ResourceManager.Resources.Policy/src
```

## Root cause

`Update-MgmtPackageFolder` in `eng/scripts/automation/GenerateAndBuildLib.ps1` assumed a service folder contains exactly one `Azure.ResourceManager.*` package:

```powershell
$folderinfo = Get-ChildItem -Path "sdk/resources/Azure.ResourceManager.*"
$mgmtPackageName = $folderinfo.Name
$projectFolder = "$sdkPath/sdk/$packageName/$mgmtPackageName"
```

After TypeSpec migration, `sdk/resources/` now contains **five** such folders (one swagger-based `Azure.ResourceManager.Resources`, plus four TypeSpec-migrated siblings). The wildcard matched all five, so `$folderinfo.Name` became an array which string interpolation joined with spaces into a bogus path, and msbuild failed with MSB1009.

## Fix

This function only handles swagger/AutoRest mgmt generation, and swagger-based packages have a `src/autorest.md` config (TypeSpec packages do not). Narrow the matched folders to those containing `src/$AUTOREST_CONFIG_FILE`. Fail fast with a clear message for the zero-match and multi-match cases instead of silently producing a broken path.

Verified that resolution now yields exactly `Azure.ResourceManager.Resources`, and that no service folder in the repo currently has more than one swagger-based mgmt package (so the multi-match branch is not a regression).