### PR TITLE
Support singular `connection` property in Web PubSub trigger and context bindings

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.10.2 (2026-06-01)
+
+### Features Added
+- Support singular `connection` property in Web PubSub trigger and context bindings for backward-compatibility.
+
 ## 1.10.1 (2026-04-24)
 
 ### Bugs Fixed

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/api/Microsoft.Azure.WebJobs.Extensions.WebPubSub.net10.0.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/api/Microsoft.Azure.WebJobs.Extensions.WebPubSub.net10.0.cs
@@ -179,6 +179,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
     {
         public WebPubSubContextAttribute() { }
         public WebPubSubContextAttribute(params string[] connections) { }
+        [System.ObsoleteAttribute("Use Connections instead.")]
+        public string Connection { get { throw null; } set { } }
         public string[] Connections { get { throw null; } set { } }
     }
     public partial class WebPubSubFunctionsOptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
@@ -203,6 +205,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         public WebPubSubTriggerAttribute(string hub, Microsoft.Azure.WebPubSub.Common.WebPubSubEventType eventType, string eventName) { }
         public WebPubSubTriggerAttribute(string hub, Microsoft.Azure.WebPubSub.Common.WebPubSubEventType eventType, string eventName, params string[] connections) { }
         public Microsoft.Azure.WebJobs.Extensions.WebPubSub.WebPubSubTriggerAcceptedClientProtocols ClientProtocols { get { throw null; } set { } }
+        [System.ObsoleteAttribute("Use Connections instead.")]
+        public string Connection { get { throw null; } set { } }
         public string[] Connections { get { throw null; } }
         [System.ComponentModel.DataAnnotations.RequiredAttribute]
         public string EventName { get { throw null; } }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/api/Microsoft.Azure.WebJobs.Extensions.WebPubSub.net8.0.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/api/Microsoft.Azure.WebJobs.Extensions.WebPubSub.net8.0.cs
@@ -179,6 +179,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
     {
         public WebPubSubContextAttribute() { }
         public WebPubSubContextAttribute(params string[] connections) { }
+        [System.ObsoleteAttribute("Use Connections instead.")]
+        public string Connection { get { throw null; } set { } }
         public string[] Connections { get { throw null; } set { } }
     }
     public partial class WebPubSubFunctionsOptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
@@ -203,6 +205,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         public WebPubSubTriggerAttribute(string hub, Microsoft.Azure.WebPubSub.Common.WebPubSubEventType eventType, string eventName) { }
         public WebPubSubTriggerAttribute(string hub, Microsoft.Azure.WebPubSub.Common.WebPubSubEventType eventType, string eventName, params string[] connections) { }
         public Microsoft.Azure.WebJobs.Extensions.WebPubSub.WebPubSubTriggerAcceptedClientProtocols ClientProtocols { get { throw null; } set { } }
+        [System.ObsoleteAttribute("Use Connections instead.")]
+        public string Connection { get { throw null; } set { } }
         public string[] Connections { get { throw null; } }
         [System.ComponentModel.DataAnnotations.RequiredAttribute]
         public string EventName { get { throw null; } }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/api/Microsoft.Azure.WebJobs.Extensions.WebPubSub.netstandard2.0.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/api/Microsoft.Azure.WebJobs.Extensions.WebPubSub.netstandard2.0.cs
@@ -179,6 +179,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
     {
         public WebPubSubContextAttribute() { }
         public WebPubSubContextAttribute(params string[] connections) { }
+        [System.ObsoleteAttribute("Use Connections instead.")]
+        public string Connection { get { throw null; } set { } }
         public string[] Connections { get { throw null; } set { } }
     }
     public partial class WebPubSubFunctionsOptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
@@ -203,6 +205,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         public WebPubSubTriggerAttribute(string hub, Microsoft.Azure.WebPubSub.Common.WebPubSubEventType eventType, string eventName) { }
         public WebPubSubTriggerAttribute(string hub, Microsoft.Azure.WebPubSub.Common.WebPubSubEventType eventType, string eventName, params string[] connections) { }
         public Microsoft.Azure.WebJobs.Extensions.WebPubSub.WebPubSubTriggerAcceptedClientProtocols ClientProtocols { get { throw null; } set { } }
+        [System.ObsoleteAttribute("Use Connections instead.")]
+        public string Connection { get { throw null; } set { } }
         public string[] Connections { get { throw null; } }
         [System.ComponentModel.DataAnnotations.RequiredAttribute]
         public string EventName { get { throw null; } }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
@@ -5,7 +5,7 @@
     <PackageId>Microsoft.Azure.WebJobs.Extensions.WebPubSub</PackageId>
     <PackageTags>Azure, WebPubSub</PackageTags>
     <Description>Azure Functions extension for the WebPubSub service</Description>
-    <Version>1.10.1</Version>
+    <Version>1.10.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.10.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);CS8632;CA1056;CA2227</NoWarn>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerAttribute.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerAttribute.cs
@@ -98,6 +98,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             get => Connections?.Length > 0 ? Connections[0] : null;
             set
             {
+                if (string.IsNullOrEmpty(value))
+                {
+                    return;
+                }
+
                 if (Connections == null || Connections.Length == 0)
                 {
                     Connections = [value];

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerAttribute.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerAttribute.cs
@@ -83,9 +83,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         public WebPubSubEventType EventType { get; }
 
         /// <summary>
-        /// Allowed service upstream ConnectionString for Signature checks.
+        /// Allowed service upstream validation
         /// </summary>
-        public string[] Connections { get; }
+        public string[] Connections { get; private set; }
+
+        /// <summary>
+        /// Allowed service upstream validation.
+        /// Use <see cref="Connections"/> instead for multiple connections.
+        /// If both <see cref="Connection"/> and <see cref="Connections"/> are set, <see cref="Connections"/> takes precedence.
+        /// </summary>
+        [Obsolete("Use Connections instead.")]
+        public string Connection
+        {
+            get => Connections?.Length > 0 ? Connections[0] : null;
+            set
+            {
+                if (Connections == null || Connections.Length == 0)
+                {
+                    Connections = [value];
+                }
+            }
+        }
 
         /// <summary>
         /// Specifies which client protocol can trigger the Web PubSub trigger functions. By default, it accepts all client protocols.

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerAttribute.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerAttribute.cs
@@ -83,12 +83,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         public WebPubSubEventType EventType { get; }
 
         /// <summary>
-        /// Allowed service upstream validation
+        /// The connection setting names or configuration section names allowed for abuse protection and signature validation.
         /// </summary>
         public string[] Connections { get; private set; }
 
         /// <summary>
-        /// Allowed service upstream validation.
+        /// The connection setting names or configuration section names allowed for abuse protection and signature validation.
         /// Use <see cref="Connections"/> instead for multiple connections.
         /// If both <see cref="Connection"/> and <see cref="Connections"/> are set, <see cref="Connections"/> takes precedence.
         /// </summary>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/WebPubSubContextAttribute.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/WebPubSubContextAttribute.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             get => Connections?.Length > 0 ? Connections[0] : null;
             set
             {
+                if (string.IsNullOrEmpty(value))
+                {
+                    return;
+                }
+
                 if (Connections == null || Connections.Length == 0)
                 {
                     Connections = new[] { value };

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/WebPubSubContextAttribute.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/WebPubSubContextAttribute.cs
@@ -19,6 +19,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         public string[] Connections { get; set; }
 
         /// <summary>
+        /// Allowed Web PubSub service connection used for Abuse Protection and signature checks.
+        /// Use <see cref="Connections"/> instead for multiple connections.
+        /// If both <see cref="Connection"/> and <see cref="Connections"/> are set, <see cref="Connections"/> takes precedence.
+        /// </summary>
+        [Obsolete("Use Connections instead.")]
+        public string Connection
+        {
+            get => Connections?.Length > 0 ? Connections[0] : null;
+            set
+            {
+                if (Connections == null || Connections.Length == 0)
+                {
+                    Connections = new[] { value };
+                }
+            }
+        }
+
+        /// <summary>
         /// Constructor to build the attribute.
         /// </summary>
         /// <param name="connections">Allowed service connections.</param>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/WebPubSubContextAttribute.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/WebPubSubContextAttribute.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
     public class WebPubSubContextAttribute : Attribute
     {
         /// <summary>
-        /// Allowed Web PubSub service connections used for Abuse Protection and signature checks.
+        /// The connection setting names or configuration section names allowed for abuse protection and signature validation.
         /// </summary>
         public string[] Connections { get; set; }
 
         /// <summary>
-        /// Allowed Web PubSub service connection used for Abuse Protection and signature checks.
+        /// The connection setting name or configuration section name allowed for abuse protection and signature validation.
         /// Use <see cref="Connections"/> instead for multiple connections.
         /// If both <see cref="Connection"/> and <see cref="Connections"/> are set, <see cref="Connections"/> takes precedence.
         /// </summary>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubRequestBindingProviderTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubRequestBindingProviderTests.cs
@@ -61,6 +61,63 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             Assert.True((request.Request as PreflightRequest).IsValid);
         }
 
+        [TestCase]
+        public void ContextAttribute_LegacyConnection_NullOrEmpty_DoesNotPopulateConnections()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            var attributeWithNull = new WebPubSubContextAttribute
+            {
+                Connection = null,
+            };
+
+            var attributeWithEmpty = new WebPubSubContextAttribute
+            {
+                Connection = string.Empty,
+            };
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.IsNull(attributeWithNull.Connections);
+            Assert.IsNull(attributeWithEmpty.Connections);
+        }
+
+        [TestCase]
+        public void ContextAttribute_LegacyConnection_WithValue_PopulatesConnections()
+        {
+            var attribute = new WebPubSubContextAttribute();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            attribute.Connection = "connectionA";
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.NotNull(attribute.Connections);
+            Assert.AreEqual(1, attribute.Connections.Length);
+            Assert.AreEqual("connectionA", attribute.Connections[0]);
+        }
+
+        [TestCase]
+        public void ContextAttribute_LegacyConnection_DoesNotOverrideConnections_WhenAlreadySet()
+        {
+            var attribute = new WebPubSubContextAttribute("connectionA", "connectionB");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            attribute.Connection = "connectionC";
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual(2, attribute.Connections.Length);
+            Assert.AreEqual("connectionA", attribute.Connections[0]);
+            Assert.AreEqual("connectionB", attribute.Connections[1]);
+        }
+
+        [TestCase]
+        public void ContextAttribute_LegacyConnection_Getter_ReturnsFirstConnection()
+        {
+            var attribute = new WebPubSubContextAttribute("connectionA", "connectionB");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("connectionA", attribute.Connection);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
         public static void TestFunc(
             [WebPubSubContext] WebPubSubContext request)
         {

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerBindingProviderTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerBindingProviderTests.cs
@@ -2,8 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.WebPubSub.Common;
 using Microsoft.Extensions.Configuration;
@@ -68,6 +72,63 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var binding = await _provider.TryCreateAsync(context);
 
             Assert.NotNull(binding);
+        }
+
+        [TestCase]
+        public void TriggerAttribute_LegacyConnection_NullOrEmpty_DoesNotPopulateConnections()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            var attributeWithNull = new WebPubSubTriggerAttribute("defaulthub", WebPubSubEventType.System, "testevent")
+            {
+                Connection = null,
+            };
+
+            var attributeWithEmpty = new WebPubSubTriggerAttribute("defaulthub", WebPubSubEventType.System, "testevent")
+            {
+                Connection = string.Empty,
+            };
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.IsNull(attributeWithNull.Connections);
+            Assert.IsNull(attributeWithEmpty.Connections);
+        }
+
+        [TestCase]
+        public void TriggerAttribute_LegacyConnection_WithValue_PopulatesConnections()
+        {
+            var attribute = new WebPubSubTriggerAttribute("defaulthub", WebPubSubEventType.System, "testevent");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            attribute.Connection = "connectionA";
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.NotNull(attribute.Connections);
+            Assert.AreEqual(1, attribute.Connections.Length);
+            Assert.AreEqual("connectionA", attribute.Connections[0]);
+        }
+
+        [TestCase]
+        public void TriggerAttribute_LegacyConnection_DoesNotOverrideConnections_WhenAlreadySet()
+        {
+            var attribute = new WebPubSubTriggerAttribute("defaulthub", WebPubSubEventType.System, "testevent", "connectionA", "connectionB");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            attribute.Connection = "connectionC";
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual(2, attribute.Connections.Length);
+            Assert.AreEqual("connectionA", attribute.Connections[0]);
+            Assert.AreEqual("connectionB", attribute.Connections[1]);
+        }
+
+        [TestCase]
+        public void TriggerAttribute_LegacyConnection_Getter_ReturnsFirstConnection()
+        {
+            var attribute = new WebPubSubTriggerAttribute("defaulthub", WebPubSubEventType.System, "testevent", "connectionA", "connectionB");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("connectionA", attribute.Connection);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public static void TestFunc(


### PR DESCRIPTION
As the dependencies in current main branch are not compatible with functions runtime (see details below), we need to append the fix as a hotfix.