### PR TITLE
[Skills] Add RESNAME001 rule for single-word generic resource trio names

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -687,13 +687,16 @@ foreach ($typeName in $typeInfos.Keys) {
     $info = $typeInfos[$typeName]
 
     $noun = $null
+    $suffix = $null
     if ($typeName -like '*Resource' -and (Test-InheritsFrom $typeName 'ArmResource')) {
         $noun = $typeName -replace 'Resource$',''
+        $suffix = 'Resource'
     }
     elseif ($typeName -like '*Data' -and (
             (Test-InheritsFrom $typeName 'ResourceData') -or
             (Test-InheritsFrom $typeName 'TrackedResourceData'))) {
         $noun = $typeName -replace 'Data$',''
+        $suffix = 'Data'
         # Strip an optional 'Resource' infix so we evaluate the same noun as the
         # *Resource / *Collection classes (RESINFIX001 already flags the infix).
         if ($noun -like '*Resource' -and $noun -ne 'Resource') {
@@ -702,6 +705,7 @@ foreach ($typeName in $typeInfos.Keys) {
     }
     elseif ($typeName -like '*Collection' -and (Test-InheritsFrom $typeName 'ArmCollection')) {
         $noun = $typeName -replace 'Collection$',''
+        $suffix = 'Collection'
         if ($noun -like '*Resource' -and $noun -ne 'Resource') {
             $noun = $noun -replace 'Resource$',''
         }
@@ -711,11 +715,13 @@ foreach ($typeName in $typeInfos.Keys) {
     # This catches 'Drill', 'Goal', 'Recovery', 'Enrollment' but allows
     # 'DrillRun', 'RecoveryPlan', 'GoalAssignment', 'UsagePlan', etc.
     if ($noun -cmatch '^[A-Z][a-z]+$') {
+        $message = "Resource trio noun '$noun' is a single generic word. After stripping the reserved '$suffix' suffix, the name carries no RP/domain context and will collide with similarly-named types in other mgmt packages."
+        $fix = "Rename the whole trio ('${noun}Resource' / '${noun}Data' / '${noun}Collection') with an RP/domain prefix so the noun becomes multi-word and service-scoped (e.g., '<RpPrefix>${noun}*')."
         $violations.Add([NamingViolation]::new(
             'RESNAME001', 'Warning', 'Resource Naming',
             $typeName, '',
-            "Resource trio noun '$noun' is a single generic word. After stripping the reserved '$(($typeName -replace ".*$noun",''))' suffix, the name carries no RP/domain context and will collide with similarly-named types in other mgmt packages.",
-            "Rename the whole trio ('${noun}Resource' / '${noun}Data' / '${noun}Collection') with an RP/domain prefix so the noun becomes multi-word and service-scoped (e.g., '<RpPrefix>${noun}*').",
+            $message,
+            $fix,
             $info.Line
         )) | Out-Null
     }

--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -668,6 +668,60 @@ foreach ($typeName in $typeInfos.Keys) {
 }
 
 # =====================================================
+# RULE: RESNAME001 - Single-word generic resource trio names
+# =====================================================
+# After stripping the reserved ARM suffix (Resource / Data / Collection), the
+# remaining noun must still carry RP/domain context. A bare single word like
+# 'Drill', 'Goal', 'Recovery', 'Enrollment' is too generic - reviewers cannot
+# tell which RP it belongs to in IntelliSense and the name will collide with
+# similarly-generic types from other mgmt packages. This rule fires only when
+# the class actually inherits the ARM resource trio base (ArmResource /
+# ResourceData / TrackedResourceData / ArmCollection) so plain models named
+# 'FooData' that aren't resource data types are not flagged here.
+$resourceNameAllowList = @(
+    'GenericResource'     # ARM common, intentionally generic
+)
+foreach ($typeName in $typeInfos.Keys) {
+    if ($ExcludeRules -contains 'RESNAME001') { continue }
+    if ($resourceNameAllowList -contains $typeName) { continue }
+    $info = $typeInfos[$typeName]
+
+    $noun = $null
+    if ($typeName -like '*Resource' -and (Test-InheritsFrom $typeName 'ArmResource')) {
+        $noun = $typeName -replace 'Resource$',''
+    }
+    elseif ($typeName -like '*Data' -and (
+            (Test-InheritsFrom $typeName 'ResourceData') -or
+            (Test-InheritsFrom $typeName 'TrackedResourceData'))) {
+        $noun = $typeName -replace 'Data$',''
+        # Strip an optional 'Resource' infix so we evaluate the same noun as the
+        # *Resource / *Collection classes (RESINFIX001 already flags the infix).
+        if ($noun -like '*Resource' -and $noun -ne 'Resource') {
+            $noun = $noun -replace 'Resource$',''
+        }
+    }
+    elseif ($typeName -like '*Collection' -and (Test-InheritsFrom $typeName 'ArmCollection')) {
+        $noun = $typeName -replace 'Collection$',''
+        if ($noun -like '*Resource' -and $noun -ne 'Resource') {
+            $noun = $noun -replace 'Resource$',''
+        }
+    }
+    if (-not $noun) { continue }
+    # Single-word noun: starts with a capital letter and has no further capitals.
+    # This catches 'Drill', 'Goal', 'Recovery', 'Enrollment' but allows
+    # 'DrillRun', 'RecoveryPlan', 'GoalAssignment', 'UsagePlan', etc.
+    if ($noun -cmatch '^[A-Z][a-z]+$') {
+        $violations.Add([NamingViolation]::new(
+            'RESNAME001', 'Warning', 'Resource Naming',
+            $typeName, '',
+            "Resource trio noun '$noun' is a single generic word. After stripping the reserved '$(($typeName -replace ".*$noun",''))' suffix, the name carries no RP/domain context and will collide with similarly-named types in other mgmt packages.",
+            "Rename the whole trio ('${noun}Resource' / '${noun}Data' / '${noun}Collection') with an RP/domain prefix so the noun becomes multi-word and service-scoped (e.g., '<RpPrefix>${noun}*').",
+            $info.Line
+        )) | Out-Null
+    }
+}
+
+# =====================================================
 # Contextual / generic naming is intentionally NOT enforced by this script.
 # =====================================================
 # Naming context is too case-by-case to encode reliably in regex/allowlists -

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -67,7 +67,7 @@ To determine the review scope:
    The scanner currently emits these rule families (see "API Review Checklist" for details):
    - `SUFFIX001`–`SUFFIX010` – forbidden type-name suffixes (Parameters, Request, Options, Response, Data, Definition, Operation, Collection, **Update**, …)
    - `RESINFIX001` – `Resource` infix in `*Data`/`*Collection` model names (with PrivateLinkResource exception)
-   - `RESNAME001` – single-word generic resource trio noun (after stripping `Resource`/`Data`/`Collection`, e.g., `Drill`, `Goal`, `Recovery`, `Enrollment`); only fires when the class actually inherits `ArmResource` / `ResourceData` / `TrackedResourceData` / `ArmCollection`
+   - `RESNAME001` – single-word generic resource trio noun (after stripping `Resource`/`Data`/`Collection`); only fires when the class actually inherits `ArmResource` / `ResourceData` / `TrackedResourceData` / `ArmCollection`
    - `ACRONYM001` – curated acronyms in wrong casing (HTTP/TCP/SSL/TLS/…)
    - `ACRONYM002` – generic 3+ letter all-caps run inside a name (NNI, IPV, BFD, …)
    - `ARMCOMMON001` – type duplicates an Azure.ResourceManager/Azure.Core common type (`OperationStatusResult`, `ManagedServiceIdentity*`, `TagsUpdate`, `ErrorResponse`, …)

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -67,6 +67,7 @@ To determine the review scope:
    The scanner currently emits these rule families (see "API Review Checklist" for details):
    - `SUFFIX001`–`SUFFIX010` – forbidden type-name suffixes (Parameters, Request, Options, Response, Data, Definition, Operation, Collection, **Update**, …)
    - `RESINFIX001` – `Resource` infix in `*Data`/`*Collection` model names (with PrivateLinkResource exception)
+   - `RESNAME001` – single-word generic resource trio noun (after stripping `Resource`/`Data`/`Collection`, e.g., `Drill`, `Goal`, `Recovery`, `Enrollment`); only fires when the class actually inherits `ArmResource` / `ResourceData` / `TrackedResourceData` / `ArmCollection`
    - `ACRONYM001` – curated acronyms in wrong casing (HTTP/TCP/SSL/TLS/…)
    - `ACRONYM002` – generic 3+ letter all-caps run inside a name (NNI, IPV, BFD, …)
    - `ARMCOMMON001` – type duplicates an Azure.ResourceManager/Azure.Core common type (`OperationStatusResult`, `ManagedServiceIdentity*`, `TagsUpdate`, `ErrorResponse`, …)
@@ -152,6 +153,12 @@ The following types are provided by `Azure.ResourceManager` / `Azure.Core` and *
   - **Collection types:** `ArmCollection` types must not include "Resource" before "Collection" — e.g., `VirtualMachineResourceCollection` is **not allowed**; use `VirtualMachineCollection` instead.
   - **Exception – PrivateLinkResource:** `*PrivateLinkResourceData` and `*PrivateLinkResourceCollection` are allowed because "PrivateLinkResource" is the established ARM resource name.
   - **When to flag:** Flag all other violations unless the PR provides explicit justification for keeping the "Resource" infix.
+- **No single-word generic resource trio names (RESNAME001).**
+  - After stripping the reserved ARM suffix (`Resource`, `Data`, or `Collection`), the remaining noun on a resource trio (a class that inherits `ArmResource`, `ResourceData`/`TrackedResourceData`, or `ArmCollection`) must still carry RP/domain context.
+  - **Bad examples:** `DrillResource` / `DrillData` / `DrillCollection` (noun is bare `Drill`), `GoalResource` (`Goal`), `RecoveryResource` (`Recovery`), `EnrollmentResource` (`Enrollment`) — readers cannot tell from IntelliSense which Azure service these belong to, and the names will collide with similarly-generic types in other mgmt packages.
+  - **Good examples:** `VirtualMachineResource`, `RecoveryPlanResource`, `UsagePlanResource`, `GoalAssignmentResource`, `DrillRunResource` — the noun is multi-word and service/resource-scoped.
+  - **Fix:** Rename the whole trio together (e.g., `DrillResource` / `DrillData` / `DrillCollection` → `ResilienceDrillResource` / `ResilienceDrillData` / `ResilienceDrillCollection`). The scanner emits this as `RESNAME001` automatically; reviewers should always recommend a renamed trio rather than fixing just one of the three.
+  - **Exception:** `GenericResource` (an established ARM common type that is intentionally generic). Any other exception requires explicit reviewer justification.
 
 #### Operation Body Parameters
 - **PATCH operation body:** Must be named `[Model]Patch`


### PR DESCRIPTION
## Why

Reviewing PR #59743 (initial release of `Azure.ResourceManager.ResilienceManagement`) surfaced a recurring naming gap that the mgmt review skill did not catch automatically: **single-word generic resource trio names**. After stripping the reserved ARM suffix (`Resource` / `Data` / `Collection`), nouns like `Drill`, `Goal`, `Recovery`, and `Enrollment` carry no RP/domain context and will collide with similarly-named types from other mgmt packages once GA.

The .NET mgmt naming convention is that the noun left after stripping the suffix must still be multi-word and service/resource-scoped (e.g., `VirtualMachine`, `RecoveryPlan`, `DrillRun`, `GoalAssignment`). This PR encodes that convention.

## What

- `Check-MgmtNamingRules.ps1`: new rule **`RESNAME001`** that fires when:
  - the class is a real resource trio member (inherits `ArmResource`, `ResourceData`/`TrackedResourceData`, or `ArmCollection` — uses the existing `Test-InheritsFrom` helper, so unrelated `*Data` / `*Collection` models are not flagged), **and**
  - the noun left after stripping `Resource`/`Data`/`Collection` (and an optional `Resource` infix already covered by RESINFIX001) matches `^[A-Z][a-z]+$` (single capitalized word).
  - Allowlist: `GenericResource` (intentionally generic ARM common type).
- `SKILL.md`:
  - Added `RESNAME001` to the rule-families list (step 3).
  - Added a new bullet under **Resource Naming** with bad/good examples and fix guidance (rename the *whole trio together* with an RP/domain prefix, not just one of the three).

## Verification

Ran the scanner against PR #59743 and confirmed:
- Flags the four offending trios: `DrillResource`/`DrillData`/`DrillCollection`, `EnrollmentResource`/`EnrollmentData`/`EnrollmentCollection`, `GoalResource`/`GoalResourceData`/`GoalResourceCollection`, `RecoveryResource`/`RecoveryResourceData`/`RecoveryResourceCollection` — 12 violations total.
- Does **not** flag correctly-named multi-word trios in the same package: `DrillRun*`, `DrillTarget*`, `RecoveryPlan*`, `RecoveryJob*`, `GoalAssignment*`, `GoalTemplate*`, `UsagePlan*`, `UnifiedResilienceItem*`.
- `GenericResource` from other packages remains unflagged via the allowlist.

## Related

- Surfaced during review of #59743.