### PR TITLE
Peel Azure.AI.AgentServer.Core and Azure.ResourceManager.Cdn off the NoWarn skip-list

### DIFF
--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -16,7 +16,6 @@
 #
 # To remove a project from this list, see the workflow in eng/analyzerallowlist/README.md.
 Azure.AI.Agents.Persistent
-Azure.AI.AgentServer.Core
 Azure.AI.AgentServer.Invocations
 Azure.AI.AgentServer.Responses
 Azure.AI.AnomalyDetector

--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -138,7 +138,6 @@ Azure.Provisioning.WebPubSub
 Azure.ResourceManager
 Azure.ResourceManager.AppService
 Azure.ResourceManager.Batch
-Azure.ResourceManager.Cdn
 Azure.ResourceManager.Chaos
 Azure.ResourceManager.Compute
 Azure.ResourceManager.ContainerRegistry

--- a/eng/analyzerallowlist/Azure.AI.AgentServer.Core.txt
+++ b/eng/analyzerallowlist/Azure.AI.AgentServer.Core.txt
@@ -1,0 +1,19 @@
+# Azure.AI.AgentServer.Core approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# AZC0100 fires on awaits that omit ConfigureAwait(false). This package is a
+# server-side hosting library that runs on the ASP.NET Core request pipeline,
+# where there is no UI / SynchronizationContext to capture; ConfigureAwait(false)
+# is at best unnecessary and at worst incorrect for hosted-service / middleware
+# scenarios. The Azure.Core guideline that AZC0100 enforces is targeted at
+# client libraries called from arbitrary contexts and does not apply here.
+# See AGENTS.md §0.VI for the broader rationale across AgentServer packages.
+nowarn:AZC0100
+
+# AZC0004 fires on async APIs that lack a corresponding sync variant. This
+# package only exposes async APIs by design — its surface area is hosting and
+# pipeline glue (port binding, graceful shutdown, OpenTelemetry hooks,
+# AgentHostBuilder) where sync variants would either deadlock under ASP.NET
+# Core or duplicate code without value. This is the same exemption granted to
+# AMQP-based SDKs whose I/O model is intrinsically async.
+nowarn:AZC0004

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
@@ -8,10 +8,6 @@
     <PackageTags>Microsoft Azure AI Agent Server Core ASP.NET Core OpenTelemetry</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <!-- AZC0100: Server-side hosting library on ASP.NET Core async pipeline — ConfigureAwait(false) is unnecessary and harmful.
-         AZC0004: Async-only API — no sync variants needed (same exemption as AMQP-based SDKs).
-         See AGENTS.md §0.VI for rationale. -->
-    <NoWarn>$(NoWarn);AZC0100;AZC0004</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Azure.ResourceManager.Cdn.csproj
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Azure.ResourceManager.Cdn.csproj
@@ -7,6 +7,5 @@
     <Description>Microsoft Azure Resource Manager client SDK for Azure resource provider Microsoft.Cdn.</Description>
     <PackageTags>azure;management;arm;resource manager;cdn</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
-    <NoWarn>$(NoWarn);CS1591;</NoWarn>
   </PropertyGroup>
 </Project>

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CacheExpirationActionProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CacheExpirationActionProperties.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old constructor and ActionType property (bridging to TypeName) are preserved here, marked as EditorBrowsable.Never.
     public partial class CacheExpirationActionProperties
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CacheExpirationActionProperties(CacheExpirationActionType actionType, CacheBehaviorSetting cacheBehavior, CdnCacheLevel cacheType) : this(cacheBehavior, cacheType)
         {
             ActionType = actionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CacheExpirationActionType ActionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CacheKeyQueryStringActionProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CacheKeyQueryStringActionProperties.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old constructor and ActionType property (bridging to TypeName) are preserved here, marked as EditorBrowsable.Never.
     public partial class CacheKeyQueryStringActionProperties
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CacheKeyQueryStringActionProperties(CacheKeyQueryStringActionType actionType, QueryStringBehavior queryStringBehavior) : this(queryStringBehavior)
         {
             ActionType = actionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CacheKeyQueryStringActionType ActionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CanMigrateContent.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CanMigrateContent.cs
@@ -17,6 +17,7 @@ namespace Azure.ResourceManager.Cdn.Models
     public partial class CanMigrateContent
     {
         // Backward compatibility: old API used ctor(WritableSubResource)
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CanMigrateContent(WritableSubResource classicResourceReference) : this()
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CanMigrateResult.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CanMigrateResult.cs
@@ -12,6 +12,7 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old string Id property is preserved here (delegating to ResourceId?.ToString()) and marked as EditorBrowsable.Never.
     public partial class CanMigrateResult
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string Id => ResourceId?.ToString();
     }

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CdnCertificateSource.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CdnCertificateSource.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old API is preserved here and bridges to TypeName.
     public partial class CdnCertificateSource
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CdnCertificateSource(CdnCertificateSourceType sourceType, CdnManagedCertificateType certificateType) : this(certificateType)
         {
             SourceType = sourceType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CdnCertificateSourceType SourceType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/ClientPortMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/ClientPortMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class ClientPortMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ClientPortMatchCondition(ClientPortMatchConditionType conditionType, ClientPortOperator clientPortOperator) : this(clientPortOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ClientPortMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CookiesMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CookiesMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class CookiesMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CookiesMatchCondition(CookiesMatchConditionType conditionType, CookiesOperator cookiesOperator) : this(cookiesOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CookiesMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CustomerCertificateProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/CustomerCertificateProperties.cs
@@ -23,6 +23,7 @@ namespace Azure.ResourceManager.Cdn.Models
     public partial class CustomerCertificateProperties
     {
         // Backward compatibility: old API used ctor(WritableSubResource)
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CustomerCertificateProperties(WritableSubResource secretSource) : this()
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/DeliveryRuleSslProtocolMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/DeliveryRuleSslProtocolMatchCondition.cs
@@ -13,12 +13,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // After the TypeSpec migration, the discriminator was changed to the string-typed TypeName property. The old API is preserved here and bridges to TypeName.
     public partial class DeliveryRuleSslProtocolMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public DeliveryRuleSslProtocolMatchCondition(SslProtocolMatchConditionType sslProtocolMatchConditionType, SslProtocolOperator sslProtocolOperator) : this(sslProtocolOperator)
         {
             SslProtocolMatchConditionType = sslProtocolMatchConditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SslProtocolMatchConditionType SslProtocolMatchConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/HeaderActionProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/HeaderActionProperties.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old constructor and ActionType property (bridging to TypeName) are preserved here, marked as EditorBrowsable.Never.
     public partial class HeaderActionProperties
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HeaderActionProperties(HeaderActionType actionType, HeaderAction headerAction, string headerName) : this(headerAction, headerName)
         {
             ActionType = actionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HeaderActionType ActionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/HostNameMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/HostNameMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class HostNameMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HostNameMatchCondition(HostNameMatchConditionType conditionType, HostNameOperator hostNameOperator) : this(hostNameOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HostNameMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/HttpVersionMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/HttpVersionMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class HttpVersionMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HttpVersionMatchCondition(HttpVersionMatchConditionType conditionType, HttpVersionOperator httpVersionOperator) : this(httpVersionOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HttpVersionMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/IsDeviceMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/IsDeviceMatchCondition.cs
@@ -14,11 +14,13 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class IsDeviceMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IsDeviceMatchCondition(IsDeviceMatchConditionType conditionType, IsDeviceOperator isDeviceOperator) : this(isDeviceOperator)
         {
             ConditionType = conditionType;
         }
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IsDeviceMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/KeyVaultCertificateSource.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/KeyVaultCertificateSource.cs
@@ -14,6 +14,7 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old API is preserved here and bridges to TypeName.
     public partial class KeyVaultCertificateSource
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public KeyVaultCertificateSource
             (
@@ -37,6 +38,7 @@ namespace Azure.ResourceManager.Cdn.Models
             SourceType = sourceType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public KeyVaultCertificateSourceType SourceType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/MigrateResult.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/MigrateResult.cs
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old string Id property is preserved here (delegating to ResourceId?.ToString()) and marked as EditorBrowsable.Never.
     public partial class MigrateResult
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string Id => ResourceId?.ToString();
     }

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/OriginGroupOverrideActionProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/OriginGroupOverrideActionProperties.cs
@@ -17,6 +17,7 @@ namespace Azure.ResourceManager.Cdn.Models
     public partial class OriginGroupOverrideActionProperties
     {
         // Backward compatibility: old API had ActionType property and constructor with WritableSubResource
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public OriginGroupOverrideActionType ActionType
         {
@@ -28,6 +29,7 @@ namespace Azure.ResourceManager.Cdn.Models
         }
 
         // Backward compatibility: old API had ctor(OriginGroupOverrideActionType, WritableSubResource)
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public OriginGroupOverrideActionProperties(OriginGroupOverrideActionType actionType, WritableSubResource originGroup) : this()
         {
@@ -39,6 +41,7 @@ namespace Azure.ResourceManager.Cdn.Models
         }
 
         // Backward compatibility: old API had ctor(WritableSubResource)
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public OriginGroupOverrideActionProperties(WritableSubResource originGroup) : this()
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/PostArgsMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/PostArgsMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class PostArgsMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public PostArgsMatchCondition(PostArgsMatchConditionType conditionType, PostArgsOperator postArgsOperator) : this(postArgsOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public PostArgsMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/ProfileChangeSkuWafMapping.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/ProfileChangeSkuWafMapping.cs
@@ -16,6 +16,7 @@ namespace Azure.ResourceManager.Cdn.Models
     public partial class ProfileChangeSkuWafMapping
     {
         // Backward compatibility: old API used ctor(string, WritableSubResource)
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ProfileChangeSkuWafMapping(string securityPolicyName, WritableSubResource changeToWafPolicy) : this(securityPolicyName)
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/QueryStringMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/QueryStringMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class QueryStringMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public QueryStringMatchCondition(QueryStringMatchConditionType conditionType, QueryStringOperator queryStringOperator) : this(queryStringOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public QueryStringMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RemoteAddressMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RemoteAddressMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class RemoteAddressMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RemoteAddressMatchCondition(RemoteAddressMatchConditionType conditionType, RemoteAddressOperator remoteAddressOperator) : this(remoteAddressOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RemoteAddressMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestBodyMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestBodyMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class RequestBodyMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestBodyMatchCondition(RequestBodyMatchConditionType conditionType, RequestBodyOperator requestBodyOperator) : this(requestBodyOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestBodyMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestHeaderMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestHeaderMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class RequestHeaderMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestHeaderMatchCondition(RequestHeaderMatchConditionType conditionType, RequestHeaderOperator requestHeaderOperator) : this(requestHeaderOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestHeaderMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestMethodMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestMethodMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class RequestMethodMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestMethodMatchCondition(RequestMethodMatchConditionType conditionType, RequestMethodOperator requestMethodOperator) : this(requestMethodOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestMethodMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestSchemeMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestSchemeMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class RequestSchemeMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestSchemeMatchCondition(RequestSchemeMatchConditionType conditionType, RequestSchemeOperator requestSchemeOperator) : this(requestSchemeOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestSchemeMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestUriMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RequestUriMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class RequestUriMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestUriMatchCondition(RequestUriMatchConditionType conditionType, RequestUriOperator requestUriOperator) : this(requestUriOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RequestUriMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RouteConfigurationOverrideActionProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/RouteConfigurationOverrideActionProperties.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old constructor and ActionType property (bridging to TypeName) are preserved here, marked as EditorBrowsable.Never.
     public partial class RouteConfigurationOverrideActionProperties
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RouteConfigurationOverrideActionProperties(RouteConfigurationOverrideActionType actionType) : this()
         {
             ActionType = actionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RouteConfigurationOverrideActionType ActionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/ServerPortMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/ServerPortMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class ServerPortMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ServerPortMatchCondition(ServerPortMatchConditionType conditionType, ServerPortOperator serverPortOperator) : this(serverPortOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ServerPortMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/SocketAddressMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/SocketAddressMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class SocketAddressMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SocketAddressMatchCondition(SocketAddressMatchConditionType conditionType, SocketAddressOperator socketAddressOperator) : this(socketAddressOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SocketAddressMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriFileExtensionMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriFileExtensionMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class UriFileExtensionMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriFileExtensionMatchCondition(UriFileExtensionMatchConditionType conditionType, UriFileExtensionOperator uriFileExtensionOperator) : this(uriFileExtensionOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriFileExtensionMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriFileNameMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriFileNameMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class UriFileNameMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriFileNameMatchCondition(UriFileNameMatchConditionType conditionType, UriFileNameOperator uriFileNameOperator) : this(uriFileNameOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriFileNameMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriPathMatchCondition.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriPathMatchCondition.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // marked as EditorBrowsable.Never.
     public partial class UriPathMatchCondition
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriPathMatchCondition(UriPathMatchConditionType conditionType, UriPathOperator uriPathOperator) : this(uriPathOperator)
         {
             ConditionType = conditionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriPathMatchConditionType ConditionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriRedirectActionProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriRedirectActionProperties.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old constructor and ActionType property (bridging to TypeName) are preserved here, marked as EditorBrowsable.Never.
     public partial class UriRedirectActionProperties
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriRedirectActionProperties(UriRedirectActionType actionType, RedirectType redirectType) : this(redirectType)
         {
             ActionType = actionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriRedirectActionType ActionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriRewriteActionProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriRewriteActionProperties.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old constructor and ActionType property (bridging to TypeName) are preserved here, marked as EditorBrowsable.Never.
     public partial class UriRewriteActionProperties
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriRewriteActionProperties(UriRewriteActionType actionType, string sourcePattern, string destination) : this(sourcePattern, destination)
         {
             ActionType = actionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriRewriteActionType ActionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriSigningActionProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriSigningActionProperties.cs
@@ -14,12 +14,14 @@ namespace Azure.ResourceManager.Cdn.Models
     // The old constructor and ActionType property (bridging to TypeName) are preserved here, marked as EditorBrowsable.Never.
     public partial class UriSigningActionProperties
     {
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriSigningActionProperties(UriSigningActionType actionType) : this()
         {
             ActionType = actionType;
         }
 
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriSigningActionType ActionType
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriSigningKeyProperties.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/UriSigningKeyProperties.cs
@@ -19,6 +19,7 @@ namespace Azure.ResourceManager.Cdn.Models
     public partial class UriSigningKeyProperties
     {
         // Backward compatibility: old API used WritableSubResource secretSource parameter
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UriSigningKeyProperties(string keyId, WritableSubResource secretSource) : base(SecretType.UriSigningKey)
         {

--- a/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/ValidateSecretContent.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/src/Customization/Models/ValidateSecretContent.cs
@@ -16,6 +16,7 @@ namespace Azure.ResourceManager.Cdn.Models
     public partial class ValidateSecretContent
     {
         // Backward compatibility: old API used ctor(SecretType, WritableSubResource)
+        /// <summary> Backward-compatibility shim retained when the model was regenerated from TypeSpec; hidden from IntelliSense. See the file-level comment for details. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ValidateSecretContent(SecretType secretType, WritableSubResource secretSource) : this(secretType)
         {


### PR DESCRIPTION
Peels two more packages off `eng/NoWarnSkipValidation.txt` as part of the ongoing NoWarn-visibility migration.

### Commit 1 — `Azure.AI.AgentServer.Core`

Drop the project-wide `<NoWarn>AZC0100;AZC0004</NoWarn>` block from the csproj and move both suppressions to `eng/analyzerallowlist/Azure.AI.AgentServer.Core.txt` with their architectural justifications:

- `AZC0100` (no `ConfigureAwait(false)`) — server-side hosting library on the ASP.NET Core request pipeline; there is no UI / SynchronizationContext to capture, so `ConfigureAwait(false)` is unnecessary and harmful for hosted-service / middleware scenarios.
- `AZC0004` (no sync variant) — async-only by design. Hosting and pipeline glue (port binding, graceful shutdown, OpenTelemetry hooks, `AgentHostBuilder`) where sync variants would deadlock under ASP.NET Core or duplicate code without value. Same exemption granted to AMQP-based SDKs.

### Commit 2 — `Azure.ResourceManager.Cdn`

Drop the project-wide `<NoWarn>CS1591</NoWarn>` from the csproj. `CS1591` fires on **66 backward-compatibility shim members across 36 files** in `src/Customization/Models/`. These are `[EditorBrowsable(EditorBrowsableState.Never)]` discriminator-aliases and legacy constructors preserved from the pre-TypeSpec API; they're hidden from IntelliSense by design. A single-line `<summary>` referencing the file-level explanatory comment is added to each undocumented member.

### Validation
`dotnet build` of both projects → **Build succeeded, 0 errors** across all TFMs.