### PR TITLE
Don't merge: an example of how to use azure monitor exporter in a console app

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
@@ -11,7 +11,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo
 {
     public class Program
     {
-        private const string ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+        private static readonly string ConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")
+            ?? "InstrumentationKey=00000000-0000-0000-0000-000000000000";
 
         public static void Main()
         {
@@ -19,14 +20,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo
             // var credential = new DefaultAzureCredential();
             // using var traceDemo = new TraceDemo(ConnectionString, credential);
 
-            using var traceDemo = new TraceDemo(ConnectionString);
-            traceDemo.GenerateTraces();
+            // using var traceDemo = new TraceDemo(ConnectionString);
+            // traceDemo.GenerateTraces();
 
-            using var metricDemo = new MetricDemo(ConnectionString);
-            metricDemo.GenerateMetrics();
+            // using var metricDemo = new MetricDemo(ConnectionString);
+            // metricDemo.GenerateMetrics();
 
-            using var logDemo = new LogDemo(ConnectionString);
-            logDemo.GenerateLogs();
+            // using var logDemo = new LogDemo(ConnectionString);
+            // logDemo.GenerateLogs();
+
+            using var useAzureMonitorDemo = new UseAzureMonitorExporterDemo(ConnectionString);
+            useAzureMonitorDemo.GenerateTrace();
+
+            Console.WriteLine("Waiting for telemetry to flush...");
+            System.Threading.Thread.Sleep(10000);
 
             Console.WriteLine("Press any key to exit.");
             Console.ReadLine();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/UseAzureMonitorExporterDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/UseAzureMonitorExporterDemo.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
+{
+    internal sealed class UseAzureMonitorExporterDemo : IDisposable
+    {
+        private const string ActivitySourceName = "MyCompany.MyProduct.MyLibrary.UseAzureMonitorExporter";
+        private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
+
+        private readonly ServiceProvider _serviceProvider;
+
+        public UseAzureMonitorExporterDemo(string connectionString)
+        {
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_SDKSTATS_DISABLED", "false");
+            // Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL", "60");
+
+            var services = new ServiceCollection();
+
+            services.AddOpenTelemetry()
+                .UseAzureMonitorExporter(options =>
+                {
+                    options.ConnectionString = connectionString;
+                    options.TracesPerSecond = null;
+                    options.SamplingRatio = 1.0F;
+                })
+                .WithTracing(tracerProviderBuilder =>
+                {
+                    tracerProviderBuilder.AddSource(ActivitySourceName);
+                });
+
+            _serviceProvider = services.BuildServiceProvider();
+
+            // Force provider creation so listeners are active.
+            _ = _serviceProvider.GetRequiredService<TracerProvider>();
+
+            // Manually start hosted services (including ExporterRegistrationHostedService)
+            // since we don't have a full IHost.
+            foreach (var service in _serviceProvider.GetServices<IHostedService>())
+            {
+                service.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+            }
+        }
+
+        public void GenerateTrace()
+        {
+            using var activity = s_activitySource.StartActivity("MinimalUseAzureMonitorExporterTrace", ActivityKind.Client);
+            Console.WriteLine($"Activity created: {activity != null}");
+            if (activity != null)
+            {
+                activity.SetTag("demo.kind", "minimal");
+                activity.SetStatus(ActivityStatusCode.Ok);
+                Console.WriteLine($"Activity ID: {activity.Id}");
+                Console.WriteLine($"Activity Source: {activity.Source.Name}");
+            }
+        }
+
+        public void Dispose()
+        {
+            _serviceProvider.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
- Add UseAzureMonitorExporterDemo class using IOpenTelemetryBuilder with manual hosted service startup for console app compatibility
- Update Program.cs to read connection string from APPLICATIONINSIGHTS_CONNECTION_STRING env var
- Comment out per-signal demo calls in favor of UseAzureMonitorExporter demo

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
