### PR TITLE
Clean up provisioning resource projection metadata

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/emitter/src/lib/lib.ts
+++ b/eng/packages/http-client-csharp-provisioning/emitter/src/lib/lib.ts
@@ -23,12 +23,6 @@ const diags: { [code: string]: DiagnosticDefinition<DiagnosticMessages> } = {
     messages: {
       default: paramMessage`${"message"}`
     }
-  },
-  "inconsistent-parent-resource-id": {
-    severity: "warning",
-    messages: {
-      default: paramMessage`${"message"}`
-    }
   }
 };
 

--- a/eng/packages/http-client-csharp-provisioning/emitter/src/lib/lib.ts
+++ b/eng/packages/http-client-csharp-provisioning/emitter/src/lib/lib.ts
@@ -1,15 +1,40 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { createTypeSpecLibrary } from "@typespec/compiler";
+import {
+  createTypeSpecLibrary,
+  DiagnosticDefinition,
+  DiagnosticMessages,
+  paramMessage
+} from "@typespec/compiler";
 import { $lib as mgmtLib } from "@azure-typespec/http-client-csharp-mgmt";
 import { AzureProvisioningEmitterOptionsSchema } from "../options.js";
 
+const diags: { [code: string]: DiagnosticDefinition<DiagnosticMessages> } = {
+  ...mgmtLib.diagnostics,
+  "rbac-role-guid-conflict": {
+    severity: "warning",
+    messages: {
+      default: paramMessage`${"message"}`
+    }
+  },
+  "rbac-role-name-collision": {
+    severity: "warning",
+    messages: {
+      default: paramMessage`${"message"}`
+    }
+  },
+  "inconsistent-parent-resource-id": {
+    severity: "warning",
+    messages: {
+      default: paramMessage`${"message"}`
+    }
+  }
+};
+
 export const $lib = createTypeSpecLibrary({
   name: "@azure-typespec/http-client-csharp-provisioning",
-  diagnostics: {
-    ...mgmtLib.diagnostics
-  },
+  diagnostics: diags,
   emitter: {
     options: AzureProvisioningEmitterOptionsSchema
   }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -175,42 +175,14 @@ namespace Azure.Generator.Provisioning.Primitives
         private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)
             where T : notnull
         {
-            comparer ??= EqualityComparer<T>.Default;
-            using var enumerator = values.GetEnumerator();
-            if (!enumerator.MoveNext())
-            {
-                return defaultValue;
-            }
-
-            var first = enumerator.Current;
-            while (enumerator.MoveNext())
-            {
-                if (!comparer.Equals(first, enumerator.Current))
-                {
-                    return defaultValue;
-                }
-            }
-            return first;
+            var distinctValues = values.Distinct(comparer).Take(2).ToArray();
+            return distinctValues.Length == 1 ? distinctValues[0] : defaultValue;
         }
 
         private static T? GetSameNullableValueOrDefault<T>(IEnumerable<T?> values, T? defaultValue, IEqualityComparer<T?>? comparer = null)
         {
-            comparer ??= EqualityComparer<T?>.Default;
-            using var enumerator = values.GetEnumerator();
-            if (!enumerator.MoveNext())
-            {
-                return defaultValue;
-            }
-
-            var first = enumerator.Current;
-            while (enumerator.MoveNext())
-            {
-                if (!comparer.Equals(first, enumerator.Current))
-                {
-                    return defaultValue;
-                }
-            }
-            return first;
+            var distinctValues = values.Distinct(comparer).Take(2).ToArray();
+            return distinctValues.Length == 1 ? distinctValues[0] : defaultValue;
         }
 
         private static IEnumerable<RequestPathPattern> CollectResourceIdPatterns(IReadOnlyList<ArmResourceMetadata> metadata)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -22,9 +22,7 @@ namespace Azure.Generator.Provisioning.Primitives
             ResourceType = GetSameResourceType(metadata);
             ResourceName = GetSameValueOrDefault(metadata.Select(resource => resource.ResourceName), ResourceModel.Name, StringComparer.Ordinal);
             SingletonResourceName = GetSameNullableValueOrDefault(metadata.Select(resource => resource.SingletonResourceName), null, StringComparer.Ordinal);
-            // TODO: Revisit parent merging in the parent/scope PR. For now, preserve
-            // the previous behavior by using the first detected parent.
-            ParentResourceId = metadata[0].ParentResourceId;
+            ParentResourceId = GetSameNullableValueOrDefault(metadata.Select(resource => resource.ParentResourceId), null);
             NameConstraints = GetSameValueOrDefault(
                 metadata.Select(resource => resource.NameConstraints),
                 new ArmResourceNameConstraints(null, null, null));

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -151,26 +151,14 @@ namespace Azure.Generator.Provisioning.Primitives
         private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)
             where T : notnull
         {
-            comparer ??= EqualityComparer<T>.Default;
-            var firstValue = values.FirstOrDefault();
-            return firstValue is not null && values.All(value => comparer.Equals(firstValue, value))
-                ? firstValue
-                : defaultValue;
+            var distinctValues = values.Distinct(comparer).Take(2).ToArray();
+            return distinctValues.Length == 1 ? distinctValues[0] : defaultValue;
         }
 
         private static T? GetSameNullableValueOrDefault<T>(IEnumerable<T?> values, T? defaultValue, IEqualityComparer<T?>? comparer = null)
         {
-            comparer ??= EqualityComparer<T?>.Default;
-            var valueList = values.ToArray();
-            if (valueList.Length == 0)
-            {
-                return defaultValue;
-            }
-
-            var firstValue = valueList[0];
-            return valueList.All(value => comparer.Equals(firstValue, value))
-                ? firstValue
-                : defaultValue;
+            var distinctValues = values.Distinct(comparer).Take(2).ToArray();
+            return distinctValues.Length == 1 ? distinctValues[0] : defaultValue;
         }
 
         private static IEnumerable<RequestPathPattern> CollectResourceIdPatterns(IReadOnlyList<ArmResourceMetadata> metadata)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Generator.Management.Models;
+using Azure.Generator.Provisioning;
 using Microsoft.TypeSpec.Generator.Input;
 using System;
 using System.Collections.Generic;
@@ -22,7 +23,7 @@ namespace Azure.Generator.Provisioning.Primitives
             ResourceType = GetSameResourceType(metadata);
             ResourceName = GetSameValueOrDefault(metadata.Select(resource => resource.ResourceName), ResourceModel.Name, StringComparer.Ordinal);
             SingletonResourceName = GetSameNullableValueOrDefault(metadata.Select(resource => resource.SingletonResourceName), null, StringComparer.Ordinal);
-            ParentResourceId = GetSameNullableValueOrDefault(metadata.Select(resource => resource.ParentResourceId), null);
+            ParentResourceId = GetConsistentParentResourceId(metadata);
             NameConstraints = GetSameValueOrDefault(
                 metadata.Select(resource => resource.NameConstraints),
                 new ArmResourceNameConstraints(null, null, null));
@@ -146,6 +147,36 @@ namespace Azure.Generator.Provisioning.Primitives
                 throw new InvalidOperationException("Collapsed provisioning resources must share the same resource type.");
             }
             return resourceType;
+        }
+
+        private static RequestPathPattern? GetConsistentParentResourceId(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var parentResourceId = metadata[0].ParentResourceId;
+            if (metadata.Any(resource => !EqualityComparer<RequestPathPattern?>.Default.Equals(resource.ParentResourceId, parentResourceId)))
+            {
+                ReportInconsistentParentResourceId(metadata);
+                return null;
+            }
+            return parentResourceId;
+        }
+
+        private static void ReportInconsistentParentResourceId(IReadOnlyList<ArmResourceMetadata> metadata)
+        {
+            var parents = metadata
+                .Select(resource => resource.ParentResourceId?.SerializedPath ?? "<none>")
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(parent => parent, StringComparer.Ordinal);
+
+            try
+            {
+                ProvisioningGenerator.Instance.Emitter.ReportDiagnostic(
+                    "inconsistent-parent-resource-id",
+                    $"Collapsed provisioning resource '{metadata[0].ResourceName}' ({metadata[0].ResourceType}) has inconsistent parent resource IDs [{string.Join(", ", parents)}]. Parent metadata will be omitted.");
+            }
+            catch (InvalidOperationException)
+            {
+                // Unit tests can construct projections without initializing the generator.
+            }
         }
 
         private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -167,16 +167,9 @@ namespace Azure.Generator.Provisioning.Primitives
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(parent => parent, StringComparer.Ordinal);
 
-            try
-            {
-                ProvisioningGenerator.Instance.Emitter.ReportDiagnostic(
-                    "inconsistent-parent-resource-id",
-                    $"Collapsed provisioning resource '{metadata[0].ResourceName}' ({metadata[0].ResourceType}) has inconsistent parent resource IDs [{string.Join(", ", parents)}]. Parent metadata will be omitted.");
-            }
-            catch (InvalidOperationException)
-            {
-                // Unit tests can construct projections without initializing the generator.
-            }
+            ProvisioningGenerator.Instance.Emitter.ReportDiagnostic(
+                "inconsistent-parent-resource-id",
+                $"Collapsed provisioning resource '{metadata[0].ResourceName}' ({metadata[0].ResourceType}) has inconsistent parent resource IDs [{string.Join(", ", parents)}]. Parent metadata will be omitted.");
         }
 
         private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Generator.Management.Models;
-using Azure.Generator.Provisioning;
 using Microsoft.TypeSpec.Generator.Input;
 using System;
 using System.Collections.Generic;
@@ -23,7 +22,7 @@ namespace Azure.Generator.Provisioning.Primitives
             ResourceType = GetSameResourceType(metadata);
             ResourceName = GetSameValueOrDefault(metadata.Select(resource => resource.ResourceName), ResourceModel.Name, StringComparer.Ordinal);
             SingletonResourceName = GetSameNullableValueOrDefault(metadata.Select(resource => resource.SingletonResourceName), null, StringComparer.Ordinal);
-            ParentResourceId = GetConsistentParentResourceId(metadata);
+            ParentResourceId = GetSameNullableValueOrDefault(metadata.Select(resource => resource.ParentResourceId), null);
             NameConstraints = GetSameValueOrDefault(
                 metadata.Select(resource => resource.NameConstraints),
                 new ArmResourceNameConstraints(null, null, null));
@@ -147,29 +146,6 @@ namespace Azure.Generator.Provisioning.Primitives
                 throw new InvalidOperationException("Collapsed provisioning resources must share the same resource type.");
             }
             return resourceType;
-        }
-
-        private static RequestPathPattern? GetConsistentParentResourceId(IReadOnlyList<ArmResourceMetadata> metadata)
-        {
-            var parentResourceId = metadata[0].ParentResourceId;
-            if (metadata.Any(resource => !EqualityComparer<RequestPathPattern?>.Default.Equals(resource.ParentResourceId, parentResourceId)))
-            {
-                ReportInconsistentParentResourceId(metadata);
-                return null;
-            }
-            return parentResourceId;
-        }
-
-        private static void ReportInconsistentParentResourceId(IReadOnlyList<ArmResourceMetadata> metadata)
-        {
-            var parents = metadata
-                .Select(resource => resource.ParentResourceId?.SerializedPath ?? "<none>")
-                .Distinct(StringComparer.Ordinal)
-                .OrderBy(parent => parent, StringComparer.Ordinal);
-
-            ProvisioningGenerator.Instance.Emitter.ReportDiagnostic(
-                "inconsistent-parent-resource-id",
-                $"Collapsed provisioning resource '{metadata[0].ResourceName}' ({metadata[0].ResourceType}) has inconsistent parent resource IDs [{string.Join(", ", parents)}]. Parent metadata will be omitted.");
         }
 
         private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -151,14 +151,26 @@ namespace Azure.Generator.Provisioning.Primitives
         private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)
             where T : notnull
         {
-            var distinctValues = values.Distinct(comparer).Take(2).ToArray();
-            return distinctValues.Length == 1 ? distinctValues[0] : defaultValue;
+            comparer ??= EqualityComparer<T>.Default;
+            var firstValue = values.FirstOrDefault();
+            return firstValue is not null && values.All(value => comparer.Equals(firstValue, value))
+                ? firstValue
+                : defaultValue;
         }
 
         private static T? GetSameNullableValueOrDefault<T>(IEnumerable<T?> values, T? defaultValue, IEqualityComparer<T?>? comparer = null)
         {
-            var distinctValues = values.Distinct(comparer).Take(2).ToArray();
-            return distinctValues.Length == 1 ? distinctValues[0] : defaultValue;
+            comparer ??= EqualityComparer<T?>.Default;
+            var valueList = values.ToArray();
+            if (valueList.Length == 0)
+            {
+                return defaultValue;
+            }
+
+            var firstValue = valueList[0];
+            return valueList.All(value => comparer.Equals(firstValue, value))
+                ? firstValue
+                : defaultValue;
         }
 
         private static IEnumerable<RequestPathPattern> CollectResourceIdPatterns(IReadOnlyList<ArmResourceMetadata> metadata)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -145,6 +145,34 @@ namespace Azure.Generator.Provisioning.Tests
         }
 
         [Test]
+        public void CollapsedProjectionComparesParentResourceIdByEqualityNotHashCode()
+        {
+            var model = CreateModel("TestResourceData");
+            var firstParent = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}");
+            var secondParent = new RequestPathPattern(firstParent.AsEnumerable());
+            var firstResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/first",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                parentResourceIdPattern: firstParent);
+            var secondResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/second",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                parentResourceIdPattern: secondParent);
+
+            var projection = ProvisioningResourceProjection.Create([firstResource, secondResource])[0];
+
+            Assert.That(firstParent, Is.EqualTo(secondParent));
+            Assert.That(firstParent.GetHashCode(), Is.Not.EqualTo(secondParent.GetHashCode()));
+            Assert.That(projection.ParentResourceId, Is.EqualTo(firstParent));
+        }
+
+        [Test]
         public void CollapsedProjectionKeepsOnlyConsistentSingletonResourceName()
         {
             var model = CreateModel("TestResourceData");
@@ -186,6 +214,7 @@ namespace Azure.Generator.Provisioning.Tests
             string? resourceName = null,
             string? singletonResourceName = null,
             string? parentResourceId = null,
+            RequestPathPattern? parentResourceIdPattern = null,
             ArmResourceNameConstraints? nameConstraints = null)
         {
             var path = new RequestPathPattern(resourceIdPattern);
@@ -197,7 +226,7 @@ namespace Azure.Generator.Provisioning.Tests
                 new ArmScopeInfo(scope, RequestPathPattern.GetFromScope(scope, path), null),
                 [],
                 singletonResourceName,
-                parentResourceId is null ? null : new RequestPathPattern(parentResourceId),
+                parentResourceIdPattern ?? (parentResourceId is null ? null : new RequestPathPattern(parentResourceId)),
                 [],
                 nameConstraints ?? new ArmResourceNameConstraints(null, null, null),
                 apiVersions,

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -145,34 +145,6 @@ namespace Azure.Generator.Provisioning.Tests
         }
 
         [Test]
-        public void CollapsedProjectionComparesParentResourceIdByEqualityNotHashCode()
-        {
-            var model = CreateModel("TestResourceData");
-            var firstParent = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}");
-            var secondParent = new RequestPathPattern(firstParent.AsEnumerable());
-            var firstResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/first",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"],
-                parentResourceIdPattern: firstParent);
-            var secondResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/second",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"],
-                parentResourceIdPattern: secondParent);
-
-            var projection = ProvisioningResourceProjection.Create([firstResource, secondResource])[0];
-
-            Assert.That(firstParent, Is.EqualTo(secondParent));
-            Assert.That(firstParent.GetHashCode(), Is.Not.EqualTo(secondParent.GetHashCode()));
-            Assert.That(projection.ParentResourceId, Is.EqualTo(firstParent));
-        }
-
-        [Test]
         public void CollapsedProjectionKeepsOnlyConsistentSingletonResourceName()
         {
             var model = CreateModel("TestResourceData");
@@ -214,7 +186,6 @@ namespace Azure.Generator.Provisioning.Tests
             string? resourceName = null,
             string? singletonResourceName = null,
             string? parentResourceId = null,
-            RequestPathPattern? parentResourceIdPattern = null,
             ArmResourceNameConstraints? nameConstraints = null)
         {
             var path = new RequestPathPattern(resourceIdPattern);
@@ -226,7 +197,7 @@ namespace Azure.Generator.Provisioning.Tests
                 new ArmScopeInfo(scope, RequestPathPattern.GetFromScope(scope, path), null),
                 [],
                 singletonResourceName,
-                parentResourceIdPattern ?? (parentResourceId is null ? null : new RequestPathPattern(parentResourceId)),
+                parentResourceId is null ? null : new RequestPathPattern(parentResourceId),
                 [],
                 nameConstraints ?? new ArmResourceNameConstraints(null, null, null),
                 apiVersions,

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -3,6 +3,7 @@
 
 using Azure.Generator.Management.Models;
 using Azure.Generator.Provisioning.Primitives;
+using Azure.Generator.Provisioning.Tests.TestHelpers;
 using Microsoft.TypeSpec.Generator.Input;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -12,6 +13,12 @@ namespace Azure.Generator.Provisioning.Tests
 {
     public class ProvisioningResourceProjectionTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            ProvisioningMockHelpers.LoadMockGenerator();
+        }
+
         [Test]
         public void SameResourceTypeAndModelCollapse()
         {

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -100,8 +100,41 @@ namespace Azure.Generator.Provisioning.Tests
 
             Assert.That(projection.ResourceName, Is.EqualTo(model.Name));
             Assert.That(projection.SingletonResourceName, Is.Null);
-            Assert.That(projection.ParentResourceId, Is.EqualTo(firstResource.ParentResourceId));
+            Assert.That(projection.ParentResourceId, Is.Null);
             Assert.That(projection.NameConstraints, Is.EqualTo(new ArmResourceNameConstraints(null, null, null)));
+        }
+
+        [Test]
+        public void CollapsedProjectionKeepsOnlyConsistentParentResourceId()
+        {
+            var model = CreateModel("TestResourceData");
+            const string parentResourceId = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+            var firstResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/first",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                parentResourceId: parentResourceId);
+            var secondResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/second",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                parentResourceId: parentResourceId);
+            var parentlessResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/third",
+                "Microsoft.Test/widgets/children",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"]);
+
+            var consistentProjection = ProvisioningResourceProjection.Create([firstResource, secondResource])[0];
+            var mixedNullProjection = ProvisioningResourceProjection.Create([firstResource, parentlessResource])[0];
+
+            Assert.That(consistentProjection.ParentResourceId, Is.EqualTo(firstResource.ParentResourceId));
+            Assert.That(mixedNullProjection.ParentResourceId, Is.Null);
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- clean up remaining projection metadata issues after the projection-collapse and extension-scope updates
- use the shared consistency fallback for structural parent metadata instead of special-casing parent handling
- keep parent metadata only when collapsed resource entries agree on the same parent; otherwise omit it conservatively
- remove the unused parent-specific diagnostic path
- simplify projection consistency helpers for readability
- add focused tests for consistent, inconsistent, and mixed-null parent metadata

## Context
This PR is a cleanup follow-up to the resource projection work in #59492 and the extension-scope work in #59572.

The previous PRs introduced the projection layer and started using projection metadata to drive generated Bicep shape. This PR tightens the remaining projection metadata behavior so parent metadata follows the same consistency model as other collapsed fields and ambiguous parent relationships do not leak into generated `Parent` relationships.

This is intentionally not a broader parent/name-shape redesign. More complex skipped-parent or multi-segment-name cases should be handled by the individual provisioning libraries when they arise.

## Validation
- `dotnet test eng\packages\http-client-csharp-provisioning\generator\Azure.Generator.Provisioning\test\Azure.Generator.Provisioning.Tests.csproj --no-restore`
- `eng\packages\http-client-csharp-provisioning\eng\scripts\Generate.ps1`