### PR TITLE
Handle HEAD response-as-bool in mgmt generator

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/OperationContexts/ParameterContextRegistry.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/OperationContexts/ParameterContextRegistry.cs
@@ -71,21 +71,8 @@ internal class ParameterContextRegistry : IReadOnlyDictionary<string, ParameterC
     public IReadOnlyList<ValueExpression> PopulateArguments(
         ScopedApi<ResourceIdentifier> idProperty,
         IReadOnlyList<ParameterProvider> requestParameters,
-        VariableExpression requestContext,
+        VariableExpression? requestContext,
         IReadOnlyList<ParameterProvider> methodParameters)
-        => PopulateArguments(idProperty, requestParameters, methodParameters, requestContext);
-
-    public IReadOnlyList<ValueExpression> PopulateArguments(
-        ScopedApi<ResourceIdentifier> idProperty,
-        IReadOnlyList<ParameterProvider> requestParameters,
-        IReadOnlyList<ParameterProvider> methodParameters)
-        => PopulateArguments(idProperty, requestParameters, methodParameters, requestContext: null);
-
-    private IReadOnlyList<ValueExpression> PopulateArguments(
-        ScopedApi<ResourceIdentifier> idProperty,
-        IReadOnlyList<ParameterProvider> requestParameters,
-        IReadOnlyList<ParameterProvider> methodParameters,
-        VariableExpression? requestContext)
     {
         var arguments = new List<ValueExpression>();
         // here we always assume that the parameter name matches the parameter name in the request path.

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/OperationContexts/ParameterContextRegistry.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/OperationContexts/ParameterContextRegistry.cs
@@ -73,6 +73,19 @@ internal class ParameterContextRegistry : IReadOnlyDictionary<string, ParameterC
         IReadOnlyList<ParameterProvider> requestParameters,
         VariableExpression requestContext,
         IReadOnlyList<ParameterProvider> methodParameters)
+        => PopulateArguments(idProperty, requestParameters, methodParameters, requestContext);
+
+    public IReadOnlyList<ValueExpression> PopulateArguments(
+        ScopedApi<ResourceIdentifier> idProperty,
+        IReadOnlyList<ParameterProvider> requestParameters,
+        IReadOnlyList<ParameterProvider> methodParameters)
+        => PopulateArguments(idProperty, requestParameters, methodParameters, requestContext: null);
+
+    private IReadOnlyList<ValueExpression> PopulateArguments(
+        ScopedApi<ResourceIdentifier> idProperty,
+        IReadOnlyList<ParameterProvider> requestParameters,
+        IReadOnlyList<ParameterProvider> methodParameters,
+        VariableExpression? requestContext)
     {
         var arguments = new List<ValueExpression>();
         // here we always assume that the parameter name matches the parameter name in the request path.
@@ -177,7 +190,7 @@ internal class ParameterContextRegistry : IReadOnlyDictionary<string, ParameterC
             }
             else if (parameter.Type.Equals(typeof(RequestContext)))
             {
-                arguments.Add(requestContext);
+                arguments.Add(requestContext ?? Default);
             }
             else if (IsMatchConditionType(parameter.Type))
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
@@ -56,6 +56,9 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
 
         private readonly ParameterContextRegistry _parameterMappings;
 
+        private bool IsHeadAsBooleanOperation => _originalBodyType?.Equals(typeof(bool)) == true
+            && _serviceMethod.Operation.HttpMethod.Equals("HEAD", StringComparison.OrdinalIgnoreCase);
+
         /// <summary>
         /// Creates a new instance of <see cref="ResourceOperationMethodProvider"/> which represents a method on a client
         /// </summary>
@@ -301,6 +304,15 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             VariableExpression contextVariable,
             out ScopedApi<Response> responseVariable)
         {
+            if (IsHeadAsBooleanOperation)
+            {
+                return ResourceMethodSnippets.CreateNonGenericResponsePipelineProcessing(
+                    messageVariable,
+                    contextVariable,
+                    _isAsync,
+                    out responseVariable);
+            }
+
             if (_originalBodyType != null && !IsLongRunningOperation)
             {
                 return ResourceMethodSnippets.CreateGenericResponsePipelineProcessing(
@@ -524,6 +536,16 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
         // TODO: re-examine if this method need to be virtual or not after tags related method providers are implmented.
         protected virtual IReadOnlyList<MethodBodyStatement> BuildReturnStatements(ScopedApi<Response> responseVariable, MethodSignature signature)
         {
+            if (IsHeadAsBooleanOperation)
+            {
+                return [
+                    Return(
+                        ResponseSnippets.FromValue(
+                            responseVariable.Property(nameof(Response.Status)).Equal(Literal(200)),
+                            responseVariable))
+                ];
+            }
+
             var nullCheckStatement = new IfStatement(
                 responseVariable.Value().Equal(Null))
             {
@@ -535,7 +557,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
 
             // if the return type is Response with no content, no need to check null.
             List<MethodBodyStatement> statements =
-                CheckIfReturnTypeIsResponseWithNoContent()
+                CheckIfReturnTypeIsResponseWithNoContent() || CheckIfReturnBodyTypeIsNonNullableValueType()
                 ? []
                 : [nullCheckStatement];
 
@@ -564,6 +586,9 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
                 var returnType = signature.ReturnType;
                 return returnType != null && (returnType.Equals(typeof(Response)) || returnType.Equals(typeof(Task<Response>)));
             }
+
+            bool CheckIfReturnBodyTypeIsNonNullableValueType()
+                => _returnBodyType is { IsValueType: true, IsNullable: false };
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
@@ -308,7 +308,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             var idExpression = _scopeParameter != null
                 ? _scopeParameter.As<Azure.Core.ResourceIdentifier>()
                 : This.As<ArmResource>().Id();
-            var arguments = _parameterMappings.PopulateArguments(idExpression, _convenienceMethod.Signature.Parameters, _signature.Parameters);
+            var arguments = _parameterMappings.PopulateArguments(idExpression, _convenienceMethod.Signature.Parameters, null, _signature.Parameters);
             var responseDeclaration = Declare(
                 "response",
                 new CSharpType(typeof(Response<>), typeof(bool)),

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
@@ -266,6 +266,10 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
         private TryExpression BuildTryExpression()
         {
             var cancellationTokenParameter = KnownParameters.CancellationTokenParameter;
+            if (IsHeadAsBooleanOperation && !ShouldApplyLroHandling)
+            {
+                return BuildHeadAsBooleanTryExpression();
+            }
 
             var requestMethod = _restClient.GetRequestMethodByOperation(_serviceMethod.Operation);
             var tryStatements = new List<MethodBodyStatement>
@@ -299,20 +303,25 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             return new TryExpression(tryStatements);
         }
 
+        private TryExpression BuildHeadAsBooleanTryExpression()
+        {
+            var idExpression = _scopeParameter != null
+                ? _scopeParameter.As<Azure.Core.ResourceIdentifier>()
+                : This.As<ArmResource>().Id();
+            var arguments = _parameterMappings.PopulateArguments(idExpression, _convenienceMethod.Signature.Parameters, _signature.Parameters);
+            var responseDeclaration = Declare(
+                "response",
+                new CSharpType(typeof(Response<>), typeof(bool)),
+                _restClientField.Invoke(_convenienceMethod.Signature.Name, arguments, null, _isAsync),
+                out var responseVariable);
+            return new TryExpression([responseDeclaration, Return(responseVariable)]);
+        }
+
         protected virtual IReadOnlyList<MethodBodyStatement> BuildClientPipelineProcessing(
             VariableExpression messageVariable,
             VariableExpression contextVariable,
             out ScopedApi<Response> responseVariable)
         {
-            if (IsHeadAsBooleanOperation)
-            {
-                return ResourceMethodSnippets.CreateNonGenericResponsePipelineProcessing(
-                    messageVariable,
-                    contextVariable,
-                    _isAsync,
-                    out responseVariable);
-            }
-
             if (_originalBodyType != null && !IsLongRunningOperation)
             {
                 return ResourceMethodSnippets.CreateGenericResponsePipelineProcessing(
@@ -536,16 +545,6 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
         // TODO: re-examine if this method need to be virtual or not after tags related method providers are implmented.
         protected virtual IReadOnlyList<MethodBodyStatement> BuildReturnStatements(ScopedApi<Response> responseVariable, MethodSignature signature)
         {
-            if (IsHeadAsBooleanOperation)
-            {
-                return [
-                    Return(
-                        ResponseSnippets.FromValue(
-                            responseVariable.Property(nameof(Response.Status)).Equal(Literal(200)),
-                            responseVariable))
-                ];
-            }
-
             var nullCheckStatement = new IfStatement(
                 responseVariable.Value().Equal(Null))
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
@@ -211,6 +211,59 @@ namespace Azure.Generator.Management.Tests.Common
         }
 
         /// <summary>
+        /// Creates a client with a resource action modeled as HEAD returning bool.
+        /// This mirrors @responseAsBool operations and exercises the value-type response body path.
+        /// </summary>
+        public static (InputClient InputClient, IReadOnlyList<InputModelType> InputModels) ClientWithResourceHeadAsBooleanAction()
+        {
+            const string TestClientName = "TestClient";
+            const string ResourceModelName = "ResponseType";
+
+            var responseModel = InputFactory.Model(ResourceModelName,
+                        usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                        properties:
+                        [
+                            InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                        ],
+                        decorators: []);
+            var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: responseModel);
+            var boolResponseType = InputFactory.OperationResponse(statusCodes: [200, 404], bodytype: InputPrimitiveType.Boolean);
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+
+            var resourcePath = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}";
+            var actionPath = resourcePath + "/checkNameExists";
+
+            var subsIdOpParameter = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var rgOpParameter = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var testNameOpParameter = InputFactory.PathParameter("testName", InputPrimitiveType.String, isRequired: true);
+            var getOperation = InputFactory.Operation(name: "get", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: resourcePath);
+            var actionOperation = InputFactory.Operation(name: "checkNameExists", responses: [boolResponseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: actionPath, httpMethod: "HEAD");
+
+            var subscriptionIdParameter = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var resourceGroupParameter = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var testNameParameter = InputFactory.MethodParameter("testName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+
+            var getMethod = InputFactory.BasicServiceMethod("get", getOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var actionMethod = InputFactory.BasicServiceMethod("checkNameExists", actionOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+
+            var resourceIdPattern = new RequestPathPattern(resourcePath);
+            var armProviderDecorator = BuildArmProviderSchema(responseModel, [
+                new ResourceMethod(ResourceOperationKind.Read, getMethod, new RequestPathPattern(getMethod.Operation.Path), new ArmScopeInfo(ResourceScope.ResourceGroup, resourceIdPattern, null), null!),
+                new ResourceMethod(ResourceOperationKind.Action, actionMethod, new RequestPathPattern(actionMethod.Operation.Path), new ArmScopeInfo(ResourceScope.ResourceGroup, resourceIdPattern, null), null!)
+            ], resourceIdPattern, "Microsoft.Tests/tests", null, ResourceScope.ResourceGroup, "ResponseType");
+
+            var client = InputFactory.Client(
+                TestClientName,
+                methods: [getMethod, actionMethod],
+                decorators: [armProviderDecorator],
+                crossLanguageDefinitionId: $"Test.{TestClientName}");
+
+            return (client, [responseModel]);
+        }
+
+        /// <summary>
         /// Creates a client with a resource where PUT/PATCH body parameters are marked as optional in the spec.
         /// This tests that the generator still emits them as required.
         /// </summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceClientProviderTests.cs
@@ -143,6 +143,43 @@ namespace Azure.Generator.Management.Tests.Providers
         }
 
         [TestCase]
+        public void Verify_HeadAsBooleanAction_UsesStatusCodeReturn()
+        {
+            var (client, models) = InputResourceData.ClientWithResourceHeadAsBooleanAction();
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => models, clients: () => [client]);
+            var resourceProvider = plugin.Object.OutputLibrary.TypeProviders
+                .OfType<ResourceClientProvider>()
+                .FirstOrDefault();
+            Assert.That(resourceProvider, Is.Not.Null);
+
+            var syncMethod = resourceProvider!.Methods.FirstOrDefault(m => m.Signature.Name == "CheckNameExists");
+            Assert.That(syncMethod, Is.Not.Null);
+            var asyncMethod = resourceProvider.Methods.FirstOrDefault(m => m.Signature.Name == "CheckNameExistsAsync");
+            Assert.That(asyncMethod, Is.Not.Null);
+
+            Assert.That(syncMethod!.Signature.ReturnType?.FrameworkType, Is.EqualTo(typeof(Response<>)));
+            Assert.That(syncMethod.Signature.ReturnType?.Arguments[0].FrameworkType, Is.EqualTo(typeof(bool)));
+            Assert.That(syncMethod.Signature.Parameters.Any(p => p.Name == "accept"), Is.False);
+
+            Assert.That(asyncMethod!.Signature.ReturnType?.FrameworkType, Is.EqualTo(typeof(Task<>)));
+            Assert.That(asyncMethod.Signature.ReturnType?.Arguments[0].FrameworkType, Is.EqualTo(typeof(Response<>)));
+            Assert.That(asyncMethod.Signature.ReturnType?.Arguments[0].Arguments[0].FrameworkType, Is.EqualTo(typeof(bool)));
+            Assert.That(asyncMethod.Signature.Parameters.Any(p => p.Name == "accept"), Is.False);
+
+            var syncBody = syncMethod.BodyStatements?.ToDisplayString();
+            Assert.That(syncBody, Is.Not.Null);
+            Assert.That(syncBody, Does.Contain("return global::Azure.Response.FromValue((response.Status == 200), response);"));
+            Assert.That(syncBody, Does.Not.Contain("ModelReaderWriter.Read"));
+            Assert.That(syncBody, Does.Not.Contain("response.Value == null"));
+
+            var asyncBody = asyncMethod.BodyStatements?.ToDisplayString();
+            Assert.That(asyncBody, Is.Not.Null);
+            Assert.That(asyncBody, Does.Contain("return global::Azure.Response.FromValue((response.Status == 200), response);"));
+            Assert.That(asyncBody, Does.Not.Contain("ModelReaderWriter.Read"));
+            Assert.That(asyncBody, Does.Not.Contain("response.Value == null"));
+        }
+
+        [TestCase]
         public void Verify_ConstructorWithData()
         {
             var constructor = GetResourceClientProviderConstructorByName("data");

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceClientProviderTests.cs
@@ -168,13 +168,13 @@ namespace Azure.Generator.Management.Tests.Providers
 
             var syncBody = syncMethod.BodyStatements?.ToDisplayString();
             Assert.That(syncBody, Is.Not.Null);
-            Assert.That(syncBody, Does.Contain("return global::Azure.Response.FromValue((response.Status == 200), response);"));
+            Assert.That(syncBody, Does.Contain("Response<bool> response = _testClientRestClient.CheckNameExists"));
             Assert.That(syncBody, Does.Not.Contain("ModelReaderWriter.Read"));
             Assert.That(syncBody, Does.Not.Contain("response.Value == null"));
 
             var asyncBody = asyncMethod.BodyStatements?.ToDisplayString();
             Assert.That(asyncBody, Is.Not.Null);
-            Assert.That(asyncBody, Does.Contain("return global::Azure.Response.FromValue((response.Status == 200), response);"));
+            Assert.That(asyncBody, Does.Contain("Response<bool> response = await _testClientRestClient.CheckNameExistsAsync"));
             Assert.That(asyncBody, Does.Not.Contain("ModelReaderWriter.Read"));
             Assert.That(asyncBody, Does.Not.Contain("response.Value == null"));
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/FooResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/FooResource.cs
@@ -563,10 +563,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 HttpMessage message = _foosRestClient.CreateGetProvisioningStateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Name, context);
                 Response result = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
                 Response<FooProvisioningState> response = Response.FromValue(new FooProvisioningState(JsonDocument.Parse(result.Content, ModelSerializationExtensions.JsonDocumentOptions).RootElement.GetString()), result);
-                if (response.Value == null)
-                {
-                    throw new RequestFailedException(response.GetRawResponse());
-                }
                 return response;
             }
             catch (Exception e)
@@ -611,10 +607,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 HttpMessage message = _foosRestClient.CreateGetProvisioningStateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Name, context);
                 Response result = Pipeline.ProcessMessage(message, context);
                 Response<FooProvisioningState> response = Response.FromValue(new FooProvisioningState(JsonDocument.Parse(result.Content, ModelSerializationExtensions.JsonDocumentOptions).RootElement.GetString()), result);
-                if (response.Value == null)
-                {
-                    throw new RequestFailedException(response.GetRawResponse());
-                }
                 return response;
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes #59089.

The base generator already emits the correct HEAD-as-boolean RestOperations method: no `accept` parameter, no body deserialization, and status-to-bool mapping. This updates the management wrapper path to delegate HEAD `Response<bool>` methods to that base-generated convenience method instead of rebuilding the request pipeline and reimplementing response handling.

It also keeps the generated management output from emitting impossible null checks for non-nullable value-type responses.

Validation:
- `eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1`
- `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --no-restore`
- `npm run lint` (`eng/packages/http-client-csharp-mgmt`)
- `npm run prettier` (`eng/packages/http-client-csharp-mgmt`)
- `git diff --check`