### PR TITLE
Peel Azure.ResourceManager.Storage off the NoWarn skip-list

### DIFF
--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -161,7 +161,6 @@ Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes
 Azure.ResourceManager.MachineLearning
 Azure.ResourceManager.Network
 Azure.ResourceManager.RecoveryServicesBackup
-Azure.ResourceManager.Storage
 Azure.Search.Documents
 Azure.Security.Attestation
 Azure.Security.CodeTransparency

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Azure.ResourceManager.Storage.csproj
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Azure.ResourceManager.Storage.csproj
@@ -7,6 +7,5 @@
     <Description>Microsoft Azure management client SDK for Azure resource provider Microsoft.Storage.</Description>
     <PackageTags>azure;management;storage</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobContainerCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobContainerCollection.cs
@@ -23,9 +23,9 @@ namespace Azure.ResourceManager.Storage
     {
         // Backward-compatible overload with int maxpagesize: Lists all containers.
         /// <summary> Lists all containers in the storage account via the Storage management API. Unlike the data-plane blob service, this management API does not support prefix-based filtering and the response is returned as a single page (no continuation token). </summary>
-        /// <param name="maxpagesize"> Optional. Specified maximum number of containers that can be included in the list. </param>
-        /// <param name="filter"> Optional. When specified, only container names starting with the filter will be listed. </param>
-        /// <param name="include"> Optional, used to include the properties for soft deleted blob containers. </param>
+        /// <param name="maxpagesize"> Optional. The maximum number of containers that can be included in the list. </param>
+        /// <param name="filter"> Optional. When specified, only container names starting with the filter are listed. </param>
+        /// <param name="include"> Optional. Used to include properties for soft-deleted blob containers. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="BlobContainerResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -35,9 +35,9 @@ namespace Azure.ResourceManager.Storage
 
         // Backward-compatible overload with int maxpagesize: Lists all containers.
         /// <summary> Lists all containers in the storage account via the Storage management API. Unlike the data-plane blob service, this management API does not support prefix-based filtering and the response is returned as a single page (no continuation token). </summary>
-        /// <param name="maxpagesize"> Optional. Specified maximum number of containers that can be included in the list. </param>
-        /// <param name="filter"> Optional. When specified, only container names starting with the filter will be listed. </param>
-        /// <param name="include"> Optional, used to include the properties for soft deleted blob containers. </param>
+        /// <param name="maxpagesize"> Optional. The maximum number of containers that can be included in the list. </param>
+        /// <param name="filter"> Optional. When specified, only container names starting with the filter are listed. </param>
+        /// <param name="include"> Optional. Used to include properties for soft-deleted blob containers. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="BlobContainerResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobContainerCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobContainerCollection.cs
@@ -22,7 +22,7 @@ namespace Azure.ResourceManager.Storage
     public partial class BlobContainerCollection
     {
         // Backward-compatible overload with int maxpagesize: Lists all containers.
-        /// <summary> Lists all containers and does not support a prefix like data plane. Also SRP today does not return continuation token. </summary>
+        /// <summary> Lists all containers in the storage account via the Storage management API. Unlike the data-plane blob service, this management API does not support prefix-based filtering and the response is returned as a single page (no continuation token). </summary>
         /// <param name="maxpagesize"> Optional. Specified maximum number of containers that can be included in the list. </param>
         /// <param name="filter"> Optional. When specified, only container names starting with the filter will be listed. </param>
         /// <param name="include"> Optional, used to include the properties for soft deleted blob containers. </param>
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Storage
             => GetAll(maxpagesize?.ToString(), filter, include, cancellationToken);
 
         // Backward-compatible overload with int maxpagesize: Lists all containers.
-        /// <summary> Lists all containers and does not support a prefix like data plane. Also SRP today does not return continuation token. </summary>
+        /// <summary> Lists all containers in the storage account via the Storage management API. Unlike the data-plane blob service, this management API does not support prefix-based filtering and the response is returned as a single page (no continuation token). </summary>
         /// <param name="maxpagesize"> Optional. Specified maximum number of containers that can be included in the list. </param>
         /// <param name="filter"> Optional. When specified, only container names starting with the filter will be listed. </param>
         /// <param name="include"> Optional, used to include the properties for soft deleted blob containers. </param>

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobContainerCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobContainerCollection.cs
@@ -22,12 +22,24 @@ namespace Azure.ResourceManager.Storage
     public partial class BlobContainerCollection
     {
         // Backward-compatible overload with int maxpagesize: Lists all containers.
+        /// <summary> Lists all containers and does not support a prefix like data plane. Also SRP today does not return continuation token. </summary>
+        /// <param name="maxpagesize"> Optional. Specified maximum number of containers that can be included in the list. </param>
+        /// <param name="filter"> Optional. When specified, only container names starting with the filter will be listed. </param>
+        /// <param name="include"> Optional, used to include the properties for soft deleted blob containers. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="BlobContainerResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [ForwardsClientCalls]
         public virtual Pageable<BlobContainerResource> GetAll(int? maxpagesize, string filter, BlobContainerState? include, CancellationToken cancellationToken)
             => GetAll(maxpagesize?.ToString(), filter, include, cancellationToken);
 
         // Backward-compatible overload with int maxpagesize: Lists all containers.
+        /// <summary> Lists all containers and does not support a prefix like data plane. Also SRP today does not return continuation token. </summary>
+        /// <param name="maxpagesize"> Optional. Specified maximum number of containers that can be included in the list. </param>
+        /// <param name="filter"> Optional. When specified, only container names starting with the filter will be listed. </param>
+        /// <param name="include"> Optional, used to include the properties for soft deleted blob containers. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="BlobContainerResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [ForwardsClientCalls]
         public virtual AsyncPageable<BlobContainerResource> GetAllAsync(int? maxpagesize, string filter, BlobContainerState? include, CancellationToken cancellationToken)

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobInventoryPolicyResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobInventoryPolicyResource.cs
@@ -16,10 +16,10 @@ namespace Azure.ResourceManager.Storage
     {
         // Backward-compatible CreateResourceIdentifier was generated for singleton resource previously.
         /// <summary> Generates the resource identifier of a <see cref="BlobInventoryPolicyResource"/> instance. </summary>
-        /// <param name="subscriptionId"> The subscriptionId. </param>
-        /// <param name="resourceGroupName"> The resourceGroupName. </param>
-        /// <param name="accountName"> The accountName. </param>
-        /// <param name="blobInventoryPolicyName"> The blobInventoryPolicyName. </param>
+        /// <param name="subscriptionId"> The subscription ID. </param>
+        /// <param name="resourceGroupName"> The resource group name. </param>
+        /// <param name="accountName"> The account name. </param>
+        /// <param name="blobInventoryPolicyName"> The blob inventory policy name. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, BlobInventoryPolicyName blobInventoryPolicyName)
         {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobInventoryPolicyResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/BlobInventoryPolicyResource.cs
@@ -15,6 +15,11 @@ namespace Azure.ResourceManager.Storage
     public partial class BlobInventoryPolicyResource
     {
         // Backward-compatible CreateResourceIdentifier was generated for singleton resource previously.
+        /// <summary> Generates the resource identifier of a <see cref="BlobInventoryPolicyResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="blobInventoryPolicyName"> The blobInventoryPolicyName. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, BlobInventoryPolicyName blobInventoryPolicyName)
         {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Extensions/MockableStorageSubscriptionResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Extensions/MockableStorageSubscriptionResource.cs
@@ -15,12 +15,18 @@ namespace Azure.ResourceManager.Storage.Mocking
     public partial class MockableStorageSubscriptionResource
     {
         // Backward-compatible overload: Lists deleted accounts under the subscription.
+        /// <summary> Lists deleted accounts under the subscription. </summary>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="DeletedAccountResource"/> that may take multiple service requests to iterate over. </returns>
         [Obsolete("This overload is no longer supported. Use GetDeletedAccounts() to obtain the DeletedAccountCollection, then access individual deleted accounts by location and name.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual AsyncPageable<DeletedAccountResource> GetDeletedAccountsAsync(CancellationToken cancellationToken = default)
             => throw new NotSupportedException("This overload is no longer supported. Use GetDeletedAccounts() to obtain the DeletedAccountCollection, then access individual deleted accounts by location and name.");
 
         // Backward-compatible overload: Lists deleted accounts under the subscription.
+        /// <summary> Lists deleted accounts under the subscription. </summary>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="DeletedAccountResource"/> that may take multiple service requests to iterate over. </returns>
         [Obsolete("This overload is no longer supported. Use GetDeletedAccounts() to obtain the DeletedAccountCollection, then access individual deleted accounts by location and name.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Pageable<DeletedAccountResource> GetDeletedAccounts(CancellationToken cancellationToken = default)

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Extensions/StorageExtensions.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Extensions/StorageExtensions.cs
@@ -16,6 +16,10 @@ namespace Azure.ResourceManager.Storage
     public static partial class StorageExtensions
     {
         // Backward-compatible overload: Lists deleted accounts under the subscription.
+        /// <summary> Lists deleted accounts under the subscription. </summary>
+        /// <param name="subscriptionResource"> The subscription resource. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="DeletedAccountResource"/> that may take multiple service requests to iterate over. </returns>
         [Obsolete("This overload is no longer supported. Use GetDeletedAccounts() to obtain the DeletedAccountCollection, then access individual deleted accounts by location and name.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static AsyncPageable<DeletedAccountResource> GetDeletedAccountsAsync(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)
@@ -26,6 +30,10 @@ namespace Azure.ResourceManager.Storage
         }
 
         // Backward-compatible overload: Lists deleted accounts under the subscription.
+        /// <summary> Lists deleted accounts under the subscription. </summary>
+        /// <param name="subscriptionResource"> The subscription resource. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="DeletedAccountResource"/> that may take multiple service requests to iterate over. </returns>
         [Obsolete("This overload is no longer supported. Use GetDeletedAccounts() to obtain the DeletedAccountCollection, then access individual deleted accounts by location and name.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static Pageable<DeletedAccountResource> GetDeletedAccounts(this SubscriptionResource subscriptionResource, CancellationToken cancellationToken = default)

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/FileShareCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/FileShareCollection.cs
@@ -19,7 +19,7 @@ namespace Azure.ResourceManager.Storage
         /// <summary> Lists all shares. </summary>
         /// <param name="maxpagesize"> Optional. Specified maximum number of shares that can be included in the list. </param>
         /// <param name="filter"> Optional. When specified, only share names starting with the filter will be listed. </param>
-        /// <param name="expand"> Optional, used to expand the properties within share's properties. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','. </param>
+        /// <param name="expand"> Optional, used to expand the properties on the share. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="FileShareResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -31,7 +31,7 @@ namespace Azure.ResourceManager.Storage
         /// <summary> Lists all shares. </summary>
         /// <param name="maxpagesize"> Optional. Specified maximum number of shares that can be included in the list. </param>
         /// <param name="filter"> Optional. When specified, only share names starting with the filter will be listed. </param>
-        /// <param name="expand"> Optional, used to expand the properties within share's properties. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','. </param>
+        /// <param name="expand"> Optional, used to expand the properties on the share. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="FileShareResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/FileShareCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/FileShareCollection.cs
@@ -16,12 +16,24 @@ namespace Azure.ResourceManager.Storage
     public partial class FileShareCollection
     {
         // Backward-compatible overload with int maxpagesize: Lists all file shares.
+        /// <summary> Lists all shares. </summary>
+        /// <param name="maxpagesize"> Optional. Specified maximum number of shares that can be included in the list. </param>
+        /// <param name="filter"> Optional. When specified, only share names starting with the filter will be listed. </param>
+        /// <param name="expand"> Optional, used to expand the properties within share's properties. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="FileShareResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [ForwardsClientCalls]
         public virtual Pageable<FileShareResource> GetAll(int? maxpagesize, string filter, string expand, CancellationToken cancellationToken)
             => GetAll(maxpagesize?.ToString(), filter, expand, cancellationToken);
 
         // Backward-compatible overload with int maxpagesize: Lists all file shares.
+        /// <summary> Lists all shares. </summary>
+        /// <param name="maxpagesize"> Optional. Specified maximum number of shares that can be included in the list. </param>
+        /// <param name="filter"> Optional. When specified, only share names starting with the filter will be listed. </param>
+        /// <param name="expand"> Optional, used to expand the properties within share's properties. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="FileShareResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [ForwardsClientCalls]
         public virtual AsyncPageable<FileShareResource> GetAllAsync(int? maxpagesize, string filter, string expand, CancellationToken cancellationToken)

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/FileShareCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/FileShareCollection.cs
@@ -17,8 +17,8 @@ namespace Azure.ResourceManager.Storage
     {
         // Backward-compatible overload with int maxpagesize: Lists all file shares.
         /// <summary> Lists all shares. </summary>
-        /// <param name="maxpagesize"> Optional. Specified maximum number of shares that can be included in the list. </param>
-        /// <param name="filter"> Optional. When specified, only share names starting with the filter will be listed. </param>
+        /// <param name="maxpagesize"> Optional. The maximum number of shares that can be included in the list. </param>
+        /// <param name="filter"> Optional. When specified, only share names starting with the filter are listed. </param>
         /// <param name="expand"> Optional, used to expand the properties on the share. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="FileShareResource"/> that may take multiple service requests to iterate over. </returns>
@@ -29,8 +29,8 @@ namespace Azure.ResourceManager.Storage
 
         // Backward-compatible overload with int maxpagesize: Lists all file shares.
         /// <summary> Lists all shares. </summary>
-        /// <param name="maxpagesize"> Optional. Specified maximum number of shares that can be included in the list. </param>
-        /// <param name="filter"> Optional. When specified, only share names starting with the filter will be listed. </param>
+        /// <param name="maxpagesize"> Optional. The maximum number of shares that can be included in the list. </param>
+        /// <param name="filter"> Optional. When specified, only share names starting with the filter are listed. </param>
         /// <param name="expand"> Optional, used to expand the properties on the share. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="FileShareResource"/> that may take multiple service requests to iterate over. </returns>

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/ImmutabilityPolicyResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/ImmutabilityPolicyResource.cs
@@ -16,31 +16,53 @@ namespace Azure.ResourceManager.Storage
     public partial class ImmutabilityPolicyResource
     {
         // Backward-compatible overload: Delete with ETag parameter.
+        /// <summary> Deletes an immutability policy. </summary>
+        /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ArmOperation<ImmutabilityPolicyResource> Delete(WaitUntil waitUntil, ETag ifMatch, CancellationToken cancellationToken = default)
             => Delete(waitUntil, ifMatch.ToString(), cancellationToken);
 
         // Backward-compatible overload: DeleteAsync with ETag parameter.
+        /// <summary> Deletes an immutability policy. </summary>
+        /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<ArmOperation<ImmutabilityPolicyResource>> DeleteAsync(WaitUntil waitUntil, ETag ifMatch, CancellationToken cancellationToken = default)
             => DeleteAsync(waitUntil, ifMatch.ToString(), cancellationToken);
 
         // Backward-compatible overload: ExtendImmutabilityPolicy with ETag parameter.
+        /// <summary> Extends the immutability period of an unlocked immutability policy. </summary>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="data"> The ImmutabilityPolicy Properties that will be extended for a blob container. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Response<ImmutabilityPolicyResource> ExtendImmutabilityPolicy(ETag ifMatch, ImmutabilityPolicyData data, CancellationToken cancellationToken = default)
             => ExtendImmutabilityPolicy(ifMatch.ToString(), data, cancellationToken);
 
         // Backward-compatible overload: ExtendImmutabilityPolicyAsync with ETag parameter.
+        /// <summary> Extends the immutability period of an unlocked immutability policy. </summary>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="data"> The ImmutabilityPolicy Properties that will be extended for a blob container. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<Response<ImmutabilityPolicyResource>> ExtendImmutabilityPolicyAsync(ETag ifMatch, ImmutabilityPolicyData data, CancellationToken cancellationToken = default)
             => ExtendImmutabilityPolicyAsync(ifMatch.ToString(), data, cancellationToken);
 
         // Backward-compatible overload: LockImmutabilityPolicy with ETag parameter.
+        /// <summary> Locks an unlocked immutability policy. </summary>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Response<ImmutabilityPolicyResource> LockImmutabilityPolicy(ETag ifMatch, CancellationToken cancellationToken = default)
             => LockImmutabilityPolicy(ifMatch.ToString(), cancellationToken);
 
         // Backward-compatible overload: LockImmutabilityPolicyAsync with ETag parameter.
+        /// <summary> Locks an unlocked immutability policy. </summary>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<Response<ImmutabilityPolicyResource>> LockImmutabilityPolicyAsync(ETag ifMatch, CancellationToken cancellationToken = default)
             => LockImmutabilityPolicyAsync(ifMatch.ToString(), cancellationToken);

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/ImmutabilityPolicyResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/ImmutabilityPolicyResource.cs
@@ -18,7 +18,7 @@ namespace Azure.ResourceManager.Storage
         // Backward-compatible overload: Delete with ETag parameter.
         /// <summary> Deletes an immutability policy. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
-        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to return to the server for this operation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ArmOperation<ImmutabilityPolicyResource> Delete(WaitUntil waitUntil, ETag ifMatch, CancellationToken cancellationToken = default)
@@ -27,7 +27,7 @@ namespace Azure.ResourceManager.Storage
         // Backward-compatible overload: DeleteAsync with ETag parameter.
         /// <summary> Deletes an immutability policy. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
-        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to return to the server for this operation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<ArmOperation<ImmutabilityPolicyResource>> DeleteAsync(WaitUntil waitUntil, ETag ifMatch, CancellationToken cancellationToken = default)
@@ -35,8 +35,8 @@ namespace Azure.ResourceManager.Storage
 
         // Backward-compatible overload: ExtendImmutabilityPolicy with ETag parameter.
         /// <summary> Extends the immutability period of an unlocked immutability policy. </summary>
-        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
-        /// <param name="data"> The ImmutabilityPolicy Properties that will be extended for a blob container. </param>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to return to the server for this operation. </param>
+        /// <param name="data"> The immutability policy properties to extend for a blob container. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Response<ImmutabilityPolicyResource> ExtendImmutabilityPolicy(ETag ifMatch, ImmutabilityPolicyData data, CancellationToken cancellationToken = default)
@@ -44,8 +44,8 @@ namespace Azure.ResourceManager.Storage
 
         // Backward-compatible overload: ExtendImmutabilityPolicyAsync with ETag parameter.
         /// <summary> Extends the immutability period of an unlocked immutability policy. </summary>
-        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
-        /// <param name="data"> The ImmutabilityPolicy Properties that will be extended for a blob container. </param>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to return to the server for this operation. </param>
+        /// <param name="data"> The immutability policy properties to extend for a blob container. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<Response<ImmutabilityPolicyResource>> ExtendImmutabilityPolicyAsync(ETag ifMatch, ImmutabilityPolicyData data, CancellationToken cancellationToken = default)
@@ -53,7 +53,7 @@ namespace Azure.ResourceManager.Storage
 
         // Backward-compatible overload: LockImmutabilityPolicy with ETag parameter.
         /// <summary> Locks an unlocked immutability policy. </summary>
-        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to return to the server for this operation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Response<ImmutabilityPolicyResource> LockImmutabilityPolicy(ETag ifMatch, CancellationToken cancellationToken = default)
@@ -61,7 +61,7 @@ namespace Azure.ResourceManager.Storage
 
         // Backward-compatible overload: LockImmutabilityPolicyAsync with ETag parameter.
         /// <summary> Locks an unlocked immutability policy. </summary>
-        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. </param>
+        /// <param name="ifMatch"> The entity state (ETag) version of the immutability policy to return to the server for this operation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<Response<ImmutabilityPolicyResource>> LockImmutabilityPolicyAsync(ETag ifMatch, CancellationToken cancellationToken = default)

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/FailoverRequestFailoverType.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/FailoverRequestFailoverType.cs
@@ -47,13 +47,15 @@ namespace Azure.ResourceManager.Storage.Models
         /// <inheritdoc />
         public override string ToString() => _value;
 
-        // Backward-compatible: Converts to StorageAccountFailoverType.
+        /// <summary> Implicit conversion between the two equivalent extensible-enum representations. </summary>
+        /// <param name="value"> The value. </param>
         public static implicit operator StorageAccountFailoverType(FailoverRequestFailoverType value) => new StorageAccountFailoverType(value._value);
-        // Backward-compatible: Converts from StorageAccountFailoverType.
+        /// <summary> Implicit conversion between the two equivalent extensible-enum representations. </summary>
+        /// <param name="value"> The value. </param>
         public static implicit operator FailoverRequestFailoverType(StorageAccountFailoverType value) => new FailoverRequestFailoverType(value.ToString());
     }
 
-    // Backward-compatible alias for FailoverRequestFailoverType.
+    /// <summary> The failover type for a storage account. </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly partial struct StorageAccountFailoverType : IEquatable<StorageAccountFailoverType>
     {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/ListKeysRequestExpand.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/ListKeysRequestExpand.cs
@@ -32,7 +32,7 @@ namespace Azure.ResourceManager.Storage.Models
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        /// <summary> Gets the Kerb. </summary>
+        /// <summary> Kerb. </summary>
         public static ListKeysRequestExpand Kerb { get; } = new ListKeysRequestExpand(KerbValue);
 
         /// <inheritdoc />
@@ -55,7 +55,7 @@ namespace Azure.ResourceManager.Storage.Models
         public static implicit operator ListKeysRequestExpand(StorageListKeyExpand value) => new ListKeysRequestExpand(value.ToString());
     }
 
-    /// <summary> Specifies type of the key to be listed. </summary>
+    /// <summary> Specifies the type of key to list. </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly partial struct StorageListKeyExpand : IEquatable<StorageListKeyExpand>
     {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/ListKeysRequestExpand.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/ListKeysRequestExpand.cs
@@ -47,13 +47,15 @@ namespace Azure.ResourceManager.Storage.Models
         /// <inheritdoc />
         public override string ToString() => _value;
 
-        // Backward-compatible: Converts to StorageListKeyExpand.
+        /// <summary> Implicit conversion between the two equivalent extensible-enum representations. </summary>
+        /// <param name="value"> The value. </param>
         public static implicit operator StorageListKeyExpand(ListKeysRequestExpand value) => new StorageListKeyExpand(value._value);
-        // Backward-compatible: Converts from StorageListKeyExpand.
+        /// <summary> Implicit conversion between the two equivalent extensible-enum representations. </summary>
+        /// <param name="value"> The value. </param>
         public static implicit operator ListKeysRequestExpand(StorageListKeyExpand value) => new ListKeysRequestExpand(value.ToString());
     }
 
-    // Backward-compatible alias for ListKeysRequestExpand.
+    /// <summary> Specifies type of the key to be listed. </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly partial struct StorageListKeyExpand : IEquatable<StorageListKeyExpand>
     {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountCreateOrUpdateContent.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountCreateOrUpdateContent.cs
@@ -14,6 +14,7 @@ namespace Azure.ResourceManager.Storage.Models
 {
     public partial class StorageAccountCreateOrUpdateContent
     {
+        /// <summary> Indicates whether the default authentication is OAuth or shared key. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.defaultToOAuthAuthentication")]
         public bool? IsDefaultToOAuthAuthentication
@@ -29,6 +30,7 @@ namespace Azure.ResourceManager.Storage.Models
             }
         }
 
+        /// <summary> Indicates whether extended groups are enabled. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.enableExtendedGroups")]
         public bool? IsExtendedGroupEnabled
@@ -44,6 +46,7 @@ namespace Azure.ResourceManager.Storage.Models
             }
         }
 
+        /// <summary> Account NFSv3 protocol enabled if set to true. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.isNfsV3Enabled")]
         public bool? IsNfsV3Enabled
@@ -59,6 +62,7 @@ namespace Azure.ResourceManager.Storage.Models
             }
         }
 
+        /// <summary> Indicates whether the IPv6 endpoint should be published for the storage account. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.dualStackEndpointPreference.publishIpv6Endpoint")]
         public bool? IsIPv6EndpointToBePublished
@@ -74,6 +78,10 @@ namespace Azure.ResourceManager.Storage.Models
             }
         }
 
+        /// <summary> Initializes a new instance of <see cref="StorageAccountCreateOrUpdateContent"/>. </summary>
+        /// <param name="sku"> Required. Gets or sets the SKU name. </param>
+        /// <param name="kind"> Required. Indicates the type of storage account. </param>
+        /// <param name="location"> Required. Gets or sets the location of the resource. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public StorageAccountCreateOrUpdateContent(StorageSku sku, StorageKind kind, AzureLocation location) : this(sku, kind, location.ToString(), default, new ChangeTrackingList<string>(), default, new ChangeTrackingDictionary<string, string>(), default, default, default)
         {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountCreateOrUpdateContent.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountCreateOrUpdateContent.cs
@@ -46,7 +46,7 @@ namespace Azure.ResourceManager.Storage.Models
             }
         }
 
-        /// <summary> Account NFSv3 protocol enabled if set to true. </summary>
+        /// <summary> Indicates whether the account NFSv3 protocol is enabled. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.isNfsV3Enabled")]
         public bool? IsNfsV3Enabled
@@ -79,9 +79,9 @@ namespace Azure.ResourceManager.Storage.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="StorageAccountCreateOrUpdateContent"/>. </summary>
-        /// <param name="sku"> Required. Gets or sets the SKU name. </param>
-        /// <param name="kind"> Required. Indicates the type of storage account. </param>
-        /// <param name="location"> Required. Gets or sets the location of the resource. </param>
+        /// <param name="sku"> Required. The SKU name. </param>
+        /// <param name="kind"> Required. The type of storage account. </param>
+        /// <param name="location"> Required. The location of the resource. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public StorageAccountCreateOrUpdateContent(StorageSku sku, StorageKind kind, AzureLocation location) : this(sku, kind, location.ToString(), default, new ChangeTrackingList<string>(), default, new ChangeTrackingDictionary<string, string>(), default, default, default)
         {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountIPRuleAction.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountIPRuleAction.cs
@@ -12,7 +12,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Storage.Models
 {
-    /// <summary> The action of IP ACL rule. </summary>
+    /// <summary> The action of an IP ACL rule. </summary>
     public readonly partial struct StorageAccountIPRuleAction : IEquatable<StorageAccountIPRuleAction>
     {
         private readonly string _value;

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountIPRuleAction.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountIPRuleAction.cs
@@ -12,10 +12,14 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Storage.Models
 {
+    /// <summary> The action of IP ACL rule. </summary>
     public readonly partial struct StorageAccountIPRuleAction : IEquatable<StorageAccountIPRuleAction>
     {
         private readonly string _value;
 
+        /// <summary> Initializes a new instance of <see cref="StorageAccountIPRuleAction"/>. </summary>
+        /// <param name="value"> The value. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         public StorageAccountIPRuleAction(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
@@ -23,20 +27,27 @@ namespace Azure.ResourceManager.Storage.Models
 
         private const string AllowValue = "Allow";
 
+        /// <summary> Allow. </summary>
         public static StorageAccountIPRuleAction Allow { get; } = new StorageAccountIPRuleAction(AllowValue);
 
-        // Backward-compatible: Implicit conversion to StorageAccountNetworkRuleAction.
+        /// <summary> Implicit conversion between the two equivalent extensible-enum representations. </summary>
+        /// <param name="value"> The value. </param>
         public static implicit operator StorageAccountNetworkRuleAction(StorageAccountIPRuleAction value) => new StorageAccountNetworkRuleAction(value.ToString());
 
-        // Implicit conversion from unified StorageAccountNetworkRuleAction.
+        /// <summary> Implicit conversion between the two equivalent extensible-enum representations. </summary>
+        /// <param name="value"> The value. </param>
         public static implicit operator StorageAccountIPRuleAction(StorageAccountNetworkRuleAction value) => new StorageAccountIPRuleAction(value.ToString());
 
+        /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is StorageAccountIPRuleAction other && Equals(other);
+        /// <inheritdoc />
         public bool Equals(StorageAccountIPRuleAction other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
+        /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value != null ? StringComparer.InvariantCultureIgnoreCase.GetHashCode(_value) : 0;
+        /// <inheritdoc />
         public override string ToString() => _value;
     }
 }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountVirtualNetworkRule.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountVirtualNetworkRule.cs
@@ -14,7 +14,7 @@ using Azure.ResourceManager.Storage;
 
 namespace Azure.ResourceManager.Storage.Models
 {
-    /// <summary> Virtual Network rule. </summary>
+    /// <summary> A virtual network rule. </summary>
     public partial class StorageAccountVirtualNetworkRule
     {
         /// <summary> Keeps track of any properties unknown to the library. </summary>
@@ -31,8 +31,8 @@ namespace Azure.ResourceManager.Storage.Models
 
         /// <summary> Initializes a new instance of <see cref="StorageAccountVirtualNetworkRule"/>. </summary>
         /// <param name="virtualNetworkResourceId"> Resource ID of a subnet. </param>
-        /// <param name="action"> The action of virtual network rule. </param>
-        /// <param name="state"> Gets the state of virtual network rule. </param>
+        /// <param name="action"> The action of a virtual network rule. </param>
+        /// <param name="state"> Gets the state of a virtual network rule. </param>
         /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
         internal StorageAccountVirtualNetworkRule(ResourceIdentifier virtualNetworkResourceId, StorageAccountVirtualNetworkRuleAction? action, StorageAccountNetworkRuleState? state, IDictionary<string, BinaryData> additionalBinaryDataProperties)
         {
@@ -48,11 +48,11 @@ namespace Azure.ResourceManager.Storage.Models
 
         // Prior GA used the unified StorageAccountNetworkRuleAction type; generator would
         // produce a VNet-specific StorageAccountVirtualNetworkRuleAction type instead.
-        /// <summary> The action of virtual network rule. </summary>
+        /// <summary> The action of a virtual network rule. </summary>
         [WirePath("action")]
         public StorageAccountNetworkRuleAction? Action { get; set; }
 
-        /// <summary> Gets the state of virtual network rule. </summary>
+        /// <summary> Gets the state of a virtual network rule. </summary>
         [WirePath("state")]
         public StorageAccountNetworkRuleState? State { get; set; }
     }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountVirtualNetworkRule.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountVirtualNetworkRule.cs
@@ -22,6 +22,8 @@ namespace Azure.ResourceManager.Storage.Models
 
         // Prior GA had a public ctor taking only virtualNetworkResourceId; generated code
         // only has an internal ctor with all params.
+        /// <summary> Initializes a new instance of <see cref="StorageAccountVirtualNetworkRule"/>. </summary>
+        /// <param name="virtualNetworkResourceId"> Resource ID of a subnet. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public StorageAccountVirtualNetworkRule(ResourceIdentifier virtualNetworkResourceId) : this(virtualNetworkResourceId, default(StorageAccountVirtualNetworkRuleAction?), default, default)
         {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountVirtualNetworkRuleAction.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountVirtualNetworkRuleAction.cs
@@ -12,7 +12,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Storage.Models
 {
-    /// <summary> The action of virtual network rule. </summary>
+    /// <summary> The action of a virtual network rule. </summary>
     public readonly partial struct StorageAccountVirtualNetworkRuleAction : IEquatable<StorageAccountVirtualNetworkRuleAction>
     {
         private readonly string _value;

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountVirtualNetworkRuleAction.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageAccountVirtualNetworkRuleAction.cs
@@ -12,10 +12,14 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Storage.Models
 {
+    /// <summary> The action of virtual network rule. </summary>
     public readonly partial struct StorageAccountVirtualNetworkRuleAction : IEquatable<StorageAccountVirtualNetworkRuleAction>
     {
         private readonly string _value;
 
+        /// <summary> Initializes a new instance of <see cref="StorageAccountVirtualNetworkRuleAction"/>. </summary>
+        /// <param name="value"> The value. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         public StorageAccountVirtualNetworkRuleAction(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
@@ -23,20 +27,27 @@ namespace Azure.ResourceManager.Storage.Models
 
         private const string AllowValue = "Allow";
 
+        /// <summary> Allow. </summary>
         public static StorageAccountVirtualNetworkRuleAction Allow { get; } = new StorageAccountVirtualNetworkRuleAction(AllowValue);
 
-        // Backward-compatible: Implicit conversion to StorageAccountNetworkRuleAction.
+        /// <summary> Implicit conversion between the two equivalent extensible-enum representations. </summary>
+        /// <param name="value"> The value. </param>
         public static implicit operator StorageAccountNetworkRuleAction(StorageAccountVirtualNetworkRuleAction value) => new StorageAccountNetworkRuleAction(value.ToString());
 
-        // Implicit conversion from unified StorageAccountNetworkRuleAction.
+        /// <summary> Implicit conversion between the two equivalent extensible-enum representations. </summary>
+        /// <param name="value"> The value. </param>
         public static implicit operator StorageAccountVirtualNetworkRuleAction(StorageAccountNetworkRuleAction value) => new StorageAccountVirtualNetworkRuleAction(value.ToString());
 
+        /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is StorageAccountVirtualNetworkRuleAction other && Equals(other);
+        /// <inheritdoc />
         public bool Equals(StorageAccountVirtualNetworkRuleAction other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
+        /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value != null ? StringComparer.InvariantCultureIgnoreCase.GetHashCode(_value) : 0;
+        /// <inheritdoc />
         public override string ToString() => _value;
     }
 }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageMinimumTlsVersion.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageMinimumTlsVersion.cs
@@ -14,15 +14,19 @@ namespace Azure.ResourceManager.Storage.Models
     public readonly partial struct StorageMinimumTlsVersion
     {
         // Backward-compatible alias for Tls10.
+        /// <summary> Tls1_0. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static StorageMinimumTlsVersion Tls1_0 { get; } = new StorageMinimumTlsVersion("TLS1_0");
         // Backward-compatible alias for Tls11.
+        /// <summary> Tls1_1. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static StorageMinimumTlsVersion Tls1_1 { get; } = new StorageMinimumTlsVersion("TLS1_1");
         // Backward-compatible alias for Tls12.
+        /// <summary> Tls1_2. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static StorageMinimumTlsVersion Tls1_2 { get; } = new StorageMinimumTlsVersion("TLS1_2");
         // Backward-compatible alias for Tls13.
+        /// <summary> Tls1_3. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static StorageMinimumTlsVersion Tls1_3 { get; } = new StorageMinimumTlsVersion("TLS1_3");
     }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageTaskAssignmentPatchProperties.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageTaskAssignmentPatchProperties.cs
@@ -22,6 +22,7 @@ namespace Azure.ResourceManager.Storage.Models
         public StorageProvisioningState? ProvisioningState { get; }
 
         // Backward-compatible alias: exposes the generated type alongside the prior GA type.
+        /// <summary> Represents the provisioning state of the storage task assignment. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("provisioningState")]
         public StorageTaskAssignmentProvisioningState? StorageTaskAssignmentProvisioningState
@@ -36,6 +37,7 @@ namespace Azure.ResourceManager.Storage.Models
 
         // Prior GA property name was "Enabled"; generated code renamed it.
         // Hidden alias preserves the old name for binary compat.
+        /// <summary> Whether the storage task assignment is enabled or not. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageTaskAssignmentPatchProperties.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageTaskAssignmentPatchProperties.cs
@@ -37,12 +37,12 @@ namespace Azure.ResourceManager.Storage.Models
 
         // Prior GA property name was "Enabled"; generated code renamed it.
         // Hidden alias preserves the old name for binary compat.
-        /// <summary> Whether the storage task assignment is enabled or not. </summary>
+        /// <summary> Indicates whether the storage task assignment is enabled. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
 
-        /// <summary> Id of the corresponding storage task. </summary>
+        /// <summary> The ID of the corresponding storage task. </summary>
         [WirePath("taskId")]
         public string TaskId { get; set; }
     }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageTaskAssignmentProperties.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageTaskAssignmentProperties.cs
@@ -30,6 +30,7 @@ namespace Azure.ResourceManager.Storage.Models
 
         // Prior GA property name was "Enabled"; generated code renamed it.
         // Hidden alias preserves the old name for binary compat.
+        /// <summary> Whether the storage task assignment is enabled or not. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("enabled")]
         public bool IsEnabled { get; set; }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageTaskAssignmentProperties.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/Models/StorageTaskAssignmentProperties.cs
@@ -30,14 +30,14 @@ namespace Azure.ResourceManager.Storage.Models
 
         // Prior GA property name was "Enabled"; generated code renamed it.
         // Hidden alias preserves the old name for binary compat.
-        /// <summary> Whether the storage task assignment is enabled or not. </summary>
+        /// <summary> Indicates whether the storage task assignment is enabled. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("enabled")]
         public bool IsEnabled { get; set; }
 
         /// <summary> Initializes a new instance of <see cref="StorageTaskAssignmentProperties"/>. </summary>
-        /// <param name="taskId"> Id of the corresponding storage task. </param>
-        /// <param name="isEnabled"> Whether the storage task assignment is enabled or not. </param>
+        /// <param name="taskId"> The ID of the corresponding storage task. </param>
+        /// <param name="isEnabled"> Indicates whether the storage task assignment is enabled. </param>
         /// <param name="description"> Text that describes the purpose of the storage task assignment. </param>
         /// <param name="executionContext"> The storage task assignment execution context. </param>
         /// <param name="report"> The storage task assignment report. </param>

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountData.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountData.cs
@@ -34,6 +34,7 @@ namespace Azure.ResourceManager.Storage
         }
 
         // Backward-compatible alias for StorageAccountProvisioningState.
+        /// <summary> Gets the status of the storage account at the time the operation was called. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.provisioningState")]
         public Azure.ResourceManager.Storage.Models.StorageAccountProvisioningState? StorageAccountProvisioningState => Properties?.ProvisioningState;
@@ -41,31 +42,37 @@ namespace Azure.ResourceManager.Storage
         // --- Renamed property aliases (backward-compat, different name from generated) ---
 
         // Backward-compatible alias for AccountMigrationInProgress.
+        /// <summary> Indicates whether account migration is in progress. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.accountMigrationInProgress")]
         public bool? IsAccountMigrationInProgress { get => Properties?.IsAccountMigrationInProgress; }
 
         // Backward-compatible alias for IsDefaultToOAuthAuthentication.
+        /// <summary> Indicates whether the default authentication is OAuth or shared key. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.defaultToOAuthAuthentication")]
         public bool? IsDefaultToOAuthAuthentication { get => Properties?.IsDefaultToOAuthAuthentication; set { } }
 
         // Backward-compatible alias for IsExtendedGroupEnabled.
+        /// <summary> Indicates whether extended groups are enabled. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.enableExtendedGroups")]
         public bool? IsExtendedGroupEnabled { get => Properties?.IsExtendedGroupEnabled; set { } }
 
         // Backward-compatible alias for IsFailoverInProgress.
+        /// <summary> Indicates whether account failover is in progress. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.failoverInProgress")]
         public bool? IsFailoverInProgress { get => Properties?.IsFailoverInProgress; }
 
         // Backward-compatible alias for IsIPv6EndpointToBePublished.
+        /// <summary> Indicates whether the IPv6 endpoint should be published for the storage account. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.dualStackEndpointPreference.publishIpv6Endpoint")]
         public bool? IsIPv6EndpointToBePublished { get => Properties?.IsIPv6EndpointToBePublished; set { } }
 
         // Backward-compatible alias for IsNfsV3Enabled.
+        /// <summary> Account NFSv3 protocol enabled if set to true. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.isNfsV3Enabled")]
         public bool? IsNfsV3Enabled { get => Properties?.IsNfsV3Enabled; set { } }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountData.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountData.cs
@@ -72,7 +72,7 @@ namespace Azure.ResourceManager.Storage
         public bool? IsIPv6EndpointToBePublished { get => Properties?.IsIPv6EndpointToBePublished; set { } }
 
         // Backward-compatible alias for IsNfsV3Enabled.
-        /// <summary> Account NFSv3 protocol enabled if set to true. </summary>
+        /// <summary> Indicates whether the account NFSv3 protocol is enabled. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [WirePath("properties.isNfsV3Enabled")]
         public bool? IsNfsV3Enabled { get => Properties?.IsNfsV3Enabled; set { } }

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountManagementPolicyResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountManagementPolicyResource.cs
@@ -13,6 +13,11 @@ namespace Azure.ResourceManager.Storage
     public partial class StorageAccountManagementPolicyResource
     {
         // Backward-compatible overload: 4-param CreateResourceIdentifier (old GA took ManagementPolicyName).
+        /// <summary> Generates the resource identifier of a <see cref="StorageAccountManagementPolicyResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="managementPolicyName"> The managementPolicyName. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, ManagementPolicyName managementPolicyName)
         {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountManagementPolicyResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountManagementPolicyResource.cs
@@ -14,10 +14,10 @@ namespace Azure.ResourceManager.Storage
     {
         // Backward-compatible overload: 4-param CreateResourceIdentifier (old GA took ManagementPolicyName).
         /// <summary> Generates the resource identifier of a <see cref="StorageAccountManagementPolicyResource"/> instance. </summary>
-        /// <param name="subscriptionId"> The subscriptionId. </param>
-        /// <param name="resourceGroupName"> The resourceGroupName. </param>
-        /// <param name="accountName"> The accountName. </param>
-        /// <param name="managementPolicyName"> The managementPolicyName. </param>
+        /// <param name="subscriptionId"> The subscription ID. </param>
+        /// <param name="resourceGroupName"> The resource group name. </param>
+        /// <param name="accountName"> The account name. </param>
+        /// <param name="managementPolicyName"> The management policy name. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, ManagementPolicyName managementPolicyName)
         {

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountResource.cs
@@ -32,21 +32,35 @@ namespace Azure.ResourceManager.Storage
     public partial class StorageAccountResource
     {
         // Backward-compatible overload: Failover with no failoverType parameter.
+        /// <summary> A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. </summary>
+        /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual async Task<ArmOperation> FailoverAsync(WaitUntil waitUntil, CancellationToken cancellationToken) =>
             await FailoverAsync(waitUntil, (FailoverRequestFailoverType?)null, cancellationToken).ConfigureAwait(false);
 
         // Backward-compatible overload: Failover with no failoverType parameter.
+        /// <summary> A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. </summary>
+        /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ArmOperation Failover(WaitUntil waitUntil, CancellationToken cancellationToken) =>
             Failover(waitUntil, (FailoverRequestFailoverType?)null, cancellationToken);
 
         // Backward-compatible overload: Failover with StorageAccountFailoverType parameter.
+        /// <summary> A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. </summary>
+        /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
+        /// <param name="failoverType"> The parameter is set to 'Planned' to indicate whether a Planned failover is requested. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual async Task<ArmOperation> FailoverAsync(WaitUntil waitUntil, StorageAccountFailoverType? failoverType, CancellationToken cancellationToken) =>
             await FailoverAsync(waitUntil, failoverType.HasValue ? new FailoverRequestFailoverType(failoverType.Value.ToString()) : (FailoverRequestFailoverType?)null, cancellationToken).ConfigureAwait(false);
 
         // Backward-compatible overload: Failover with StorageAccountFailoverType parameter.
+        /// <summary> A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. </summary>
+        /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
+        /// <param name="failoverType"> The parameter is set to 'Planned' to indicate whether a Planned failover is requested. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ArmOperation Failover(WaitUntil waitUntil, StorageAccountFailoverType? failoverType, CancellationToken cancellationToken) =>
             Failover(waitUntil, failoverType.HasValue ? new FailoverRequestFailoverType(failoverType.Value.ToString()) : (FailoverRequestFailoverType?)null, cancellationToken);
@@ -54,6 +68,10 @@ namespace Azure.ResourceManager.Storage
         // Backward-compat: prior GA returned Pageable<StorageAccountKey> instead of Response<StorageAccountListKeysResult>.
 
         // Backward-compatible overload: GetKeys with old StorageListKeyExpand parameter type.
+        /// <summary> Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account. </summary>
+        /// <param name="expand"> Specifies type of the key to be listed. Possible value is kerb. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="StorageAccountKey"/>. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Pageable<StorageAccountKey> GetKeys(StorageListKeyExpand? expand, CancellationToken cancellationToken = default)
         {
@@ -62,11 +80,17 @@ namespace Azure.ResourceManager.Storage
         }
 
         // Backward-compatible parameterless overload for GetKeys.
+        /// <summary> Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account. </summary>
+        /// <returns> A collection of <see cref="StorageAccountKey"/>. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Pageable<StorageAccountKey> GetKeys()
             => GetKeys((StorageListKeyExpand?)null, default);
 
         // Backward-compatible overload: GetKeysAsync with old StorageListKeyExpand parameter type.
+        /// <summary> Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account. </summary>
+        /// <param name="expand"> Specifies type of the key to be listed. Possible value is kerb. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="StorageAccountKey"/>. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0107 // async call wraps result, no sync alternative available
         [ForwardsClientCalls(true)]
@@ -81,6 +105,8 @@ namespace Azure.ResourceManager.Storage
 #pragma warning restore AZC0107
 
         // Backward-compatible parameterless overload for GetKeysAsync.
+        /// <summary> Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account. </summary>
+        /// <returns> A collection of <see cref="StorageAccountKey"/>. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0107 // async call wraps result, no sync alternative available
         [ForwardsClientCalls(true)]
@@ -153,6 +179,9 @@ namespace Azure.ResourceManager.Storage
 #pragma warning restore AZC0107
 
         // Backward-compatible overload: Gets the private link resources that need to be created for a storage account.
+        /// <summary> Gets the private link resources that need to be created for a storage account. </summary>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="StoragePrivateLinkResourceData"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [ForwardsClientCalls]
         public virtual AsyncPageable<StoragePrivateLinkResourceData> GetPrivateLinkResourcesAsync(CancellationToken cancellationToken = default)
@@ -167,6 +196,9 @@ namespace Azure.ResourceManager.Storage
         }
 
         // Backward-compatible overload: Gets the private link resources that need to be created for a storage account.
+        /// <summary> Gets the private link resources that need to be created for a storage account. </summary>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="StoragePrivateLinkResourceData"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [ForwardsClientCalls]
         public virtual Pageable<StoragePrivateLinkResourceData> GetPrivateLinkResources(CancellationToken cancellationToken = default)

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountResource.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageAccountResource.cs
@@ -32,7 +32,7 @@ namespace Azure.ResourceManager.Storage
     public partial class StorageAccountResource
     {
         // Backward-compatible overload: Failover with no failoverType parameter.
-        /// <summary> A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. </summary>
+        /// <summary> A failover request can be triggered for a storage account if a primary endpoint becomes unavailable for any reason. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -40,7 +40,7 @@ namespace Azure.ResourceManager.Storage
             await FailoverAsync(waitUntil, (FailoverRequestFailoverType?)null, cancellationToken).ConfigureAwait(false);
 
         // Backward-compatible overload: Failover with no failoverType parameter.
-        /// <summary> A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. </summary>
+        /// <summary> A failover request can be triggered for a storage account if a primary endpoint becomes unavailable for any reason. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -48,18 +48,18 @@ namespace Azure.ResourceManager.Storage
             Failover(waitUntil, (FailoverRequestFailoverType?)null, cancellationToken);
 
         // Backward-compatible overload: Failover with StorageAccountFailoverType parameter.
-        /// <summary> A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. </summary>
+        /// <summary> A failover request can be triggered for a storage account if a primary endpoint becomes unavailable for any reason. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
-        /// <param name="failoverType"> The parameter is set to 'Planned' to indicate whether a Planned failover is requested. </param>
+        /// <param name="failoverType"> Set to 'Planned' to request a planned failover. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual async Task<ArmOperation> FailoverAsync(WaitUntil waitUntil, StorageAccountFailoverType? failoverType, CancellationToken cancellationToken) =>
             await FailoverAsync(waitUntil, failoverType.HasValue ? new FailoverRequestFailoverType(failoverType.Value.ToString()) : (FailoverRequestFailoverType?)null, cancellationToken).ConfigureAwait(false);
 
         // Backward-compatible overload: Failover with StorageAccountFailoverType parameter.
-        /// <summary> A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. </summary>
+        /// <summary> A failover request can be triggered for a storage account if a primary endpoint becomes unavailable for any reason. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. </param>
-        /// <param name="failoverType"> The parameter is set to 'Planned' to indicate whether a Planned failover is requested. </param>
+        /// <param name="failoverType"> Set to 'Planned' to request a planned failover. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ArmOperation Failover(WaitUntil waitUntil, StorageAccountFailoverType? failoverType, CancellationToken cancellationToken) =>
@@ -68,8 +68,8 @@ namespace Azure.ResourceManager.Storage
         // Backward-compat: prior GA returned Pageable<StorageAccountKey> instead of Response<StorageAccountListKeysResult>.
 
         // Backward-compatible overload: GetKeys with old StorageListKeyExpand parameter type.
-        /// <summary> Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account. </summary>
-        /// <param name="expand"> Specifies type of the key to be listed. Possible value is kerb. </param>
+        /// <summary> Lists the access keys for the specified storage account, or the Kerberos keys if Active Directory is enabled. </summary>
+        /// <param name="expand"> Specifies the type of key to list. The possible value is 'kerb'. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="StorageAccountKey"/>. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -80,15 +80,15 @@ namespace Azure.ResourceManager.Storage
         }
 
         // Backward-compatible parameterless overload for GetKeys.
-        /// <summary> Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account. </summary>
+        /// <summary> Lists the access keys for the specified storage account, or the Kerberos keys if Active Directory is enabled. </summary>
         /// <returns> A collection of <see cref="StorageAccountKey"/>. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Pageable<StorageAccountKey> GetKeys()
             => GetKeys((StorageListKeyExpand?)null, default);
 
         // Backward-compatible overload: GetKeysAsync with old StorageListKeyExpand parameter type.
-        /// <summary> Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account. </summary>
-        /// <param name="expand"> Specifies type of the key to be listed. Possible value is kerb. </param>
+        /// <summary> Lists the access keys for the specified storage account, or the Kerberos keys if Active Directory is enabled. </summary>
+        /// <param name="expand"> Specifies the type of key to list. The possible value is 'kerb'. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="StorageAccountKey"/>. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -105,7 +105,7 @@ namespace Azure.ResourceManager.Storage
 #pragma warning restore AZC0107
 
         // Backward-compatible parameterless overload for GetKeysAsync.
-        /// <summary> Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account. </summary>
+        /// <summary> Lists the access keys for the specified storage account, or the Kerberos keys if Active Directory is enabled. </summary>
         /// <returns> A collection of <see cref="StorageAccountKey"/>. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0107 // async call wraps result, no sync alternative available
@@ -121,7 +121,7 @@ namespace Azure.ResourceManager.Storage
         /// <summary>
         /// Regenerates one of the access keys or Kerberos keys for the specified storage account.
         /// </summary>
-        /// <param name="content"> Specifies name of the key which should be regenerated -- key1, key2, kerb1, kerb2. </param>
+        /// <param name="content"> Specifies the name of the key to regenerate: key1, key2, kerb1, or kerb2. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
         public virtual Pageable<StorageAccountKey> RegenerateKey(StorageAccountRegenerateKeyContent content, CancellationToken cancellationToken = default)
@@ -148,7 +148,7 @@ namespace Azure.ResourceManager.Storage
         /// <summary>
         /// Regenerates one of the access keys or Kerberos keys for the specified storage account.
         /// </summary>
-        /// <param name="content"> Specifies name of the key which should be regenerated -- key1, key2, kerb1, kerb2. </param>
+        /// <param name="content"> Specifies the name of the key to regenerate: key1, key2, kerb1, or kerb2. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
 #pragma warning disable AZC0107 // async wrapper with pageable return
@@ -213,18 +213,18 @@ namespace Azure.ResourceManager.Storage
         }
 
         /// <summary>
-        /// Restore blobs in the specified blob ranges
+        /// Restores blobs in the specified blob ranges.
         /// <list type="bullet">
         /// <item>
         /// <term>Request Path</term>
         /// <description>/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/restoreBlobRanges</description>
         /// </item>
         /// <item>
-        /// <term>Operation Id</term>
+        /// <term>Operation ID</term>
         /// <description>StorageAccounts_RestoreBlobRanges</description>
         /// </item>
         /// <item>
-        /// <term>Default Api Version</term>
+        /// <term>Default API Version</term>
         /// <description>2022-09-01</description>
         /// </item>
         /// <item>
@@ -234,7 +234,7 @@ namespace Azure.ResourceManager.Storage
         /// </list>
         /// </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
-        /// <param name="content"> The parameters to provide for restore blob ranges. </param>
+        /// <param name="content"> The parameters to provide for restoring blob ranges. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
         public virtual async Task<StorageAccountRestoreBlobRangesOperation> RestoreBlobRangesAsync(WaitUntil waitUntil, BlobRestoreContent content, CancellationToken cancellationToken = default)
@@ -261,18 +261,18 @@ namespace Azure.ResourceManager.Storage
         }
 
         /// <summary>
-        /// Restore blobs in the specified blob ranges
+        /// Restores blobs in the specified blob ranges.
         /// <list type="bullet">
         /// <item>
         /// <term>Request Path</term>
         /// <description>/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/restoreBlobRanges</description>
         /// </item>
         /// <item>
-        /// <term>Operation Id</term>
+        /// <term>Operation ID</term>
         /// <description>StorageAccounts_RestoreBlobRanges</description>
         /// </item>
         /// <item>
-        /// <term>Default Api Version</term>
+        /// <term>Default API Version</term>
         /// <description>2022-09-01</description>
         /// </item>
         /// <item>
@@ -282,7 +282,7 @@ namespace Azure.ResourceManager.Storage
         /// </list>
         /// </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
-        /// <param name="content"> The parameters to provide for restore blob ranges. </param>
+        /// <param name="content"> The parameters to provide for restoring blob ranges. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
         public virtual StorageAccountRestoreBlobRangesOperation RestoreBlobRanges(WaitUntil waitUntil, BlobRestoreContent content, CancellationToken cancellationToken = default)

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageQueueCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageQueueCollection.cs
@@ -18,7 +18,7 @@ namespace Azure.ResourceManager.Storage
         // Backward-compatible overload with int maxpagesize: Lists all queues.
         /// <summary> Gets a list of all the queues under the specified storage account. </summary>
         /// <param name="maxpagesize"> Optional, a maximum number of queues that should be included in a list queue response. </param>
-        /// <param name="filter"> Optional, When specified, only the queues with a name starting with the given filter will be listed. </param>
+        /// <param name="filter"> Optional. When specified, only the queues with a name starting with the given filter will be listed. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="StorageQueueResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -29,7 +29,7 @@ namespace Azure.ResourceManager.Storage
         // Backward-compatible overload with int maxpagesize: Lists all queues.
         /// <summary> Gets a list of all the queues under the specified storage account. </summary>
         /// <param name="maxpagesize"> Optional, a maximum number of queues that should be included in a list queue response. </param>
-        /// <param name="filter"> Optional, When specified, only the queues with a name starting with the given filter will be listed. </param>
+        /// <param name="filter"> Optional. When specified, only the queues with a name starting with the given filter will be listed. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="StorageQueueResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageQueueCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageQueueCollection.cs
@@ -17,8 +17,8 @@ namespace Azure.ResourceManager.Storage
     {
         // Backward-compatible overload with int maxpagesize: Lists all queues.
         /// <summary> Gets a list of all the queues under the specified storage account. </summary>
-        /// <param name="maxpagesize"> Optional, a maximum number of queues that should be included in a list queue response. </param>
-        /// <param name="filter"> Optional. When specified, only the queues with a name starting with the given filter will be listed. </param>
+        /// <param name="maxpagesize"> Optional. The maximum number of queues that should be included in a list queue response. </param>
+        /// <param name="filter"> Optional. When specified, only queues with a name starting with the given filter are listed. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="StorageQueueResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -28,8 +28,8 @@ namespace Azure.ResourceManager.Storage
 
         // Backward-compatible overload with int maxpagesize: Lists all queues.
         /// <summary> Gets a list of all the queues under the specified storage account. </summary>
-        /// <param name="maxpagesize"> Optional, a maximum number of queues that should be included in a list queue response. </param>
-        /// <param name="filter"> Optional. When specified, only the queues with a name starting with the given filter will be listed. </param>
+        /// <param name="maxpagesize"> Optional. The maximum number of queues that should be included in a list queue response. </param>
+        /// <param name="filter"> Optional. When specified, only queues with a name starting with the given filter are listed. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="StorageQueueResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageQueueCollection.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageQueueCollection.cs
@@ -16,12 +16,22 @@ namespace Azure.ResourceManager.Storage
     public partial class StorageQueueCollection
     {
         // Backward-compatible overload with int maxpagesize: Lists all queues.
+        /// <summary> Gets a list of all the queues under the specified storage account. </summary>
+        /// <param name="maxpagesize"> Optional, a maximum number of queues that should be included in a list queue response. </param>
+        /// <param name="filter"> Optional, When specified, only the queues with a name starting with the given filter will be listed. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="StorageQueueResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [ForwardsClientCalls]
         public virtual Pageable<StorageQueueResource> GetAll(int? maxpagesize, string filter, CancellationToken cancellationToken)
             => GetAll(maxpagesize?.ToString(), filter, cancellationToken);
 
         // Backward-compatible overload with int maxpagesize: Lists all queues.
+        /// <summary> Gets a list of all the queues under the specified storage account. </summary>
+        /// <param name="maxpagesize"> Optional, a maximum number of queues that should be included in a list queue response. </param>
+        /// <param name="filter"> Optional, When specified, only the queues with a name starting with the given filter will be listed. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <returns> A collection of <see cref="StorageQueueResource"/> that may take multiple service requests to iterate over. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [ForwardsClientCalls]
         public virtual AsyncPageable<StorageQueueResource> GetAllAsync(int? maxpagesize, string filter, CancellationToken cancellationToken)

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageTaskAssignmentData.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Customize/StorageTaskAssignmentData.cs
@@ -7,6 +7,7 @@
 
 #nullable disable
 
+using System;
 using System.ComponentModel;
 using Azure.Core;
 using Azure.ResourceManager.Storage.Models;
@@ -16,6 +17,9 @@ namespace Azure.ResourceManager.Storage
     public partial class StorageTaskAssignmentData
     {
         // Backward-compatible constructor.
+        /// <summary> Initializes a new instance of <see cref="StorageTaskAssignmentData"/>. </summary>
+        /// <param name="properties"> Properties of the storage task assignment. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="properties"/> is null. </exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public StorageTaskAssignmentData(StorageTaskAssignmentProperties properties)
         {

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -32,7 +32,7 @@
       SA1649;
     </NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(IsClientLibrary)' == 'true'">
+  <PropertyGroup Condition="'$(IsClientLibrary)' == 'true' and '$(IsMgmtLibrary)' != 'true'">
     <!--
     These analyzers are blocked by https://github.com/Azure/azure-sdk-tools/issues/127
      -->
@@ -57,7 +57,7 @@
     <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkId=235168</PackageProjectUrl>
     -->
   </PropertyGroup>
-  <PropertyGroup Condition="'$(HasReleaseVersion)' != 'true'">
+  <PropertyGroup Condition="'$(HasReleaseVersion)' != 'true' and '$(IsMgmtLibrary)' != 'true'">
     <!-- Verify that latest service version is used only when we ship release. -->
     <NoWarn>
       $(NoWarn);


### PR DESCRIPTION
## Goal

Peel `Azure.ResourceManager.Storage` off the NoWarn skip-list -- second peel-off PR following Azure.AI.Projects (#59507).

## What changed

**CS1591 (the package's only NoWarn entry) -> fixed with doc comments.**

Added XML `<summary>` doc comments to 73 distinct public members across 20 hand-written `Customize\` files:
- Extensible-enum struct shims (`StorageAccountIPRuleAction`, `StorageAccountVirtualNetworkRuleAction`, `StorageMinimumTlsVersion`, `FailoverRequestFailoverType`, `ListKeysRequestExpand`)
- Collection paging overloads (`BlobContainerCollection`, `FileShareCollection`, `StorageQueueCollection`)
- Resource ctors/methods (`StorageAccountResource`, `StorageAccountData`, `ImmutabilityPolicyResource`, etc.)
- ResourceManager extensions (`MockableStorageSubscriptionResource`, `StorageExtensions`)

No `#pragma` suppressions. No allow-list file. No `Generated\` files touched.

**Props scope tightening.**

`sdk/storage/Directory.Build.props` had two `<NoWarn>` PropertyGroups (`AZC0006;AZC0007;CA1835;CA2249` and `AZC0010;AZC0011`) that leaked into `Azure.ResourceManager.Storage` even though none of those codes actually fire for mgmt code (verified by `dotnet build /p:NoWarn=` -> 0 warnings). They are defensive shields meant for data-plane storage libs.

Added `and '$(IsMgmtLibrary)' != 'true'` to both conditions. `Azure.Storage.Blobs` still builds clean -- data-plane unaffected.

**Skip-list and csproj cleanup.**

- Removed `<NoWarn>$(NoWarn);CS1591</NoWarn>` from `Azure.ResourceManager.Storage.csproj`.
- Removed `Azure.ResourceManager.Storage` line from `eng/NoWarnSkipValidation.txt`.

## Validation

- `dotnet build sdk/storage/Azure.ResourceManager.Storage/src/Azure.ResourceManager.Storage.csproj` -> **0 Warning(s), 0 Error(s)**.
- `dotnet build sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj` -> **0 Warning(s), 0 Error(s)** (data-plane verification).

## Why no allow-list file

Every NoWarn code on this project was either:
- **Fixable** (CS1591 -> add docs), or
- **Shouldn't have applied** (props leak from over-broad condition).

Neither warrants an approved exception, so `eng/analyzerallowlist/Azure.ResourceManager.Storage.txt` is intentionally absent.

## Related

- #59507 -- Azure.AI.Projects peel-off (precedent; introduced the auto-injection mechanism).
- #58243 -- overall NoWarn-visibility tracking issue.