### PR TITLE
Clarify management review dismissal criteria

### DIFF
--- a/.github/workflows/mgmt-review.lock.yml
+++ b/.github/workflows/mgmt-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e9b80199ed471536f70b3e7e3f733ae5eeb956caba8e561c9b8033e2095b83a0","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"beba795cb9ec1358bbb7a98025b9e85c2c6653fea7192f2f53d956dd97f76781","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -219,20 +219,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_7c805fa413c71c8c_EOF'
+          cat << 'GH_AW_PROMPT_41d76886a5317cb5_EOF'
           <system>
-          GH_AW_PROMPT_7c805fa413c71c8c_EOF
+          GH_AW_PROMPT_41d76886a5317cb5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7c805fa413c71c8c_EOF'
+          cat << 'GH_AW_PROMPT_41d76886a5317cb5_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:100), submit_pull_request_review, missing_tool, missing_data, noop, dismiss_stale_change_requests
           </safe-output-tools>
-          GH_AW_PROMPT_7c805fa413c71c8c_EOF
+          GH_AW_PROMPT_41d76886a5317cb5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_7c805fa413c71c8c_EOF'
+          cat << 'GH_AW_PROMPT_41d76886a5317cb5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -264,9 +264,9 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_7c805fa413c71c8c_EOF
+          GH_AW_PROMPT_41d76886a5317cb5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7c805fa413c71c8c_EOF'
+          cat << 'GH_AW_PROMPT_41d76886a5317cb5_EOF'
           </system>
           # Azure .NET Management SDK PR Review
           
@@ -353,7 +353,8 @@ jobs:
           Then submit exactly one review using `submit_pull_request_review`:
           
           - Use `REQUEST_CHANGES` if any blocking issue was found.
-          - Use `COMMENT` if no blocking issue was found.
+          - Use `REQUEST_CHANGES` if any prior blocking management-review issue is still unresolved, even if the latest review pass does not find new issues in newly changed files.
+          - Use `COMMENT` only if no blocking management-review issue remains for the PR.
           - Do not use `APPROVE`.
           - When submitting `COMMENT`, also emit the `dismiss_stale_change_requests` safe-output tool with no arguments. The deterministic safe-output job will check that this workflow's latest review is the new non-blocking comment on the current head, then dismiss this workflow's prior stale `REQUEST_CHANGES` review from an older commit. Do not attempt to dismiss reviews directly from the agent.
           
@@ -374,7 +375,7 @@ jobs:
           
           If there are no findings, submit a neutral `COMMENT` review with a short body indicating that no blocking management SDK review issues were found.
           
-          GH_AW_PROMPT_7c805fa413c71c8c_EOF
+          GH_AW_PROMPT_41d76886a5317cb5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -582,9 +583,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c7aedafcb5c6841c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1423b410be143eba_EOF'
           {"create_pull_request_review_comment":{"max":100,"side":"RIGHT","target":"${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number }}"},"create_report_incomplete_issue":{},"dismiss_stale_change_requests":{"description":"Dismiss the prior management review change request after a newer non-blocking review","output":"Stale management review change request dismissed"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","REQUEST_CHANGES"],"footer":"if-body","max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c7aedafcb5c6841c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_1423b410be143eba_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -822,7 +823,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_024d307124ec15a9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_7c25e7e8aed8db4c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -863,7 +864,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_024d307124ec15a9_EOF
+          GH_AW_MCP_CONFIG_7c25e7e8aed8db4c_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/mgmt-review.md
+++ b/.github/workflows/mgmt-review.md
@@ -208,7 +208,8 @@ Post one inline comment per distinct finding so large refresh PRs (which can tou
 Then submit exactly one review using `submit_pull_request_review`:
 
 - Use `REQUEST_CHANGES` if any blocking issue was found.
-- Use `COMMENT` if no blocking issue was found.
+- Use `REQUEST_CHANGES` if any prior blocking management-review issue is still unresolved, even if the latest review pass does not find new issues in newly changed files.
+- Use `COMMENT` only if no blocking management-review issue remains for the PR.
 - Do not use `APPROVE`.
 - When submitting `COMMENT`, also emit the `dismiss_stale_change_requests` safe-output tool with no arguments. The deterministic safe-output job will check that this workflow's latest review is the new non-blocking comment on the current head, then dismiss this workflow's prior stale `REQUEST_CHANGES` review from an older commit. Do not attempt to dismiss reviews directly from the agent.
 


### PR DESCRIPTION
## Summary
- Clarify that the management review must submit `REQUEST_CHANGES` when prior blocking management-review findings remain unresolved, even if the latest pass finds no new issues.
- Keep `COMMENT` and `dismiss_stale_change_requests` limited to truly clean reviews where no blocking management-review issue remains for the PR.

## Validation
- `gh aw compile mgmt-review --no-check-update`
- `git diff --check`