### PR TITLE
[KeyVault] Add Keys support for service version 2026-03-01-preview

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Features Added
 
-- Added support for service API version `2026-03-01-preview` (now the default).
+- Added support for service API version `2026-03-01-preview` on `KeyClientOptions.ServiceVersion` and `CryptographyClientOptions.ServiceVersion`.
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- The default service version for `KeyClient` and `CryptographyClient` is now `2026-03-01-preview`.
 
 ## 4.11.0-beta.1 (2026-06-04)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for service API version `2026-03-01-preview` (now the default).
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net10.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net10.0.cs
@@ -181,7 +181,7 @@ namespace Azure.Security.KeyVault.Keys
     }
     public partial class KeyClientOptions : Azure.Core.ClientOptions
     {
-        public KeyClientOptions(Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion.V2026_01_01_Preview) { }
+        public KeyClientOptions(Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion.V2026_03_01_Preview) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -195,6 +195,7 @@ namespace Azure.Security.KeyVault.Keys
             V7_6 = 6,
             V2025_07_01 = 7,
             V2026_01_01_Preview = 8,
+            V2026_03_01_Preview = 9,
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -443,7 +444,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
     }
     public partial class CryptographyClientOptions : Azure.Core.ClientOptions
     {
-        public CryptographyClientOptions(Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion.V2026_01_01_Preview) { }
+        public CryptographyClientOptions(Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion.V2026_03_01_Preview) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -457,6 +458,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             V7_6 = 6,
             V2025_07_01 = 7,
             V2026_01_01_Preview = 8,
+            V2026_03_01_Preview = 9,
         }
     }
     public partial class DecryptParameters

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net8.0.cs
@@ -181,7 +181,7 @@ namespace Azure.Security.KeyVault.Keys
     }
     public partial class KeyClientOptions : Azure.Core.ClientOptions
     {
-        public KeyClientOptions(Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion.V2026_01_01_Preview) { }
+        public KeyClientOptions(Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion.V2026_03_01_Preview) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -195,6 +195,7 @@ namespace Azure.Security.KeyVault.Keys
             V7_6 = 6,
             V2025_07_01 = 7,
             V2026_01_01_Preview = 8,
+            V2026_03_01_Preview = 9,
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -443,7 +444,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
     }
     public partial class CryptographyClientOptions : Azure.Core.ClientOptions
     {
-        public CryptographyClientOptions(Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion.V2026_01_01_Preview) { }
+        public CryptographyClientOptions(Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion.V2026_03_01_Preview) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -457,6 +458,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             V7_6 = 6,
             V2025_07_01 = 7,
             V2026_01_01_Preview = 8,
+            V2026_03_01_Preview = 9,
         }
     }
     public partial class DecryptParameters

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
@@ -181,7 +181,7 @@ namespace Azure.Security.KeyVault.Keys
     }
     public partial class KeyClientOptions : Azure.Core.ClientOptions
     {
-        public KeyClientOptions(Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion.V2026_01_01_Preview) { }
+        public KeyClientOptions(Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion.V2026_03_01_Preview) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Keys.KeyClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -195,6 +195,7 @@ namespace Azure.Security.KeyVault.Keys
             V7_6 = 6,
             V2025_07_01 = 7,
             V2026_01_01_Preview = 8,
+            V2026_03_01_Preview = 9,
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -443,7 +444,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
     }
     public partial class CryptographyClientOptions : Azure.Core.ClientOptions
     {
-        public CryptographyClientOptions(Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion.V2026_01_01_Preview) { }
+        public CryptographyClientOptions(Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion version = Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion.V2026_03_01_Preview) { }
         public bool DisableChallengeResourceVerification { get { throw null; } set { } }
         public Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -457,6 +458,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             V7_6 = 6,
             V2025_07_01 = 7,
             V2026_01_01_Preview = 8,
+            V2026_03_01_Preview = 9,
         }
     }
     public partial class DecryptParameters

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/assets.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/keyvault/Azure.Security.KeyVault.Keys",
-  "Tag": "net/keyvault/Azure.Security.KeyVault.Keys_2a89cdb5c8"
+  "Tag": "net/keyvault/Azure.Security.KeyVault.Keys_782e0ff1a4"
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/assets.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/keyvault/Azure.Security.KeyVault.Keys",
-  "Tag": "net/keyvault/Azure.Security.KeyVault.Keys_782e0ff1a4"
+  "Tag": "net/keyvault/Azure.Security.KeyVault.Keys_2a89cdb5c8"
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_01_01_Preview;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_03_01_Preview;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client
@@ -69,6 +69,11 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             /// The Key Vault API version 2026-01-01-preview.
             /// </summary>
             V2026_01_01_Preview = 8,
+
+            /// <summary>
+            /// The Key Vault API version 2026-03-01-preview.
+            /// </summary>
+            V2026_03_01_Preview = 9,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -112,6 +117,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
                 ServiceVersion.V7_6 => "7.6",
                 ServiceVersion.V2025_07_01 => "2025-07-01",
                 ServiceVersion.V2026_01_01_Preview => "2026-01-01-preview",
+                ServiceVersion.V2026_03_01_Preview => "2026-03-01-preview",
                 _ => throw new ArgumentException(Version.ToString()),
             };
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Keys
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_01_01_Preview;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_03_01_Preview;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client
@@ -69,6 +69,11 @@ namespace Azure.Security.KeyVault.Keys
             /// The Key Vault API version 2026-01-01-preview.
             /// </summary>
             V2026_01_01_Preview = 8,
+
+            /// <summary>
+            /// The Key Vault API version 2026-03-01-preview.
+            /// </summary>
+            V2026_03_01_Preview = 9,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -112,6 +117,7 @@ namespace Azure.Security.KeyVault.Keys
                 ServiceVersion.V7_6 => "7.6",
                 ServiceVersion.V2025_07_01 => "2025-07-01",
                 ServiceVersion.V2026_01_01_Preview => "2026-01-01-preview",
+                ServiceVersion.V2026_03_01_Preview => "2026-03-01-preview",
                 _ => throw new ArgumentException(Version.ToString()),
             };
         }


### PR DESCRIPTION
Adds `2026-03-01-preview` to `Azure.Security.KeyVault.Keys` to match the betas we shipped today for the other 5 languages (Python, Java, JS, Go, Rust). Also matches what we already did for `Azure.Security.KeyVault.Certificates` in #59537.

## Changes
- `KeyClientOptions.ServiceVersion.V2026_03_01_Preview = 9`
- `LatestVersion` → `V2026_03_01_Preview` (new default)
- `GetVersionString` case for `2026-03-01-preview`
- Bump `Azure.Security.KeyVault.Keys` to `4.11.0-beta.2`
- CHANGELOG entry

## Scope (deliberately minimal)
This PR ships **only the new service version**. The new data-plane operations in `2026-03-01-preview` —

- `POST /keys/{name}/{version}/securewrapkey`
- `POST /keys/{name}/{version}/secureunwrapkey`

— and the supporting public models (`SecureKeyOperationResult`, `JsonWebKeyWrapAlgorithm`, `SecureKey{Wrap,UnWrap}OperationParameters`) are NOT yet exposed in the public .NET surface. They need hand-written wrappers on `CryptographyClient` plus tests and recordings, which I'll do as a follow-up PR. Following the same incremental approach we used for `2026-01-01-preview` / `ExternalKey`.

## Verification
- `dotnet build` — clean (0 warnings, 0 errors)
- Backward compatible: `V2026_01_01_Preview` and earlier remain selectable

cc @tlupes, @kashifkhan, @JonathanGiles