### PR TITLE
Fix custom base discriminator hierarchy generation

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/InheritableSystemObjectModelVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/InheritableSystemObjectModelVisitor.cs
@@ -10,6 +10,8 @@ using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace Azure.Generator.Management.Visitors;
 
@@ -25,9 +27,9 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
             EnsureFrameworkTypeRegistered(systemType);
         }
 
-        if (type?.BaseModelProvider is not null && type is not SystemObjectModelProvider)
+        if (type is ModelProvider modelProvider && modelProvider is not SystemObjectModelProvider && ShouldUpdateInheritance(modelProvider))
         {
-            UpdateRegularModelInheritance(type);
+            UpdateRegularModelInheritance(modelProvider, updateSerialization: false);
         }
         return type;
     }
@@ -40,9 +42,9 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
             EnsureFrameworkTypeRegistered(systemType);
         }
 
-        if (type is ModelProvider model3 && model3.BaseModelProvider is not null && model3 is not SystemObjectModelProvider)
+        if (type is ModelProvider model && model is not SystemObjectModelProvider && ShouldUpdateInheritance(model))
         {
-            UpdateRegularModelInheritance(model3);
+            UpdateRegularModelInheritance(model, updateSerialization: true);
         }
 
         return type;
@@ -71,15 +73,28 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
     }
 
     private HashSet<ModelProvider> _regularUpdated = new();
+    private Dictionary<ModelProvider, CSharpType?> _customBaseTypes = new();
 
-    private void UpdateRegularModelInheritance(ModelProvider model)
+    private static bool HasInheritableBase(ModelProvider model)
+        => model.BaseModelProvider is not null || GetCustomBaseType(model) is not null;
+
+    private bool ShouldUpdateInheritance(ModelProvider model)
+        => HasInheritableBase(model) || _customBaseTypes.ContainsKey(model);
+
+    private void UpdateRegularModelInheritance(ModelProvider model, bool updateSerialization)
     {
+        var customBaseType = GetCachedCustomBaseType(model);
+
         if (_regularUpdated.Contains(model))
         {
+            if (updateSerialization)
+            {
+                UpdateSerializationMethodModifiers(model, customBaseType);
+            }
             return;
         }
 
-        var basePropertyNames = EnumerateBaseModelProperties(model.BaseModelProvider!);
+        var basePropertyNames = EnumerateBaseModelProperties(model.BaseModelProvider, customBaseType);
         var removedPropertyNames = new HashSet<string>();
         var remainingProperties = new List<PropertyProvider>();
 
@@ -100,15 +115,24 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
             }
         }
 
-        StripOrphanedVirtualModifiers(model.BaseModelProvider!, removedPropertyNames);
+        if (model.BaseModelProvider is not null)
+        {
+            StripOrphanedVirtualModifiers(model.BaseModelProvider, removedPropertyNames);
+        }
+
         // Reset cached constructors, serialization, and model factories so they do not keep
         // references to inherited ARM properties removed from the model surface.
         model.Update(name: model.Name, properties: remainingProperties.ToArray(), reset: true);
 
         _regularUpdated.Add(model);
+
+        if (updateSerialization)
+        {
+            UpdateSerializationMethodModifiers(model, customBaseType);
+        }
     }
 
-    private static HashSet<string> EnumerateBaseModelProperties(ModelProvider baseModel)
+    private static HashSet<string> EnumerateBaseModelProperties(ModelProvider? baseModel, CSharpType? customBaseType)
     {
         var basePropertyNames = new HashSet<string>(StringComparer.Ordinal);
         ModelProvider? currentModel = baseModel;
@@ -118,10 +142,150 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
             {
                 basePropertyNames.Add(property.Name);
             }
+            foreach (var property in currentModel.CustomCodeView?.Properties ?? [])
+            {
+                basePropertyNames.Add(property.Name);
+            }
             currentModel = currentModel.BaseModelProvider;
         }
+
+        if (customBaseType is not null)
+        {
+            AddPropertiesFromCSharpType(customBaseType, basePropertyNames);
+        }
+
         return basePropertyNames;
     }
+
+    private static void AddPropertiesFromCSharpType(CSharpType baseType, HashSet<string> propertyNames)
+    {
+        var typeMap = ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap;
+        if (typeMap.TryGetValue(baseType, out var provider) && provider is not null)
+        {
+            foreach (var property in provider.Properties)
+            {
+                propertyNames.Add(property.Name);
+            }
+            foreach (var property in provider.CustomCodeView?.Properties ?? [])
+            {
+                propertyNames.Add(property.Name);
+            }
+
+            if (provider is ModelProvider modelProvider)
+            {
+                foreach (var property in EnumerateBaseModelProperties(modelProvider.BaseModelProvider, GetCustomBaseType(modelProvider)))
+                {
+                    propertyNames.Add(property);
+                }
+            }
+            else if (provider.BaseType is not null && !provider.BaseType.Equals(baseType))
+            {
+                AddPropertiesFromCSharpType(provider.BaseType, propertyNames);
+            }
+        }
+
+        if (baseType.IsFrameworkType && baseType.FrameworkType is { } frameworkType)
+        {
+            foreach (var property in frameworkType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                propertyNames.Add(property.Name);
+            }
+        }
+    }
+
+    private static void UpdateSerializationMethodModifiers(ModelProvider model, CSharpType? customBaseType)
+    {
+        if (customBaseType is null)
+        {
+            return;
+        }
+
+        foreach (var method in model.SerializationProviders.SelectMany(p => p.Methods))
+        {
+            if (!IsSerializationCoreMethod(method.Signature.Name))
+            {
+                continue;
+            }
+
+            var modifiers = method.Signature.Modifiers & ~MethodSignatureModifiers.Virtual & ~MethodSignatureModifiers.New & ~MethodSignatureModifiers.Override;
+            var shouldOverride = !TryGetInheritedSerializationMethod(customBaseType, method.Signature.Name, out var inheritedOverride)
+                || inheritedOverride;
+            modifiers |= shouldOverride ? MethodSignatureModifiers.Override : MethodSignatureModifiers.New;
+            method.Signature.Update(modifiers: modifiers);
+            method.Update(signature: method.Signature);
+        }
+    }
+
+    private static CSharpType? GetCustomBaseType(ModelProvider model)
+        => model.CustomCodeView?.BaseType ?? model.BaseType;
+
+    private CSharpType? GetCachedCustomBaseType(ModelProvider model)
+    {
+        if (!_customBaseTypes.TryGetValue(model, out var customBaseType))
+        {
+            customBaseType = GetCustomBaseType(model);
+            _customBaseTypes[model] = customBaseType;
+        }
+
+        return customBaseType;
+    }
+
+    private static bool TryGetInheritedSerializationMethod(CSharpType baseType, string methodName, out bool shouldOverride)
+    {
+        if (!IsSerializationCoreMethod(methodName))
+        {
+            shouldOverride = false;
+            return false;
+        }
+
+        var typeMap = ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap;
+        if (typeMap.TryGetValue(baseType, out var provider) && provider is not null)
+        {
+            var providerMethod = provider.Methods.FirstOrDefault(m => m.Signature.Name == methodName);
+            if (providerMethod is not null)
+            {
+                shouldOverride = providerMethod.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Virtual)
+                    || providerMethod.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Override);
+                return true;
+            }
+
+            if (provider.BaseType is not null)
+            {
+                if (IsResourceDataType(provider.BaseType))
+                {
+                    shouldOverride = true;
+                    return true;
+                }
+
+                return TryGetInheritedSerializationMethod(provider.BaseType, methodName, out shouldOverride);
+            }
+        }
+
+        if (baseType.IsFrameworkType)
+        {
+            for (var frameworkType = baseType.FrameworkType; frameworkType is not null; frameworkType = frameworkType.BaseType)
+            {
+                var inheritedMethod = frameworkType
+                    .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                    .FirstOrDefault(m => m.Name == methodName);
+                if (inheritedMethod is not null)
+                {
+                    shouldOverride = inheritedMethod.IsVirtual && !inheritedMethod.IsFinal;
+                    return true;
+                }
+            }
+        }
+
+        shouldOverride = false;
+        return false;
+    }
+
+    private static bool IsSerializationCoreMethod(string methodName)
+        => methodName is "JsonModelWriteCore" or "JsonModelCreateCore" or "PersistableModelWriteCore" or "PersistableModelCreateCore";
+
+    private static bool IsResourceDataType(CSharpType type)
+        => type.Name is "ResourceData" or "TrackedResourceData"
+            && type.Namespace is "Azure.ResourceManager.Models" or "Azure.ResourceManager.Resources.Models";
 
     private static void StripOrphanedVirtualModifiers(ModelProvider baseModel, HashSet<string> removedPropertyNames)
     {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ResourceDataModelProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ResourceDataModelProviderTests.cs
@@ -6,6 +6,7 @@ using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
 using Azure.Generator.Management.Visitors;
 using Azure.Generator.Management;
+using Azure.Core;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Models;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
@@ -100,8 +101,8 @@ namespace Azure.Generator.Mgmt.Tests
             _ = resourceDataModel.Constructors;
             _ = resourceDataModel.SerializationProviders.SelectMany(s => s.Methods).ToArray();
 
-            var visitor = new TestableInheritableSystemObjectModelVisitor();
-            var result = visitor.InvokePreVisitModel(resourceModel, resourceDataModel);
+            RunVisitors(resourceDataModel);
+            var result = resourceDataModel;
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result!.BaseModelProvider, Is.InstanceOf<SystemObjectModelProvider>());
@@ -125,6 +126,56 @@ namespace Azure.Generator.Mgmt.Tests
             var serializationContent = new TypeProviderWriter(serialization).Write().Content;
             Assert.That(serializationContent, Does.Contain("protected override void JsonModelWriteCore"));
             Assert.That(serializationContent, Does.Contain("base.JsonModelWriteCore(writer, options);"));
+        }
+
+        [Test]
+        public void ResourceDataModelWithCustomSourceBaseFiltersInheritedPropertiesAndOverridesSerialization()
+        {
+            var resourceModel = InputFactory.Model(
+                "ExternalSolution",
+                properties:
+                [
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("location", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("kind", InputPrimitiveType.String, isRequired: true, isDiscriminator: true),
+                    InputFactory.Property("properties", InputPrimitiveType.String),
+                ],
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json);
+
+            _ = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [resourceModel]);
+
+            var resourceDataModel = new ResourceDataModelProvider(resourceModel);
+            ManagementMockHelpers.SetCustomCodeView(resourceDataModel, new ExternalSolutionDataCustomCodeView(resourceDataModel));
+            Assert.That(resourceDataModel.BaseType, Is.Not.Null);
+            ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap[resourceDataModel.BaseType!] =
+                new LegacyExternalSolutionCustomCodeView(resourceDataModel.BaseType!);
+
+            // Reproduce real generation ordering where constructors and serialization can be
+            // built before inherited custom-base members are reconciled.
+            _ = resourceDataModel.Constructors;
+            _ = resourceDataModel.SerializationProviders.SelectMany(s => s.Methods).ToArray();
+
+            RunVisitors(resourceDataModel);
+            var result = resourceDataModel;
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.BaseModelProvider, Is.Null, "The custom base is source-only, not a generated model provider.");
+
+            var propertyNames = result.Properties.Select(p => p.Name).ToList();
+            Assert.That(propertyNames, Does.Not.Contain("Name"));
+            Assert.That(propertyNames, Does.Not.Contain("Location"));
+            Assert.That(propertyNames, Does.Not.Contain("Kind"));
+            Assert.That(propertyNames, Does.Not.Contain("Properties"));
+
+            var modelContent = new TypeProviderWriter(result).Write().Content;
+            Assert.That(modelContent, Does.Contain("ExternalSolutionData : global::Azure.Generator.Mgmt.Tests.ResourceDataModelProviderTests.LegacyExternalSolution"));
+            Assert.That(modelContent, Does.Not.Contain("public string Name"));
+            Assert.That(modelContent, Does.Not.Contain("public string Kind"));
+
+            var serialization = result.SerializationProviders.OfType<MrwSerializationTypeDefinition>().Single();
+            var serializationContent = new TypeProviderWriter(serialization).Write().Content;
+            Assert.That(serializationContent, Does.Contain("protected override void JsonModelWriteCore"));
+            Assert.That(serializationContent, Does.Not.Contain("global::."));
         }
 
         [Test]
@@ -180,6 +231,11 @@ namespace Azure.Generator.Mgmt.Tests
             {
                 return base.PreVisitModel(inputType, type);
             }
+
+            public TypeProvider? InvokeVisitType(TypeProvider type)
+            {
+                return base.VisitType(type);
+            }
         }
 
         private class TestableResourceVisitor : ResourceVisitor
@@ -187,6 +243,65 @@ namespace Azure.Generator.Mgmt.Tests
             public TypeProvider? InvokeVisitType(TypeProvider type)
             {
                 return base.VisitType(type);
+            }
+        }
+
+        private static void RunVisitors(TypeProvider provider)
+        {
+            var visitTypeCore = typeof(Microsoft.TypeSpec.Generator.LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.That(visitTypeCore, Is.Not.Null);
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [provider]);
+            }
+        }
+
+        public class LegacyExternalSolution : ResourceData
+        {
+            public string? Kind { get; set; }
+            public AzureLocation? Location { get; }
+            public string? Properties { get; set; }
+        }
+
+        private class ExternalSolutionDataCustomCodeView : TypeProvider
+        {
+            private readonly string _name;
+
+            public ExternalSolutionDataCustomCodeView(TypeProvider enclosingType)
+            {
+                _name = enclosingType.Name;
+            }
+
+            protected override CSharpType BuildBaseType() => new CSharpType(typeof(LegacyExternalSolution));
+            protected override string BuildName() => _name;
+            protected override string BuildRelativeFilePath() => $"{Name}.cs";
+        }
+
+        private class LegacyExternalSolutionCustomCodeView : TypeProvider
+        {
+            private readonly CSharpType _type;
+
+            public LegacyExternalSolutionCustomCodeView(CSharpType type)
+            {
+                _type = type;
+            }
+
+            protected override CSharpType BuildBaseType() => new CSharpType(typeof(ResourceData));
+            protected override string BuildName() => _type.Name;
+            protected override string BuildNamespace() => _type.Namespace;
+            protected override string BuildRelativeFilePath() => $"{Name}.cs";
+
+            protected override PropertyProvider[] BuildProperties()
+            {
+                return
+                [
+                    new PropertyProvider(null, MethodSignatureModifiers.Public, typeof(string), "Kind", new AutoPropertyBody(true), this),
+                    new PropertyProvider(null, MethodSignatureModifiers.Public, typeof(AzureLocation?), "Location", new AutoPropertyBody(false), this),
+                    new PropertyProvider(null, MethodSignatureModifiers.Public, typeof(string), "Properties", new AutoPropertyBody(true), this),
+                ];
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/TestHelpers/ManagementMockHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/TestHelpers/ManagementMockHelpers.cs
@@ -86,10 +86,15 @@ namespace Azure.Generator.Management.Tests.TestHelpers
 
         public static void SetCustomCodeView(TypeProvider typeProvider, TypeProvider customCodeTypeProvider)
         {
-            typeProvider.GetType().BaseType!.GetField(
-                    "_customCodeView",
-                    BindingFlags.NonPublic | BindingFlags.Instance)?
-                .SetValue(typeProvider, new Lazy<TypeProvider>(() => customCodeTypeProvider));
+            for (var type = typeProvider.GetType(); type is not null; type = type.BaseType)
+            {
+                var field = type.GetField("_customCodeView", BindingFlags.NonPublic | BindingFlags.Instance);
+                if (field is not null)
+                {
+                    field.SetValue(typeProvider, new Lazy<TypeProvider>(() => customCodeTypeProvider));
+                    return;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #59622

## Summary
- account for source-only custom base types when filtering inherited duplicate model properties
- preserve discriminator serialization generation while avoiding duplicate public API members from custom bases
- add a regression for custom-base resource data with discriminator-like inherited members

## Validation
- `dotnet test eng\packages\http-client-csharp-mgmt\generator\Azure.Generator.Management\test\Azure.Generator.Mgmt.Tests.csproj --no-restore --verbosity minimal`