### PR TITLE
Configure auto-sdk-build-fix label for failed-build SDK PRs (#59651)

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -29,6 +29,7 @@
     },
     "updateMetadataScript": {
       "path": "./eng/scripts/Export-API.ps1"
-    }
+    },
+    "buildFailedLabel": "auto-sdk-build-fix"
   }
 }


### PR DESCRIPTION
## Summary

Configures the `auto-sdk-build-fix` eligibility label for release-planner-created SDK pull requests, the .NET side of #59651 (epic #59658).

## What changed

Adds `packageOptions.buildFailedLabel: "auto-sdk-build-fix"` to `eng/swagger_to_sdk_config.json`.

With the corresponding `spec-gen-sdk` change (Azure/azure-sdk-tools#15887), when a **data-plane** package result is `warning` (generation succeeded but build/pack/Export-API failed — see `eng/scripts/automation/GenerateAndBuildLib.ps1`), `spec-gen-sdk` emits `buildFailedLabel` + `shouldLabelBuildFailed: true` in its execution report. The release-planner PR-creation pipeline then applies the label to the generated SDK PR, opting it into automated custom-code build-failure repair by the Generator Agent (the repair workflow lands in #59652 / PR #59666).

Management-plane builds are forced to `succeeded` and never `warning`, so they are never labeled.

## Label

The `auto-sdk-build-fix` label has been created in this repo:
> SDK PR with failed build; eligible for automated Generator Agent build-fix repair

## Notes
- The config value is inert until the new `spec-gen-sdk` version ships; the config schema allows the field (no `additionalProperties: false`), so this is forward-compatible.
- Not applied in plain spec-PR CI, which never creates or labels an SDK PR.

Closes #59651
