### PR TITLE
Fix management SDK package selection

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -305,11 +305,25 @@ function Update-MgmtPackageFolder() {
     $projectFolder = (Join-Path $sdkPath "sdk" $packageName "Azure.ResourceManager.*")
     $mgmtPackageName = ""
     $projectFolder = $projectFolder -replace "\\", "/"
-    if (Test-Path -Path $projectFolder) {
+    $projectFolders = @(Get-ChildItem -Path $projectFolder -Directory -ErrorAction SilentlyContinue)
+    if ($projectFolders.Count -gt 0) {
       Write-Host "Path exists!"
-      $folderinfo = Get-ChildItem -Path $projectFolder
+      if ($projectFolders.Count -eq 1) {
+        $folderinfo = $projectFolders[0]
+      } else {
+        $autorestProjectFolders = @($projectFolders | Where-Object {
+          Test-Path -Path (Join-Path $_.FullName "src" $AUTOREST_CONFIG_FILE)
+        })
+        if ($autorestProjectFolders.Count -eq 1) {
+          $folderinfo = $autorestProjectFolders[0]
+        } else {
+          $projectFolderNames = $projectFolders.Name -join ", "
+          Write-Host "[ERROR] Multiple management SDK packages match sdk/${packageName}: $projectFolderNames. Cannot infer which package to generate for readme '$readme'."
+          exit 1
+        }
+      }
       $mgmtPackageName = $folderinfo.Name
-      $projectFolder = "$sdkPath/sdk/$packageName/$mgmtPackageName"
+      $projectFolder = $folderinfo.FullName -replace "\\", "/"
     } else {
       Write-Host "[ERROR] Project directory doesn't exist. It is a new .NET SDK. We will not support onboard a new service SDK from swagger. Please contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
       exit 1

--- a/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
+++ b/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
@@ -124,6 +124,51 @@ Describe "Generate and Build SDK" -Tag "Unit" {
     }
 }
 
+Describe "Update-MgmtPackageFolder function" -Tag "UnitTest" {
+    BeforeEach {
+        $script:testRootDir = Join-Path ([System.IO.Path]::GetTempPath()) "mgmt-package-folder-test-$(Get-Random)"
+        $script:testSdkRoot = Join-Path $script:testRootDir "sdk-root"
+        $script:testServiceDir = Join-Path $script:testSdkRoot "sdk" "resources"
+        $script:testLegacyPackageDir = Join-Path $script:testServiceDir "Azure.ResourceManager.Resources"
+        $script:testLegacySrcDir = Join-Path $script:testLegacyPackageDir "src"
+        $script:testOutputJson = Join-Path $script:testRootDir "output.json"
+
+        New-Item -ItemType Directory -Path $script:testLegacySrcDir -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:testServiceDir "Azure.ResourceManager.Resources.Bicep") -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:testServiceDir "Azure.ResourceManager.Resources.Deployments") -Force | Out-Null
+        Set-Content -Path (Join-Path $script:testLegacySrcDir "autorest.md") -Value "require: old/readme.md"
+    }
+
+    AfterEach {
+        if (Test-Path $script:testRootDir) {
+            Remove-Item -Recurse -Force $script:testRootDir
+        }
+    }
+
+    It "should select the package containing autorest.md when multiple management packages match" {
+        $readme = "https://github.com/Azure/azure-rest-api-specs/blob/test/specification/resources/resource-manager/Microsoft.Resources/resources/readme.md"
+
+        $projectFolder = Update-MgmtPackageFolder `
+            -service "resources" `
+            -packageName "resources" `
+            -sdkPath $script:testSdkRoot `
+            -readme $readme `
+            -outputJsonFile $script:testOutputJson
+
+        $expectedProjectFolder = $script:testLegacyPackageDir -replace "\\", "/"
+        $projectFolder | Should -Be $expectedProjectFolder
+
+        $outputJson = Get-Content $script:testOutputJson -Raw | ConvertFrom-Json
+        $outputJson.packageName | Should -Be "Azure.ResourceManager.Resources"
+        $outputJson.projectFolder | Should -Be $expectedProjectFolder
+
+        $autorestContent = Get-Content (Join-Path $script:testLegacySrcDir "autorest.md") -Raw
+        $autorestContent | Should -Match ([regex]::Escape("require: $readme"))
+        $outputJson.projectFolder | Should -Not -Match "Azure\.ResourceManager\.Resources\.Bicep"
+        $outputJson.projectFolder | Should -Not -Match "Azure\.ResourceManager\.Resources\.Deployments"
+    }
+}
+
 Describe "GetSDKProjectFolder function" -Tag "UnitTest" {
     BeforeAll {
         $testTspConfigDir = Join-Path $PSScriptRoot "test-data"


### PR DESCRIPTION
## Description
Fixes management SDK validation package discovery when a service directory contains multiple `Azure.ResourceManager.*` packages.

`Update-MgmtPackageFolder` now selects the single matching package that contains `src/autorest.md` instead of interpolating all wildcard matches into one space-separated path.

## Validation
- `Invoke-Pester .\GenerateAndBuildLib-functions.tests.ps1 -FullNameFilter '*Update-MgmtPackageFolder*'`