### PR TITLE
Peel Azure.AI.Extensions.OpenAI off the NoWarn skip-list

### DIFF
--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -22,7 +22,6 @@ Azure.AI.AgentServer.Responses
 Azure.AI.AnomalyDetector
 Azure.AI.ContentSafety
 Azure.AI.DocumentIntelligence
-Azure.AI.Extensions.OpenAI
 Azure.AI.FormRecognizer
 Azure.AI.Inference
 Azure.AI.Language.Conversations

--- a/eng/analyzerallowlist/Azure.AI.Extensions.OpenAI.txt
+++ b/eng/analyzerallowlist/Azure.AI.Extensions.OpenAI.txt
@@ -9,12 +9,3 @@
 # exists so external consumers explicitly acknowledge experimental usage;
 # acknowledging it once at the assembly level matches intent.
 nowarn:OPENAI001
-
-# AZC0035 fires on output model types that lack a corresponding ModelFactory
-# method. Here it fires on ResponseResult and StreamingResponseUpdate, both of
-# which originate in the external OpenAI SDK (not declared in this assembly),
-# so a ModelFactory method cannot meaningfully be added in this package. This
-# is the known AZC0035 false-positive pattern on externally-originating types
-# tracked as one of the "Big 4" analyzer fixes; remove this entry once the
-# upstream analyzer learns to skip types declared outside the current assembly.
-nowarn:AZC0035

--- a/eng/analyzerallowlist/Azure.AI.Extensions.OpenAI.txt
+++ b/eng/analyzerallowlist/Azure.AI.Extensions.OpenAI.txt
@@ -1,0 +1,20 @@
+# Azure.AI.Extensions.OpenAI approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# OPENAI001 is the [Experimental] marker on the OpenAI SDK types this library
+# extends (response items, streaming updates, derived clients, etc.). The whole
+# purpose of this library is to wrap and extend OpenAI's preview surface for
+# Microsoft Foundry, so the experimental opt-in is by design across both the
+# hand-written extension types and the generated client surface. The diagnostic
+# exists so external consumers explicitly acknowledge experimental usage;
+# acknowledging it once at the assembly level matches intent.
+nowarn:OPENAI001
+
+# AZC0035 fires on output model types that lack a corresponding ModelFactory
+# method. Here it fires on ResponseResult and StreamingResponseUpdate, both of
+# which originate in the external OpenAI SDK (not declared in this assembly),
+# so a ModelFactory method cannot meaningfully be added in this package. This
+# is the known AZC0035 false-positive pattern on externally-originating types
+# tracked as one of the "Big 4" analyzer fixes; remove this entry once the
+# upstream analyzer learns to skip types declared outside the current assembly.
+nowarn:AZC0035

--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -233,7 +233,7 @@
   <!--                  package dependencies                          -->
   <!-- ============================================================== -->
   <ItemGroup>
-    <PackageVersion Include="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20260129.1" PrivateAssets="All" />
+    <PackageVersion Include="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20260604.1" PrivateAssets="All" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20251023.1" PrivateAssets="All" />
 

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Azure.AI.Extensions.OpenAI.csproj
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Azure.AI.Extensions.OpenAI.csproj
@@ -18,17 +18,6 @@
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Acknowledge experimental OpenAI features -->
-    <NoWarn>$(NoWarn);OPENAI001</NoWarn>
-    <!-- Temporary suppression of XML doc requirement -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <!-- Ignore ModelFactory error (applied to externally originating types) -->
-    <NoWarn>$(NoWarn);AZC0035</NoWarn>
-    <!-- Ignore warnings about the experimental features -->
-    <NoWarn>$(NoWarn);AAIP001</NoWarn>
-  </PropertyGroup>
-  
   <ItemGroup>
     <PackageReference Include="OpenAI" />
     <PackageReference Include="Azure.Core" />

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentReference.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentReference.cs
@@ -14,6 +14,9 @@ public partial class AgentReference
     [CodeGenMember("Version")]
     public string Version { get; }
 
+    /// <summary> Initializes a new instance of <see cref="AgentReference"/>. </summary>
+    /// <param name="name"> The name of the agent. </param>
+    /// <param name="version"> The optional version identifier of the agent. </param>
     public AgentReference(string name, string version = null)
     {
         Name = name;
@@ -21,5 +24,8 @@ public partial class AgentReference
         _additionalBinaryDataProperties = new ChangeTrackingDictionary<string, BinaryData>();
     }
 
+    /// <summary> Converts a string assistant or agent identifier into an <see cref="AgentReference"/>. </summary>
+    /// <param name="agentName"> The assistant or agent identifier. </param>
+    /// <returns> The agent reference created from the supplied identifier. </returns>
     public static implicit operator AgentReference(string agentName) => new(agentName);
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentResponseItem.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentResponseItem.cs
@@ -13,13 +13,23 @@ namespace Azure.AI.Extensions.OpenAI;
 [CodeGenType("AgentResponseItem")]
 public abstract partial class AgentResponseItem
 {
+    /// <summary> Gets the response item ID. </summary>
     public string Id { get; }
 
+    /// <summary> Creates a response item that contains structured output data. </summary>
+    /// <param name="output"> The structured output data. </param>
+    /// <returns> The response item containing the structured output data. </returns>
     public static AgentResponseItem CreateStructuredOutputsItem(BinaryData output = null)
         => new AgentStructuredOutputsResponseItem(output);
+    /// <summary> Creates a response item that represents a workflow preview action. </summary>
+    /// <param name="actionKind"> The kind of workflow action. </param>
+    /// <param name="actionId"> The ID of the workflow action. </param>
+    /// <returns> The response item representing the workflow preview action. </returns>
     public static AgentResponseItem CreateWorkflowPreviewActionItem(string actionKind, string actionId)
         => new AgentWorkflowPreviewActionResponseItem(actionKind, actionId, status: null);
 
+    /// <summary> Converts this agent response item into an OpenAI response item. </summary>
+    /// <returns> The OpenAI response item representation. </returns>
     public ResponseItem AsResponseResultItem()
     {
         BinaryData serializedAgentResponseItem = ModelReaderWriter.Write(
@@ -32,7 +42,13 @@ public abstract partial class AgentResponseItem
             OpenAIContext.Default);
     }
 
+    /// <summary> Converts an <see cref="AgentResponseItem"/> into an OpenAI <see cref="ResponseItem"/>. </summary>
+    /// <param name="agentResponseItem"> The agent response item to convert. </param>
+    /// <returns> The OpenAI response item representation. </returns>
     public static implicit operator ResponseItem(AgentResponseItem agentResponseItem) => agentResponseItem.AsResponseResultItem();
 
+    /// <summary> Converts an OpenAI <see cref="ResponseItem"/> into an <see cref="AgentResponseItem"/>. </summary>
+    /// <param name="responseItem"> The OpenAI response item to convert. </param>
+    /// <returns> The agent response item representation. </returns>
     public static implicit operator AgentResponseItem(ResponseItem responseItem) => responseItem.AsAgentResponseItem();
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentResponseItemKind.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentResponseItemKind.cs
@@ -9,5 +9,6 @@ public readonly partial struct AgentResponseItemKind
     // Customization: manually restore kinds pruned by code generator
     // (due to lack of model grounding in client view)
     private const string MessageValue = "message";
+    /// <summary> Indicates the item represents a message in an agent conversation. </summary>
     public static AgentResponseItemKind Message { get; } = new AgentResponseItemKind(MessageValue);
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentStructuredOutputsResponseItem.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentStructuredOutputsResponseItem.cs
@@ -11,6 +11,8 @@ namespace Azure.AI.Extensions.OpenAI;
 [CodeGenType("StructuredOutputsOutputItem")]
 public partial class AgentStructuredOutputsResponseItem
 {
+    /// <summary> Initializes a new instance of <see cref="AgentStructuredOutputsResponseItem"/>. </summary>
+    /// <param name="output"> The structured output data. </param>
     public AgentStructuredOutputsResponseItem(BinaryData output)
         : this(AgentResponseItemKind.StructuredOutputs, id: null, agentReference: null, responseId: null, additionalBinaryDataProperties: null, output: output)
     { }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentWorkflowPreviewActionResponseItem.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AgentWorkflowPreviewActionResponseItem.cs
@@ -8,6 +8,7 @@ namespace Azure.AI.Extensions.OpenAI;
 [CodeGenType("WorkflowActionOutputItem")]
 public partial class AgentWorkflowPreviewActionResponseItem
 {
+    /// <summary> Gets the status of the workflow preview action. </summary>
     [CodeGenMember("Status")]
     public AgentWorkflowPreviewActionStatus? Status { get; }
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AzureAIExtensions.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/AzureAIExtensions.cs
@@ -23,6 +23,9 @@ namespace Azure.AI.Extensions.OpenAI;
 public static partial class AzureAIExtensions
 {
     // ResponseItem
+    /// <summary> Converts an OpenAI response item into an agent response item. </summary>
+    /// <param name="responseItem"> The OpenAI response item to convert. </param>
+    /// <returns> The agent response item representation. </returns>
     public static AgentResponseItem AsAgentResponseItem(this ResponseItem responseItem)
     {
         BinaryData serializedResponseItem = ModelReaderWriter.Write(responseItem, ModelSerializationExtensions.WireOptions, AzureAIExtensionsOpenAIContext.Default);
@@ -32,12 +35,20 @@ public static partial class AzureAIExtensions
     // ResponseResult
     extension(ResponseResult response)
     {
+        /// <summary> Gets the agent associated with the response result. </summary>
         public AgentReference Agent => response.Patch.GetJsonModelEx<AgentReference>("$.agent_reference"u8);
 
+        /// <summary> Gets the agent conversation ID associated with the response result. </summary>
         public string AgentConversationId => response.Patch.GetStringEx("$.conversation.id"u8);
     }
 
     // ResponsesClient
+    /// <summary> Creates a response for an existing project conversation and agent. </summary>
+    /// <param name="responseClient"> The response client used to send the request. </param>
+    /// <param name="conversation"> The project conversation to continue. </param>
+    /// <param name="agentRef"> The agent that should create the response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public static ClientResult<ResponseResult> CreateResponse(this ResponsesClient responseClient, ProjectConversation conversation, AgentReference agentRef, CancellationToken cancellationToken = default)
     {
         using BinaryContent content = RemoveItems(conversation: conversation, agentRef: agentRef);
@@ -49,6 +60,12 @@ public static partial class AzureAIExtensions
         return ClientResult.FromValue(convenienceValue, protocolResult.GetRawResponse());
     }
 
+    /// <summary> Asynchronously creates a response for an existing project conversation and agent. </summary>
+    /// <param name="responseClient"> The response client used to send the request. </param>
+    /// <param name="conversation"> The project conversation to continue. </param>
+    /// <param name="agentRef"> The agent that should create the response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public static async Task<ClientResult<ResponseResult>> CreateResponseAsync(this ResponsesClient responseClient, ProjectConversation conversation, AgentReference agentRef, CancellationToken cancellationToken = default)
     {
         using BinaryContent content = RemoveItems(conversation: conversation, agentRef: agentRef);
@@ -76,6 +93,9 @@ public static partial class AzureAIExtensions
         return BinaryContent.CreateJson(options.ToJsonString());
     }
 
+    /// <summary> Gets the Azure file status value recorded on an OpenAI file. </summary>
+    /// <param name="file"> The OpenAI file to inspect. </param>
+    /// <returns> The Azure file status, or null when no status is available. </returns>
     public static string GetAzureFileStatus(this OpenAIFile file)
     {
         using BinaryContent contentBytes = BinaryContent.Create(file, ModelSerializationExtensions.WireOptions);
@@ -96,12 +116,14 @@ public static partial class AzureAIExtensions
 
     extension(CreateResponseOptions options)
     {
+        /// <summary> Gets or sets the agent associated with the response options. </summary>
         public AgentReference Agent
         {
             get => options.Patch.GetJsonModelEx<AgentReference>("$.agent_reference"u8);
             set => options.Patch.SetOrClearEx("$.agent_reference"u8, "$.agent_reference"u8, value);
         }
 
+        /// <summary> Gets or sets the agent conversation ID associated with the response options. </summary>
         public string AgentConversationId
         {
             get => options.Patch.GetStringEx("$.conversation.id"u8);

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/CodeGenStubs.Tools.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/CodeGenStubs.Tools.cs
@@ -13,6 +13,7 @@ namespace Azure.AI.Extensions.OpenAI;
 [CodeGenType("AzureFunctionStorageQueue")] public partial class ResponsesAzureFunctionStorageQueue { }
 [CodeGenType("AzureFunctionTool")] public partial class ResponsesAzureFunctionTool { }
 [CodeGenType("AzureAISearchTool")] public partial class ResponsesAzureAISearchTool { }
+/// <summary> Represents options for the Azure AI Search response tool. </summary>
 [CodeGenType("AzureAISearchToolOptions")] public partial class ResponsesAzureAISearchToolOptions { }
 [CodeGenType("AzureAISearchQueryType")] public readonly partial struct ResponsesAzureAISearchQueryType { }
 [CodeGenType("BingCustomSearchConfiguration")] public partial class ResponsesBingCustomSearchConfiguration { }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/ContentFilterConfiguration.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/ContentFilterConfiguration.cs
@@ -5,15 +5,16 @@ using System;
 
 namespace Azure.AI.Extensions.OpenAI;
 
+/// <summary> Represents the content filter configuration used for requests. </summary>
 [CodeGenType("RaiConfig")]
 public partial class ContentFilterConfiguration
 {
-    /// <summary> The name of the RAI policy to apply. </summary>
+    /// <summary> The name of the responsible AI policy to apply. </summary>
     [CodeGenMember("RaiPolicyName")]
     public string PolicyName { get; set; }
 
     /// <summary> Initializes a new instance of <see cref="ContentFilterConfiguration"/>. </summary>
-    /// <param name="policyName"> The name of the RAI policy to apply. </param>
+    /// <param name="policyName"> The name of the responsible AI policy to apply. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="policyName"/> is null. </exception>
     public ContentFilterConfiguration(string policyName)
     {

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OAuthConsentRequestResponseItem.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OAuthConsentRequestResponseItem.cs
@@ -9,6 +9,7 @@ public partial class OAuthConsentRequestResponseItem
     [CodeGenMember("ConsentLink")]
     internal string InternalConsentLink { get; }
 
+    /// <summary> Gets the URI the user can open to provide OAuth consent. </summary>
     public Uri ConsentLink { get => new(InternalConsentLink); }
 
     /// <summary> Initializes a new instance of <see cref="OAuthConsentRequestResponseItem"/>. </summary>

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ClientConnectionProviderExtensions.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ClientConnectionProviderExtensions.cs
@@ -9,10 +9,14 @@ using Azure.AI.Extensions.OpenAI;
 
 namespace Azure.AI.Projects;
 
+/// <summary> Provides OpenAI client extensions for project client connections. </summary>
 public static partial class ClientConnectionProviderExtensions
 {
     extension(ClientConnectionProvider connectionProvider)
     {
+        /// <summary> Gets a project OpenAI client from the client connection provider. </summary>
+        /// <param name="options"> The options used to configure the project OpenAI client. </param>
+        /// <returns> The project OpenAI client, or null when the provider does not contain a compatible connection. </returns>
         public ProjectOpenAIClient GetProjectOpenAIClient(ProjectOpenAIClientOptions options = null)
         {
             ClientConnection pipelineConnection = connectionProvider.GetConnection("Internal.DirectPipelinePassthrough");

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectConversationCreationOptions.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectConversationCreationOptions.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.Extensions.OpenAI;
 public partial class ProjectConversationCreationOptions
 {
     /// <summary>
-    /// Initial items to include the conversation context.
+    /// Gets the initial items to include in the conversation context.
     /// You may add up to 20 items at a time.
     /// </summary>
     [CodeGenMember("Items")]
@@ -26,6 +26,7 @@ public partial class ProjectConversationCreationOptions
     [CodeGenMember("Metadata")]
     private global::Azure.AI.Extensions.OpenAI.InternalMetadataContainer InternalMetadata { get; set; }
 
+    /// <summary> Gets the metadata attached to the conversation. </summary>
     public IDictionary<string, string> Metadata => InternalMetadata.AdditionalProperties;
 
     /// <summary> Initializes a new instance of <see cref="ProjectConversationCreationOptions"/>. </summary>
@@ -37,15 +38,15 @@ public partial class ProjectConversationCreationOptions
 
     /// <summary> Initializes a new instance of <see cref="ProjectConversationCreationOptions"/>. </summary>
     /// <param name="metadata">
-    /// Set of 16 key-value pairs that can be attached to an object. This can be
+    /// A set of 16 key-value pairs that can be attached to an object. This can be
     /// useful for storing additional information about the object in a structured
-    /// format, and querying for objects via API or the dashboard.
+    /// format and querying for objects through the API or the dashboard.
     ///
     /// Keys are strings with a maximum length of 64 characters. Values are strings
     /// with a maximum length of 512 characters.
     /// </param>
     /// <param name="items">
-    /// Initial items to include the conversation context.
+    /// The initial items to include in the conversation context.
     /// You may add up to 20 items at a time.
     /// </param>
     /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
@@ -62,7 +63,9 @@ public partial class ProjectConversationCreationOptions
     private static void DeserializeItemsValue(JsonProperty property, ref IList<ResponseItem> items)
         => ResponseItemHelpers.DeserializeItemsValue(property, ref items);
 
+    /// <summary> Converts project conversation creation options into binary content. </summary>
     /// <param name="projectConversationCreationOptions"> The <see cref="ProjectConversationCreationOptions"/> to serialize into <see cref="BinaryContent"/>. </param>
+    /// <returns> The binary content representation of the project conversation creation options. </returns>
     public static implicit operator BinaryContent(ProjectConversationCreationOptions projectConversationCreationOptions)
     {
         if (projectConversationCreationOptions == null)
@@ -72,6 +75,7 @@ public partial class ProjectConversationCreationOptions
         return BinaryContent.Create(projectConversationCreationOptions, ModelSerializationExtensions.WireOptions);
     }
 
+    /// <summary> Writes the model to the JSON writer. </summary>
     /// <param name="writer"> The JSON writer. </param>
     /// <param name="options"> The client options for reading and writing models. </param>
     protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectConversationUpdateOptions.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectConversationUpdateOptions.cs
@@ -13,6 +13,7 @@ public partial class ProjectConversationUpdateOptions
     [CodeGenMember("Metadata")]
     private global::Azure.AI.Extensions.OpenAI.InternalMetadataContainer InternalMetadata { get; set; }
 
+    /// <summary> Gets the metadata to update on the conversation. </summary>
     public IDictionary<string, string> Metadata => InternalMetadata.AdditionalProperties;
 
     /// <summary> Initializes a new instance of <see cref="ProjectConversationUpdateOptions"/>. </summary>
@@ -23,9 +24,9 @@ public partial class ProjectConversationUpdateOptions
 
     /// <summary> Initializes a new instance of <see cref="ProjectConversationUpdateOptions"/>. </summary>
     /// <param name="metadata">
-    /// Set of 16 key-value pairs that can be attached to an object. This can be
+    /// A set of 16 key-value pairs that can be attached to an object. This can be
     /// useful for storing additional information about the object in a structured
-    /// format, and querying for objects via API or the dashboard.
+    /// format and querying for objects through the API or the dashboard.
     ///
     /// Keys are strings with a maximum length of 64 characters. Values are strings
     /// with a maximum length of 512 characters.

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectConversationsClient.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectConversationsClient.cs
@@ -15,6 +15,7 @@ using OpenAI.Responses;
 
 namespace Azure.AI.Extensions.OpenAI;
 
+/// <summary> Provides conversation operations for an Azure AI project through the OpenAI conversation API. </summary>
 public partial class ProjectConversationsClient : ConversationClient
 {
     /*
@@ -23,12 +24,19 @@ public partial class ProjectConversationsClient : ConversationClient
 
     private readonly Uri _endpoint;
 
+    /// <summary> Initializes a new instance of <see cref="ProjectConversationsClient"/>. </summary>
+    /// <param name="pipeline"> The client pipeline used to send requests. </param>
+    /// <param name="options"> The options used to configure the client. </param>
     public ProjectConversationsClient(ClientPipeline pipeline, OpenAIClientOptions options)
         : base(pipeline, options)
     {
         _endpoint = options.Endpoint;
     }
 
+    /// <summary> Creates a project conversation. </summary>
+    /// <param name="options"> The options used to create the conversation. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created project conversation. </returns>
     public virtual ClientResult<ProjectConversation> CreateProjectConversation(ProjectConversationCreationOptions options = null, CancellationToken cancellationToken = default)
     {
         options ??= new();
@@ -36,6 +44,10 @@ public partial class ProjectConversationsClient : ConversationClient
         return protocolResult.ToAgentClientResult<ProjectConversation>();
     }
 
+    /// <summary> Asynchronously creates a project conversation. </summary>
+    /// <param name="options"> The options used to create the conversation. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created project conversation. </returns>
     public virtual async Task<ClientResult<ProjectConversation>> CreateProjectConversationAsync(ProjectConversationCreationOptions options = null, CancellationToken cancellationToken = default)
     {
         options ??= new();
@@ -43,30 +55,31 @@ public partial class ProjectConversationsClient : ConversationClient
         return protocolResult.ToAgentClientResult<ProjectConversation>();
     }
 
-    /// <summary> Returns the list of all conversations. </summary>
+    /// <summary> Gets the project conversations. </summary>
     /// <param name="agent">
-    /// If provided, only conversations associated with the referenced agent will be retrieved.
+    /// If provided, retrieves only conversations associated with the referenced agent.
     /// </param>
     /// <param name="limit">
-    /// A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+    /// The maximum number of objects to return. The value can range between 1 and 100, and the
     /// default is 20.
     /// </param>
     /// <param name="order">
-    /// Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+    /// The sort order by the `created_at` timestamp of the objects. Use `asc` for ascending order and `desc`
     /// for descending order.
     /// </param>
     /// <param name="after">
-    /// A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-    /// For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-    /// subsequent call can include after=obj_foo in order to fetch the next page of the list.
+    /// A pagination cursor. `after` is an object ID that defines your place in the list.
+    /// For instance, if you make a list request and receive 100 objects ending with obj_foo, your
+    /// subsequent call can include after=obj_foo to fetch the next page of the list.
     /// </param>
     /// <param name="before">
-    /// A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-    /// For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-    /// subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+    /// A pagination cursor. `before` is an object ID that defines your place in the list.
+    /// For instance, if you make a list request and receive 100 objects ending with obj_foo, your
+    /// subsequent call can include before=obj_foo to fetch the previous page of the list.
     /// </param>
     /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
-    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The project conversations. </returns>
+    /// <exception cref="ClientResultException"> The service returned a non-success status code. </exception>
     public virtual CollectionResult<ProjectConversation> GetProjectConversations(AgentReference agent = null, int? limit = default, string order = null, string after = default, string before = default, CancellationToken cancellationToken = default)
     {
         string agentNameToUse = string.IsNullOrEmpty(agent?.Version) ? agent?.Name : null;
@@ -88,30 +101,31 @@ public partial class ProjectConversationsClient : ConversationClient
             cancellationToken.ToRequestOptions());
     }
 
-    /// <summary> Returns the list of all conversations. </summary>
+    /// <summary> Asynchronously gets the project conversations. </summary>
     /// <param name="agent">
-    /// If provided, only conversations associated with the referenced agent will be retrieved.
+    /// If provided, retrieves only conversations associated with the referenced agent.
     /// </param>
     /// <param name="limit">
-    /// A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+    /// The maximum number of objects to return. The value can range between 1 and 100, and the
     /// default is 20.
     /// </param>
     /// <param name="order">
-    /// Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+    /// The sort order by the `created_at` timestamp of the objects. Use `asc` for ascending order and `desc`
     /// for descending order.
     /// </param>
     /// <param name="after">
-    /// A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-    /// For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-    /// subsequent call can include after=obj_foo in order to fetch the next page of the list.
+    /// A pagination cursor. `after` is an object ID that defines your place in the list.
+    /// For instance, if you make a list request and receive 100 objects ending with obj_foo, your
+    /// subsequent call can include after=obj_foo to fetch the next page of the list.
     /// </param>
     /// <param name="before">
-    /// A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-    /// For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-    /// subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+    /// A pagination cursor. `before` is an object ID that defines your place in the list.
+    /// For instance, if you make a list request and receive 100 objects ending with obj_foo, your
+    /// subsequent call can include before=obj_foo to fetch the previous page of the list.
     /// </param>
     /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
-    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The project conversations. </returns>
+    /// <exception cref="ClientResultException"> The service returned a non-success status code. </exception>
     public virtual AsyncCollectionResult<ProjectConversation> GetProjectConversationsAsync(AgentReference agent = null, int? limit = default, string order = null, string after = default, string before = default, CancellationToken cancellationToken = default)
     {
         string agentNameToUse = string.IsNullOrEmpty(agent?.Version) ? agent?.Name : null;
@@ -133,6 +147,10 @@ public partial class ProjectConversationsClient : ConversationClient
             cancellationToken.ToRequestOptions());
     }
 
+    /// <summary> Gets a project conversation by ID. </summary>
+    /// <param name="conversationId"> The ID of the conversation to retrieve. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The requested project conversation. </returns>
     public virtual ClientResult<ProjectConversation> GetProjectConversation(string conversationId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
@@ -140,6 +158,10 @@ public partial class ProjectConversationsClient : ConversationClient
         return protocolResult.ToAgentClientResult<ProjectConversation>();
     }
 
+    /// <summary> Asynchronously gets a project conversation by ID. </summary>
+    /// <param name="conversationId"> The ID of the conversation to retrieve. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The requested project conversation. </returns>
     public virtual async Task<ClientResult<ProjectConversation>> GetProjectConversationAsync(string conversationId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
@@ -147,6 +169,16 @@ public partial class ProjectConversationsClient : ConversationClient
         return protocolResult.ToAgentClientResult<ProjectConversation>();
     }
 
+    /// <summary> Gets the items in a project conversation. </summary>
+    /// <param name="conversationId"> The ID of the conversation whose items should be retrieved. </param>
+    /// <param name="itemKind"> The item kind used to filter the returned items. </param>
+    /// <param name="limit"> The maximum number of items to return. </param>
+    /// <param name="order"> The order used to sort returned items. </param>
+    /// <param name="after"> The item ID after which results should be returned. </param>
+    /// <param name="before"> The item ID before which results should be returned. </param>
+    /// <param name="include"> The additional item properties to include in the response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The project conversation items. </returns>
     public virtual CollectionResult<AgentResponseItem> GetProjectConversationItems(
         string conversationId,
         AgentResponseItemKind? itemKind = null,
@@ -174,6 +206,16 @@ public partial class ProjectConversationsClient : ConversationClient
             cancellationToken.ToRequestOptions());
     }
 
+    /// <summary> Asynchronously gets the items in a project conversation. </summary>
+    /// <param name="conversationId"> The ID of the conversation whose items should be retrieved. </param>
+    /// <param name="itemKind"> The item kind used to filter the returned items. </param>
+    /// <param name="limit"> The maximum number of items to return. </param>
+    /// <param name="order"> The order used to sort returned items. </param>
+    /// <param name="after"> The item ID after which results should be returned. </param>
+    /// <param name="before"> The item ID before which results should be returned. </param>
+    /// <param name="include"> The additional item properties to include in the response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The project conversation items. </returns>
     public virtual AsyncCollectionResult<AgentResponseItem> GetProjectConversationItemsAsync(
         string conversationId,
         AgentResponseItemKind? itemKind = null,
@@ -201,29 +243,42 @@ public partial class ProjectConversationsClient : ConversationClient
             cancellationToken.ToRequestOptions());
     }
 
+    /// <summary> Gets a single item from a project conversation. </summary>
+    /// <param name="conversationId"> The ID of the conversation that contains the item. </param>
+    /// <param name="itemId"> The ID of the item to retrieve. </param>
+    /// <param name="include"> The additional item properties to include in the response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The requested project conversation item. </returns>
     public virtual ClientResult<AgentResponseItem> GetProjectConversationItem(string conversationId, string itemId, IEnumerable<IncludedConversationItemProperty> include = null, CancellationToken cancellationToken = default)
     {
         ClientResult protocolResult = GetConversationItem(conversationId, itemId, include, cancellationToken.ToRequestOptions());
         return protocolResult.ToAgentClientResult<AgentResponseItem>();
     }
 
+    /// <summary> Asynchronously gets a single item from a project conversation. </summary>
+    /// <param name="conversationId"> The ID of the conversation that contains the item. </param>
+    /// <param name="itemId"> The ID of the item to retrieve. </param>
+    /// <param name="include"> The additional item properties to include in the response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The requested project conversation item. </returns>
     public virtual async Task<ClientResult<AgentResponseItem>> GetProjectConversationItemAsync(string conversationId, string itemId, IEnumerable<IncludedConversationItemProperty> include = null, CancellationToken cancellationToken = default)
     {
         ClientResult protocolResult = await GetConversationItemAsync(conversationId, itemId, include, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
         return protocolResult.ToAgentClientResult<AgentResponseItem>();
     }
 
-    /// <summary> Create items in a conversation with the given ID. </summary>
-    /// <param name="conversationId"> The id of the conversation on which the item needs to be created. </param>
+    /// <summary> Creates items in a conversation with the given ID. </summary>
+    /// <param name="conversationId"> The ID of the conversation in which to create the items. </param>
     /// <param name="items"> The items to add to the conversation. You may add up to 20 items at a time. </param>
     /// <param name="include">
     /// Additional fields to include in the response.
-    /// See the `include` parameter for listing Conversation items for more information.
+    /// See the `include` parameter for listing conversation items for more information.
     /// </param>
     /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created conversation items. </returns>
     /// <exception cref="ArgumentNullException"> <paramref name="conversationId"/> or <paramref name="items"/> is null. </exception>
-    /// <exception cref="ArgumentException"> <paramref name="conversationId"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="conversationId"/> is an empty string when a non-empty value was expected. </exception>
+    /// <exception cref="ClientResultException"> The service returned a non-success status code. </exception>
     public virtual ClientResult<ReadOnlyCollection<ResponseItem>> CreateProjectConversationItems(string conversationId, IEnumerable<ResponseItem> items, IEnumerable<IncludedConversationItemProperty> include = default, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
@@ -238,17 +293,18 @@ public partial class ProjectConversationsClient : ConversationClient
             protocolResult.GetRawResponse());
     }
 
-    /// <summary> Create items in a conversation with the given ID. </summary>
-    /// <param name="conversationId"> The id of the conversation on which the item needs to be created. </param>
+    /// <summary> Asynchronously creates items in a conversation with the given ID. </summary>
+    /// <param name="conversationId"> The ID of the conversation in which to create the items. </param>
     /// <param name="items"> The items to add to the conversation. You may add up to 20 items at a time. </param>
     /// <param name="include">
     /// Additional fields to include in the response.
-    /// See the `include` parameter for listing Conversation items for more information.
+    /// See the `include` parameter for listing conversation items for more information.
     /// </param>
     /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created conversation items. </returns>
     /// <exception cref="ArgumentNullException"> <paramref name="conversationId"/> or <paramref name="items"/> is null. </exception>
-    /// <exception cref="ArgumentException"> <paramref name="conversationId"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="conversationId"/> is an empty string when a non-empty value was expected. </exception>
+    /// <exception cref="ClientResultException"> The service returned a non-success status code. </exception>
     public virtual async Task<ClientResult<ReadOnlyCollection<ResponseItem>>> CreateProjectConversationItemsAsync(string conversationId, IEnumerable<ResponseItem> items, IEnumerable<IncludedConversationItemProperty> include = default, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
@@ -263,18 +319,29 @@ public partial class ProjectConversationsClient : ConversationClient
             protocolResult.GetRawResponse());
     }
 
+    /// <summary> Updates a project conversation. </summary>
+    /// <param name="conversationId"> The ID of the conversation to update. </param>
+    /// <param name="options"> The options containing the conversation updates. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The updated project conversation. </returns>
     public virtual ClientResult<ProjectConversation> UpdateProjectConversation(string conversationId, ProjectConversationUpdateOptions options, CancellationToken cancellationToken = default)
     {
         ClientResult protocolResult = base.UpdateConversation(conversationId, BinaryContent.Create(ModelReaderWriter.Write(options, ModelSerializationExtensions.WireOptions, AzureAIExtensionsOpenAIContext.Default)), cancellationToken.ToRequestOptions());
         return protocolResult.ToAgentClientResult<ProjectConversation>();
     }
 
+    /// <summary> Asynchronously updates a project conversation. </summary>
+    /// <param name="conversationId"> The ID of the conversation to update. </param>
+    /// <param name="options"> The options containing the conversation updates. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The updated project conversation. </returns>
     public virtual async Task<ClientResult<ProjectConversation>> UpdateProjectConversationAsync(string conversationId, ProjectConversationUpdateOptions options, CancellationToken cancellationToken = default)
     {
         ClientResult protocolResult = await base.UpdateConversationAsync(conversationId, BinaryContent.Create(ModelReaderWriter.Write(options, ModelSerializationExtensions.WireOptions, AzureAIExtensionsOpenAIContext.Default)), cancellationToken.ToRequestOptions()).ConfigureAwait(false);
         return protocolResult.ToAgentClientResult<ProjectConversation>();
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectConversationsClient"/> for mocking. </summary>
     protected ProjectConversationsClient()
     { }
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectFilesClient.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectFilesClient.cs
@@ -7,6 +7,7 @@ using OpenAI.Files;
 
 namespace Azure.AI.Extensions.OpenAI;
 
+/// <summary> Provides file operations for an Azure AI project through the OpenAI file API. </summary>
 public partial class ProjectFilesClient : OpenAIFileClient
 {
     internal ProjectFilesClient(ClientPipeline pipeline, OpenAIClientOptions options)
@@ -14,6 +15,7 @@ public partial class ProjectFilesClient : OpenAIFileClient
     {
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectFilesClient"/> for mocking. </summary>
     protected ProjectFilesClient()
     { }
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClient.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClient.cs
@@ -13,6 +13,7 @@ using OpenAI.Files;
 
 namespace Azure.AI.Extensions.OpenAI;
 
+/// <summary> Provides OpenAI clients scoped to an Azure AI project. </summary>
 public partial class ProjectOpenAIClient : OpenAIClient
 {
     private ProjectConversationsClient _cachedConversationClient;
@@ -32,6 +33,10 @@ public partial class ProjectOpenAIClient : OpenAIClient
     {
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectOpenAIClient"/>. </summary>
+    /// <param name="projectEndpoint"> The Azure AI project endpoint. </param>
+    /// <param name="tokenProvider"> The token provider used to authenticate requests. </param>
+    /// <param name="options"> The options used to configure the client. </param>
     public ProjectOpenAIClient(Uri projectEndpoint, AuthenticationTokenProvider tokenProvider, ProjectOpenAIClientOptions options = null)
         : base(
             pipeline: CreatePipeline(
@@ -45,6 +50,9 @@ public partial class ProjectOpenAIClient : OpenAIClient
         _options = GetMergedOptions(projectEndpoint, tokenProvider, options);
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectOpenAIClient"/>. </summary>
+    /// <param name="authenticationPolicy"> The authentication policy used by the client pipeline. </param>
+    /// <param name="options"> The options used to configure the client. </param>
     public ProjectOpenAIClient(AuthenticationPolicy authenticationPolicy, ProjectOpenAIClientOptions options)
         : base(
             pipeline: CreatePipeline(authenticationPolicy, options),
@@ -57,19 +65,27 @@ public partial class ProjectOpenAIClient : OpenAIClient
         _options = options;
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectOpenAIClient"/>. </summary>
+    /// <param name="pipeline"> The client pipeline used to send requests. </param>
+    /// <param name="options"> The options used to configure the client. </param>
     protected internal ProjectOpenAIClient(ClientPipeline pipeline, ProjectOpenAIClientOptions options)
         : base(pipeline, options)
     {
         _options = options;
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectOpenAIClient"/> for mocking. </summary>
     protected ProjectOpenAIClient()
     { }
 
+    /// <summary> Gets the project conversations client as the default conversation client. </summary>
+    /// <returns> The project conversations client. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override ConversationClient GetConversationClient()
         => GetProjectConversationsClient();
 
+    /// <summary> Gets a client for project conversation operations. </summary>
+    /// <returns> The project conversations client. </returns>
     public virtual ProjectConversationsClient GetProjectConversationsClient()
     {
         return Volatile.Read(ref _cachedConversationClient)
@@ -77,6 +93,8 @@ public partial class ProjectOpenAIClient : OpenAIClient
             ?? _cachedConversationClient;
     }
 
+    /// <summary> Gets a client for project file operations. </summary>
+    /// <returns> The project files client. </returns>
     public virtual ProjectFilesClient GetProjectFilesClient()
     {
         return Volatile.Read(ref _cachedFileClient)
@@ -84,9 +102,13 @@ public partial class ProjectOpenAIClient : OpenAIClient
             ?? _cachedFileClient;
     }
 
+    /// <summary> Gets the project files client as the default OpenAI file client. </summary>
+    /// <returns> The project files client. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override OpenAIFileClient GetOpenAIFileClient() => GetProjectFilesClient();
 
+    /// <summary> Gets a client for project vector store operations. </summary>
+    /// <returns> The project vector stores client. </returns>
     public virtual ProjectVectorStoresClient GetProjectVectorStoresClient()
     {
         return Volatile.Read(ref _cachedVectorStoreClient)
@@ -94,6 +116,8 @@ public partial class ProjectOpenAIClient : OpenAIClient
             ?? _cachedVectorStoreClient;
     }
 
+    /// <summary> Gets a client for project response operations. </summary>
+    /// <returns> The project responses client. </returns>
     public virtual ProjectResponsesClient GetProjectResponsesClient()
     {
         return Volatile.Read(ref _cachedResponseClient)
@@ -101,6 +125,10 @@ public partial class ProjectOpenAIClient : OpenAIClient
             ?? _cachedResponseClient;
     }
 
+    /// <summary> Gets a project responses client that uses a default agent. </summary>
+    /// <param name="defaultAgent"> The default agent used for response requests. </param>
+    /// <param name="defaultConversationId"> The default conversation ID used for response requests. </param>
+    /// <returns> The project responses client configured with the default agent. </returns>
     public virtual ProjectResponsesClient GetProjectResponsesClientForAgent(AgentReference defaultAgent, string defaultConversationId = null)
     {
         Argument.AssertNotNull(defaultAgent, nameof(defaultAgent));
@@ -111,6 +139,11 @@ public partial class ProjectOpenAIClient : OpenAIClient
             defaultConversationId);
     }
 
+    /// <summary> Gets a project responses client that sends requests to the specified agent endpoint. </summary>
+    /// <param name="agentName"> The name of the agent endpoint to use. </param>
+    /// <param name="defaultConversationId"> The default conversation ID used for response requests. </param>
+    /// <param name="options"> The options used to configure the project responses client. </param>
+    /// <returns> The project responses client configured for the agent endpoint. </returns>
     public virtual ProjectResponsesClient GetProjectResponsesClientForAgentEndpoint(string agentName, string defaultConversationId = null, ProjectOpenAIClientOptions options = null)
     {
         Argument.AssertNotNull(agentName, nameof(agentName));
@@ -131,6 +164,10 @@ public partial class ProjectOpenAIClient : OpenAIClient
         );
     }
 
+    /// <summary> Gets a project responses client that uses a default model. </summary>
+    /// <param name="defaultModel"> The default model used for response requests. </param>
+    /// <param name="defaultConversationId"> The default conversation ID used for response requests. </param>
+    /// <returns> The project responses client configured with the default model. </returns>
     public virtual ProjectResponsesClient GetProjectResponsesClientForModel(string defaultModel, string defaultConversationId = null)
     {
         Argument.AssertNotNullOrEmpty(defaultModel, nameof(defaultModel));

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClientOptions.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClientOptions.cs
@@ -6,10 +6,12 @@ using OpenAI;
 
 namespace Azure.AI.Extensions.OpenAI;
 
+/// <summary> Represents options for configuring a project OpenAI client. </summary>
 public partial class ProjectOpenAIClientOptions : OpenAIClientOptions
 {
     private string _apiVersion;
 
+    /// <summary> Gets or sets the API version used for project OpenAI requests. </summary>
     public string ApiVersion
     {
         get => _apiVersion;
@@ -20,11 +22,13 @@ public partial class ProjectOpenAIClientOptions : OpenAIClientOptions
         }
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectOpenAIClientOptions"/>. </summary>
     public ProjectOpenAIClientOptions() : base()
     {
         _apiVersion = "v1";
     }
 
+    /// <summary> Gets or sets the agent name used when building an agent endpoint. </summary>
     public string AgentName { get; set; } = null;
     internal AuthenticationTokenProvider TokenProvider { get; set; }
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectResponsesClient.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectResponsesClient.cs
@@ -16,6 +16,7 @@ namespace Azure.AI.Extensions.OpenAI;
 
 #pragma warning disable SCME0001
 
+/// <summary> Provides response operations for an Azure AI project through the OpenAI responses API. </summary>
 public partial class ProjectResponsesClient : ResponsesClient
 {
     private readonly string _defaultModelName;
@@ -27,27 +28,25 @@ public partial class ProjectResponsesClient : ResponsesClient
     /// Creates a new instance of <see cref="ProjectResponsesClient"/>.
     /// </summary>
     /// <remarks>
-    /// This constructor will automatically construct the base URI for requests from the supplied <paramref name="projectEndpoint"/>
+    /// This constructor automatically constructs the base URI for requests from the supplied <paramref name="projectEndpoint"/>
     /// value. To use a base URI directly, use the alternative constructor and set <see cref="OpenAIClientOptions.Endpoint"/> on the
-    /// options supplied.
+    /// supplied options.
     /// </remarks>
-    /// <param name="projectEndpoint"></param>
-    /// <param name="tokenProvider"></param>
-    /// <param name="options"></param>
+    /// <param name="projectEndpoint"> The Azure AI project endpoint. </param>
+    /// <param name="tokenProvider"> The token provider used to authenticate requests. </param>
+    /// <param name="options"> The options used to configure the client. </param>
     public ProjectResponsesClient(Uri projectEndpoint, AuthenticationTokenProvider tokenProvider, ProjectResponsesClientOptions options = null)
         : this(projectEndpoint, tokenProvider, defaultAgent: null, defaultConversationId: null, options)
     { }
 
     /// <summary>
-    /// Creates a new instance of <see cref="ProjectResponsesClient"/>.
+    /// Creates a new instance of <see cref="ProjectResponsesClient"/> with default agent settings.
     /// </summary>
-    /// <remarks>
-    /// </remarks>
-    /// <param name="projectEndpoint"></param>
-    /// <param name="tokenProvider"></param>
-    /// <param name="defaultAgent"></param>
-    /// <param name="defaultConversationId"></param>
-    /// <param name="options"></param>
+    /// <param name="projectEndpoint"> The Azure AI project endpoint. </param>
+    /// <param name="tokenProvider"> The token provider used to authenticate requests. </param>
+    /// <param name="defaultAgent"> The default agent used for response requests. </param>
+    /// <param name="defaultConversationId"> The default conversation ID used for response requests. </param>
+    /// <param name="options"> The options used to configure the client. </param>
     public ProjectResponsesClient(Uri projectEndpoint, AuthenticationTokenProvider tokenProvider, AgentReference defaultAgent, string defaultConversationId = null, ProjectResponsesClientOptions options = null)
         : this(
               pipeline: ProjectOpenAIClient.CreatePipeline(
@@ -64,15 +63,20 @@ public partial class ProjectResponsesClient : ResponsesClient
     /// Creates a new instance of <see cref="ProjectResponsesClient"/>.
     /// </summary>
     /// <remarks>
-    /// This constructor will directly use the supplied value from the provided <see cref="OpenAIClientOptions.Endpoint"/>
-    /// and will perform no additional automatic resolution.
+    /// This constructor directly uses the supplied value from the provided <see cref="OpenAIClientOptions.Endpoint"/>
+    /// and performs no additional automatic resolution.
     /// </remarks>
-    /// <param name="tokenProvider"></param>
-    /// <param name="options"></param>
+    /// <param name="tokenProvider"> The token provider used to authenticate requests. </param>
+    /// <param name="options"> The options used to configure the client. </param>
     public ProjectResponsesClient(AuthenticationTokenProvider tokenProvider, ProjectResponsesClientOptions options)
         : this(projectEndpoint: null, tokenProvider, defaultAgent: null, defaultConversationId: null, options)
     { }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectResponsesClient"/>. </summary>
+    /// <param name="tokenProvider"> The token provider used to authenticate requests. </param>
+    /// <param name="options"> The options used to configure the client. </param>
+    /// <param name="defaultAgent"> The default agent used for response requests. </param>
+    /// <param name="defaultConversationId"> The default conversation ID used for response requests. </param>
     public ProjectResponsesClient(AuthenticationTokenProvider tokenProvider, ProjectResponsesClientOptions options = null, AgentReference defaultAgent = null, string defaultConversationId = null)
         : this(projectEndpoint: null, tokenProvider, defaultAgent, defaultConversationId, options)
     { }
@@ -92,9 +96,14 @@ public partial class ProjectResponsesClient : ResponsesClient
         _defaultConversationId = defaultConversationId;
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectResponsesClient"/> for mocking. </summary>
     protected ProjectResponsesClient()
     { }
 
+    /// <summary> Creates a response using the supplied response options. </summary>
+    /// <param name="options"> The options used to create the response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public override ClientResult<ResponseResult> CreateResponse(CreateResponseOptions options, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(options, nameof(options));
@@ -113,11 +122,22 @@ public partial class ProjectResponsesClient : ResponsesClient
         }
     }
 
+    /// <summary> Creates a response from the supplied input items. </summary>
+    /// <param name="inputItems"> The input items used to create the response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public virtual ClientResult<ResponseResult> CreateResponse(IEnumerable<ResponseItem> inputItems, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         return CreateResponse(null, inputItems, previousResponseId, cancellationToken);
     }
 
+    /// <summary> Creates a response for the specified model from the supplied input items. </summary>
+    /// <param name="model"> The model used to create the response. </param>
+    /// <param name="inputItems"> The input items used to create the response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public override ClientResult<ResponseResult> CreateResponse(string model, IEnumerable<ResponseItem> inputItems, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(inputItems, nameof(inputItems));
@@ -134,11 +154,22 @@ public partial class ProjectResponsesClient : ResponsesClient
         return base.CreateResponse(options, cancellationToken);
     }
 
+    /// <summary> Creates a response from user input text. </summary>
+    /// <param name="userInputText"> The user input text used to create the response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public virtual ClientResult<ResponseResult> CreateResponse(string userInputText, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         return CreateResponse(null, userInputText, previousResponseId, cancellationToken);
     }
 
+    /// <summary> Creates a response for the specified model from user input text. </summary>
+    /// <param name="model"> The model used to create the response. </param>
+    /// <param name="userInputText"> The user input text used to create the response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public override ClientResult<ResponseResult> CreateResponse(string model, string userInputText, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(userInputText, nameof(userInputText));
@@ -163,6 +194,10 @@ public partial class ProjectResponsesClient : ResponsesClient
         }
     }
 
+    /// <summary> Asynchronously creates a response using the supplied response options. </summary>
+    /// <param name="options"> The options used to create the response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public override async Task<ClientResult<ResponseResult>> CreateResponseAsync(CreateResponseOptions options, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(options, nameof(options));
@@ -181,11 +216,22 @@ public partial class ProjectResponsesClient : ResponsesClient
         }
     }
 
+    /// <summary> Asynchronously creates a response from the supplied input items. </summary>
+    /// <param name="inputItems"> The input items used to create the response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public virtual async Task<ClientResult<ResponseResult>> CreateResponseAsync(IEnumerable<ResponseItem> inputItems, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         return await CreateResponseAsync(null, inputItems, previousResponseId, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary> Asynchronously creates a response for the specified model from the supplied input items. </summary>
+    /// <param name="model"> The model used to create the response. </param>
+    /// <param name="inputItems"> The input items used to create the response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public override async Task<ClientResult<ResponseResult>> CreateResponseAsync(string model, IEnumerable<ResponseItem> inputItems, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(inputItems, nameof(inputItems));
@@ -214,10 +260,21 @@ public partial class ProjectResponsesClient : ResponsesClient
         }
     }
 
+    /// <summary> Asynchronously creates a response from user input text. </summary>
+    /// <param name="userInputText"> The user input text used to create the response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public async virtual Task<ClientResult<ResponseResult>> CreateResponseAsync(string userInputText, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         return await CreateResponseAsync(null, userInputText, previousResponseId, cancellationToken).ConfigureAwait(false);
     }
+    /// <summary> Asynchronously creates a response for the specified model from user input text. </summary>
+    /// <param name="model"> The model used to create the response. </param>
+    /// <param name="userInputText"> The user input text used to create the response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The created response result. </returns>
     public async override Task<ClientResult<ResponseResult>> CreateResponseAsync(string model, string userInputText, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(userInputText, nameof(userInputText));
@@ -242,6 +299,10 @@ public partial class ProjectResponsesClient : ResponsesClient
         }
     }
 
+    /// <summary> Creates a streaming response using the supplied response options. </summary>
+    /// <param name="options"> The options used to create the streaming response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public override CollectionResult<StreamingResponseUpdate> CreateResponseStreaming(CreateResponseOptions options, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(options, nameof(options));
@@ -268,11 +329,22 @@ public partial class ProjectResponsesClient : ResponsesClient
         }
     }
 
+    /// <summary> Creates a streaming response from the supplied input items. </summary>
+    /// <param name="inputItems"> The input items used to create the streaming response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public virtual CollectionResult<StreamingResponseUpdate> CreateResponseStreaming(IEnumerable<ResponseItem> inputItems, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         return CreateResponseStreaming(null, inputItems, previousResponseId, cancellationToken);
     }
 
+    /// <summary> Creates a streaming response for the specified model from the supplied input items. </summary>
+    /// <param name="model"> The model used to create the streaming response. </param>
+    /// <param name="inputItems"> The input items used to create the streaming response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public override CollectionResult<StreamingResponseUpdate> CreateResponseStreaming(string model, IEnumerable<ResponseItem> inputItems, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(inputItems, nameof(inputItems));
@@ -290,11 +362,22 @@ public partial class ProjectResponsesClient : ResponsesClient
         return CreateResponseStreaming(options, cancellationToken);
     }
 
+    /// <summary> Creates a streaming response from user input text. </summary>
+    /// <param name="userInputText"> The user input text used to create the streaming response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public virtual CollectionResult<StreamingResponseUpdate> CreateResponseStreaming(string userInputText, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         return CreateResponseStreaming(null, userInputText, previousResponseId, cancellationToken);
     }
 
+    /// <summary> Creates a streaming response for the specified model from user input text. </summary>
+    /// <param name="model"> The model used to create the streaming response. </param>
+    /// <param name="userInputText"> The user input text used to create the streaming response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public override CollectionResult<StreamingResponseUpdate> CreateResponseStreaming(string model, string userInputText, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(userInputText, nameof(userInputText));
@@ -309,6 +392,10 @@ public partial class ProjectResponsesClient : ResponsesClient
         return CreateResponseStreaming(options, cancellationToken);
     }
 
+    /// <summary> Asynchronously creates a streaming response using the supplied response options. </summary>
+    /// <param name="options"> The options used to create the streaming response. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public override AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(CreateResponseOptions options, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(options, nameof(options));
@@ -335,11 +422,22 @@ public partial class ProjectResponsesClient : ResponsesClient
         }
     }
 
+    /// <summary> Asynchronously creates a streaming response from the supplied input items. </summary>
+    /// <param name="inputItems"> The input items used to create the streaming response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public virtual AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(IEnumerable<ResponseItem> inputItems, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         return CreateResponseStreamingAsync(null, inputItems, previousResponseId, cancellationToken);
     }
 
+    /// <summary> Asynchronously creates a streaming response for the specified model from the supplied input items. </summary>
+    /// <param name="model"> The model used to create the streaming response. </param>
+    /// <param name="inputItems"> The input items used to create the streaming response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public override AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(string model, IEnumerable<ResponseItem> inputItems, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(inputItems, nameof(inputItems));
@@ -357,10 +455,21 @@ public partial class ProjectResponsesClient : ResponsesClient
         return CreateResponseStreamingAsync(options, cancellationToken);
     }
 
+    /// <summary> Asynchronously creates a streaming response from user input text. </summary>
+    /// <param name="userInputText"> The user input text used to create the streaming response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public virtual AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(string userInputText, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         return CreateResponseStreamingAsync(null, userInputText, previousResponseId, cancellationToken);
     }
+    /// <summary> Asynchronously creates a streaming response for the specified model from user input text. </summary>
+    /// <param name="model"> The model used to create the streaming response. </param>
+    /// <param name="userInputText"> The user input text used to create the streaming response. </param>
+    /// <param name="previousResponseId"> The ID of the previous response to continue. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The streaming response updates. </returns>
     public override AsyncCollectionResult<StreamingResponseUpdate> CreateResponseStreamingAsync(string model, string userInputText, string previousResponseId = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(userInputText, nameof(userInputText));
@@ -375,6 +484,15 @@ public partial class ProjectResponsesClient : ResponsesClient
         return CreateResponseStreamingAsync(options, cancellationToken);
     }
 
+    /// <summary> Gets project responses, optionally filtered by agent or conversation. </summary>
+    /// <param name="agent"> The agent used to filter the returned responses. </param>
+    /// <param name="conversationId"> The conversation ID used to filter the returned responses. </param>
+    /// <param name="limit"> The maximum number of responses to return. </param>
+    /// <param name="order"> The order used to sort returned responses. </param>
+    /// <param name="after"> The response ID after which results should be returned. </param>
+    /// <param name="before"> The response ID before which results should be returned. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The project responses. </returns>
     public virtual CollectionResult<ResponseResult> GetProjectResponses(AgentReference agent = null, string conversationId = null, int? limit = default, string order = null, string after = default, string before = default, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string> extraQueryForProtocol = new()
@@ -401,6 +519,15 @@ public partial class ProjectResponsesClient : ResponsesClient
             cancellationToken.ToRequestOptions());
     }
 
+    /// <summary> Asynchronously gets project responses, optionally filtered by agent or conversation. </summary>
+    /// <param name="agent"> The agent used to filter the returned responses. </param>
+    /// <param name="conversationId"> The conversation ID used to filter the returned responses. </param>
+    /// <param name="limit"> The maximum number of responses to return. </param>
+    /// <param name="order"> The order used to sort returned responses. </param>
+    /// <param name="after"> The response ID after which results should be returned. </param>
+    /// <param name="before"> The response ID before which results should be returned. </param>
+    /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+    /// <returns> The project responses. </returns>
     public virtual AsyncCollectionResult<ResponseResult> GetProjectResponsesAsync(AgentReference agent = null, string conversationId = null, int? limit = default, string order = null, string after = default, string before = default, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string> extraQueryForProtocol = new()

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectResponsesClientOptions.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectResponsesClientOptions.cs
@@ -3,6 +3,7 @@
 
 namespace Azure.AI.Extensions.OpenAI;
 
+/// <summary> Represents options for configuring a project responses client. </summary>
 public partial class ProjectResponsesClientOptions : ProjectOpenAIClientOptions
 {
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectVectorStoresClient.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectVectorStoresClient.cs
@@ -7,6 +7,7 @@ using OpenAI.VectorStores;
 
 namespace Azure.AI.Extensions.OpenAI;
 
+/// <summary> Provides vector store operations for an Azure AI project through the OpenAI vector store API. </summary>
 public partial class ProjectVectorStoresClient : VectorStoreClient
 {
     internal ProjectVectorStoresClient(ClientPipeline pipeline, OpenAIClientOptions options)
@@ -14,6 +15,7 @@ public partial class ProjectVectorStoresClient : VectorStoreClient
     {
     }
 
+    /// <summary> Initializes a new instance of <see cref="ProjectVectorStoresClient"/> for mocking. </summary>
     protected ProjectVectorStoresClient()
     { }
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ResponsesGrammarSyntax.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ResponsesGrammarSyntax.cs
@@ -3,11 +3,12 @@
 
 namespace Azure.AI.Extensions.OpenAI;
 
+/// <summary> Specifies the grammar syntax used by a response grammar. </summary>
 [CodeGenType("GrammarSyntax1")]
 public enum ResponsesGrammarSyntax
 {
-    /// <summary> Lark. </summary>
+    /// <summary> Uses Lark syntax. </summary>
     Lark,
-    /// <summary> Regex. </summary>
+    /// <summary> Uses regular expression syntax. </summary>
     Regex
 }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/ProjectConversation.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/ProjectConversation.cs
@@ -11,8 +11,12 @@ public partial class ProjectConversation
     [CodeGenMember("Object")]
     private string Object { get; } = "conversation";
 
+    /// <summary> Gets the metadata attached to the conversation. </summary>
     [CodeGenMember("Metadata")]
     public IDictionary<string, string> Metadata { get; }
 
+    /// <summary> Converts a project conversation into its conversation ID. </summary>
+    /// <param name="conversation"> The project conversation to convert. </param>
+    /// <returns> The conversation ID. </returns>
     public static implicit operator string(ProjectConversation conversation) => conversation.Id;
 }


### PR DESCRIPTION
Peels `Azure.AI.Extensions.OpenAI` off the `eng/NoWarnSkipValidation.txt` skip-list as part of the ongoing NoWarn-visibility migration.

### What's in this PR

**Peel-off (first commit):**
- Remove from `eng/NoWarnSkipValidation.txt`.
- Drop the project-wide `<NoWarn>` block from `src/Azure.AI.Extensions.OpenAI.csproj` (was `CS1591;OPENAI001;AZC0035;AAIP001`).
- Add `eng/analyzerallowlist/Azure.AI.Extensions.OpenAI.txt` covering `OPENAI001` (this library is by design a wrapper of the preview OpenAI surface, so the experimental opt-in is acknowledged once at the assembly level).
- Drop stale `CS1591` and `AAIP001` entries from the csproj (neither fires).
- Add XML doc comments to 90 hand-written public members across 21 `Custom/` files so `CS1591` no longer needs a project-wide suppression.

**Analyzer version bump (second commit):**
- Bump `Azure.ClientSdk.Analyzers` `0.1.1-dev.20260129.1` → `0.1.1-dev.20260604.1` in `eng/centralpackagemanagement/Directory.Packages.props`. The new package picks up the AZC0035 external-types fix from #59647.
- With that fix in place, `AZC0035` no longer fires on `ResponseResult` / `StreamingResponseUpdate` (both declared in the external OpenAI SDK), so no `AZC0035` suppression is needed for this project.

### Validation
`dotnet build src/Azure.AI.Extensions.OpenAI.csproj` → **Build succeeded, 0 warnings, 0 errors** across net8.0 / net10.0 / netstandard2.0.

### Related
- #59647 — migrated `ModelFactoryAnalyzer` into `sdk/tools/Azure.SdkAnalyzers` and fixed the AZC0035 external-types false-positive (merged).
- Azure/azure-sdk-tools#15884 — removed the duplicate analyzer from `azure-sdk-tools` (merged).