### PR TITLE
[Identity] Polish experimental Token Binding feature and mark it as experimental

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -187,7 +187,7 @@
     <!-- Other approved packages -->
     <PackageVersion Include="Microsoft.Azure.Amqp" Version="2.7.0" />
     <PackageVersion Include="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2-preview3-mtls-pop-host-check" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2-preview4-getmanagedidentitycapabilitiesasync" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.1" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.84.1" />
     <PackageVersion Include="Microsoft.Identity.Client.KeyAttestation" Version="4.84.2-preview3-mtls-pop-host-check" />

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1004,13 +1004,21 @@ namespace Azure.Core.Pipeline
     public partial class BearerTokenAuthenticationPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
     {
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+        public event System.Action<Azure.Core.Pipeline.HttpPipelineTransportOptions>? TransportOptionsChanged { add { } remove { } }
         protected void AuthenticateAndAuthorizeRequest(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { }
         protected System.Threading.Tasks.ValueTask AuthenticateAndAuthorizeRequestAsync(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { throw null; }
         protected virtual void AuthorizeRequest(Azure.Core.HttpMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask AuthorizeRequestAsync(Azure.Core.HttpMessage message) { throw null; }
         protected virtual bool AuthorizeRequestOnChallenge(Azure.Core.HttpMessage message) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> AuthorizeRequestOnChallengeAsync(Azure.Core.HttpMessage message) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+        protected void OnTransportOptionsChanged(Azure.Core.Pipeline.HttpPipelineTransportOptions options) { }
         public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
     }

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -989,13 +989,17 @@ namespace Azure.Core.Pipeline
     public partial class BearerTokenAuthenticationPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
     {
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes) { }
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope) { }
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
+        public event System.Action<Azure.Core.Pipeline.HttpPipelineTransportOptions>? TransportOptionsChanged { add { } remove { } }
         protected void AuthenticateAndAuthorizeRequest(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { }
         protected System.Threading.Tasks.ValueTask AuthenticateAndAuthorizeRequestAsync(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { throw null; }
         protected virtual void AuthorizeRequest(Azure.Core.HttpMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask AuthorizeRequestAsync(Azure.Core.HttpMessage message) { throw null; }
         protected virtual bool AuthorizeRequestOnChallenge(Azure.Core.HttpMessage message) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> AuthorizeRequestOnChallengeAsync(Azure.Core.HttpMessage message) { throw null; }
+        protected void OnTransportOptionsChanged(Azure.Core.Pipeline.HttpPipelineTransportOptions options) { }
         public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
     }

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -989,13 +989,17 @@ namespace Azure.Core.Pipeline
     public partial class BearerTokenAuthenticationPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
     {
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes) { }
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope) { }
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
+        public event System.Action<Azure.Core.Pipeline.HttpPipelineTransportOptions>? TransportOptionsChanged { add { } remove { } }
         protected void AuthenticateAndAuthorizeRequest(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { }
         protected System.Threading.Tasks.ValueTask AuthenticateAndAuthorizeRequestAsync(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { throw null; }
         protected virtual void AuthorizeRequest(Azure.Core.HttpMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask AuthorizeRequestAsync(Azure.Core.HttpMessage message) { throw null; }
         protected virtual bool AuthorizeRequestOnChallenge(Azure.Core.HttpMessage message) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> AuthorizeRequestOnChallengeAsync(Azure.Core.HttpMessage message) { throw null; }
+        protected void OnTransportOptionsChanged(Azure.Core.Pipeline.HttpPipelineTransportOptions options) { }
         public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
     }

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1004,13 +1004,21 @@ namespace Azure.Core.Pipeline
     public partial class BearerTokenAuthenticationPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
     {
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+        public event System.Action<Azure.Core.Pipeline.HttpPipelineTransportOptions>? TransportOptionsChanged { add { } remove { } }
         protected void AuthenticateAndAuthorizeRequest(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { }
         protected System.Threading.Tasks.ValueTask AuthenticateAndAuthorizeRequestAsync(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { throw null; }
         protected virtual void AuthorizeRequest(Azure.Core.HttpMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask AuthorizeRequestAsync(Azure.Core.HttpMessage message) { throw null; }
         protected virtual bool AuthorizeRequestOnChallenge(Azure.Core.HttpMessage message) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> AuthorizeRequestOnChallengeAsync(Azure.Core.HttpMessage message) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+        protected void OnTransportOptionsChanged(Azure.Core.Pipeline.HttpPipelineTransportOptions options) { }
         public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
     }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -989,13 +989,17 @@ namespace Azure.Core.Pipeline
     public partial class BearerTokenAuthenticationPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
     {
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes) { }
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
         public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope) { }
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { }
+        public event System.Action<Azure.Core.Pipeline.HttpPipelineTransportOptions>? TransportOptionsChanged { add { } remove { } }
         protected void AuthenticateAndAuthorizeRequest(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { }
         protected System.Threading.Tasks.ValueTask AuthenticateAndAuthorizeRequestAsync(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { throw null; }
         protected virtual void AuthorizeRequest(Azure.Core.HttpMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask AuthorizeRequestAsync(Azure.Core.HttpMessage message) { throw null; }
         protected virtual bool AuthorizeRequestOnChallenge(Azure.Core.HttpMessage message) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> AuthorizeRequestOnChallengeAsync(Azure.Core.HttpMessage message) { throw null; }
+        protected void OnTransportOptionsChanged(Azure.Core.Pipeline.HttpPipelineTransportOptions options) { }
         public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
     }

--- a/sdk/core/Azure.Core/src/Identity/MsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalManagedIdentityClient.cs
@@ -124,11 +124,10 @@ namespace Azure.Identity
             if (isTokenBindingAvailable)
             {
                 builder.WithMtlsProofOfPossession();
-                AzureIdentityEventSource.Singleton.LogMsal(LogLevel.Verbose, $"MsalManagedIdentityClient called builder.WithMtlsProofOfPossession()");
+                AzureIdentityEventSource.Singleton.LogMsal(LogLevel.Verbose, "Managed identity token request configured with mTLS proof-of-possession.");
             }
 
             _beforeTokenAcquisition?.Invoke(builder);
-            AzureIdentityEventSource.Singleton.LogMsal(LogLevel.Verbose, $"MsalManagedIdentityClient called _beforeTokenAcquisition?.Invoke(builder) and the _beforeTokenAcquisition is not null: {_beforeTokenAcquisition is not null}");
 
             if (_isForceRefreshEnabled)
             {

--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -278,7 +278,7 @@ namespace Azure.Core.Pipeline
             _lastBindingCertificate = newCert;
             var options = _transportOptions?.Clone() ?? new HttpPipelineTransportOptions();
             options.ClientCertificates.Add(newCert);
-            AzureCoreEventSource.Singleton.TokenBinding("Updating transport options with new binding certificate. Certificate Thumbprint: " + newCert.Thumbprint);
+            AzureCoreEventSource.Singleton.TokenBinding("Updating transport options with a new binding certificate.");
 #pragma warning disable AZID0004 // Internal usage of experimental token binding API
             OnTransportOptionsChanged(options);
 #pragma warning restore AZID0004
@@ -469,7 +469,10 @@ namespace Azure.Core.Pipeline
                     false when _tokenRefreshOffset.Ticks > token.ExpiresOn.Ticks => token.ExpiresOn,
                     _ => token.ExpiresOn - _tokenRefreshOffset
                 };
-                AzureCoreEventSource.Singleton.TokenBinding($"Fetched new token with new binding certificate. Certificate Thumbprint: {token.BindingCertificate?.Thumbprint}, tokenType: {token.TokenType}, expiresOn: {token.ExpiresOn}, refreshOn: {refreshOn}");
+                if (token.BindingCertificate != null)
+                {
+                    AzureCoreEventSource.Singleton.TokenBinding("Token acquired with a binding certificate.");
+                }
                 targetTcs.SetResult(new AuthHeaderValueInfo(token.TokenType + " " + token.Token, token.ExpiresOn, refreshOn, token.BindingCertificate));
             }
 

--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
@@ -26,6 +27,7 @@ namespace Azure.Core.Pipeline
         /// <summary>
         /// Event that is triggered when the transport needs to be updated.
         /// </summary>
+        [Experimental("AZID0004")]
         public event Action<HttpPipelineTransportOptions>? TransportOptionsChanged;
 
         /// <summary>
@@ -41,6 +43,7 @@ namespace Azure.Core.Pipeline
         /// <param name="credential">The token credential to use for authentication.</param>
         /// <param name="scope">The scope to be included in acquired tokens.</param>
         /// <param name="transportOptions">The <see cref="HttpPipelineTransportOptions"/> to use as a base when updating transport options. If provided, a clone of this instance will be used when updating the transport with new client certificates.</param>
+        [Experimental("AZID0004")]
         public BearerTokenAuthenticationPolicy(TokenCredential credential, string scope, HttpPipelineTransportOptions transportOptions) : this(credential, new[] { scope }, transportOptions) { }
 
         /// <summary>
@@ -60,6 +63,7 @@ namespace Azure.Core.Pipeline
         /// <param name="scopes">Scopes to be included in acquired tokens.</param>
         /// <param name="transportOptions">The <see cref="HttpPipelineTransportOptions"/> to use as a base when updating transport options. If provided, a clone of this instance will be used when updating the transport with new client certificates.</param>
         /// <exception cref="ArgumentNullException">When <paramref name="credential"/> or <paramref name="scopes"/> is null.</exception>
+        [Experimental("AZID0004")]
         public BearerTokenAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes, HttpPipelineTransportOptions transportOptions)
             : this(credential, scopes, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(30), transportOptions)
         { }
@@ -252,6 +256,7 @@ namespace Azure.Core.Pipeline
         /// This can be used to trigger transport updates when token refreshes happen in the background and new tokens have different requirements for the transport, such as a different client certificate.
         /// </summary>
         /// <param name="options"></param>
+        [Experimental("AZID0004")]
         protected void OnTransportOptionsChanged(HttpPipelineTransportOptions options)
         {
             TransportOptionsChanged?.Invoke(options);
@@ -274,7 +279,9 @@ namespace Azure.Core.Pipeline
             var options = _transportOptions?.Clone() ?? new HttpPipelineTransportOptions();
             options.ClientCertificates.Add(newCert);
             AzureCoreEventSource.Singleton.TokenBinding("Updating transport options with new binding certificate. Certificate Thumbprint: " + newCert.Thumbprint);
+#pragma warning disable AZID0004 // Internal usage of experimental token binding API
             OnTransportOptionsChanged(options);
+#pragma warning restore AZID0004
         }
 
         internal class AccessTokenCache

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -149,7 +148,7 @@ namespace Azure.Core.Pipeline
         /// <inheritdoc />
         public override void Update(HttpPipelineTransportOptions options)
         {
-            AzureCoreEventSource.Singleton.TokenBinding("HttpClientTransport received request to update transport options. Options containing client certificates: " + (options.ClientCertificates.Count > 0 ? string.Join(", ", options.ClientCertificates.Select(c => c.Thumbprint)) : "none")    );
+            AzureCoreEventSource.Singleton.TokenBinding("HttpClientTransport updating transport options with " + options.ClientCertificates.Count + " client certificate(s).");
             if (this == Shared)
             {
                 throw new InvalidOperationException("Cannot update the shared HttpClientTransport instance.");
@@ -181,7 +180,7 @@ namespace Azure.Core.Pipeline
 
             var newWrapper = new HttpClientWrapper(newClient);
             var oldWrapper = Interlocked.Exchange(ref _clientWrapper!, newWrapper);
-            AzureCoreEventSource.Singleton.TokenBinding("HttpClientTransport updated client.");
+            AzureCoreEventSource.Singleton.TokenBinding("HttpClientTransport replaced HttpClient for updated transport options.");
 
             // Release the transport's reference to the old client
             oldWrapper?.Release();
@@ -300,7 +299,6 @@ namespace Azure.Core.Pipeline
 
         private static HttpMessageHandler CreateDefaultHandler(HttpPipelineTransportOptions? options = null)
         {
-            AzureCoreEventSource.Singleton.TokenBinding("Creating default HTTP message handler with options containing client certificates: " + (options?.ClientCertificates.Count > 0 ? string.Join(", ", options.ClientCertificates.Select(c => c.Thumbprint)) : "none"));
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
             {
                 // UseCookies is not supported on "browser"
@@ -366,28 +364,6 @@ namespace Azure.Core.Pipeline
                 httpHandler.SslOptions.ClientCertificates ??= new X509CertificateCollection();
                 httpHandler.SslOptions.ClientCertificates!.Add(cert);
             }
-
-            // Log client certificate selection during TLS handshake
-            if (options.ClientCertificates.Count > 0)
-            {
-                httpHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCerts, remoteCert, acceptableIssuers) =>
-                {
-                    if (localCerts.Count > 0)
-                    {
-                        var selected = localCerts[0] as X509Certificate2;
-                        AzureCoreEventSource.Singleton.TokenBinding(
-                            $"TLS handshake selected client certificate: Subject='{selected?.Subject}', Thumbprint='{selected?.Thumbprint}' for host '{targetHost}'");
-                        return localCerts[0];
-                    }
-                    AzureCoreEventSource.Singleton.TokenBinding(
-                        $"TLS handshake: no client certificate available for host '{targetHost}'");
-                    return null!;
-                };
-            }
-            else
-            {
-                AzureCoreEventSource.Singleton.TokenBinding("TLS handshake: no client certificates configured.");
-            }
 #pragma warning restore CA1416 // 'X509Certificate2' is unsupported on 'browser'
             return httpHandler;
         }
@@ -414,7 +390,7 @@ namespace Azure.Core.Pipeline
                 httpHandler.ClientCertificates.Add(cert);
             }
 
-            // Log client certificate selection during TLS handshake
+            // Ensure client certificates are sent during TLS handshake
             if (options.ClientCertificates.Count > 0)
             {
                 httpHandler.ClientCertificateOptions = ClientCertificateOption.Manual;

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -64,7 +64,7 @@ namespace Azure.Core.Pipeline
                 // If the policy implements ISupportsTransportCertificateUpdate, we need to subscribe to its TransportUpdated event
                 if (policies[i] is ISupportsTransportUpdate transportUpdated)
                 {
-                    AzureCoreEventSource.Singleton.TokenBinding("HttpPipeline wired up to listen for transport option updates from policy: " + policies[i].GetType().FullName);
+                    AzureCoreEventSource.Singleton.TokenBinding("HttpPipeline subscribed to transport option updates.");
                     transportUpdated.TransportOptionsChanged += options => _transport.Update(options);
                     break;
                 }

--- a/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
+++ b/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
@@ -155,3 +155,30 @@ Or in your project file:
   <NoWarn>$(NoWarn);AZID0003</NoWarn>
 </PropertyGroup>
 ```
+
+## AZID0004 - Identity: mTLS Token Binding Experimental API
+
+### Description
+
+The mTLS token binding APIs enable proof-of-possession token support for managed identity scenarios. These APIs allow transport-level certificate binding for token requests, enabling mTLS-based token binding on supported Azure VMs. These APIs are experimental and subject to change as the feature matures.
+
+### Affected APIs
+
+- `Azure.Core.Pipeline.BearerTokenAuthenticationPolicy` constructors accepting `HttpPipelineTransportOptions`
+- `Azure.Core.Pipeline.BearerTokenAuthenticationPolicy.TransportOptionsChanged` event
+- `Azure.Core.Pipeline.BearerTokenAuthenticationPolicy.OnTransportOptionsChanged` method
+- `Azure.Identity.Broker.ManagedIdentityCredentialAttestationOptions` class
+
+### Suppression
+
+```csharp
+#pragma warning disable AZID0004
+```
+
+Or in your project file:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);AZID0004</NoWarn>
+</PropertyGroup>
+```

--- a/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
+++ b/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
@@ -167,7 +167,6 @@ The mTLS token binding APIs enable proof-of-possession token support for managed
 - `Azure.Core.Pipeline.BearerTokenAuthenticationPolicy` constructors accepting `HttpPipelineTransportOptions`
 - `Azure.Core.Pipeline.BearerTokenAuthenticationPolicy.TransportOptionsChanged` event
 - `Azure.Core.Pipeline.BearerTokenAuthenticationPolicy.OnTransportOptionsChanged` method
-- `Azure.Identity.Broker.ManagedIdentityCredentialAttestationOptions` class
 
 ### Suppression
 

--- a/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net10.0.cs
+++ b/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net10.0.cs
@@ -20,7 +20,6 @@ namespace Azure.Identity.Broker
         public bool? IsLegacyMsaPassthroughEnabled { get { throw null; } set { } }
         public bool UseDefaultBrokerAccount { get { throw null; } set { } }
     }
-    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
     public partial class ManagedIdentityCredentialAttestationOptions : Azure.Identity.ManagedIdentityCredentialOptions
     {
         public ManagedIdentityCredentialAttestationOptions(Azure.Identity.ManagedIdentityId managedIdentityId = null) : base (default(Azure.Identity.ManagedIdentityId)) { }

--- a/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net10.0.cs
+++ b/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net10.0.cs
@@ -20,6 +20,11 @@ namespace Azure.Identity.Broker
         public bool? IsLegacyMsaPassthroughEnabled { get { throw null; } set { } }
         public bool UseDefaultBrokerAccount { get { throw null; } set { } }
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+    public partial class ManagedIdentityCredentialAttestationOptions : Azure.Identity.ManagedIdentityCredentialOptions
+    {
+        public ManagedIdentityCredentialAttestationOptions(Azure.Identity.ManagedIdentityId managedIdentityId = null) : base (default(Azure.Identity.ManagedIdentityId)) { }
+    }
     [System.ObsoleteAttribute("SharedTokenCacheCredential is deprecated. For brokered authentication, consider using InteractiveBrowserCredential.")]
     public partial class SharedTokenCacheCredentialBrokerOptions : Azure.Identity.SharedTokenCacheCredentialOptions
     {

--- a/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net462.cs
+++ b/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net462.cs
@@ -17,6 +17,10 @@ namespace Azure.Identity.Broker
         public bool? IsLegacyMsaPassthroughEnabled { get { throw null; } set { } }
         public bool UseDefaultBrokerAccount { get { throw null; } set { } }
     }
+    public partial class ManagedIdentityCredentialAttestationOptions : Azure.Identity.ManagedIdentityCredentialOptions
+    {
+        public ManagedIdentityCredentialAttestationOptions(Azure.Identity.ManagedIdentityId managedIdentityId = null) : base (default(Azure.Identity.ManagedIdentityId)) { }
+    }
     [System.ObsoleteAttribute("SharedTokenCacheCredential is deprecated. For brokered authentication, consider using InteractiveBrowserCredential.")]
     public partial class SharedTokenCacheCredentialBrokerOptions : Azure.Identity.SharedTokenCacheCredentialOptions
     {

--- a/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net8.0.cs
+++ b/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net8.0.cs
@@ -20,7 +20,6 @@ namespace Azure.Identity.Broker
         public bool? IsLegacyMsaPassthroughEnabled { get { throw null; } set { } }
         public bool UseDefaultBrokerAccount { get { throw null; } set { } }
     }
-    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
     public partial class ManagedIdentityCredentialAttestationOptions : Azure.Identity.ManagedIdentityCredentialOptions
     {
         public ManagedIdentityCredentialAttestationOptions(Azure.Identity.ManagedIdentityId managedIdentityId = null) : base (default(Azure.Identity.ManagedIdentityId)) { }

--- a/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net8.0.cs
+++ b/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net8.0.cs
@@ -20,6 +20,11 @@ namespace Azure.Identity.Broker
         public bool? IsLegacyMsaPassthroughEnabled { get { throw null; } set { } }
         public bool UseDefaultBrokerAccount { get { throw null; } set { } }
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0004")]
+    public partial class ManagedIdentityCredentialAttestationOptions : Azure.Identity.ManagedIdentityCredentialOptions
+    {
+        public ManagedIdentityCredentialAttestationOptions(Azure.Identity.ManagedIdentityId managedIdentityId = null) : base (default(Azure.Identity.ManagedIdentityId)) { }
+    }
     [System.ObsoleteAttribute("SharedTokenCacheCredential is deprecated. For brokered authentication, consider using InteractiveBrowserCredential.")]
     public partial class SharedTokenCacheCredentialBrokerOptions : Azure.Identity.SharedTokenCacheCredentialOptions
     {

--- a/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.netstandard2.0.cs
@@ -17,6 +17,10 @@ namespace Azure.Identity.Broker
         public bool? IsLegacyMsaPassthroughEnabled { get { throw null; } set { } }
         public bool UseDefaultBrokerAccount { get { throw null; } set { } }
     }
+    public partial class ManagedIdentityCredentialAttestationOptions : Azure.Identity.ManagedIdentityCredentialOptions
+    {
+        public ManagedIdentityCredentialAttestationOptions(Azure.Identity.ManagedIdentityId managedIdentityId = null) : base (default(Azure.Identity.ManagedIdentityId)) { }
+    }
     [System.ObsoleteAttribute("SharedTokenCacheCredential is deprecated. For brokered authentication, consider using InteractiveBrowserCredential.")]
     public partial class SharedTokenCacheCredentialBrokerOptions : Azure.Identity.SharedTokenCacheCredentialOptions
     {

--- a/sdk/identity/Azure.Identity.Broker/src/ManagedIdentityCredentialAttestationOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/ManagedIdentityCredentialAttestationOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.KeyAttestation;
 
@@ -14,6 +15,7 @@ namespace Azure.Identity.Broker
     /// Microsoft.Identity.Client.KeyAttestation package) will be applied to each managed identity token request
     /// alongside the default <c>WithMtlsProofOfPossession()</c> configuration.
     /// </summary>
+    [Experimental("AZID0004")]
     public class ManagedIdentityCredentialAttestationOptions : ManagedIdentityCredentialOptions, IMsalManagedIdentityInitializerOptions
     {
         /// <summary>

--- a/sdk/identity/Azure.Identity.Broker/src/ManagedIdentityCredentialAttestationOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/ManagedIdentityCredentialAttestationOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.KeyAttestation;
 
@@ -15,7 +14,6 @@ namespace Azure.Identity.Broker
     /// Microsoft.Identity.Client.KeyAttestation package) will be applied to each managed identity token request
     /// alongside the default <c>WithMtlsProofOfPossession()</c> configuration.
     /// </summary>
-    [Experimental("AZID0004")]
     public class ManagedIdentityCredentialAttestationOptions : ManagedIdentityCredentialOptions, IMsalManagedIdentityInitializerOptions
     {
         /// <summary>


### PR DESCRIPTION
Add [Experimental("AZID0004")] to all new public API surface introduced for mTLS token binding support:
- BearerTokenAuthenticationPolicy: TransportOptionsChanged event, new constructors with HttpPipelineTransportOptions, OnTransportOptionsChanged
- ManagedIdentityCredentialAttestationOptions class (Broker)
- Updated ExperimentalFeatures.md with AZID0004 documentation
- Re-exported public API baselines