### PR TITLE
Fix mgmt clientName on model properties

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
@@ -211,23 +211,23 @@ export function setHasClientNameOverride(
     const sdkModel = sdkModelByKey.get(
       `${inputModel.namespace}.${inputModel.name}`
     );
-    const raw = sdkModel?.__raw;
-    if (!raw) {
+    if (!sdkModel) {
       continue;
     }
-    const override = getClientNameOverride(sdkContext, raw, "csharp");
-    if (override === undefined) {
-      continue;
-    }
-    inputModel.decorators ??= [];
-    const marker: DecoratorInfo = {
-      name: hasClientNameOverrideDecorator,
-      arguments: {}
-    };
-    inputModel.decorators.push(marker);
-  }
 
-  for (const sdkModel of sdkContext.sdkPackage.models) {
+    const raw = sdkModel.__raw;
+    if (raw) {
+      const override = getClientNameOverride(sdkContext, raw, "csharp");
+      if (override !== undefined) {
+        inputModel.decorators ??= [];
+        const marker: DecoratorInfo = {
+          name: hasClientNameOverrideDecorator,
+          arguments: {}
+        };
+        inputModel.decorators.push(marker);
+      }
+    }
+
     for (const sdkProperty of sdkModel.properties) {
       const raw = sdkProperty.__raw;
       if (!raw) {

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
@@ -227,6 +227,24 @@ export function setHasClientNameOverride(
     inputModel.decorators.push(marker);
   }
 
+  for (const sdkModel of sdkContext.sdkPackage.models) {
+    for (const sdkProperty of sdkModel.properties) {
+      const raw = sdkProperty.__raw;
+      if (!raw) {
+        continue;
+      }
+      const override = getClientNameOverride(sdkContext, raw, "csharp");
+      if (override === undefined) {
+        continue;
+      }
+      sdkProperty.decorators ??= [];
+      sdkProperty.decorators.push({
+        name: hasClientNameOverrideDecorator,
+        arguments: {}
+      });
+    }
+  }
+
   for (const sdkClient of getAllSdkClients(sdkContext)) {
     for (const sdkMethod of sdkClient.methods) {
       const raw = sdkMethod.__raw;

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/sdk-context-options.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/sdk-context-options.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, it } from "vitest";
+import { createModel } from "@typespec/http-client-csharp";
+import { strictEqual } from "assert";
+import {
+  createCSharpSdkContext,
+  createEmitterContext,
+  createEmitterTestHost,
+  typeSpecCompile
+} from "./test-util.js";
+import {
+  hasClientNameOverrideDecorator,
+  setHasClientNameOverride
+} from "../src/sdk-context-options.js";
+import { TestHost } from "@typespec/compiler/testing";
+
+describe("SDK context options", () => {
+  let runner: TestHost;
+
+  beforeEach(async () => {
+    runner = await createEmitterTestHost();
+  });
+
+  it("marks read-only model properties with clientName overrides", async () => {
+    const program = await typeSpecCompile(
+      `
+model TestModel {
+  @visibility(Lifecycle.Read)
+  privateIpAddress?: string | null;
+}
+
+@@clientName(TestModel.privateIpAddress, "PrivateIPAddress", "csharp");
+@@alternateType(TestModel.privateIpAddress, Azure.Core.ipV4Address | null, "csharp");
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Test operation intentionally uses a simple route."
+@get
+op get(): TestModel;
+`,
+      runner
+    );
+    const context = await createCSharpSdkContext(createEmitterContext(program));
+    const [model] = createModel(context);
+
+    setHasClientNameOverride(model, context);
+
+    const testModel = model.models.find((m) => m.name === "TestModel");
+    const property = testModel?.properties.find(
+      (p) => p.serializedName === "privateIpAddress"
+    );
+    strictEqual(property?.name, "PrivateIPAddress");
+    strictEqual(property?.type.kind, "nullable");
+    strictEqual(property?.type.type.kind, "string");
+    strictEqual(property?.type.type.name, "ipV4Address");
+    strictEqual(
+      property?.decorators?.some(
+        (d) => d.name === hasClientNameOverrideDecorator
+      ),
+      true
+    );
+  });
+});

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/sdk-context-options.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/sdk-context-options.test.ts
@@ -20,16 +20,20 @@ describe("SDK context options", () => {
     runner = await createEmitterTestHost();
   });
 
-  it("marks read-only model properties with clientName overrides", async () => {
+  it("marks model properties with clientName overrides", async () => {
     const program = await typeSpecCompile(
       `
 model TestModel {
   @visibility(Lifecycle.Read)
   privateIpAddress?: string | null;
+
+  publicIpAddress?: string | null;
 }
 
 @@clientName(TestModel.privateIpAddress, "PrivateIPAddress", "csharp");
+@@clientName(TestModel.publicIpAddress, "PublicIPAddress", "csharp");
 @@alternateType(TestModel.privateIpAddress, Azure.Core.ipV4Address | null, "csharp");
+@@alternateType(TestModel.publicIpAddress, Azure.Core.ipV4Address | null, "csharp");
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Test operation intentionally uses a simple route."
 @get
@@ -46,12 +50,25 @@ op get(): TestModel;
     const property = testModel?.properties.find(
       (p) => p.serializedName === "privateIpAddress"
     );
+    const writableProperty = testModel?.properties.find(
+      (p) => p.serializedName === "publicIpAddress"
+    );
     strictEqual(property?.name, "PrivateIPAddress");
     strictEqual(property?.type.kind, "nullable");
     strictEqual(property?.type.type.kind, "string");
     strictEqual(property?.type.type.name, "ipV4Address");
     strictEqual(
       property?.decorators?.some(
+        (d) => d.name === hasClientNameOverrideDecorator
+      ),
+      true
+    );
+    strictEqual(writableProperty?.name, "PublicIPAddress");
+    strictEqual(writableProperty?.type.kind, "nullable");
+    strictEqual(writableProperty?.type.type.kind, "string");
+    strictEqual(writableProperty?.type.type.name, "ipV4Address");
+    strictEqual(
+      writableProperty?.decorators?.some(
         (d) => d.name === hasClientNameOverrideDecorator
       ),
       true

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
@@ -17,7 +17,7 @@ namespace Azure.Generator.Management
         private const string ArmProviderSchemaDecoratorName = "Azure.ClientGenerator.Core.@armProviderSchema";
         private const string FlattenPropertyDecoratorName = "Azure.ResourceManager.@flattenProperty";
         private const string ClientOptionDecoratorName = "Azure.ClientGenerator.Core.@clientOption";
-        private const string HasClientNameOverrideDecoratorName = "Azure.ResourceManager.@hasClientNameOverride";
+        internal const string HasClientNameOverrideDecoratorName = "Azure.ResourceManager.@hasClientNameOverride";
         private const string DisableSafeFlattenKey = "disable-safe-flatten";
         private const string CSharpScope = "csharp";
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/NameVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/NameVisitor.cs
@@ -106,11 +106,35 @@ internal class NameVisitor : ScmLibraryVisitor
 
     protected override PropertyProvider? PreVisitProperty(InputProperty property, PropertyProvider? propertyProvider)
     {
+        if (DoPreVisitPropertyForClientNameOverride(property, propertyProvider))
+        {
+            return base.PreVisitProperty(property, propertyProvider);
+        }
+
         DoPreVisitPropertyForResourceTypeName(property, propertyProvider);
         DoPreVisitPropertyForUrlPropertyName(property, propertyProvider);
         DoPreVisitPropertyForTimePropertyName(property, propertyProvider);
         DoPreVisitPropertyNameRenaming(property, propertyProvider);
         return base.PreVisitProperty(property, propertyProvider);
+    }
+
+    private static bool DoPreVisitPropertyForClientNameOverride(InputProperty property, PropertyProvider? propertyProvider)
+    {
+        if (propertyProvider is null)
+        {
+             return false;
+        }
+
+        foreach (var decorator in property.Decorators)
+        {
+            if (decorator.Name == ManagementInputLibrary.HasClientNameOverrideDecoratorName)
+            {
+                propertyProvider.Update(name: property.Name);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void DoPreVisitPropertyForResourceTypeName(InputProperty property, PropertyProvider? propertyProvider)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
@@ -157,6 +157,7 @@ namespace Azure.Generator.Management.Tests.Common
         /// <param name="summary"></param>
         /// <param name="serializedName"></param>
         /// <param name="doc"></param>
+        /// <param name="decorators"></param>
         /// <returns></returns>
         public static InputModelProperty Property(
             string name,
@@ -170,9 +171,10 @@ namespace Azure.Generator.Management.Tests.Common
             string? wireName = null,
             string? summary = null,
             string? serializedName = null,
-            string? doc = null)
+            string? doc = null,
+            IReadOnlyList<InputDecoratorInfo>? decorators = null)
         {
-            return new InputModelProperty(
+            var property = new InputModelProperty(
                 name: name,
                 summary: summary,
                 doc: doc ?? $"Description for {name}",
@@ -186,6 +188,13 @@ namespace Azure.Generator.Management.Tests.Common
                 isDiscriminator: isDiscriminator,
                 serializedName: serializedName ?? wireName ?? name.ToVariableName(),
                 serializationOptions: new(json: new(wireName ?? name.ToVariableName())));
+            if (decorators is not null)
+            {
+                typeof(InputProperty).GetProperty(nameof(InputProperty.Decorators))!
+                    .GetSetMethod(true)!
+                    .Invoke(property, [decorators]);
+            }
+            return property;
         }
 
         public static InputHeaderParameter HeaderParameter(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
@@ -147,7 +147,7 @@ namespace Azure.Generator.Mgmt.Tests
             const string testModelName = "TestModel";
             const string testPropertyName = "PrivateIPAddress";
             var clientNameOverrideMarker = new InputDecoratorInfo(
-                "Azure.ResourceManager.@hasClientNameOverride",
+                ManagementInputLibrary.HasClientNameOverrideDecoratorName,
                 new Dictionary<string, BinaryData>());
             var modelProperty = InputFactory.Property(
                 testPropertyName,

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
@@ -141,8 +141,9 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(type?.Properties[0].Name, Is.EqualTo("ETag"));
         }
 
-        [Test]
-        public void TestClientNameOverridePreservesPropertyNameExactly()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestClientNameOverridePreservesPropertyNameExactly(bool isReadOnly)
         {
             const string testModelName = "TestModel";
             const string testPropertyName = "PrivateIPAddress";
@@ -153,7 +154,7 @@ namespace Azure.Generator.Mgmt.Tests
                 testPropertyName,
                 InputPrimitiveType.String,
                 serializedName: "privateIpAddress",
-                isReadOnly: true,
+                isReadOnly: isReadOnly,
                 decorators: [clientNameOverrideMarker]);
             var model = InputFactory.Model(testModelName, properties: [modelProperty]);
             var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: model);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
@@ -142,6 +142,35 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
+        public void TestClientNameOverridePreservesPropertyNameExactly()
+        {
+            const string testModelName = "TestModel";
+            const string testPropertyName = "PrivateIPAddress";
+            var clientNameOverrideMarker = new InputDecoratorInfo(
+                "Azure.ResourceManager.@hasClientNameOverride",
+                new Dictionary<string, BinaryData>());
+            var modelProperty = InputFactory.Property(
+                testPropertyName,
+                InputPrimitiveType.String,
+                serializedName: "privateIpAddress",
+                isReadOnly: true,
+                decorators: [clientNameOverrideMarker]);
+            var model = InputFactory.Model(testModelName, properties: [modelProperty]);
+            var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: model);
+            var operation = InputFactory.Operation(name: "get", responses: [responseType], path: "/providers/a/test", decorators: []);
+            var client = InputFactory.Client(
+                TestClientName,
+                methods: [InputFactory.BasicServiceMethod("Get", operation)],
+                crossLanguageDefinitionId: $"Test.{TestClientName}",
+                decorators: []);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [model], clients: () => [client]);
+
+            var type = plugin.Object.TypeFactory.CreateModel(model);
+            Assert.That(type?.Properties[0].Name, Is.EqualTo(testPropertyName));
+        }
+
+        [Test]
         public void TestPatchModelRenameRespectsResourceDerivedClientNameOverride()
         {
             var (client, models, patchModel) = InputResourceData.ClientWithResourcePatchBodyEquivalentModelInstance();


### PR DESCRIPTION
Fixes #59796.

This preserves explicit C# `@@clientName` overrides for management model properties. The root cause is not specific to read-only properties: during base `PropertyProvider` creation, property names are normalized with `ToIdentifierName()` unless `InputProperty.IsExactName` is set. The management generator did not have a property-level signal that a name came from explicit `@@clientName`, so acronym casing like `PrivateIPAddress` could become `PrivateIpAddress`.

Changes:
- Stamp the existing `Azure.ResourceManager.@hasClientNameOverride` marker onto SDK model properties with C# `@@clientName` overrides.
- Teach `NameVisitor` to restore the exact input property name when that marker is present, after base `PropertyProvider` creation normalizes names.
- Add emitter and generator regression coverage for both read-only and writable property `@@clientName` preservation, including the `@@alternateType` IP address scenario from the issue.

Validation:
- `npm install`
- `npm run prettier`
- `npm run lint`
- `npm run build:emitter`
- `eng\scripts\Generate.ps1`
- `npm run build`
- Focused emitter regression test
- Focused `NameVisitorTests`
- Direct full generator test project (`227` tests)

Note: the full `npm run test` / `npm run test:emitter` wrappers stalled in this local environment with no active child process; the direct/focused tests covering the change passed.