### PR TITLE
Peel Azure.Core and Azure.AI.Projects.Agents off the NoWarn skip-list

### DIFF
--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -34,7 +34,6 @@ Azure.AI.Language.Text.Authoring
 Azure.AI.OpenAI
 Azure.AI.OpenAI.Assistants
 Azure.AI.Personalizer
-Azure.AI.Projects.Agents
 Azure.AI.Speech.Transcription
 Azure.AI.TextAnalytics
 Azure.AI.TextAnalytics.Legacy

--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -59,7 +59,6 @@ Azure.Communication.Messages
 Azure.Communication.ShortCodes
 Azure.Compute.Batch
 Azure.Containers.ContainerRegistry
-Azure.Core
 Azure.Core.Experimental
 Azure.Data.AppConfiguration
 Azure.Developer.DevCenter

--- a/eng/analyzerallowlist/Azure.AI.Projects.Agents.txt
+++ b/eng/analyzerallowlist/Azure.AI.Projects.Agents.txt
@@ -1,0 +1,22 @@
+# Azure.AI.Projects.Agents approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# OPENAI001 is the [Experimental] marker on the OpenAI SDK types this library
+# extends and depends on (response items, streaming updates, derived clients,
+# tool/output models, etc.). The library builds directly on the official OpenAI
+# .NET SDK to maintain rapid upstream feature propagation, so the experimental
+# opt-in is by design across both the hand-written extension types and the
+# generated client surface. The diagnostic exists so external consumers
+# explicitly acknowledge experimental usage; acknowledging it once at the
+# assembly level matches intent.
+nowarn:OPENAI001
+
+# AAIP001 is this library's own [Experimental] marker for preview Foundry Agent
+# features (HostedAgentDefinition, WorkflowAgentDefinition, AgentToolboxes,
+# AgentSessionFiles, AgentOptimizationJobs, ProjectAgentSkills). The library's
+# generated client surface and supporting types reference these experimental
+# members internally, so AAIP001 fires throughout the assembly. External
+# consumers opt in once via `#pragma warning disable AAIP001` (documented in
+# the README); acknowledging it once at the assembly level matches the same
+# intent for the library's own implementation.
+nowarn:AAIP001

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Azure.AI.Projects.Agents.csproj
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Azure.AI.Projects.Agents.csproj
@@ -16,17 +16,6 @@
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Acknowledge experimental OpenAI features -->
-    <NoWarn>$(NoWarn);OPENAI001</NoWarn>
-    <!-- Temporary suppression of XML doc requirement -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <!-- Ignore ModelFactory error (applied to externally originating types) -->
-    <NoWarn>$(NoWarn);AZC0035</NoWarn>
-    <!-- Ignore warnings about the experimental features -->
-    <NoWarn>$(NoWarn);AAIP001</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="OpenAI" />
     <PackageReference Include="Azure.Core" />

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/AgentAdministrationClient.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/AgentAdministrationClient.cs
@@ -57,6 +57,13 @@ public partial class AgentAdministrationClient
     private ProjectAgentSkills _cachedAgentSkills;
     private AgentSessionFiles _cachedAgentSessionFiles;
     private AgentOptimizationJobs _cachedAgentOptimizationJobs;
+    /// <summary>
+    /// Initializes a new <see cref="AgentAdministrationClient"/> with the specified
+    /// service endpoint and authentication token provider.
+    /// </summary>
+    /// <param name="endpoint">The service endpoint to target.</param>
+    /// <param name="tokenProvider">The token provider used to authenticate requests.</param>
+    /// <param name="options">Optional client configuration options.</param>
     public AgentAdministrationClient(Uri endpoint, AuthenticationTokenProvider tokenProvider, AgentAdministrationClientOptions options =null)
     {
         Argument.AssertNotNull(endpoint, nameof(endpoint));
@@ -162,6 +169,11 @@ public partial class AgentAdministrationClient
         return result.ToProjectAgentsResult<ProjectsAgentVersion>();
     }
 
+    /// <summary> Creates a new version of an agent from an agent manifest. </summary>
+    /// <param name="agentName">The name of the agent to create a version for.</param>
+    /// <param name="manifestId">The identifier of the agent manifest to use.</param>
+    /// <param name="options">Options describing the manifest-based creation request.</param>
+    /// <param name="cancellationToken">The cancellation token to use.</param>
     public virtual ClientResult<ProjectsAgentVersion> CreateAgentVersionFromManifest(string agentName, string manifestId, AgentManifestOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(agentName, nameof(agentName));
@@ -174,6 +186,11 @@ public partial class AgentAdministrationClient
         return result.ToProjectAgentsResult<ProjectsAgentVersion>();
     }
 
+    /// <summary> Creates a new version of an agent from an agent manifest. </summary>
+    /// <param name="agentName">The name of the agent to create a version for.</param>
+    /// <param name="manifestId">The identifier of the agent manifest to use.</param>
+    /// <param name="options">Options describing the manifest-based creation request.</param>
+    /// <param name="cancellationToken">The cancellation token to use.</param>
     public virtual async Task<ClientResult<ProjectsAgentVersion>> CreateAgentVersionFromManifestAsync(string agentName, string manifestId, AgentManifestOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(agentName, nameof(agentName));
@@ -982,21 +999,25 @@ public partial class AgentAdministrationClient
         return result;
     }
 
+    /// <summary> Gets the lazily-initialized agent toolboxes sub-client. </summary>
     public virtual AgentToolboxes GetAgentToolboxes()
     {
         return Volatile.Read(ref _cachedAgentsToolboxes) ?? Interlocked.CompareExchange(ref _cachedAgentsToolboxes, new AgentToolboxes(Pipeline, _endpoint, _apiVersion), null) ?? _cachedAgentsToolboxes;
     }
 
+    /// <summary> Gets the lazily-initialized project agent skills sub-client. </summary>
     public virtual ProjectAgentSkills GetAgentSkills()
     {
         return Volatile.Read(ref _cachedAgentSkills) ?? Interlocked.CompareExchange(ref _cachedAgentSkills, new ProjectAgentSkills(Pipeline, _endpoint, _apiVersion), null) ?? _cachedAgentSkills;
     }
 
+    /// <summary> Gets the lazily-initialized agent session files sub-client. </summary>
     public virtual AgentSessionFiles GetAgentSessionFiles()
     {
         return Volatile.Read(ref _cachedAgentSessionFiles) ?? Interlocked.CompareExchange(ref _cachedAgentSessionFiles, new AgentSessionFiles(Pipeline, _endpoint, _apiVersion), null) ?? _cachedAgentSessionFiles;
     }
 
+    /// <summary> Gets the lazily-initialized agent optimization jobs sub-client. </summary>
     public virtual AgentOptimizationJobs GetAgentOptimizationJobs()
     {
         return Volatile.Read(ref _cachedAgentOptimizationJobs) ?? Interlocked.CompareExchange(ref _cachedAgentOptimizationJobs, new AgentOptimizationJobs(Pipeline, _endpoint, _apiVersion), null) ?? _cachedAgentOptimizationJobs;

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/AgentListOrder.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/AgentListOrder.cs
@@ -6,9 +6,11 @@ namespace Azure.AI.Projects.Agents;
 [CodeGenType("PageOrder")]
 public readonly partial struct AgentListOrder
 {
+    /// <summary> Sort the list in ascending order by created-at timestamp. </summary>
     [CodeGenMember("Asc")]
     public static AgentListOrder Ascending { get; } = new AgentListOrder(AscValue);
 
+    /// <summary> Sort the list in descending order by created-at timestamp. </summary>
     [CodeGenMember("Desc")]
     public static AgentListOrder Descending { get; } = new AgentListOrder(DescValue);
 }

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/AzureFunctionDefinitionFunction.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/AzureFunctionDefinitionFunction.cs
@@ -8,6 +8,7 @@ namespace Azure.AI.Projects.Agents;
 /// <summary> The AzureFunctionDefinitionFunction. </summary>
 public partial class AzureFunctionDefinitionFunction
 {
+    /// <summary> The JSON-encoded parameter schema for the Azure Function. </summary>
     // Customization: retain IDictionary<string, BinaryData> despite Record<unknown> basis
     [CodeGenMember("parameters")]
     public BinaryData Parameters { get; set; }

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ClientConnectionProviderExtensions.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ClientConnectionProviderExtensions.cs
@@ -6,10 +6,20 @@ using System.ClientModel.Primitives;
 
 namespace Azure.AI.Projects.Agents;
 
+/// <summary>
+/// Extension methods on <see cref="ClientConnectionProvider"/> that produce
+/// Foundry-project-specific agent clients.
+/// </summary>
 public static partial class ClientConnectionProviderExtensions
 {
     extension(ClientConnectionProvider connectionProvider)
     {
+        /// <summary>
+        /// Builds an <see cref="AgentAdministrationClient"/> from the connection
+        /// information surfaced by this <see cref="ClientConnectionProvider"/>.
+        /// </summary>
+        /// <param name="endpoint">Optional endpoint override; if null, the locator from the connection is used.</param>
+        /// <param name="options">Optional client configuration options.</param>
         public AgentAdministrationClient GetProjectAgentsClient(Uri endpoint = null, AgentAdministrationClientOptions options = null)
         {
             ClientConnection pipelineConnection = connectionProvider.GetConnection("Internal.AgentsPipelinePassthrough");

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/DeclarativeAgentDefinition.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/DeclarativeAgentDefinition.cs
@@ -23,9 +23,11 @@ public partial class DeclarativeAgentDefinition
     [CodeGenMember("Tools")]
     public IList<global::OpenAI.Responses.ResponseTool> Tools { get; }
 
+    /// <summary> Reasoning options controlling how the model produces its chain-of-thought response. </summary>
     [CodeGenMember("Reasoning")]
     public global::OpenAI.Responses.ResponseReasoningOptions ReasoningOptions { get; set; }
 
+    /// <summary> Configuration options for a text response from the model. Can be plain text or structured JSON data. </summary>
     [CodeGenMember("Text")]
     public global::OpenAI.Responses.ResponseTextOptions TextOptions { get; set; }
 

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/McpToolExtensions.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/McpToolExtensions.cs
@@ -7,10 +7,18 @@ using OpenAI.Responses;
 
 namespace Azure.AI.Projects.Agents;
 
+/// <summary>
+/// Extension methods on <see cref="McpTool"/> that expose Foundry-project-specific
+/// configuration (such as the project connection identifier).
+/// </summary>
 public static partial class McpToolExtensions
 {
     extension(McpTool mcpTool)
     {
+        /// <summary>
+        /// Gets or sets the Foundry project connection identifier associated with this MCP tool.
+        /// The value is stored as a JSON patch on the underlying tool definition.
+        /// </summary>
         public string ProjectConnectionId
         {
             get => mcpTool.Patch.GetStringEx("$.project_connection_id"u8);

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentDefinition.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentDefinition.cs
@@ -12,10 +12,18 @@ public abstract partial class ProjectsAgentDefinition
     [CodeGenMember("RaiConfig")]
     public ContentFilterConfiguration ContentFilterConfiguration { get; set; }
 
+    /// <summary> Creates a prompt-based declarative agent definition for the specified model. </summary>
+    /// <param name="model">The model deployment to use for this agent.</param>
     public static DeclarativeAgentDefinition CreatePromptAgentDefinition(string model)
         => new(model);
+    /// <summary> Creates a workflow-based agent definition from a workflow YAML document. </summary>
+    /// <param name="workflowYamlDocument">The workflow defined as a YAML document.</param>
     public static WorkflowAgentDefinition CreateWorkflowAgentDefinitionFromYaml(string workflowYamlDocument)
         => WorkflowAgentDefinition.FromYaml(workflowYamlDocument);
+    /// <summary> Creates a hosted agent definition with the specified container configuration. </summary>
+    /// <param name="containerProtocolVersions">Protocol versions supported by the hosted container.</param>
+    /// <param name="cpuConfiguration">The CPU configuration string for the hosted container.</param>
+    /// <param name="memoryConfiguration">The memory configuration string for the hosted container.</param>
     public static HostedAgentDefinition CreateHostedAgentDefinition(IEnumerable<ProtocolVersionRecord> containerProtocolVersions, string cpuConfiguration, string memoryConfiguration)
         => new(containerProtocolVersions, cpuConfiguration, memoryConfiguration);
 }

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentRecord.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentRecord.cs
@@ -10,5 +10,6 @@ public partial class ProjectsAgentRecord
 {
     internal AgentObjectVersions Versions { get; }
 
+    /// <summary> Returns the most recent version of this agent. </summary>
     public ProjectsAgentVersion GetLatestVersion() => Versions.Latest;
 }

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentTool.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentTool.cs
@@ -15,19 +15,46 @@ namespace Azure.AI.Projects.Agents;
 [CodeGenType("Tool")]
 public abstract partial class ProjectsAgentTool
 {
+    /// <summary> Creates a Bing grounding tool with the supplied options. </summary>
+    /// <param name="options">Configuration options for the Bing grounding tool.</param>
     public static BingGroundingTool CreateBingGroundingTool(BingGroundingSearchToolOptions options) => new BingGroundingTool(options);
+    /// <summary> Creates a Microsoft Fabric data agent tool with the supplied options. </summary>
+    /// <param name="options">Configuration options for the Fabric data agent tool.</param>
     public static MicrosoftFabricPreviewTool CreateMicrosoftFabricTool(FabricDataAgentToolOptions options) => new MicrosoftFabricPreviewTool(options);
+    /// <summary> Creates a SharePoint grounding tool with the supplied options. </summary>
+    /// <param name="options">Configuration options for the SharePoint grounding tool.</param>
     public static SharepointPreviewTool CreateSharepointTool(SharePointGroundingToolOptions options) => new SharepointPreviewTool(options);
+    /// <summary> Creates an Azure AI Search tool with the supplied options. </summary>
+    /// <param name="options">Optional configuration options for the Azure AI Search tool.</param>
     public static AzureAISearchTool CreateAzureAISearchTool(AzureAISearchToolOptions options = null) => new AzureAISearchTool(options ?? new());
+    /// <summary> Creates an OpenAPI tool from the supplied function definition. </summary>
+    /// <param name="definition">The OpenAPI function definition.</param>
     public static OpenAPITool CreateOpenApiTool(OpenApiFunctionDefinition definition) => new OpenAPITool(definition);
+    /// <summary> Creates a Bing custom search tool with the supplied options. </summary>
+    /// <param name="parameters">Configuration options for the Bing custom search tool.</param>
     public static BingCustomSearchPreviewTool CreateBingCustomSearchTool(BingCustomSearchToolOptions parameters) => new BingCustomSearchPreviewTool(parameters);
+    /// <summary> Creates a browser-automation tool with the supplied options. </summary>
+    /// <param name="parameters">Configuration options for the browser-automation tool.</param>
     public static BrowserAutomationPreviewTool CreateBrowserAutomationTool(BrowserAutomationToolOptions parameters) => new BrowserAutomationPreviewTool(parameters);
+    /// <summary> Creates a tool that captures structured outputs from the agent. </summary>
+    /// <param name="outputs">The structured output definition the agent should produce.</param>
     public static CaptureStructuredOutputsTool CreateStructuredOutputsTool(StructuredOutputDefinition outputs) => new CaptureStructuredOutputsTool(outputs);
+    /// <summary>
+    /// Creates a new tool that lets the agent communicate with another agent over the
+    /// Agent-to-Agent (A2A) protocol.
+    /// </summary>
+    /// <param name="baseUri">The base URI of the remote agent endpoint.</param>
+    /// <param name="agentCardPath">Optional path to the remote agent's agent card.</param>
     public static ResponseTool CreateA2ATool(Uri baseUri, string agentCardPath = null) => new A2APreviewTool(baseUri)
     {
         AgentCardPath = agentCardPath,
     };
 
+    /// <summary>
+    /// Implicitly converts a <see cref="ProjectsAgentTool"/> into the underlying
+    /// <see cref="ResponseTool"/> representation by round-tripping through the wire format.
+    /// </summary>
+    /// <param name="agentTool">The agent tool to convert.</param>
     public static implicit operator ResponseTool(ProjectsAgentTool agentTool)
     {
         return ModelReaderWriter.Read<ResponseTool>(
@@ -38,6 +65,13 @@ public abstract partial class ProjectsAgentTool
             ModelSerializationExtensions.WireOptions,
             OpenAIContext.Default);
     }
+
+    /// <summary>
+    /// Reinterprets a tool from the OpenAI <c>ResponseTool</c> hierarchy as a
+    /// <see cref="ProjectsAgentTool"/> by round-tripping through the wire format.
+    /// </summary>
+    /// <typeparam name="T">The source tool type.</typeparam>
+    /// <param name="tool">The source tool instance.</param>
     public static ProjectsAgentTool AsProjectTool<T>(T tool)
     {
         Argument.AssertNotNull(tool, nameof(tool));

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentVersionCreationOptions.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentVersionCreationOptions.cs
@@ -13,6 +13,7 @@ public partial class ProjectsAgentVersionCreationOptions
     [CodeGenMember("Description")]
     public string Description { get; set; }
 
+    /// <summary> The agent definition that this version represents. </summary>
     [CodeGenMember("Definition")]
     public ProjectsAgentDefinition Definition { get; set; }
 

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentsModelFactory.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ProjectsAgentsModelFactory.cs
@@ -5,6 +5,9 @@ namespace Azure.AI.Projects.Agents;
 
 public partial class ProjectsAgentsModelFactory
 {
+    /// <summary> Creates a new instance of <see cref="Agents.ProjectsAgentRecord"/> for mocking. </summary>
+    /// <param name="id">The agent identifier.</param>
+    /// <param name="name">The agent name.</param>
     public static ProjectsAgentRecord ProjectsAgentRecord(string id = default, string name = default)
     {
         return new ProjectsAgentRecord("agent", id, name, new AgentObjectVersions(), default, default, default, default, default, null);

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ResponseToolExtensions.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/ResponseToolExtensions.cs
@@ -7,8 +7,17 @@ using OpenAI.Responses;
 
 namespace Azure.AI.Projects.Agents;
 
+/// <summary>
+/// Extension methods that convert OpenAI <see cref="ResponseTool"/> instances into the
+/// equivalent <see cref="ProjectsAgentTool"/> representation.
+/// </summary>
 public static partial class ResponseToolExtensions
 {
+    /// <summary>
+    /// Reinterprets an OpenAI <see cref="ResponseTool"/> as a <see cref="ProjectsAgentTool"/>
+    /// by round-tripping through the wire format.
+    /// </summary>
+    /// <param name="responseTool">The OpenAI response tool to convert.</param>
     public static ProjectsAgentTool AsAgentTool(this ResponseTool responseTool)
     {
         return ModelReaderWriter.Read<ProjectsAgentTool>(

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/StructuredInputDefinition.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/StructuredInputDefinition.cs
@@ -8,6 +8,7 @@ namespace Azure.AI.Projects.Agents;
 [CodeGenType("StructuredInputDefinition")]
 public partial class StructuredInputDefinition
 {
+    /// <summary> Whether this input is required when invoking the agent. </summary>
     [CodeGenMember("Required")]
     public bool? IsRequired { get; set; }
 }

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/WebSearchToolExtensions.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/WebSearchToolExtensions.cs
@@ -8,10 +8,18 @@ using OpenAI.Responses;
 
 namespace Azure.AI.Projects.Agents;
 
+/// <summary>
+/// Extension methods that expose Microsoft Foundry-specific configuration on
+/// <see cref="WebSearchTool"/> instances.
+/// </summary>
 public static partial class WebSearchToolExtensions
 {
     extension(WebSearchTool webSearchTool)
     {
+        /// <summary>
+        /// Gets or sets the Foundry-specific custom search configuration applied to this web
+        /// search tool. The value is stored as a JSON patch on the underlying tool definition.
+        /// </summary>
         public ProjectWebSearchConfiguration CustomSearchConfiguration
         {
             get => webSearchTool.Patch.GetJsonModelEx<ProjectWebSearchConfiguration>("$.custom_search_configuration"u8);

--- a/sdk/ai/Azure.AI.Projects.Agents/src/Custom/WorkflowAgentDefinition.cs
+++ b/sdk/ai/Azure.AI.Projects.Agents/src/Custom/WorkflowAgentDefinition.cs
@@ -16,6 +16,10 @@ public partial class WorkflowAgentDefinition
     {
     }
 
+    /// <summary>
+    /// Creates a new <see cref="WorkflowAgentDefinition"/> from a workflow YAML document.
+    /// </summary>
+    /// <param name="workflowYamlDocument">The workflow defined as a YAML document.</param>
     public static WorkflowAgentDefinition FromYaml(string workflowYamlDocument)
     {
         return new()


### PR DESCRIPTION
Peels two packages off `eng/NoWarnSkipValidation.txt` as part of the ongoing NoWarn-visibility migration.

### Commit 1 — `Azure.Core`

Pure skip-list cleanup. `NoWarnValidationMode=record` reports no unapproved NoWarn codes for `Azure.Core` across any of its TFMs; no project-level `<NoWarn>` element exists in the csproj or any imported props. The skip-list entry was stale.

### Commit 2 — `Azure.AI.Projects.Agents`

- Drop the project-wide `<NoWarn>OPENAI001;CS1591;AZC0035;AAIP001</NoWarn>` block from `src/Azure.AI.Projects.Agents.csproj`.
- Add `eng/analyzerallowlist/Azure.AI.Projects.Agents.txt` covering:
  - `OPENAI001` — external experimental opt-in for the OpenAI SDK surface this library builds on.
  - `AAIP001` — this library's own `[Experimental]` marker for preview Foundry Agent features (`HostedAgentDefinition`, `WorkflowAgentDefinition`, `AgentToolboxes`, `AgentSessionFiles`, `AgentOptimizationJobs`, `ProjectAgentSkills`), referenced pervasively by the generated client surface.
- `AZC0035` no longer fires after the analyzer external-types fix (#59647) flowed through to main.
- Add XML doc comments to 28 hand-written public members across 13 `Custom/` files so `CS1591` no longer needs a project-wide suppression.

### Validation
`dotnet build` of `Azure.Core.csproj` and `Azure.AI.Projects.Agents.csproj` → **Build succeeded, 0 errors, 0 warnings** across all TFMs.