### PR TITLE
Migrate ModelFactoryAnalyzer (AZC0035) into azure-sdk-for-net and fix external-type false positive

### DIFF
--- a/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
@@ -34,5 +34,14 @@ namespace Azure.SdkAnalyzers
             DiagnosticSeverity.Warning,
             true,
             "Methods that accept a CancellationToken should propagate it to RequestContext parameters in Azure SDK method calls to ensure proper cancellation support.");
+
+        public static readonly DiagnosticDescriptor AZC0035 = new(
+            nameof(AZC0035),
+            "Output model type should have a corresponding model factory method",
+            "Output model type '{0}' should have a corresponding method in a model factory class. Add a static method that returns '{0}' to a class ending with 'ModelFactory'.",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Warning,
+            true,
+            "Output model types returned from client methods should have corresponding model factory methods for mocking support.");
     }
 }

--- a/sdk/tools/Azure.SdkAnalyzers/src/ModelFactoryAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ModelFactoryAnalyzer.cs
@@ -1,0 +1,341 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.SdkAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ModelFactoryAnalyzer : DiagnosticAnalyzer
+    {
+        private const string ClientSuffix = "Client";
+        private const string ModelFactorySuffix = "ModelFactory";
+
+        private const string AzureNamespace = "Azure";
+        private const string SystemClientModelNamespace = "System.ClientModel";
+        private const string SystemNamespace = "System";
+        private const string PageableTypeName = "Pageable";
+        private const string AsyncPageableTypeName = "AsyncPageable";
+        private const string ResponseTypeName = "Response";
+        private const string NullableResponseTypeName = "NullableResponse";
+        private const string OperationTypeName = "Operation";
+        private const string TaskTypeName = "Task";
+        private const string ClientResultTypeName = "ClientResult";
+        private const string CollectionResultTypeName = "CollectionResult";
+        private const string AsyncCollectionResultTypeName = "AsyncCollectionResult";
+        private const string PageableOperationTypeName = "PageableOperation";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+            Descriptors.AZC0035
+        );
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationAction(AnalyzeCompilation);
+        }
+
+        private static void AnalyzeCompilation(CompilationAnalysisContext context)
+        {
+            var outputModels = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+            var modelFactoryMethods = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+
+            // Find all client classes and extract output models from their methods
+            // Only process types defined in the current source tree (not dependencies)
+            foreach (var namedType in GetAllTypes(context.Compilation.GlobalNamespace))
+            {
+                if (!SymbolEqualityComparer.Default.Equals(namedType.ContainingAssembly, context.Compilation.Assembly))
+                {
+                    continue;
+                }
+
+                if (IsClientType(namedType))
+                {
+                    ExtractOutputModelsFromClientType(namedType, outputModels);
+                }
+                else if (IsModelFactoryType(namedType))
+                {
+                    ExtractReturnTypesFromModelFactory(namedType, modelFactoryMethods);
+                }
+            }
+
+            // Check if all output models have corresponding model factory methods
+            foreach (var outputModel in outputModels)
+            {
+                // Only flag models defined in the current compilation's assembly.
+                // External (referenced-assembly) types are owned by another
+                // library and aren't part of this assembly's model-factory contract.
+                if (!SymbolEqualityComparer.Default.Equals(outputModel.ContainingAssembly, context.Compilation.Assembly))
+                {
+                    continue;
+                }
+
+                if (!modelFactoryMethods.Contains(outputModel))
+                {
+                    // Find a location to report the diagnostic - use the first location of the type
+                    var location = outputModel.Locations.FirstOrDefault();
+                    if (location != null)
+                    {
+                        var diagnostic = Diagnostic.Create(
+                            Descriptors.AZC0035,
+                            location,
+                            outputModel.Name);
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+
+        private static bool IsClientType(INamedTypeSymbol namedType)
+        {
+            return namedType.TypeKind == TypeKind.Class &&
+                   namedType.Name.EndsWith(ClientSuffix) &&
+                   namedType.DeclaredAccessibility == Accessibility.Public;
+        }
+
+        private static bool IsModelFactoryType(INamedTypeSymbol namedType)
+        {
+            return namedType.TypeKind == TypeKind.Class &&
+                   namedType.Name.EndsWith(ModelFactorySuffix) &&
+                   namedType.IsStatic &&
+                   namedType.DeclaredAccessibility == Accessibility.Public;
+        }
+
+        private static void ExtractOutputModelsFromClientType(INamedTypeSymbol clientType, HashSet<ITypeSymbol> outputModels)
+        {
+            foreach (var member in clientType.GetMembers())
+            {
+                if (member is IMethodSymbol method && method.DeclaredAccessibility == Accessibility.Public)
+                {
+                    // Skip property accessors as they are not client methods
+                    if (method.AssociatedSymbol is IPropertySymbol)
+                    {
+                        continue;
+                    }
+
+                    var outputModel = ExtractOutputModelFromReturnType(method.ReturnType);
+                    if (outputModel != null)
+                    {
+                        outputModels.Add(outputModel);
+                    }
+                }
+            }
+        }
+
+        private static void ExtractReturnTypesFromModelFactory(INamedTypeSymbol factoryType, HashSet<ITypeSymbol> modelFactoryMethods)
+        {
+            foreach (var member in factoryType.GetMembers())
+            {
+                if (member is IMethodSymbol method &&
+                    method.DeclaredAccessibility == Accessibility.Public &&
+                    method.IsStatic)
+                {
+                    // Add the return type of the factory method
+                    modelFactoryMethods.Add(method.ReturnType);
+                }
+            }
+        }
+
+        private static ITypeSymbol ExtractOutputModelFromReturnType(ITypeSymbol returnType)
+        {
+            ITypeSymbol unwrappedType = returnType;
+
+            // Unwrap Task<T>
+            if (returnType is INamedTypeSymbol namedType &&
+                namedType.IsGenericType &&
+                namedType.Name == TaskTypeName)
+            {
+                unwrappedType = namedType.TypeArguments.FirstOrDefault();
+                if (unwrappedType == null) return null;
+            }
+
+            ITypeSymbol modelType = null;
+
+            // Check for Azure client method return types and extract the model type
+            if (IsOrImplements(unwrappedType, ResponseTypeName, AzureNamespace) ||
+                IsOrImplements(unwrappedType, NullableResponseTypeName, AzureNamespace) ||
+                IsOrImplements(unwrappedType, ClientResultTypeName, SystemClientModelNamespace) ||
+                IsOrImplements(unwrappedType, OperationTypeName, AzureNamespace) ||
+                IsOrImplements(unwrappedType, PageableTypeName, AzureNamespace) ||
+                IsOrImplements(unwrappedType, AsyncPageableTypeName, AzureNamespace) ||
+                IsOrImplements(unwrappedType, CollectionResultTypeName, SystemClientModelNamespace) ||
+                IsOrImplements(unwrappedType, AsyncCollectionResultTypeName, SystemClientModelNamespace) ||
+                IsOrImplements(unwrappedType, PageableOperationTypeName, AzureNamespace))
+            {
+                if (unwrappedType is INamedTypeSymbol genericType && genericType.IsGenericType)
+                {
+                    modelType = genericType.TypeArguments.FirstOrDefault();
+                }
+            }
+
+            // Only return user-defined types, not built-in types
+            if (modelType != null && IsUserDefinedModelType(modelType))
+            {
+                return modelType;
+            }
+
+            return null;
+        }
+
+        private static bool IsUserDefinedModelType(ITypeSymbol typeSymbol)
+        {
+            // Filter out System types, unless defined in System.ClientModel
+            var containingNamespace = typeSymbol.ContainingNamespace?.ToString() ?? string.Empty;
+
+            if (containingNamespace == SystemNamespace || containingNamespace.StartsWith($"{SystemNamespace}.")
+                && containingNamespace != SystemClientModelNamespace
+                && (!containingNamespace.StartsWith($"{SystemClientModelNamespace}.")))
+            {
+                return false;
+            }
+
+            // Filter out built-in types
+            if (typeSymbol.SpecialType != SpecialType.None)
+            {
+                return false;
+            }
+
+            // Only consider class and struct types, but not enums
+            if (typeSymbol.TypeKind != TypeKind.Class && typeSymbol.TypeKind != TypeKind.Struct)
+            {
+                return false;
+            }
+
+            // Filter out client types - they are not models
+            if (typeSymbol.Name.EndsWith(ClientSuffix))
+            {
+                return false;
+            }
+
+            // Filter out types that can be easily instantiated (have public constructors with all properties settable)
+            if (CanBeConstructedUsingPublicApis(typeSymbol))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool CanBeConstructedUsingPublicApis(ITypeSymbol typeSymbol)
+        {
+            if (!(typeSymbol is INamedTypeSymbol namedType))
+            {
+                return false;
+            }
+
+            // Check if there is at least one public constructor
+            var publicConstructors = namedType.Constructors.Where(c => c.DeclaredAccessibility == Accessibility.Public).ToList();
+            if (!publicConstructors.Any())
+            {
+                return false;
+            }
+
+            // Get all instance properties
+            var properties = namedType.GetMembers()
+                .OfType<IPropertySymbol>()
+                .Where(p => !p.IsStatic)
+                .ToList();
+
+            // If there are no properties, it can be constructed via public constructor
+            if (!properties.Any())
+            {
+                return true;
+            }
+
+            // Get properties that don't have public setters - these must be set via constructor
+            var propertiesNeedingConstructor = properties
+                .Where(p => p.SetMethod?.DeclaredAccessibility != Accessibility.Public)
+                .ToList();
+
+            // If all properties have public setters, the type can be constructed
+            if (!propertiesNeedingConstructor.Any())
+            {
+                return true;
+            }
+
+            // Check if at least one public constructor can set all properties that need constructor parameters
+            foreach (var constructor in publicConstructors)
+            {
+                bool allPropertiesCanBeSet = true;
+
+                foreach (var property in propertiesNeedingConstructor)
+                {
+                    // Check if this constructor has a parameter that can set this property
+                    bool hasMatchingParameter = constructor.Parameters.Any(p =>
+                        string.Equals(p.Name, property.Name, StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(p.Name, property.Name.Substring(0, 1).ToLower() + property.Name.Substring(1), StringComparison.Ordinal));
+
+                    if (!hasMatchingParameter)
+                    {
+                        allPropertiesCanBeSet = false;
+                        break;
+                    }
+                }
+
+                // If this constructor can set all required properties, the type can be constructed
+                if (allPropertiesCanBeSet)
+                {
+                    return true;
+                }
+            }
+
+            // No constructor can set all required properties
+            return false;
+        }
+
+        private static bool IsOrImplements(ITypeSymbol typeSymbol, string typeName, string namespaceName)
+        {
+            if (typeSymbol.Name == typeName && GetFullNamespaceName(typeSymbol.ContainingNamespace) == namespaceName)
+            {
+                return true;
+            }
+
+            if (typeSymbol.BaseType != null)
+            {
+                return IsOrImplements(typeSymbol.BaseType, typeName, namespaceName);
+            }
+
+            return false;
+        }
+
+        private static string GetFullNamespaceName(INamespaceSymbol namespaceSymbol)
+        {
+            if (namespaceSymbol.IsGlobalNamespace)
+            {
+                return "";
+            }
+
+            var parts = new List<string>();
+            var current = namespaceSymbol;
+            while (current != null && !current.IsGlobalNamespace)
+            {
+                parts.Insert(0, current.Name);
+                current = current.ContainingNamespace;
+            }
+
+            return string.Join(".", parts);
+        }
+
+        private static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol namespaceSymbol)
+        {
+            foreach (var type in namespaceSymbol.GetTypeMembers())
+            {
+                yield return type;
+            }
+
+            foreach (var childNamespace in namespaceSymbol.GetNamespaceMembers())
+            {
+                foreach (var type in GetAllTypes(childNamespace))
+                {
+                    yield return type;
+                }
+            }
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0035Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0035Tests.cs
@@ -1,0 +1,645 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.ModelFactoryAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0035Tests
+    {
+        [TestCase("Response<TestModel>")]
+        [TestCase("Task<Response<TestModel>>")]
+        [TestCase("NullableResponse<TestModel>")]
+        [TestCase("Operation<TestModel>")]
+        [TestCase("Task<Operation<TestModel>>")]
+        [TestCase("Pageable<TestModel>")]
+        [TestCase("AsyncPageable<TestModel>")]
+        public async Task AZC0035_ProducedWhenOutputModelMissingFromModelFactory(string returnType)
+        {
+            string code = $@"
+using Azure;
+using System.Threading.Tasks;
+
+namespace Azure.Test
+{{
+    public class {{|AZC0035:TestModel|}}
+    {{
+        private TestModel() {{ }}
+        public string Name {{ get; }}
+    }}
+
+    public class TestClient
+    {{
+        public virtual {returnType} GetTestModel()
+        {{
+            return null;
+        }}
+    }}
+}}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_NotProducedWhenOutputModelHasCorrespondingModelFactory()
+        {
+            const string code = @"
+using Azure;
+using System.Threading.Tasks;
+
+namespace Azure.Test
+{
+    public class TestModel1
+    {
+    }
+
+    public class TestModel2
+    {
+    }
+
+    public class TestClient
+    {
+        public virtual Response<TestModel1> GetTestModel1()
+        {
+            return null;
+        }
+
+        public virtual Task<Operation<TestModel2>> GetTestModel2Async()
+        {
+            return null;
+        }
+    }
+
+    public static class TestModelFactory
+    {
+        public static TestModel1 TestModel1()
+        {
+            return null;
+        }
+
+        public static TestModel2 TestModel2()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_IgnoresNonClientClassesAndBuiltInTypes()
+        {
+            const string code = @"
+using Azure;
+using System.Threading.Tasks;
+
+namespace Azure.Test
+{
+    public class TestModel
+    {
+    }
+
+    public class SomeService
+    {
+        public virtual Response<TestModel> GetTestModel()
+        {
+            return null;
+        }
+    }
+
+    public class TestClient
+    {
+        public virtual Response GetResponse()
+        {
+            return null;
+        }
+
+        public virtual Response<string> GetString()
+        {
+            return null;
+        }
+
+        public virtual Response<int> GetInt()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_IgnoresEmptyClassesWithPublicConstructors()
+        {
+            const string code = @"
+using Azure;
+using System.Threading.Tasks;
+
+namespace Azure.Test
+{
+    public class EmptyModel
+    {
+    }
+
+    public class EmptyModelExplicit
+    {
+        public EmptyModelExplicit() { }
+    }
+
+    public class TestClient
+    {
+        public virtual Response<EmptyModel> GetEmptyModel()
+        {
+            return null;
+        }
+
+        public virtual Response<EmptyModelExplicit> GetEmptyModelExplicit()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_FlagsEmptyClassesWithNoPublicConstructor()
+        {
+            const string code = @"
+using Azure;
+using System.Threading.Tasks;
+
+namespace Azure.Test
+{
+    public class {|AZC0035:EmptyModelPrivate|}
+    {
+        private EmptyModelPrivate() { }
+    }
+
+    public class TestClient
+    {
+        public virtual Response<EmptyModelPrivate> GetEmptyModel()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_FlagsTypesWithPartiallySettableProperties()
+        {
+            const string code = @"
+using Azure;
+using System.Threading.Tasks;
+
+namespace Azure.Test
+{
+    public class {|AZC0035:ExampleModel|}
+    {
+        public int Age { get; }
+        public string Name { get; }
+
+        public ExampleModel(string name)
+        {
+            Name = name;
+        }
+    }
+
+    public class TestClient
+    {
+        public virtual Response<ExampleModel> GetExampleModel()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_RealWorldExamples()
+        {
+            const string code = @"
+using Azure;
+using System;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.Blobs
+{
+    public class BlobContainerClient
+    {
+        public string Name { get; set; }
+        public string AccountName { get; set; }
+    }
+
+    public class BlobServiceProperties
+    {
+        public string Version { get; set; }
+        public bool LoggingEnabled { get; set; }
+        public int RetentionDays { get; set; }
+    }
+
+    public class BlobImmutabilityPolicy
+    {
+        public BlobImmutabilityPolicy(string policyType, int retentionDays)
+        {
+            PolicyType = policyType;
+            RetentionDays = retentionDays;
+        }
+
+        public string PolicyType { get; }
+        public int RetentionDays { get; }
+    }
+
+    public class ReleasedObjectInfo
+    {
+        public ReleasedObjectInfo(string objectId)
+        {
+            ObjectId = objectId;
+        }
+
+        public string ObjectId { get; }
+        public string Status { get; set; }
+        public DateTime? ReleasedAt { get; set; }
+    }
+
+    public class {|AZC0035:PrivateConstructorModel|}
+    {
+        private PrivateConstructorModel() { }
+        public string Name { get; set; }
+    }
+
+    public class {|AZC0035:ReadOnlyModel|}
+    {
+        public string Name { get; }
+        public int Value { get; }
+    }
+
+    public class TestClient
+    {
+        public virtual Response<BlobContainerClient> GetBlobContainer() => null;
+        public virtual Response<BlobServiceProperties> GetServiceProperties() => null;
+        public virtual Response<BlobImmutabilityPolicy> GetImmutabilityPolicy() => null;
+        public virtual Response<ReleasedObjectInfo> GetReleasedObjectInfo() => null;
+        public virtual Response<PrivateConstructorModel> GetPrivateConstructorModel() => null;
+        public virtual Response<ReadOnlyModel> GetReadOnlyModel() => null;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_IgnoresSystemTypes()
+        {
+            const string code = @"
+using Azure;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System
+{
+    public class BinaryData
+    {
+        public string Content { get; }
+    }
+}
+
+namespace System.Threading
+{
+    public class Thread
+    {
+        public string Name { get; set; }
+        public bool IsAlive { get; }
+    }
+}
+
+namespace Azure.Test
+{
+    public class TestClient
+    {
+        public virtual Response<BinaryData> GetBinaryData()
+        {
+            return null;
+        }
+
+        public virtual Task<Response<Thread>> GetThreadAsync()
+        {
+            return null;
+        }
+
+        public virtual Task<Operation<BinaryData>> GetOperationOfBinaryDataAsync()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_AllowsSystemClientModelTypes()
+        {
+            const string code = @"
+using Azure;
+using System.Threading.Tasks;
+
+namespace System.ClientModel
+{
+    public class {|AZC0035:CustomClientModel|}
+    {
+        private CustomClientModel() { }
+        public string Name { get; }
+    }
+
+    public class AllowedClientModel
+    {
+        public AllowedClientModel(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}
+
+namespace System.ClientModel.Primitives
+{
+    public class {|AZC0035:PrimitiveModel|}
+    {
+        private PrimitiveModel() { }
+        public string Value { get; }
+    }
+}
+
+namespace Azure.Test
+{
+    public class TestClient
+    {
+        public virtual Response<System.ClientModel.CustomClientModel> GetCustomClientModel()
+        {
+            return null;
+        }
+
+        public virtual Response<System.ClientModel.AllowedClientModel> GetAllowedClientModel()
+        {
+            return null;
+        }
+
+        public virtual Response<System.ClientModel.Primitives.PrimitiveModel> GetPrimitiveModel()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_GenericUnwrappingWithSystemTypes()
+        {
+            const string code = @"
+using Azure;
+using System;
+using System.Threading.Tasks;
+
+namespace System
+{
+    public class BinaryData
+    {
+        public string Content { get; }
+    }
+}
+
+namespace Azure.Test
+{
+    public class {|AZC0035:CustomModel|}
+    {
+        private CustomModel() { }
+        public string Name { get; }
+    }
+
+    public class TestClient
+    {
+        public virtual Task<Response<BinaryData>> GetBinaryDataInTaskResponseAsync()
+        {
+            return null;
+        }
+
+        public virtual Task<Operation<BinaryData>> GetBinaryDataInTaskOperationAsync()
+        {
+            return null;
+        }
+
+        public virtual Task<Pageable<BinaryData>> GetBinaryDataInTaskPageableAsync()
+        {
+            return null;
+        }
+
+        public virtual Task<Response<CustomModel>> GetCustomModelAsync()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_SystemClientModelGenericTypes()
+        {
+            const string code = @"
+using Azure;
+using System.Threading.Tasks;
+
+namespace System.ClientModel
+{
+    public class {|AZC0035:ClientResult|}
+    {
+        private ClientResult() { }
+        public string Value { get; }
+    }
+
+    public class EasyClientModel
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+    }
+}
+
+namespace Azure.Test
+{
+    public class TestClient
+    {
+        public virtual Response<System.ClientModel.ClientResult> GetClientResult()
+        {
+            return null;
+        }
+
+        public virtual Response<System.ClientModel.EasyClientModel> GetEasyClientModel()
+        {
+            return null;
+        }
+
+        public virtual Task<Response<System.ClientModel.ClientResult>> GetClientResultAsync()
+        {
+            return null;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0035_OnlyAnalyzesSourceDefinedClientTypes()
+        {
+            const string code = @"
+using Azure;
+using System.Threading.Tasks;
+
+namespace Azure.Test
+{
+    public class {|AZC0035:MyCustomModel|}
+    {
+        private MyCustomModel() { }
+        public string Value { get; }
+    }
+
+    public class MyClient
+    {
+        public virtual Response<MyCustomModel> GetModel()
+        {
+            return null;
+        }
+    }
+
+    public static class MyModelFactory
+    {
+        public static SomeOtherModel SomeOtherModel()
+        {
+            return null;
+        }
+    }
+
+    public class SomeOtherModel
+    {
+        public string Name { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        // Regression test: a client method in this assembly returns a model declared
+        // in a referenced (external) assembly. The model factory contract only
+        // applies to types this assembly owns, so AZC0035 must NOT fire here.
+        // Repros the bug seen in Azure.AI.Extensions.OpenAI on ResponseResult and
+        // StreamingResponseUpdate (both declared in the external OpenAI package).
+        //
+        // Note: bypasses Microsoft.CodeAnalysis.Testing, which silently filters
+        // diagnostics whose location is outside the test source — that filter
+        // would mask this bug. We drive the analyzer directly and inspect
+        // every diagnostic it emits.
+        [Test]
+        public async Task AZC0035_NotProducedForOutputModelsDefinedInExternalAssemblies()
+        {
+            // Compile a tiny "external" assembly containing a model that the
+            // analyzer heuristic would flag (private ctor, read-only prop).
+            const string externalSource = @"
+namespace External.Models
+{
+    public class ExternalModel
+    {
+        private ExternalModel() { }
+        public string Name { get; }
+    }
+}";
+            var externalRef = await CompileToMetadataReferenceAsync(externalSource, "External");
+
+            const string source = @"
+using Azure;
+using External.Models;
+using System.Threading.Tasks;
+
+namespace Azure.Test
+{
+    public class TestClient
+    {
+        public virtual Response<ExternalModel> GetModel()
+        {
+            return null;
+        }
+
+        public virtual Task<Response<ExternalModel>> GetModelAsync()
+        {
+            return null;
+        }
+    }
+}";
+
+            var diagnostics = await GetAllAnalyzerDiagnosticsAsync(source, externalRef);
+
+            var azc0035 = diagnostics.Where(d => d.Id == "AZC0035").ToList();
+            Assert.That(azc0035, Is.Empty,
+                "AZC0035 should not fire for models defined in referenced assemblies. " +
+                "Got: " + string.Join("; ", azc0035.Select(d => d.ToString())));
+        }
+
+        private static async Task<Microsoft.CodeAnalysis.MetadataReference> CompileToMetadataReferenceAsync(string source, string assemblyName)
+        {
+            var refAssemblies = await AzureTestReferences.DefaultReferenceAssemblies.ResolveAsync(
+                Microsoft.CodeAnalysis.LanguageNames.CSharp, System.Threading.CancellationToken.None);
+            var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source);
+            var comp = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+                assemblyName,
+                new[] { tree },
+                refAssemblies,
+                new Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary));
+            using var ms = new System.IO.MemoryStream();
+            var emit = comp.Emit(ms);
+            if (!emit.Success)
+            {
+                throw new System.Exception("External compile failed: " + string.Join("; ", emit.Diagnostics));
+            }
+            ms.Position = 0;
+            return Microsoft.CodeAnalysis.MetadataReference.CreateFromStream(ms);
+        }
+
+        private static async Task<System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.Diagnostic>> GetAllAnalyzerDiagnosticsAsync(string source, params Microsoft.CodeAnalysis.MetadataReference[] extraReferences)
+        {
+            var refAssemblies = await AzureTestReferences.DefaultReferenceAssemblies.ResolveAsync(
+                Microsoft.CodeAnalysis.LanguageNames.CSharp, System.Threading.CancellationToken.None);
+
+            var allRefs = refAssemblies.AddRange(extraReferences);
+
+            var syntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source);
+            var compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+                "TestAssembly",
+                new[] { syntaxTree },
+                allRefs,
+                new Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary));
+
+            var withAnalyzers = ((Microsoft.CodeAnalysis.Compilation)compilation).WithAnalyzers(
+                System.Collections.Immutable.ImmutableArray.Create<DiagnosticAnalyzer>(new ModelFactoryAnalyzer()));
+
+            var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync(System.Threading.CancellationToken.None);
+            return diagnostics;
+        }
+    }
+}


### PR DESCRIPTION
Migrates `ModelFactoryAnalyzer` (AZC0035) from `Azure/azure-sdk-tools` into `sdk/tools/Azure.SdkAnalyzers`, and fixes a long-standing false positive where the analyzer flagged output model types declared in **referenced (external) assemblies** rather than the current compilation.

## The bug

`AnalyzeCompilation` correctly restricted client/factory scanning to types defined in the current assembly, but `ExtractOutputModelFromReturnType` extracted the inner generic type argument (e.g. `ResponseResult` from `ClientResult<ResponseResult>`) without an assembly check. External types landed in the `outputModels` set, and since metadata symbols have a non-null `Locations.FirstOrDefault`, the diagnostic fired with a metadata location and surfaced as a `CSC :` warning with no source file/line.

## The fix

Before reporting the diagnostic, skip output models whose `ContainingAssembly` is not the current compilation''s assembly. Model-factory contracts only apply to types this assembly owns.

```csharp
foreach (var outputModel in outputModels)
{
    if (!SymbolEqualityComparer.Default.Equals(outputModel.ContainingAssembly, context.Compilation.Assembly))
    {
        continue;
    }

    if (!modelFactoryMethods.Contains(outputModel))
    ...
}
```

## End-to-end verification on Azure.AI.Extensions.OpenAI

| Build | AZC0035 warnings |
|---|---|
| Without fix | **12** -- `ResponseResult` and `StreamingResponseUpdate` from external `OpenAI.Responses.*` |
| With fix | **0** |

## Tests

- **12 migrated tests** ported from azure-sdk-tools (xUnit -> NUnit). All pass before the fix (faithful migration).
- **1 new regression test** `AZC0035_NotProducedForOutputModelsDefinedInExternalAssemblies` compiles an external assembly in-memory and asserts no AZC0035 fires. Bypasses `Microsoft.CodeAnalysis.Testing` because that framework silently filters diagnostics whose location is outside the test source -- the filter would have masked this exact bug.

Full suite: 142 / 142 passing across net462 / net8.0 / net9.0 / net10.0.

## Follow-ups

- Remove `ModelFactoryAnalyzer` from `Azure/azure-sdk-tools` once this migration lands and consuming repos pick it up.
- Drop the AZC0035 entry from `eng/analyzerallowlist/Azure.AI.Extensions.OpenAI.txt` in the pending peel-off PR once this fix is merged.