### PR TITLE
docs: fix UndeleteBlobContainer typo

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -1941,7 +1941,7 @@ namespace Azure.Storage.Blobs
         #region UndeleteBlobContainer
         /// <summary>
         /// Restores a previously deleted container.
-        /// This API is only functional is Container Soft Delete is enabled
+        /// This API is only functional if Container Soft Delete is enabled
         /// for the storage account associated with the container.
         /// </summary>
         /// <param name="deletedContainerName">
@@ -1977,7 +1977,7 @@ namespace Azure.Storage.Blobs
 
         /// <summary>
         /// Restores a previously deleted container.
-        /// This API is only functional is Container Soft Delete is enabled
+        /// This API is only functional if Container Soft Delete is enabled
         /// for the storage account associated with the container.
         /// </summary>
         /// <param name="deletedContainerName">
@@ -2013,7 +2013,7 @@ namespace Azure.Storage.Blobs
 
         /// <summary>
         /// Restores a previously deleted container.
-        /// This API is only functional is Container Soft Delete is enabled
+        /// This API is only functional if Container Soft Delete is enabled
         /// for the storage account associated with the container.
         /// </summary>
         /// <param name="deletedContainerName">
@@ -2055,7 +2055,7 @@ namespace Azure.Storage.Blobs
 
         /// <summary>
         /// Restores a previously deleted container.
-        /// This API is only functional is Container Soft Delete is enabled
+        /// This API is only functional if Container Soft Delete is enabled
         /// for the storage account associated with the container.
         /// </summary>
         /// <param name="deletedContainerName">
@@ -2097,7 +2097,7 @@ namespace Azure.Storage.Blobs
 
         /// <summary>
         /// Restores a previously deleted container.
-        /// This API is only functional is Container Soft Delete is enabled
+        /// This API is only functional if Container Soft Delete is enabled
         /// for the storage account associated with the container.
         /// </summary>
         /// <param name="deletedContainerName">


### PR DESCRIPTION
## Summary
- Fix the `BlobServiceClient.UndeleteBlobContainer` XML documentation typo from "is" to "if".
- Apply the correction to the sync, async, overload, and internal documentation comments for the same API.

Fixes #59473.

## Testing
- `rg -n "This API is only functional (is|if) Container Soft Delete" sdk\storage\Azure.Storage.Blobs\src\BlobServiceClient.cs`
- `git diff --check`

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.