### PR TITLE
Hand off @ronniegeraghty CODEOWNERS to new owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1220,7 +1220,7 @@
 ################
 
 # GitHub integration, CODEOWNERS, and bot rules
-/.github/                                                          @jsquire @ronniegeraghty @m-redding @ArthurMa1978
+/.github/                                                          @jsquire @m-redding @ArthurMa1978
 /.github/workflows/                                                @jsquire @m-redding @Azure/azure-sdk-eng
 /.github/CODEOWNERS                                                @jsquire @m-redding @Azure/azure-sdk-eng
 /.github/copilot-instructions.md                                   @jsquire @m-redding @praveenkuttappan @maririos


### PR DESCRIPTION
## Summary

Removing `@ronniegeraghty` from `.github/CODEOWNERS` as Ronnie transitions from the Azure SDK / Tools portfolio into a different role.

## What changed

See the diff. For lines where removing Ronnie would leave fewer than one human owner, a replacement was added per discussion with Ronnie. All other lines simply drop his alias.

## Reviewers

Tagging the existing co-owners on the affected lines for review.

## Related

- Workitem: Azure/projects/424 - "Review CODEOWNERS entries in SDK repos, transfer to right new owner"
- Full handoff plan: internal doc `projects/sdk-team-brain-dump/codeowners-handoff/README.md` in `ronniegeraghty/ronnies-agent-team`

---
*Opened as part of the Azure SDK handoff. Marking as draft until Ronnie reviews; flip to ready-for-review once approved internally.*
