### PR TITLE
Fix request path equality and hash code mismatch

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathPattern.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathPattern.cs
@@ -198,12 +198,21 @@ namespace Azure.Generator.Management.Models
 
         /// <inheritdoc />
         public bool Equals(RequestPathPattern? other)
+            => Equals(other, strict: false);
+
+        /// <summary>
+        /// Determines whether this path pattern equals another path pattern.
+        /// </summary>
+        /// <param name="other">The other path pattern to compare.</param>
+        /// <param name="strict">Whether variable segment names must match exactly.</param>
+        /// <returns><c>true</c> if the path patterns are equal; otherwise, <c>false</c>.</returns>
+        public bool Equals(RequestPathPattern? other, bool strict)
         {
             if (Count != other?.Count)
                 return false;
             for (int i = 0; i < Count; i++)
             {
-                if (!this[i].Equals(other[i]))
+                if (!this[i].Equals(other[i], strict))
                     return false;
             }
             return true;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathPattern.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathPattern.cs
@@ -213,7 +213,15 @@ namespace Azure.Generator.Management.Models
         public override bool Equals(object? obj) => obj is RequestPathPattern other && Equals(other);
 
         /// <inheritdoc />
-        public override int GetHashCode() => _path.GetHashCode();
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (var segment in _segments)
+            {
+                hash.Add(segment);
+            }
+            return hash.ToHashCode();
+        }
 
         /// <inheritdoc />
         public override string ToString() => _path;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathSegment.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathSegment.cs
@@ -28,6 +28,8 @@ namespace Azure.Generator.Management.Models
         {
             if (other is null)
                 return false;
+            if (!IsConstant && !other.IsConstant)
+                return true;
             return _value == other._value;
         }
 
@@ -74,7 +76,7 @@ namespace Azure.Generator.Management.Models
         public override bool Equals(object? obj) => obj is RequestPathSegment other && Equals(other);
 
         /// <inheritdoc />
-        public override int GetHashCode() => _value.GetHashCode();
+        public override int GetHashCode() => IsConstant ? _value.GetHashCode() : "{}".GetHashCode();
 
         /// <inheritdoc />
         public override string ToString() => _value;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathSegment.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathSegment.cs
@@ -25,9 +25,20 @@ namespace Azure.Generator.Management.Models
 
         /// <inheritdoc />
         public bool Equals(RequestPathSegment? other)
+            => Equals(other, strict: false);
+
+        /// <summary>
+        /// Determines whether this segment equals another segment.
+        /// </summary>
+        /// <param name="other">The other segment to compare.</param>
+        /// <param name="strict">Whether variable segment names must match exactly.</param>
+        /// <returns><c>true</c> if the segments are equal; otherwise, <c>false</c>.</returns>
+        public bool Equals(RequestPathSegment? other, bool strict)
         {
             if (other is null)
                 return false;
+            if (strict)
+                return _value == other._value;
             if (!IsConstant && !other.IsConstant)
                 return true;
             return _value == other._value;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
@@ -121,6 +121,16 @@ namespace Azure.Generator.Management.Tests
         }
 
         [Test]
+        public void GetHashCode_EqualPatternsWithDifferentVariableNamesUseEqualHashCodes()
+        {
+            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
+
+            Assert.That(second, Is.EqualTo(first));
+            Assert.That(second.GetHashCode(), Is.EqualTo(first.GetHashCode()));
+        }
+
+        [Test]
         public void GetHashCode_DifferentPatternsUseDifferentHashCodes()
         {
             var resourceGroup = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
@@ -131,6 +131,27 @@ namespace Azure.Generator.Management.Tests
         }
 
         [Test]
+        public void Equals_NonStrictTreatsVariableNamesAsEqual()
+        {
+            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
+
+            Assert.That(first.Equals(second), Is.True);
+            Assert.That(first.Equals(second, strict: false), Is.True);
+        }
+
+        [Test]
+        public void Equals_StrictComparesVariableNames()
+        {
+            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
+            var same = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+
+            Assert.That(first.Equals(second, strict: true), Is.False);
+            Assert.That(first.Equals(same, strict: true), Is.True);
+        }
+
+        [Test]
         public void GetHashCode_DifferentPatternsUseDifferentHashCodes()
         {
             var resourceGroup = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
@@ -109,5 +109,25 @@ namespace Azure.Generator.Management.Tests
                 RequestPathPattern.GetMaximumSharingSegmentsCount(right, left),
                 Is.EqualTo(RequestPathPattern.GetMaximumSharingSegmentsCount(left, right)));
         }
+
+        [Test]
+        public void GetHashCode_EqualPatternsUseEqualHashCodes()
+        {
+            var fromString = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var fromSegments = new RequestPathPattern(fromString.AsEnumerable());
+
+            Assert.That(fromSegments, Is.EqualTo(fromString));
+            Assert.That(fromSegments.GetHashCode(), Is.EqualTo(fromString.GetHashCode()));
+        }
+
+        [Test]
+        public void GetHashCode_DifferentPatternsUseDifferentHashCodes()
+        {
+            var resourceGroup = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var subscription = new RequestPathPattern("/subscriptions/{subscriptionId}");
+
+            Assert.That(resourceGroup, Is.Not.EqualTo(subscription));
+            Assert.That(resourceGroup.GetHashCode(), Is.Not.EqualTo(subscription.GetHashCode()));
+        }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
@@ -152,13 +152,18 @@ namespace Azure.Generator.Management.Tests
         }
 
         [Test]
-        public void GetHashCode_DifferentPatternsUseDifferentHashCodes()
+        [Test]
+        public void GetHashCode_DifferentPatternsCanCoexistInHashSet()
         {
             var resourceGroup = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
             var subscription = new RequestPathPattern("/subscriptions/{subscriptionId}");
 
             Assert.That(resourceGroup, Is.Not.EqualTo(subscription));
-            Assert.That(resourceGroup.GetHashCode(), Is.Not.EqualTo(subscription.GetHashCode()));
+
+            var set = new HashSet<RequestPathPattern> { resourceGroup, subscription };
+            Assert.That(set.Count, Is.EqualTo(2));
+            Assert.That(set.Contains(resourceGroup), Is.True);
+            Assert.That(set.Contains(subscription), Is.True);
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix the `RequestPathPattern` / `RequestPathSegment` `Equals` and `GetHashCode` contract mismatch
- make default request path equality and hashing consistently variable-name insensitive, matching existing path matching semantics
- add strict equality overloads for callers that need literal variable-name comparison
- add tests covering equal hash codes for equal path patterns, variable-name-insensitive equality, and strict equality

## Context
`RequestPathPattern` is used in hash-based collections. Its equality semantics must agree with its hash code semantics.

The generator already treats variable path segments as equivalent by shape for path matching. For example, these paths represent the same pattern in normal matching:

```text
/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}
/subscriptions/{subId}/resourceGroups/{rgName}
```

Before this PR, equal or shape-equivalent request paths could produce different hash codes because hashing was based on raw strings/segment values. That violates the `Equals` / `GetHashCode` contract and can cause `Distinct`, `HashSet`, or dictionary lookups to behave incorrectly.

This PR aligns hash code generation with default equality, and adds explicit strict equality overloads for the less common case where variable names must match literally.

## Validation
- `dotnet test eng\packages\http-client-csharp-mgmt\generator\Azure.Generator.Management\test\Azure.Generator.Mgmt.Tests.csproj --filter "FullyQualifiedName~RequestPathPatternTests"`