### PR TITLE
Monitor.Slis: set 1.0.0-beta.2 release date and drop empty CHANGELOG sections

### DIFF
--- a/sdk/monitor/Azure.ResourceManager.Monitor.Slis/CHANGELOG.md
+++ b/sdk/monitor/Azure.ResourceManager.Monitor.Slis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2026-06-01)
 
 ### Features Added
 
@@ -13,10 +13,6 @@
 - Changed `SliSamplingType` wire values for `Max`, `Min`, and `Sum` from `max`, `min`, and `sum` to `Max`, `Min`, and `Sum`.
 - Changed `SliConditionOperator` wire values from symbolic operators to named operators: `==` to `eq`, `!=` to `ne`, `>` to `gt`, `>=` to `gte`, `<` to `lt`, `<=` to `lte`, `@in` to `in`, `!in` to `notin`, `!contains` to `notcontains`, and `!startswith` to `notstartswith`.
 - Changed `WindowUptimeCriteriaComparator` wire values from symbolic operators to named operators: `>` to `gt`, `>=` to `gte`, `<` to `lt`, and `<=` to `lte`.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.0.0-beta.1 (2026-04-22)
 


### PR DESCRIPTION
Release pipeline [build 6379367](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6379367) failed with: