### PR TITLE
Fix derived FromResponse serialization hiding

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SerializationVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/SerializationVisitor.cs
@@ -38,7 +38,7 @@ internal class SerializationVisitor : ScmLibraryVisitor
     {
         TryUpdateExplicitCreateMethod(method);
 
-        if (method.EnclosingType is MrwSerializationTypeDefinition && method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator))
+        if (method.EnclosingType is MrwSerializationTypeDefinition serializationType && method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator))
         {
             var modifiers = method.Signature.Modifiers & ~MethodSignatureModifiers.Operator & ~MethodSignatureModifiers.Public | MethodSignatureModifiers.Internal;
             if (modifiers.HasFlag(MethodSignatureModifiers.Implicit))
@@ -49,10 +49,55 @@ internal class SerializationVisitor : ScmLibraryVisitor
             else if (modifiers.HasFlag(MethodSignatureModifiers.Explicit))
             {
                 modifiers &= ~MethodSignatureModifiers.Explicit;
+                if (HasBaseFromResponse(serializationType))
+                {
+                    // Static FromResponse methods hide by name and parameter list; the return type is not
+                    // considered. Make the intended hiding explicit when the base model also has one.
+                    modifiers |= MethodSignatureModifiers.New;
+                }
                 method.Signature.Update(modifiers: modifiers, name: FromResponseMethodName);
             }
         }
         return base.VisitMethod(method);
+    }
+
+    private static bool HasBaseFromResponse(MrwSerializationTypeDefinition serializationType)
+    {
+        if (!ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(serializationType.Type, out var typeProvider)
+            || typeProvider is not ModelProvider model)
+        {
+            return false;
+        }
+
+        var current = model.BaseModelProvider;
+        while (current is not null)
+        {
+            if (current.SerializationProviders
+                .OfType<MrwSerializationTypeDefinition>()
+                .SelectMany(provider => provider.Methods)
+                .Any(IsFromResponseMethod))
+            {
+                return true;
+            }
+
+            current = current.BaseModelProvider;
+        }
+
+        return false;
+    }
+
+    private static bool IsFromResponseMethod(MethodProvider method)
+    {
+        // SerializationVisitor rewrites the explicit Response conversion operator to FromResponse.
+        // Depending on visitor ordering, base methods may still be in their pre-rewrite operator form.
+        if (method.Signature.Parameters is not [var parameter] || !parameter.Type.AreNamesEqual(typeof(Response)))
+        {
+            return false;
+        }
+
+        return method.Signature.Name == FromResponseMethodName
+            || (method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator)
+                && method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Explicit));
     }
 
     private static bool TryUpdateExplicitCreateMethod(MethodProvider method)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ResourceDataModelProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ResourceDataModelProviderTests.cs
@@ -174,6 +174,54 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(serializationContent, Does.Not.Contain("global::Samples.Models.ResponseTypeData"));
         }
 
+        [Test]
+        public void DerivedSerializationFromResponseHidesBaseWithNewModifier()
+        {
+            var baseModel = InputFactory.Model(
+                "NetworkInterface",
+                properties: [InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true)],
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json);
+            var derivedModel = InputFactory.Model(
+                "VirtualMachineScaleSetNetworkInterface",
+                properties: [InputFactory.Property("parentId", InputPrimitiveType.String, isReadOnly: true)],
+                baseModel: baseModel,
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json);
+            var getBaseOperation = InputFactory.Operation(
+                "getBase",
+                responses: [InputFactory.OperationResponse([200], baseModel)],
+                path: "/subscriptions/{subscriptionId}/providers/Microsoft.Tests/networkInterfaces/{networkInterfaceName}");
+            var getBaseMethod = InputFactory.BasicServiceMethod(
+                "getBase",
+                getBaseOperation,
+                response: InputFactory.ServiceMethodResponse(baseModel, null));
+            var getDerivedOperation = InputFactory.Operation(
+                "getDerived",
+                responses: [InputFactory.OperationResponse([200], derivedModel)],
+                path: "/subscriptions/{subscriptionId}/providers/Microsoft.Tests/networkInterfaces/{networkInterfaceName}");
+            var getDerivedMethod = InputFactory.BasicServiceMethod(
+                "getDerived",
+                getDerivedOperation,
+                response: InputFactory.ServiceMethodResponse(derivedModel, null));
+            var client = InputFactory.Client("TestClient", methods: [getBaseMethod, getDerivedMethod]);
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [baseModel, derivedModel], clients: () => [client]);
+            var baseProvider = plugin.Object.TypeFactory.CreateModel(baseModel)!;
+            var derivedProvider = plugin.Object.TypeFactory.CreateModel(derivedModel)!;
+            var baseSerialization = baseProvider.SerializationProviders.OfType<MrwSerializationTypeDefinition>().Single();
+            var derivedSerialization = derivedProvider.SerializationProviders.OfType<MrwSerializationTypeDefinition>().Single();
+            var visitor = new TestableSerializationVisitor();
+
+            foreach (var method in derivedSerialization.Methods)
+            {
+                visitor.InvokeVisitMethod(method);
+            }
+
+            var baseResponseOperator = baseSerialization.Methods.Single(m => m.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator)
+                && m.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Explicit));
+            var derivedFromResponse = derivedSerialization.Methods.Single(m => m.Signature.Name == SerializationVisitor.FromResponseMethodName);
+            Assert.That(baseResponseOperator.Signature.Name, Is.Not.EqualTo(SerializationVisitor.FromResponseMethodName));
+            Assert.That(derivedFromResponse.Signature.Modifiers.HasFlag(MethodSignatureModifiers.New), Is.True);
+        }
+
         private class TestableInheritableSystemObjectModelVisitor : InheritableSystemObjectModelVisitor
         {
             public ModelProvider? InvokePreVisitModel(InputModelType inputType, ModelProvider? type)
@@ -187,6 +235,14 @@ namespace Azure.Generator.Mgmt.Tests
             public TypeProvider? InvokeVisitType(TypeProvider type)
             {
                 return base.VisitType(type);
+            }
+        }
+
+        private class TestableSerializationVisitor : SerializationVisitor
+        {
+            public MethodProvider? InvokeVisitMethod(MethodProvider method)
+            {
+                return base.VisitMethod(method);
             }
         }
     }


### PR DESCRIPTION
Fixes #59731

## Summary

Adds `new` to generated derived `FromResponse(Response)` methods when a base model already exposes a matching static response deserializer. This avoids CS0108 under warnings-as-errors for derived resource data models such as the Network VMSS migration models.

## Details

- Detects whether the serialization type maps to a model with a base model serialization provider that has `FromResponse(Response)` or the explicit response conversion operator before it is rewritten.
- Adds a regression test for a base response model and a derived response model both returned by operations.

## Validation

- `npm run build -- --quiet` from `eng/packages/http-client-csharp-mgmt`
- `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --filter FullyQualifiedName~ResourceDataModelProviderTests --no-restore`
