### PR TITLE
[Mgmt] Profile Network generator performance

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementClientGenerator.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementClientGenerator.cs
@@ -53,10 +53,16 @@ namespace Azure.Generator.Management
                 // Model factory back-compat overloads can be synthesized from LastContractView
                 // after normal visitors run. Repair them here so the final methods being written
                 // preserve arguments that were moved into flattened model properties.
-                ModelFactoryBackwardCompatHelper.FixModelFactoryBackwardCompatOverloads(modelFactory.Methods);
+                using (ProfilingTimer.Measure("FixModelFactoryBackwardCompatOverloads", $"{modelFactory.Name}; methods={modelFactory.Methods.Count}"))
+                {
+                    ModelFactoryBackwardCompatHelper.FixModelFactoryBackwardCompatOverloads(modelFactory.Methods);
+                }
             }
 
-            return base.GetWriter(provider);
+            using (ProfilingTimer.Measure("GetWriter", provider.Name))
+            {
+                return base.GetWriter(provider);
+            }
         }
 
         /// <summary>
@@ -64,23 +70,26 @@ namespace Azure.Generator.Management
         /// </summary>
         protected override void Configure()
         {
-            base.Configure();
-            // Include Azure.ResourceManager
-            AddMetadataReference(MetadataReference.CreateFromFile(typeof(ArmClient).Assembly.Location));
-            // renaming should come first
-            AddVisitor(new NameVisitor());
-            AddVisitor(new SerializationVisitor());
-            AddVisitor(new RestClientVisitor());
-            AddVisitor(new ResourceVisitor());
-            AddVisitor(new InheritableSystemObjectModelVisitor());
-            AddVisitor(new FlattenPropertyVisitor());
-            AddVisitor(new TypeFilterVisitor());
-            AddVisitor(new PaginationVisitor());
-            AddVisitor(new ModelFactoryVisitor());
-            AddVisitor(new ManagedIdentityV3Visitor());
-            if (IsWirePathEnabled())
+            using (ProfilingTimer.Measure(nameof(Configure)))
             {
-                AddVisitor(new WirePathVisitor());
+                base.Configure();
+                // Include Azure.ResourceManager
+                AddMetadataReference(MetadataReference.CreateFromFile(typeof(ArmClient).Assembly.Location));
+                // renaming should come first
+                AddVisitor(new NameVisitor());
+                AddVisitor(new SerializationVisitor());
+                AddVisitor(new RestClientVisitor());
+                AddVisitor(new ResourceVisitor());
+                AddVisitor(new InheritableSystemObjectModelVisitor());
+                AddVisitor(new FlattenPropertyVisitor());
+                AddVisitor(new TypeFilterVisitor());
+                AddVisitor(new PaginationVisitor());
+                AddVisitor(new ModelFactoryVisitor());
+                AddVisitor(new ManagedIdentityV3Visitor());
+                if (IsWirePathEnabled())
+                {
+                    AddVisitor(new WirePathVisitor());
+                }
             }
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -482,14 +482,19 @@ namespace Azure.Generator.Management
             if (lroMetadata != null)
             {
                 var returnType = lroMetadata.ReturnType;
-                if (returnType is InputModelType inputModelType)
+                if (returnType == null)
                 {
-                    var returnCSharpType = ManagementClientGenerator.Instance.TypeFactory.CreateCSharpType(inputModelType);
-                    if (returnCSharpType == null)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
+                var returnCSharpType = ManagementClientGenerator.Instance.TypeFactory.CreateCSharpType(returnType);
+                if (returnCSharpType == null)
+                {
+                    return;
+                }
+
+                if (returnType is InputModelType)
+                {
                     // Find all resource providers that use this data type
                     var resourceProviders = ResourceProviders.Where(r => r.ResourceData.Type.Equals(returnCSharpType)).ToList();
 
@@ -515,6 +520,11 @@ namespace Azure.Generator.Management
                         // This is a non-resource model - use the data type as the key
                         operationSources.TryAdd(returnCSharpType, new OperationSourceProvider(returnCSharpType));
                     }
+                }
+                else
+                {
+                    // Primitive or framework LRO final-result types still need an operation source.
+                    operationSources.TryAdd(returnCSharpType, new OperationSourceProvider(returnCSharpType));
                 }
             }
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -129,65 +129,83 @@ namespace Azure.Generator.Management
                 return; // already initialized
             }
 
-            var resourceMetadatas = ManagementClientGenerator.Instance.InputLibrary.ResourceMetadatas;
-            var resourceMethodCategories = new Dictionary<ArmResourceMetadata, ResourceMethodCategory>(resourceMetadatas.Count);
-
-            // build resource methods per resource metadata
-            var resourceDict = new Dictionary<ArmResourceMetadata, ResourceClientProvider>(resourceMetadatas.Count);
-            var collections = new List<ResourceCollectionClientProvider>(resourceMetadatas.Count);
-            foreach (var resourceMetadata in resourceMetadatas)
+            using (ProfilingTimer.Measure(nameof(InitializeResourceClients)))
             {
-                // categorize the resource methods
-                var categorizedMethods = resourceMetadata.CategorizeMethods();
-                // stores it because later in extensions we need it again
-                resourceMethodCategories.Add(resourceMetadata, categorizedMethods);
-                var resource = ResourceClientProvider.Create(resourceMetadata, categorizedMethods.MethodsInResource, categorizedMethods.MethodsInCollection);
-                resourceDict.Add(resourceMetadata, resource);
-                if (resource.ResourceCollection is not null)
+                var resourceMetadatas = ManagementClientGenerator.Instance.InputLibrary.ResourceMetadatas;
+                ProfilingTimer.Log($"Resource metadata count: {resourceMetadatas.Count}; non-resource method count: {ManagementClientGenerator.Instance.InputLibrary.NonResourceMethods.Count}");
+                var resourceMethodCategories = new Dictionary<ArmResourceMetadata, ResourceMethodCategory>(resourceMetadatas.Count);
+
+                // build resource methods per resource metadata
+                var resourceDict = new Dictionary<ArmResourceMetadata, ResourceClientProvider>(resourceMetadatas.Count);
+                var collections = new List<ResourceCollectionClientProvider>(resourceMetadatas.Count);
+                using (ProfilingTimer.Measure("CreateResourceProviders", $"count={resourceMetadatas.Count}"))
                 {
-                    collections.Add(resource.ResourceCollection);
-                }
-            }
-
-            // resources and collections are now initialized
-            _resourcesByIdDict = resourceDict.ToDictionary(kv => kv.Key.ResourceIdPattern, kv => kv.Value);
-            _resources = [.. resourceDict.Values];
-            _resourceCollections = collections;
-
-            // build mockable resources
-            var resourcesAndMethodsPerScope = BuildResourcesAndNonResourceMethods(
-                resourceDict,
-                resourceMethodCategories,
-                ManagementClientGenerator.Instance.InputLibrary.NonResourceMethods);
-
-            // Extract extension non-resource methods for MockableArmClientProvider
-            var extensionNonResourceMethods = resourcesAndMethodsPerScope.TryGetValue(ResourceScope.Extension, out var extensionScope)
-                ? extensionScope.NonResourceMethods
-                : [];
-
-            var mockableArmClientResource = MockableArmClientProvider.TryCreate(_resources, extensionNonResourceMethods);
-            var mockableResources = new Dictionary<ResourceScope, MockableResourceProvider>(resourcesAndMethodsPerScope.Count);
-            foreach (var (scope, (resourcesInScope, resourceMethods, nonResourceMethods)) in resourcesAndMethodsPerScope)
-            {
-                if (scope != ResourceScope.Extension)
-                {
-                    var mockableExtension = MockableResourceProvider.TryCreate(scope, resourcesInScope, resourceMethods, nonResourceMethods);
-                    if (mockableExtension != null)
+                    foreach (var resourceMetadata in resourceMetadatas)
                     {
-                        mockableResources.Add(scope, mockableExtension);
+                        // categorize the resource methods
+                        var categorizedMethods = resourceMetadata.CategorizeMethods();
+                        // stores it because later in extensions we need it again
+                        resourceMethodCategories.Add(resourceMetadata, categorizedMethods);
+                        var resource = ResourceClientProvider.Create(resourceMetadata, categorizedMethods.MethodsInResource, categorizedMethods.MethodsInCollection);
+                        resourceDict.Add(resourceMetadata, resource);
+                        if (resource.ResourceCollection is not null)
+                        {
+                            collections.Add(resource.ResourceCollection);
+                        }
                     }
                 }
-            }
 
-            _mockableResourcesByScopeDict = mockableResources;
-            var allMockableResources = new List<MockableResourceProvider>();
-            if (mockableArmClientResource != null)
-            {
-                allMockableResources.Add(mockableArmClientResource);
+                // resources and collections are now initialized
+                _resourcesByIdDict = resourceDict.ToDictionary(kv => kv.Key.ResourceIdPattern, kv => kv.Value);
+                _resources = [.. resourceDict.Values];
+                _resourceCollections = collections;
+
+                Dictionary<ResourceScope, ResourcesAndNonResourceMethodsInScope> resourcesAndMethodsPerScope;
+                using (ProfilingTimer.Measure(nameof(BuildResourcesAndNonResourceMethods)))
+                {
+                    // build mockable resources
+                    resourcesAndMethodsPerScope = BuildResourcesAndNonResourceMethods(
+                        resourceDict,
+                        resourceMethodCategories,
+                        ManagementClientGenerator.Instance.InputLibrary.NonResourceMethods);
+                }
+
+                // Extract extension non-resource methods for MockableArmClientProvider
+                var extensionNonResourceMethods = resourcesAndMethodsPerScope.TryGetValue(ResourceScope.Extension, out var extensionScope)
+                    ? extensionScope.NonResourceMethods
+                    : [];
+
+                MockableArmClientProvider? mockableArmClientResource;
+                var mockableResources = new Dictionary<ResourceScope, MockableResourceProvider>(resourcesAndMethodsPerScope.Count);
+                using (ProfilingTimer.Measure("CreateMockableProviders", $"scopes={resourcesAndMethodsPerScope.Count}"))
+                {
+                    mockableArmClientResource = MockableArmClientProvider.TryCreate(_resources, extensionNonResourceMethods);
+                    foreach (var (scope, (resourcesInScope, resourceMethods, nonResourceMethods)) in resourcesAndMethodsPerScope)
+                    {
+                        if (scope != ResourceScope.Extension)
+                        {
+                            var mockableExtension = MockableResourceProvider.TryCreate(scope, resourcesInScope, resourceMethods, nonResourceMethods);
+                            if (mockableExtension != null)
+                            {
+                                mockableResources.Add(scope, mockableExtension);
+                            }
+                        }
+                    }
+                }
+
+                _mockableResourcesByScopeDict = mockableResources;
+                var allMockableResources = new List<MockableResourceProvider>();
+                if (mockableArmClientResource != null)
+                {
+                    allMockableResources.Add(mockableArmClientResource);
+                }
+                allMockableResources.AddRange(mockableResources.Values);
+                _mockableResources = allMockableResources;
+                using (ProfilingTimer.Measure("CreateExtensionProvider", $"mockableResources={_mockableResources.Count}"))
+                {
+                    _extensionProvider = new ExtensionProvider(_mockableResources);
+                }
             }
-            allMockableResources.AddRange(mockableResources.Values);
-            _mockableResources = allMockableResources;
-            _extensionProvider = new ExtensionProvider(_mockableResources);
 
             static Dictionary<ResourceScope, ResourcesAndNonResourceMethodsInScope> BuildResourcesAndNonResourceMethods(
                 IReadOnlyDictionary<ArmResourceMetadata, ResourceClientProvider> resourceDict,
@@ -264,25 +282,28 @@ namespace Azure.Generator.Management
                 return; // already built
             }
 
-            var allModelTypes = new HashSet<CSharpType>();
-            var modelFactoryModels = new HashSet<CSharpType>();
-
-            foreach (var inputModel in ManagementClientGenerator.Instance.InputLibrary.InputNamespace.Models)
+            using (ProfilingTimer.Measure(nameof(BuildModelTypes)))
             {
-                var model = ManagementClientGenerator.Instance.TypeFactory.CreateModel(inputModel);
-                if (model is not null)
+                var allModelTypes = new HashSet<CSharpType>();
+                var modelFactoryModels = new HashSet<CSharpType>();
+
+                foreach (var inputModel in ManagementClientGenerator.Instance.InputLibrary.InputNamespace.Models)
                 {
-                    var eraseNullableType = model.Type.WithNullable(false);
-                    allModelTypes.Add(eraseNullableType);
-                    if (IsModelFactoryModel(model))
+                    var model = ManagementClientGenerator.Instance.TypeFactory.CreateModel(inputModel);
+                    if (model is not null)
                     {
-                        modelFactoryModels.Add(eraseNullableType);
+                        var eraseNullableType = model.Type.WithNullable(false);
+                        allModelTypes.Add(eraseNullableType);
+                        if (IsModelFactoryModel(model))
+                        {
+                            modelFactoryModels.Add(eraseNullableType);
+                        }
                     }
                 }
-            }
 
-            _allModelTypes = allModelTypes;
-            _modelFactoryModels = modelFactoryModels;
+                _allModelTypes = allModelTypes;
+                _modelFactoryModels = modelFactoryModels;
+            }
         }
 
         private static bool IsModelFactoryModel(ModelProvider model)
@@ -322,41 +343,69 @@ namespace Azure.Generator.Management
         /// <inheritdoc/>
         protected override TypeProvider[] BuildTypeProviders()
         {
-            // we need to add the clients (including resources, collections, mockable resources and extension static class)
-            // to the types to keep
-            // otherwise, they will be trimmed off or internalized by the post processor
-            foreach (var resource in ResourceProviders)
+            using (ProfilingTimer.Measure(nameof(BuildTypeProviders)))
             {
-                ManagementClientGenerator.Instance.AddTypeToKeep(resource.Name);
-            }
-            foreach (var collection in ResourceCollectionProviders)
-            {
-                ManagementClientGenerator.Instance.AddTypeToKeep(collection.Name);
-            }
-            foreach (var mockableResource in MockableResourceProviders)
-            {
-                ManagementClientGenerator.Instance.AddTypeToKeep(mockableResource.Name);
-            }
-            ManagementClientGenerator.Instance.AddTypeToKeep(ExtensionProvider.Name);
+                // we need to add the clients (including resources, collections, mockable resources and extension static class)
+                // to the types to keep
+                // otherwise, they will be trimmed off or internalized by the post processor
+                using (ProfilingTimer.Measure("AddTypesToKeep"))
+                {
+                    foreach (var resource in ResourceProviders)
+                    {
+                        ManagementClientGenerator.Instance.AddTypeToKeep(resource.Name);
+                    }
+                    foreach (var collection in ResourceCollectionProviders)
+                    {
+                        ManagementClientGenerator.Instance.AddTypeToKeep(collection.Name);
+                    }
+                    foreach (var mockableResource in MockableResourceProviders)
+                    {
+                        ManagementClientGenerator.Instance.AddTypeToKeep(mockableResource.Name);
+                    }
+                    ManagementClientGenerator.Instance.AddTypeToKeep(ExtensionProvider.Name);
+                }
 
-            // Extract array response collection results from all methods
-            var arrayResponseCollectionResults = ExtractArrayResponseCollectionResults();
+                // Extract array response collection results from all methods
+                List<ArrayResponseCollectionResultDefinition> arrayResponseCollectionResults;
+                using (ProfilingTimer.Measure(nameof(ExtractArrayResponseCollectionResults)))
+                {
+                    arrayResponseCollectionResults = ExtractArrayResponseCollectionResults();
+                }
 
-            return [
-                .. base.BuildTypeProviders().Where(t => t is not InheritableSystemObjectModelProvider { IsSystemBase: true }),
-                WirePathAttributeDefinition,
-                ArmOperation,
-                ArmOperationOfT,
-                .. OperationSourceDict.Values,
-                ProviderConstants,
-                .. ResourceProviders,
-                .. ResourceCollectionProviders,
-                .. MockableResourceProviders,
-                ExtensionProvider,
-                PageableWrapper,
-                AsyncPageableWrapper,
-                .. arrayResponseCollectionResults,
-                .. ResourceProviders.SelectMany(r => r.SerializationProviders)];
+                TypeProvider[] baseProviders;
+                using (ProfilingTimer.Measure("base.BuildTypeProviders"))
+                {
+                    baseProviders = [.. base.BuildTypeProviders().Where(t => t is not InheritableSystemObjectModelProvider { IsSystemBase: true })];
+                }
+
+                TypeProvider[] operationSourceProviders;
+                using (ProfilingTimer.Measure(nameof(OperationSourceDict)))
+                {
+                    operationSourceProviders = [.. OperationSourceDict.Values];
+                }
+
+                TypeProvider[] serializationProviders;
+                using (ProfilingTimer.Measure("ResourceSerializationProviders"))
+                {
+                    serializationProviders = [.. ResourceProviders.SelectMany(r => r.SerializationProviders)];
+                }
+
+                return [
+                    .. baseProviders,
+                    WirePathAttributeDefinition,
+                    ArmOperation,
+                    ArmOperationOfT,
+                    .. operationSourceProviders,
+                    ProviderConstants,
+                    .. ResourceProviders,
+                    .. ResourceCollectionProviders,
+                    .. MockableResourceProviders,
+                    ExtensionProvider,
+                    PageableWrapper,
+                    AsyncPageableWrapper,
+                    .. arrayResponseCollectionResults,
+                    .. serializationProviders];
+            }
         }
 
         private List<ArrayResponseCollectionResultDefinition> ExtractArrayResponseCollectionResults()
@@ -398,24 +447,27 @@ namespace Azure.Generator.Management
 
         private Dictionary<CSharpType, OperationSourceProvider> BuildOperationSources()
         {
-            var operationSources = new Dictionary<CSharpType, OperationSourceProvider>();
-
-            // Process resource methods
-            foreach (var metadata in ManagementClientGenerator.Instance.InputLibrary.ResourceMetadatas)
+            using (ProfilingTimer.Measure(nameof(BuildOperationSources)))
             {
-                foreach (var resourceMethod in metadata.Methods)
+                var operationSources = new Dictionary<CSharpType, OperationSourceProvider>();
+
+                // Process resource methods
+                foreach (var metadata in ManagementClientGenerator.Instance.InputLibrary.ResourceMetadatas)
                 {
-                    ProcessLroMethod(resourceMethod.InputMethod, operationSources);
+                    foreach (var resourceMethod in metadata.Methods)
+                    {
+                        ProcessLroMethod(resourceMethod.InputMethod, operationSources);
+                    }
                 }
-            }
 
-            // Process non-resource methods
-            foreach (var nonResourceMethod in ManagementClientGenerator.Instance.InputLibrary.NonResourceMethods)
-            {
-                ProcessLroMethod(nonResourceMethod.InputMethod, operationSources);
-            }
+                // Process non-resource methods
+                foreach (var nonResourceMethod in ManagementClientGenerator.Instance.InputLibrary.NonResourceMethods)
+                {
+                    ProcessLroMethod(nonResourceMethod.InputMethod, operationSources);
+                }
 
-            return operationSources;
+                return operationSources;
+            }
         }
 
         private void ProcessLroMethod(InputServiceMethod inputMethod, Dictionary<CSharpType, OperationSourceProvider> operationSources)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ProfilingTimer.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ProfilingTimer.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+
+namespace Azure.Generator.Management
+{
+    internal static class ProfilingTimer
+    {
+        private const string EnvironmentVariableName = "AZSDK_MGMT_GENERATOR_PROFILE";
+        internal static bool IsEnabled { get; } = string.Equals(Environment.GetEnvironmentVariable(EnvironmentVariableName), "1", StringComparison.Ordinal);
+
+        internal static IDisposable Measure(string name, string? detail = null)
+        {
+            return IsEnabled ? new Scope(name, detail) : NoopScope.Instance;
+        }
+
+        internal static void Log(string message)
+        {
+            if (IsEnabled)
+            {
+                Console.Error.WriteLine($"[mgmt-generator-profile] {message}");
+            }
+        }
+
+        private sealed class Scope : IDisposable
+        {
+            private readonly string _name;
+            private readonly string? _detail;
+            private readonly Stopwatch _stopwatch;
+
+            public Scope(string name, string? detail)
+            {
+                _name = name;
+                _detail = detail;
+                _stopwatch = Stopwatch.StartNew();
+            }
+
+            public void Dispose()
+            {
+                _stopwatch.Stop();
+                Console.Error.WriteLine($"[mgmt-generator-profile] {_name}{(_detail is null ? string.Empty : $" ({_detail})")}: {_stopwatch.Elapsed}");
+            }
+        }
+
+        private sealed class NoopScope : IDisposable
+        {
+            internal static readonly NoopScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Draft PR for Network MPG generator profiling. This PR adds env-gated management generator timing instrumentation and a small LRO operation-source fix needed for the Network code model to complete direct generation when an LRO final result is a primitive/framework type.

Set `AZSDK_MGMT_GENERATOR_PROFILE=1` to emit `[mgmt-generator-profile]` timings.

## Current conclusion

The latest profiling shows **`tspCodeModel.json` generation is not the 10+ minute hotspot** for Network. The TypeSpec + emitter/code-model path completes in about a minute end-to-end, and the code-model creation/serialization/write portion takes only seconds.

The dominant measured cost is in the **.NET generator Roslyn post-processing path**, specifically shared MTG simplification/name-reduction work after generated types have already been written into the in-memory Roslyn workspace.


## High-level timing

### Current manual Network regen comparison

The latest manual end-to-end Network regeneration timings are the cleanest current comparison between the migration branch and AutoRest.CSharp:

| Manual Network regen path | Elapsed |
|---|---:|
| TypeSpec/MTG on the Network migration branch | `00:11:20.27` |
| AutoRest.CSharp | `00:08:19.39` |
| Difference | `~3m00.88` |

This means the current TypeSpec/MTG Network regen is still about **3 minutes slower** than AutoRest.CSharp for the manual regen path, even after the narrow simplifier optimization. MTG is about **36% slower** than the AutoRest.CSharp run (`680.27s / 499.39s`).

### Profiling phase isolation

The profiling data below comes from the latest-main/temp profiling setup. It should be read as phase isolation for the current generator hotspot, **not** as the normal end-to-end Network `RegenSdkLocal` time. In this setup, the temporary spec/project inputs had already been prepared on disk before the measured generator-focused runs.

| Measurement | Elapsed | What it means |
|---|---:|---|
| Prepared-temp profiling run: TypeSpec compile + emitter + .NET generator, baseline/no narrow-simplifier tweak | ~12m36s | Baseline profiling run before the `Simplifier.ReduceAsync` skip experiment. This is not the normal full Network `RegenSdkLocal` workflow timing. |
| Direct .NET generator from saved `tspCodeModel.json`/`Configuration.json`, baseline/no narrow-simplifier tweak | ~11m48s to ~12m12s | Isolates the .NET generator phase; almost all time is Roslyn post-processing. |
| TypeSpec + emitter/code-model only, generator skipped | ~51s | Isolates TypeSpec compile + emitter/code-model generation and input writing. |
| Direct .NET generator from fresh saved inputs with current narrow simplifier branch | ~8m13s | Fresh 2026-06-02 rerun for the .NET generator phase; Roslyn post-processing was ~7m53.9s of this total. |

The main conclusion is: **the measured multi-minute hotspot is the .NET generator post-processing phase, not TypeSpec/emitter code-model creation**.

The narrow simplifier experiment reduced direct-generator wall-clock from about **12m12s** in the baseline profiling setup to **~8m13s** in the fresh current-branch rerun. The current manual full-regeneration comparison still shows a remaining gap versus AutoRest.CSharp, so further work should focus on reducing the direct-generator post-processing cost and validating the win in full manual regen.

## Emitter/code-model timing

I isolated the TypeSpec + emitter path with temporary local emitter instrumentation and `AZSDK_CSHARP_EMITTER_SKIP_GENERATOR=1`, so the run writes `tspCodeModel.json`/`Configuration.json` but does not invoke the .NET generator.

| Stage | Elapsed |
|---|---:|
| `RegenSdkLocal` emitter-only worker wall-clock | ~51s |
| Base emitter `createSdkContext` | 5.158s |
| Base emitter `createModel` | 0.213s |
| Mgmt `updateCodeModel` callback | ~0.046s |
| `serializeCodeModel` | 0.404s |
| Write `tspCodeModel.json` + `Configuration.json` | 0.136s |
| Base emitter total from context creation through write-inputs | 5.957s |
| Mgmt emitter total around `emitAzureCodeModel` | 11.386s |

The generated `tspCodeModel.json` was 39.9 MiB and contained 1 client, 1,065 models, and 284 enums. This confirms code-model creation and writing are seconds, not minutes.

A full non-skip emitter run currently hits the known Network customization validation issue before reaching Roslyn post-processing (`CodeGenSuppress` on `VirtualMachineScaleSetVmNetworkResource`), so it is not useful as a full-generation timing. Direct-generator profiling from saved inputs is the useful measurement for the .NET generator phase.

## Direct .NET generator timing

I reran the Network direct generator profile from fresh saved inputs with the current local MTG branch on 2026-06-02. This run used the narrow simplifier behavior, so it validates the current optimized shape rather than the older baseline.

Direct generator timing, shown as **per-step elapsed cost**:

| Step | Elapsed | Share of direct-generator time |
|---|---:|---:|
| Build providers and write generated types into the in-memory workspace | ~17.7s | ~3.5% |
| Delete old generated files | ~0.002s | ~0.0% |
| Roslyn post-processing | ~7m53.9s | ~96.1% |
| Write generated files to disk | ~1.7s | ~0.3% |
| Total direct-generator wall-clock reported by generator | ~8m13.1s | 100% |
| Shell wall-clock for the command | ~8m15.8s | n/a |

The direct generator wrote 3,542 generated files, including 1,192 `.Serialization.cs` files. This fresh run confirms that, in the isolated .NET generator phase, Roslyn post-processing still accounts for almost all elapsed time even though Network has many providers, visitors, models, and writers before post-processing.


## Roslyn simplifier category breakdown

On 2026-06-02, I reran the isolated Network direct-generator baseline to check timing drift and compared broad/root simplifier output against a temporary no-simplifier run. The ~20 minute broad/root simplifier result is reproducible.

| Run | Internal generator total | Shell elapsed | Notes |
|---|---:|---:|---|
| No Roslyn simplifier | `00:07:36.29` | `458.751s` | Fast, but generated output changes broadly. |
| Broad/root simplifier baseline rerun | `00:19:42.39` | `1185.422s` | Consistent with prior ~20m baseline. |
| Prior broad/root simplifier baseline | ~`00:19:57` | ~`20m00s` | Previous rerun before this drift check. |

The no-simplifier output differed from the baseline in `3,534 / 3,542` generated `.cs` files across `108,504` diff blocks. Categories overlap because one hunk can include several simplifications.

| Simplification category | Diff blocks | Files |
|---|---:|---:|
| `global::` / name simplification | 98,190 | 3,534 |
| `this.` qualification | 16,302 | 2,321 |
| XML `cref` simplification | 10,959 | 2,110 |
| Parentheses | 6,693 | 2,187 |
| Qualified member/name | 5,868 | 1,622 |
| Attribute suffix | 1,207 | 556 |
| Generic method inference | 1,156 | 675 |
| Predefined type keyword | 280 | 275 |

Conclusion: Roslyn is mostly doing semantic name/global-alias reduction across nearly every Network file. This explains why span filtering only produced a small win, while disabling simplification drops the isolated generator to ~7m36s but changes output everywhere. The next promising experiments should replace lower-risk generated patterns first (`this.` removal, XML `cref`, redundant parentheses/generic inference) before attempting broad `global::` type-name emission.

CPU tracing points at Roslyn simplification/semantic work:

| Inclusive sample | Method/family |
|---:|---|
| 30.38% | `ReduceAsync` task |
| 26.65% | `CSharpNameReducer.SimplifyName` |
| 18.61% | `NameSimplifier.TrySimplify` |
| 12.18% | `CSharpSemanticModel.GetSymbolInfo` |
| 10.84% | `CSharpNameReducer.Rewriter.VisitMemberAccessExpression` |

Exclusive samples are dominated by thread-pool wait/lock contention (`LowLevelLifoSemaphore.WaitForSignal`, `Monitor.Enter_Slowpath`), consistent with expensive concurrent Roslyn simplification and contention rather than management provider construction.



### CodeWriter string/byte conversion check

I checked the shared MTG `CodeWriter` path after a teammate raised possible heavy string/byte conversion overhead. The generated C# source path is mostly char/string based:

- `CodeWriter` writes chars into `UnsafeBufferSequence : IBufferWriter<char>`.
- `TypeProviderWriter.Write()` materializes one final string per generated file via `CodeWriter.ToString()`.
- `GeneratedCodeWorkspace.AddGeneratedFile` adds that string to Roslyn.
- `GetGeneratedFilesAsync` later calls Roslyn `SourceText.ToString()`.
- `CSharpGen` writes final files with `File.WriteAllTextAsync`, which encodes once at disk write time.

There is a char-to-byte conversion path in `UnsafeBufferSequence.Reader.CopyTo(Stream)` / `CopyToAsync(Stream)` via `Encoding.UTF8.GetBytes(...)`, but that is not the normal generated `.cs` source path used by Network file generation. It is used by stream/BinaryData helper paths.

The Network phase timings also bound the possible impact: in the rebuilt direct-generator run, provider construction + visitors + CodeWriter + adding generated files to the workspace reached `00:00:17.62`; visitors alone completed by `00:00:11.45`, so generated source writing/add-to-workspace was about `6.18s`. Final file write after Roslyn was about `1.95s`. Roslyn post-processing was `00:19:19.58` after that point (`00:19:37.21` cumulative from `00:00:17.62`).

Conclusion: CodeWriter/string/byte conversion is worth keeping efficient, but it is not the current Network MTG hotspot. Even eliminating all pre/post Roslyn source materialization would save seconds, while the measured issue is roughly 19 minutes of Roslyn simplification work.

### Follow-up easy category experiments

I also tried the lower-risk categories from the breakdown to see whether we could preserve exact generated output while reducing Roslyn work before tackling broad `global::` name reduction.

| Experiment | Result | Decision |
|---|---|---|
| Member-level `Simplifier.ReduceAsync(document, spans)` | Preserved generated test-project output and `npm run test:generator` passed. Rebuilt Network direct-generator run was `00:19:39.16` internal / `1182.394s` shell, with Roslyn post-processing `00:19:37.21`. | Not a meaningful win versus the broad/root baseline rerun (`00:19:42.39` internal / `1185.422s` shell). |
| Guarded `this.` emission from `Snippet.This` | Generated test-project output stayed unchanged after normal simplification, but many raw writer/unit expected baselines changed from `this.Create...` to `Create...`. | Not taking as-is; it would need an explicit generated-file/raw-render mode or broader baseline churn for a small/overlapping category. |
| Direct XML `cref` emission | A naive short-name form first broke generic cref output (`IList` vs `IList{T}`), and after fixing that still changed exact generated output (`SampleTypeSpec.Thing` -> `Thing`, `Models.Custom.Friend` -> `Friend`). | Not safe as-is because Roslyn's final cref form depends on namespace context/imports. |

One fast Network run (`~7m22`) was discarded after validation because the output still contained unsimplified tokens (`93,679` `global::System` occurrences, `12,448` `this.` occurrences, and `9,774` `global::` crefs), meaning the profiling clone had used stale/no-simplifier assemblies. After rebuilding the profiling generator, the output was properly simplified (`2` `global::System`, `31` `this.`, `0` `global::` crefs) and timing returned to the ~20 minute baseline.

Conclusion from these easy experiments: the overlapping low-risk categories do not materially reduce Network time on their own. The remaining meaningful target is still broad semantic name/global-alias simplification across nearly every file, or a more structural change that avoids asking Roslyn to rediscover reductions that the generator can emit safely.

## Local MTG post-processing profile

I temporarily wired the management generator worktree to local TypeSpec/MTG source under `/workspaces/typespec` to instrument shared MTG post-processing directly. Those local project-reference and instrumentation edits were used only for profiling and are not intended as product changes in this PR.

Local MTG direct-generator run, shown as **per-step elapsed cost** rather than cumulative markers:

| Step | Elapsed |
|---|---:|
| Build providers and write generated types into the in-memory workspace | ~16.4s |
| Delete old generated files | ~0.1s |
| Roslyn post-processing | ~11m51.4s |
| Write generated files to disk | ~1.6s |
| Remaining generator overhead | ~2.5s |
| Total direct-generator wall-clock | ~12m12s |

MTG post-processing instrumentation for 4,168 documents showed that the expensive portion was `Simplifier.ReduceAsync`; syntax-root/semantic-model lookup, member removal, library rewriters, and formatting were comparatively small.

## Optimization experiments

### Roslyn 4.1.0 comparison

I temporarily changed local MTG from `Microsoft.CodeAnalysis.CSharp.Workspaces` 4.8.0 to 4.1.0 to match AutoRest.CSharp's Roslyn version and reran the direct Network generator from saved inputs.

| Experiment | Roslyn post-processing wall-clock | Total direct generator wall-clock |
|---|---:|---:|
| MTG local baseline, Roslyn 4.8.0 | ~12m07.9s | ~12m12s |
| MTG local with Roslyn 4.1.0 | 13m22.5s | 13m27s |

The Roslyn downgrade was slower for this workload, so the Roslyn version difference does not look like the cause of AutoRest.CSharp being faster.

### Narrow simplifier experiment

I tested a local MTG change that avoids blanket `Simplifier.Annotation` on every generated document root and skips `Simplifier.ReduceAsync` for documents that have no remaining `Simplifier.Annotation` after member removal/rewriters.

| Experiment | Documents | Skipped simplifier | Roslyn post-processing wall-clock | Total direct generator wall-clock |
|---|---:|---:|---:|---:|
| MTG local baseline | 4,168 | 0 | ~12m07.9s | ~12m12s |
| Narrow simplifier | 4,171 | 3,273 | 7m59.5s | 8m03s |

This cut direct-generator wall-clock by about 4m09s versus the local baseline.

A focused MTG draft PR has been opened for this improvement: https://github.com/microsoft/typespec/pull/10846.

## AutoRest.CSharp comparison

The latest manual Network regen comparison is:

| Manual Network regen path | Elapsed |
|---|---:|
| TypeSpec/MTG on the Network migration branch | `00:11:20.27` |
| AutoRest.CSharp | `00:08:19.39` |

So AutoRest.CSharp is still faster by about **3m00.88s** for the manual Network regen path.

AutoRest.CSharp uses the same broad post-processing pattern at a high level: generated documents are added to a Roslyn workspace, generated document roots are annotated for simplification, then `Simplifier.ReduceAsync` runs during post-processing. The Network performance difference does not appear to be because AutoRest.CSharp avoids Roslyn simplification entirely.

The workloads are different:

| Comparison point | AutoRest.CSharp Network output | MTG Network migration output |
|---|---:|---:|
| Generated source files under `src/Generated` | 2,538 | 3,518 |
| Generated source size under `src/Generated` | ~31.1 MiB | ~30.3 MiB |
| Generated source lines under `src/Generated` | ~597k | ~586k |
| Largest generated source hotspot | `ArmNetworkModelFactory.cs` ~0.9 MiB | `ArmNetworkModelFactory.cs` ~1.7 MiB |
| Profiling workspace generated documents | n/a | 4,171 |

The broad `global::` fallback experiment also showed why simply matching AutoRest-style all-file simplification is not a good MTG fix: `global::` appeared in 3,681 / 4,171 generated documents, so that fallback re-enabled simplification for almost every file and erased most of the narrow-simplifier win.

Conclusion: AutoRest.CSharp is still faster in the latest manual regen comparison. The current evidence still points to generated-code shape and Roslyn post-processing workload as the main difference, not to AutoRest.CSharp avoiding Roslyn simplification altogether. The better MTG direction remains targeted simplification plus direct valid code emission where possible, while continuing to validate improvements against full manual Network regen.

## Next focus

Continue improving shared `Microsoft.TypeSpec.Generator` Roslyn post-processing, especially `GeneratedCodeWorkspace.ProcessDocument`. The current best target is to avoid full-document `Simplifier.ReduceAsync` unless a document has meaningful simplifier annotations, rather than forcing simplification across every generated file.





