### PR TITLE
Fix docs metadata pipeline to comply with docs repo branch protection

### DIFF
--- a/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+++ b/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -103,12 +103,32 @@ steps:
         ${{ if ne(parameters.NpmConfigRegistry, '') }}:
           npm_config_registry: ${{ parameters.NpmConfigRegistry }}
 
-    - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
-      parameters:
-        BaseRepoBranch: $(TargetBranchName)
-        BaseRepoOwner: ${{ parameters.TargetDocRepoOwner }}
-        CommitMsg: "Update docs metadata"
-        TargetRepoName: ${{ parameters.TargetDocRepoName }}
-        TargetRepoOwner: ${{ parameters.TargetDocRepoOwner }}
-        WorkingDirectory: $(DocRepoLocation)
-        ScriptDirectory: ${{ parameters.WorkingDirectory }}/${{ parameters.ScriptDirectory }}
+    - ${{ if eq(parameters.DailyDocsBuild, 'true') }}:
+      - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+        parameters:
+          BaseRepoBranch: $(TargetBranchName)
+          BaseRepoOwner: ${{ parameters.TargetDocRepoOwner }}
+          CommitMsg: "Update docs metadata"
+          TargetRepoName: ${{ parameters.TargetDocRepoName }}
+          TargetRepoOwner: ${{ parameters.TargetDocRepoOwner }}
+          WorkingDirectory: $(DocRepoLocation)
+          ScriptDirectory: ${{ parameters.WorkingDirectory }}/${{ parameters.ScriptDirectory }}
+
+    - ${{ if ne(parameters.DailyDocsBuild, 'true') }}:
+      - pwsh: |
+          $docsMetadataBranchName = "docs-metadata-$(Build.BuildId)"
+          Write-Host "Setting DocsMetadataBranchName=$docsMetadataBranchName"
+          Write-Host "##vso[task.setvariable variable=DocsMetadataBranchName]$docsMetadataBranchName"
+        displayName: Set docs metadata PR branch name
+
+      - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+        parameters:
+          BaseBranchName: $(TargetBranchName)
+          PRBranchName: $(DocsMetadataBranchName)
+          PROwner: ${{ parameters.TargetDocRepoOwner }}
+          CommitMsg: "Update docs metadata"
+          RepoOwner: ${{ parameters.TargetDocRepoOwner }}
+          RepoName: ${{ parameters.TargetDocRepoName }}
+          WorkingDirectory: $(DocRepoLocation)
+          ScriptDirectory: ${{ parameters.WorkingDirectory }}/${{ parameters.ScriptDirectory }}
+          PRTitle: "Update docs metadata"


### PR DESCRIPTION
Publish to Docs.MS in VoiceLive Pipeline Release Gives

-----
Push changes step attempted direct push to docs main: (link: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6414478&view=logs&j=1e4dace2-10ec-580f-9a06-648c00ed6e85&t=cf82c6e5-36c3-5919-6862-339143ddd618&s=f8bdb916-829c-55ba-9242-95c4678235d7)

git checkout main.
git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -am "Update docs metadata"
[main 700cfbab] Update docs metadata
git push azure-sdk-fork main

remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: Review all repository rules at https://github.com/MicrosoftDocs/azure-docs-sdk-dotnet/rules?ref=refs%2Fheads%2Fmain
remote: - Changes must be made through a pull request.
! [remote rejected] main -> main (push declined due to repository rule violations)
error: failed to push some refs to 'https://github.com/MicrosoftDocs/azure-docs-sdk-dotnet.git'

-----


Root cause: Root cause: non-daily docs metadata flow pushes directly to main, but docs repo policy requires PR-based updates.
