### PR TITLE
Spike #59650: provision Generator Agent MCP server for the Copilot cloud agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -42,3 +42,12 @@ jobs:
         run: |
           ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $HOME/bin
 
+      # Pre-build the Generator Agent MCP server so it is warmed and ready for the
+      # cloud agent to launch via `dotnet run ... -- --mcp-server` (see .mcp.json).
+      # This restores its NuGet dependencies (incl. ModelContextProtocol) and produces
+      # the Debug/net10.0 output up front so the agent does not spend time discovering
+      # and building them on first MCP use. The startup handshake is regression-tested
+      # separately in .github/workflows/generator-agent-mcp.yml (not on every session).
+      - name: Build Generator Agent MCP server
+        run: dotnet build sdk/tools/Azure.GeneratorAgent/src/Azure.GeneratorAgent.csproj -c Debug --framework net10.0
+

--- a/.github/workflows/generator-agent-mcp.yml
+++ b/.github/workflows/generator-agent-mcp.yml
@@ -1,0 +1,39 @@
+name: Generator Agent MCP server
+
+# Regression guard for the Azure Generator Agent MCP server that the Copilot cloud
+# agent launches (see .mcp.json). Runs only when the agent, its launch contract, or
+# the cloud-agent setup steps change — so it does not tax every cloud-agent session.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - sdk/tools/Azure.GeneratorAgent/**
+      - .mcp.json
+      - .vscode/mcp.json
+      - .github/workflows/copilot-setup-steps.yml
+      - .github/workflows/generator-agent-mcp.yml
+      - global.json
+
+permissions:
+  contents: read
+
+jobs:
+  verify-mcp-server:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build Generator Agent MCP server
+        run: dotnet build sdk/tools/Azure.GeneratorAgent/src/Azure.GeneratorAgent.csproj -c Debug --framework net10.0
+
+      # Launches the server over stdio exactly as the cloud agent does and asserts the
+      # MCP initialize + tools/list handshake succeeds with the expected repair tools.
+      - name: Verify MCP server starts and advertises repair tools
+        shell: pwsh
+        run: ./sdk/tools/Azure.GeneratorAgent/eng/Verify-McpServer.ps1

--- a/sdk/tools/Azure.GeneratorAgent/eng/Verify-McpServer.ps1
+++ b/sdk/tools/Azure.GeneratorAgent/eng/Verify-McpServer.ps1
@@ -1,0 +1,112 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Smoke-tests that the Azure Generator Agent MCP server starts and responds.
+
+.DESCRIPTION
+    Launches the Generator Agent over stdio exactly as the cloud agent does
+    (see .mcp.json), performs an MCP `initialize` + `tools/list` handshake, and
+    asserts that the server identifies itself and exposes its repair tools.
+
+    Exits 0 on success; exits 1 (failing the calling CI step) if the server does
+    not start, does not respond within the timeout, or does not advertise the
+    expected tools. This guards against regressions that would silently break the
+    cloud-agent repair flow.
+#>
+[CmdletBinding()]
+param(
+    [int]$TimeoutSeconds = 120
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..')).Path
+$project = 'sdk/tools/Azure.GeneratorAgent/src/Azure.GeneratorAgent.csproj'
+$requiredTools = @('build_and_classify', 'classify_errors', 'verify_generated_unchanged')
+
+Write-Host "Repo root: $repoRoot"
+Write-Host "Launching Generator Agent MCP server (dotnet run --project $project)..."
+
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = 'dotnet'
+foreach ($a in @('run', '--project', $project, '--framework', 'net10.0', '--', '--mcp-server')) {
+    $psi.ArgumentList.Add($a)
+}
+$psi.WorkingDirectory = $repoRoot
+$psi.RedirectStandardInput = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.UseShellExecute = $false
+
+$proc = [System.Diagnostics.Process]::new()
+$proc.StartInfo = $psi
+
+$stdout = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+$outHandler = {
+    if ($null -ne $EventArgs.Data) { $Event.MessageData.Enqueue($EventArgs.Data) }
+}
+Register-ObjectEvent -InputObject $proc -EventName OutputDataReceived -Action $outHandler -MessageData $stdout | Out-Null
+
+try {
+    [void]$proc.Start()
+    $proc.BeginOutputReadLine()
+
+    function Send-Message($obj) {
+        $json = $obj | ConvertTo-Json -Depth 10 -Compress
+        $proc.StandardInput.WriteLine($json)
+        $proc.StandardInput.Flush()
+    }
+
+    Send-Message @{ jsonrpc = '2.0'; id = 1; method = 'initialize'; params = @{ protocolVersion = '2024-11-05'; capabilities = @{}; clientInfo = @{ name = 'verify'; version = '1.0' } } }
+    Start-Sleep -Seconds 2
+    Send-Message @{ jsonrpc = '2.0'; method = 'notifications/initialized' }
+    Send-Message @{ jsonrpc = '2.0'; id = 2; method = 'tools/list' }
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $sawInit = $false
+    $toolNames = [System.Collections.Generic.HashSet[string]]::new()
+
+    while ($sw.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
+        $line = $null
+        if ($stdout.TryDequeue([ref]$line)) {
+            try { $msg = $line | ConvertFrom-Json } catch { continue }
+            if ($msg.PSObject.Properties.Name -contains 'id' -and $msg.id -eq 1 -and $msg.PSObject.Properties.Name -contains 'result') {
+                $name = $msg.result.serverInfo.name
+                Write-Host "initialize OK -> serverInfo.name = $name"
+                $sawInit = $true
+            }
+            if ($msg.PSObject.Properties.Name -contains 'id' -and $msg.id -eq 2 -and $msg.PSObject.Properties.Name -contains 'result') {
+                foreach ($t in $msg.result.tools) { [void]$toolNames.Add($t.name) }
+                Write-Host "tools/list OK -> $($toolNames.Count) tools advertised"
+                break
+            }
+        }
+        else {
+            if ($proc.HasExited) { break }
+            Start-Sleep -Milliseconds 100
+        }
+    }
+
+    if (-not $sawInit) {
+        Write-Error "MCP server did not return an initialize response within $TimeoutSeconds s."
+        exit 1
+    }
+
+    $missing = $requiredTools | Where-Object { -not $toolNames.Contains($_) }
+    if ($missing) {
+        Write-Error "MCP server is missing expected tools: $($missing -join ', '). Advertised: $($toolNames -join ', ')"
+        exit 1
+    }
+
+    Write-Host "SUCCESS: Generator Agent MCP server started and advertised the expected repair tools."
+    exit 0
+}
+finally {
+    if ($proc -and -not $proc.HasExited) {
+        try { $proc.StandardInput.Close() } catch {}
+        Start-Sleep -Milliseconds 500
+        if (-not $proc.HasExited) { try { $proc.Kill($true) } catch {} }
+    }
+    Get-EventSubscriber | Where-Object { $_.SourceObject -eq $proc } | Unregister-Event -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Part of the feasibility spike #59650 — validate that the Azure Generator Agent MCP server can be provisioned and launched in the GitHub Copilot **cloud-agent** environment, a prerequisite for auto-repairing custom-code build failures in release-planner-created SDK PRs.

## What this PR does
- **`copilot-setup-steps.yml`**: adds a step to pre-build `sdk/tools/Azure.GeneratorAgent` so the cloud-agent environment has the MCP server warmed (NuGet restored, `Debug/net10.0` output produced). The agent launches it via `dotnet run -- --mcp-server` (see `.mcp.json`); pre-building avoids a cold first-use build.
- **`generator-agent-mcp.yml`** (new CI workflow): builds the server and runs a stdio **MCP handshake smoke test** (`initialize` + `tools/list`), asserting the expected repair tools are advertised. Triggers only on changes to the agent, its launch contract (`.mcp.json`/`.vscode/mcp.json`), `global.json`, or the setup-steps file — so it does **not** add latency to every cloud-agent session.
- **`Verify-McpServer.ps1`** (new): the cross-platform smoke test, launching the server exactly as the cloud agent does.

## Validated locally
- `dotnet build` succeeds on .NET 10.
- The MCP server starts and responds: `serverInfo.name = Azure.GeneratorAgent`, **20 tools** advertised (incl. `build_and_classify`, `classify_errors`, `batch_fix`, `verify_generated_unchanged`). `Verify-McpServer.ps1` exits 0.

## Design note
The smoke test lives in a dedicated CI workflow rather than `copilot-setup-steps.yml` so per-session startup stays lean while PRs that touch the agent still get regression coverage.

Remaining spike items (live cloud-agent kickoff via Agent Tasks API, repo-level MCP config, trigger identity) are tracked in #59650 and sibling issues.

Relates to #59650

--generated by Copilot
