### PR TITLE
Add missing XML doc to AIProjectClient.Routines

### DIFF
--- a/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
+++ b/sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs
@@ -246,6 +246,7 @@ namespace Azure.AI.Projects
         public virtual EvaluatorGenerationJobs EvaluatorGenerationJobs => GetEvaluatorGenerationJobsClient();
         /// <summary> Gets the client for managing data generation jobs. </summary>
         public virtual DataGenerationJobs DataGenerationJobs => GetDataGenerationJobsClient();
+        /// <summary> Gets the client for managing project routines. </summary>
         public virtual AIProjectRoutines Routines => GetAIProjectRoutinesClient();
         /// <summary> Gets the client for telemetry operations. </summary>
         public virtual AIProjectTelemetry Telemetry { get => new AIProjectTelemetry(this); }


### PR DESCRIPTION
Adds the missing `/// <summary>` on `AIProjectClient.Routines` (line 249 of `sdk/ai/Azure.AI.Projects/src/Custom/AIProjectClient.cs`).

## Why

PR #59507 peeled `Azure.AI.Projects` off the XML-doc-warning skip-list, which turned the missing doc on the `Routines` property into a hard `CS1591` build error. This is now failing downstream service-release pipelines whose `ProjectRef` dependency groups transitively build `Azure.AI.Projects` -- e.g. the in-flight `net - core` release pipeline for `System.ClientModel` 1.14.0 ([build 6390968](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6390968)).

## Fix

One-line summary added, matching the style of every other client-accessor property on the same class.