### PR TITLE
Add AZC0040 analyzer to flag Apache.Arrow types on public API surface

### DIFF
--- a/sdk/tools/Azure.SdkAnalyzers/CHANGELOG.md
+++ b/sdk/tools/Azure.SdkAnalyzers/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added AZC0012: Avoid single word type names analyzer
 - Added AZC0020: Propagate CancellationToken to RequestContext analyzer
 - Added AZC0101: Do not use `ConfigureAwait(true)` analyzer with automatic code fix (replaces `true` with `false`)
+- Added AZC0040: Do not expose Apache.Arrow types on the public API surface analyzer
 
 ### Breaking Changes
 

--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -14,8 +14,8 @@ This package is automatically included in all Azure SDK libraries in this reposi
 |------|-------------|-----|
 | [**AZC0012**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md) | Avoid single word type names | ✅ |
 | [**AZC0020**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0020.md) | Propagate CancellationToken to RequestContext | — |
-| [**AZC0101**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
 | [**AZC0040**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md) | Do not expose Apache.Arrow types on the public API surface | — |
+| [**AZC0101**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
 
 ## For Library Authors
 

--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -15,6 +15,7 @@ This package is automatically included in all Azure SDK libraries in this reposi
 | [**AZC0012**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md) | Avoid single word type names | ✅ |
 | [**AZC0020**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0020.md) | Propagate CancellationToken to RequestContext | — |
 | [**AZC0101**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
+| [**AZC0040**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md) | Do not expose Apache.Arrow types on the public API surface | — |
 
 ## For Library Authors
 

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md
@@ -1,0 +1,65 @@
+# AZC0040: Do not expose Apache.Arrow types on the public API surface
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Warning |
+| **Code fix** | No |
+
+## Cause
+
+A public or protected API member in an Azure SDK namespace (`Azure.*`, excluding `Azure.Core.*`) exposes a type from the `Apache.Arrow` library (any type in the `Apache.Arrow` namespace or one of its child namespaces). This includes return types, parameter types, property types, field types, event types, base types, implemented interfaces, generic type arguments, and array element types.
+
+## Why this matters
+
+Exposing `Apache.Arrow` types on the public API surface couples consumers of the SDK to a third-party dependency whose versioning and breaking-change cadence are outside the SDK's control. Once an `Apache.Arrow` type appears in the public contract it cannot be changed without a breaking change, and consumers are forced to take a direct dependency on a specific `Apache.Arrow` version.
+
+## How to fix
+
+Keep `Apache.Arrow` types internal and expose abstractions that the library owns instead. Convert to and from `Apache.Arrow` types behind the scenes.
+
+```diff
+ namespace Azure.Data.Analytics
+ {
+-    public class QueryResult
+-    {
+-        public Apache.Arrow.Table Table { get; }
+-    }
++    public class QueryResult
++    {
++        public BinaryData Data { get; }
++    }
+ }
+```
+
+## Example of a violation
+
+```csharp
+using Apache.Arrow;
+
+namespace Azure.Data.Analytics
+{
+    public class AnalyticsClient
+    {
+        public Table GetTable() => null; // ❌ exposes Apache.Arrow.Table
+    }
+}
+```
+
+## Example of how to fix
+
+```csharp
+namespace Azure.Data.Analytics
+{
+    public class AnalyticsClient
+    {
+        public BinaryData GetTable() => null; // ✅ exposes an SDK-owned type
+    }
+}
+```
+
+## Notes
+
+- Only public and protected members of public types in Azure SDK namespaces (starting with `Azure.` except `Azure.Core.*`) are analyzed.
+- A type is treated as an `Apache.Arrow` type when its containing namespace is `Apache.Arrow` or begins with `Apache.Arrow.`.
+- Arrays, pointers, and generic type arguments are unwrapped, so `IReadOnlyList<Apache.Arrow.RecordBatch>` and `Apache.Arrow.Table[]` are also flagged.
+- The diagnostic can be suppressed with `#pragma warning disable AZC0040` or a `[SuppressMessage]` attribute when an exception is genuinely required.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md
@@ -62,4 +62,5 @@ namespace Azure.Data.Analytics
 - Only public and protected members of public types in Azure SDK namespaces (starting with `Azure.` except `Azure.Core.*`) are analyzed.
 - A type is treated as an `Apache.Arrow` type when its containing namespace is `Apache.Arrow` or begins with `Apache.Arrow.`.
 - Arrays, pointers, and generic type arguments are unwrapped, so `IReadOnlyList<Apache.Arrow.RecordBatch>` and `Apache.Arrow.Table[]` are also flagged.
+- Generic type parameter constraints on public types and methods are analyzed, so `where T : Apache.Arrow.Table` is also flagged.
 - The diagnostic can be suppressed with `#pragma warning disable AZC0040` or a `[SuppressMessage]` attribute when an exception is genuinely required.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md
@@ -59,7 +59,7 @@ namespace Azure.Data.Analytics
 
 ## Notes
 
-- Only public and protected members of public types in Azure SDK namespaces (starting with `Azure.` except `Azure.Core.*`) are analyzed.
+- Only public and protected members of public types in Azure SDK namespaces (starting with `Azure.` except `Azure.Core.*`) are analyzed. `protected internal` members are included (they are accessible to derived types in other assemblies); `private protected` and `internal` members are not.
 - A type is treated as an `Apache.Arrow` type when its containing namespace is `Apache.Arrow` or begins with `Apache.Arrow.`.
 - Arrays, pointers, and generic type arguments are unwrapped, so `IReadOnlyList<Apache.Arrow.RecordBatch>` and `Apache.Arrow.Table[]` are also flagged.
 - Generic type parameter constraints on public types and methods are analyzed, so `where T : Apache.Arrow.Table` is also flagged.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md
@@ -15,7 +15,7 @@ Exposing `Apache.Arrow` types on the public API surface couples consumers of the
 
 ## How to fix
 
-Keep `Apache.Arrow` types internal and expose abstractions that the library owns instead. Convert to and from `Apache.Arrow` types behind the scenes.
+Keep `Apache.Arrow` types internal and expose abstractions that the SDK owns instead. Convert to and from `Apache.Arrow` types behind the scenes.
 
 ```diff
  namespace Azure.Data.Analytics

--- a/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
@@ -209,6 +209,6 @@ namespace Azure.Data.Analytics
 
 ### Notes
 
-- This analyzer only checks public and protected members of public types in Azure SDK namespaces (namespaces starting with `Azure.` except `Azure.Core.*`)
+- This analyzer only checks public and protected members of public types in Azure SDK namespaces (namespaces starting with `Azure.` except `Azure.Core.*`). `protected internal` members are included; `private protected` and `internal` members are not
 - A type is treated as an `Apache.Arrow` type when its containing namespace is `Apache.Arrow` or begins with `Apache.Arrow.`
 - Return types, parameter types, property types, field types, event types, base types, implemented interfaces, generic type arguments, array element types, and generic type parameter constraints are all analyzed

--- a/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
@@ -157,3 +157,58 @@ public async Task GoodAsync(CancellationToken token)
 - The analyzer does not report diagnostics when a `RequestContext` is passed from a parameter or local variable
 - The analyzer works with lambda expressions and anonymous functions
 - Setting `CancellationToken` to `CancellationToken.None` or `default` when a cancellation token parameter is available will still trigger a warning
+
+## AZC0040
+
+### Cause
+
+A public or protected API member in an Azure SDK namespace exposes a type from the `Apache.Arrow` library (a type in the `Apache.Arrow` namespace or one of its child namespaces).
+
+### How to fix violation
+
+Keep `Apache.Arrow` types internal and expose abstractions owned by the library instead, converting to and from `Apache.Arrow` types behind the scenes.
+
+### Example of a violation
+
+#### Description
+
+The following code exposes `Apache.Arrow.Table` as the return type of a public method, which causes a violation of AZC0040.
+
+#### Code
+
+```c#
+using Apache.Arrow;
+
+namespace Azure.Data.Analytics
+{
+    public class AnalyticsClient
+    {
+        public Table GetTable() => null; // This will cause AZC0040
+    }
+}
+```
+
+### Example of how to fix
+
+#### Description
+
+Replace the `Apache.Arrow` type with a type owned by the SDK.
+
+#### Code
+
+```diff
+namespace Azure.Data.Analytics
+{
+    public class AnalyticsClient
+    {
+-       public Apache.Arrow.Table GetTable() => null; // This will cause AZC0040
++       public BinaryData GetTable() => null;
+    }
+}
+```
+
+### Notes
+
+- This analyzer only checks public and protected members of public types in Azure SDK namespaces (namespaces starting with `Azure.` except `Azure.Core.*`)
+- A type is treated as an `Apache.Arrow` type when its containing namespace is `Apache.Arrow` or begins with `Apache.Arrow.`
+- Return types, parameter types, property types, field types, event types, base types, implemented interfaces, generic type arguments, and array element types are all analyzed

--- a/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
@@ -211,4 +211,4 @@ namespace Azure.Data.Analytics
 
 - This analyzer only checks public and protected members of public types in Azure SDK namespaces (namespaces starting with `Azure.` except `Azure.Core.*`)
 - A type is treated as an `Apache.Arrow` type when its containing namespace is `Apache.Arrow` or begins with `Apache.Arrow.`
-- Return types, parameter types, property types, field types, event types, base types, implemented interfaces, generic type arguments, and array element types are all analyzed
+- Return types, parameter types, property types, field types, event types, base types, implemented interfaces, generic type arguments, array element types, and generic type parameter constraints are all analyzed

--- a/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
@@ -166,7 +166,7 @@ A public or protected API member in an Azure SDK namespace exposes a type from t
 
 ### How to fix violation
 
-Keep `Apache.Arrow` types internal and expose abstractions owned by the library instead, converting to and from `Apache.Arrow` types behind the scenes.
+Keep `Apache.Arrow` types internal and expose abstractions owned by the SDK instead, converting to and from `Apache.Arrow` types behind the scenes.
 
 ### Example of a violation
 

--- a/sdk/tools/Azure.SdkAnalyzers/src/ArrowPublicApiAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ArrowPublicApiAnalyzer.cs
@@ -61,6 +61,8 @@ namespace Azure.SdkAnalyzers
                 ReportIfArrow(context, implemented, namedType, location);
             }
 
+            AnalyzeTypeParameterConstraints(context, namedType.TypeParameters, namedType, location);
+
             if (namedType.TypeKind == TypeKind.Delegate && namedType.DelegateInvokeMethod is { } invoke)
             {
                 ReportIfArrow(context, invoke.ReturnType, namedType, location);
@@ -79,11 +81,30 @@ namespace Azure.SdkAnalyzers
                 return;
             }
 
-            ReportIfArrow(context, method.ReturnType, method, method.Locations.FirstOrDefault());
+            var location = method.Locations.FirstOrDefault();
+
+            ReportIfArrow(context, method.ReturnType, method, location);
 
             foreach (var parameter in method.Parameters)
             {
                 ReportIfArrow(context, parameter.Type, method, parameter.Locations.FirstOrDefault());
+            }
+
+            AnalyzeTypeParameterConstraints(context, method.TypeParameters, method, location);
+        }
+
+        private static void AnalyzeTypeParameterConstraints(
+            SymbolAnalysisContext context,
+            ImmutableArray<ITypeParameterSymbol> typeParameters,
+            ISymbol member,
+            Location location)
+        {
+            foreach (var typeParameter in typeParameters)
+            {
+                foreach (var constraint in typeParameter.ConstraintTypes)
+                {
+                    ReportIfArrow(context, constraint, member, location);
+                }
             }
         }
 
@@ -141,6 +162,7 @@ namespace Azure.SdkAnalyzers
                 case IPointerTypeSymbol pointer:
                     return FindArrowType(pointer.PointedAtType, visited);
                 case ITypeParameterSymbol:
+                    // Constraints are analyzed at the declaration site (type/method) to report once at a stable location.
                     return null;
                 case INamedTypeSymbol named:
                     if (IsArrowType(named))

--- a/sdk/tools/Azure.SdkAnalyzers/src/ArrowPublicApiAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ArrowPublicApiAnalyzer.cs
@@ -143,9 +143,19 @@ namespace Azure.SdkAnalyzers
                 context.ReportDiagnostic(Diagnostic.Create(
                     Descriptors.AZC0040,
                     location,
-                    member.Name,
+                    GetMemberDisplayName(member),
                     arrowType.ToDisplayString()));
             }
+        }
+
+        private static string GetMemberDisplayName(ISymbol member)
+        {
+            if (member is IMethodSymbol { MethodKind: MethodKind.Constructor } constructor)
+            {
+                return constructor.ContainingType.Name;
+            }
+
+            return member.Name;
         }
 
         private static ITypeSymbol FindArrowType(ITypeSymbol type, HashSet<ITypeSymbol> visited)

--- a/sdk/tools/Azure.SdkAnalyzers/src/ArrowPublicApiAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ArrowPublicApiAnalyzer.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.SdkAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ArrowPublicApiAnalyzer : SymbolAnalyzerBase
+    {
+        private const string ArrowRootNamespace = "Apache.Arrow";
+        private const string ArrowNamespacePrefix = "Apache.Arrow.";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.AZC0040);
+
+        public override SymbolKind[] SymbolKinds { get; } =
+            [SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property, SymbolKind.Field, SymbolKind.Event];
+
+        public override void Analyze(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            if (!IsPublicApi(symbol) || !AnalyzerUtils.IsSdkCode(symbol))
+            {
+                return;
+            }
+
+            switch (symbol)
+            {
+                case INamedTypeSymbol namedType:
+                    AnalyzeNamedType(context, namedType);
+                    break;
+                case IMethodSymbol method:
+                    AnalyzeMethod(context, method);
+                    break;
+                case IPropertySymbol property:
+                    AnalyzeProperty(context, property);
+                    break;
+                case IFieldSymbol field:
+                    AnalyzeField(context, field);
+                    break;
+                case IEventSymbol @event:
+                    AnalyzeEvent(context, @event);
+                    break;
+            }
+        }
+
+        private static void AnalyzeNamedType(SymbolAnalysisContext context, INamedTypeSymbol namedType)
+        {
+            var location = namedType.Locations.FirstOrDefault();
+
+            ReportIfArrow(context, namedType.BaseType, namedType, location);
+
+            foreach (var implemented in namedType.Interfaces)
+            {
+                ReportIfArrow(context, implemented, namedType, location);
+            }
+
+            if (namedType.TypeKind == TypeKind.Delegate && namedType.DelegateInvokeMethod is { } invoke)
+            {
+                ReportIfArrow(context, invoke.ReturnType, namedType, location);
+                foreach (var parameter in invoke.Parameters)
+                {
+                    ReportIfArrow(context, parameter.Type, namedType, location);
+                }
+            }
+        }
+
+        private static void AnalyzeMethod(SymbolAnalysisContext context, IMethodSymbol method)
+        {
+            // Property and event accessors are reported through their associated symbol.
+            if (method.AssociatedSymbol != null)
+            {
+                return;
+            }
+
+            ReportIfArrow(context, method.ReturnType, method, method.Locations.FirstOrDefault());
+
+            foreach (var parameter in method.Parameters)
+            {
+                ReportIfArrow(context, parameter.Type, method, parameter.Locations.FirstOrDefault());
+            }
+        }
+
+        private static void AnalyzeProperty(SymbolAnalysisContext context, IPropertySymbol property)
+        {
+            var location = property.Locations.FirstOrDefault();
+
+            ReportIfArrow(context, property.Type, property, location);
+
+            foreach (var parameter in property.Parameters)
+            {
+                ReportIfArrow(context, parameter.Type, property, parameter.Locations.FirstOrDefault() ?? location);
+            }
+        }
+
+        private static void AnalyzeField(SymbolAnalysisContext context, IFieldSymbol field)
+        {
+            ReportIfArrow(context, field.Type, field, field.Locations.FirstOrDefault());
+        }
+
+        private static void AnalyzeEvent(SymbolAnalysisContext context, IEventSymbol @event)
+        {
+            ReportIfArrow(context, @event.Type, @event, @event.Locations.FirstOrDefault());
+        }
+
+        private static void ReportIfArrow(SymbolAnalysisContext context, ITypeSymbol exposedType, ISymbol member, Location location)
+        {
+            if (location == null)
+            {
+                return;
+            }
+
+            var arrowType = FindArrowType(exposedType, new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+            if (arrowType != null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Descriptors.AZC0040,
+                    location,
+                    member.Name,
+                    arrowType.ToDisplayString()));
+            }
+        }
+
+        private static ITypeSymbol FindArrowType(ITypeSymbol type, HashSet<ITypeSymbol> visited)
+        {
+            if (type == null || !visited.Add(type))
+            {
+                return null;
+            }
+
+            switch (type)
+            {
+                case IArrayTypeSymbol array:
+                    return FindArrowType(array.ElementType, visited);
+                case IPointerTypeSymbol pointer:
+                    return FindArrowType(pointer.PointedAtType, visited);
+                case ITypeParameterSymbol:
+                    return null;
+                case INamedTypeSymbol named:
+                    if (IsArrowType(named))
+                    {
+                        return named;
+                    }
+
+                    foreach (var argument in named.TypeArguments)
+                    {
+                        var found = FindArrowType(argument, visited);
+                        if (found != null)
+                        {
+                            return found;
+                        }
+                    }
+
+                    return null;
+                default:
+                    return IsArrowType(type) ? type : null;
+            }
+        }
+
+        private static bool IsArrowType(ITypeSymbol type)
+        {
+            if (type?.ContainingNamespace is not INamespaceSymbol containingNamespace || containingNamespace.IsGlobalNamespace)
+            {
+                return false;
+            }
+
+            var namespaceName = containingNamespace.ToDisplayString();
+            return namespaceName == ArrowRootNamespace || namespaceName.StartsWith(ArrowNamespacePrefix, StringComparison.Ordinal);
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
@@ -43,5 +43,15 @@ namespace Azure.SdkAnalyzers
             DiagnosticSeverity.Warning,
             true,
             "Output model types returned from client methods should have corresponding model factory methods for mocking support.");
+
+        public static readonly DiagnosticDescriptor AZC0040 = new(
+            nameof(AZC0040),
+            "Do not expose Apache.Arrow types on the public API surface",
+            "Public API '{0}' exposes Apache.Arrow type '{1}'. Apache.Arrow types must not be exposed on the public API surface.",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Warning,
+            true,
+            "Exposing types from the Apache.Arrow library on the public API surface couples consumers to a third-party dependency whose versioning is outside the SDK's control. Keep Apache.Arrow types internal and expose abstractions owned by the library instead.",
+            "https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md");
     }
 }

--- a/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
@@ -51,7 +51,7 @@ namespace Azure.SdkAnalyzers
             DiagnosticCategory.Usage,
             DiagnosticSeverity.Warning,
             true,
-            "Exposing types from the Apache.Arrow library on the public API surface couples consumers to a third-party dependency whose versioning is outside the SDK's control. Keep Apache.Arrow types internal and expose abstractions owned by the library instead.",
+            "Exposing types from the Apache.Arrow library on the public API surface couples consumers to a third-party dependency whose versioning is outside the SDK's control. Keep Apache.Arrow types internal and expose abstractions owned by the SDK instead.",
             "https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0040.md");
     }
 }

--- a/sdk/tools/Azure.SdkAnalyzers/src/SymbolAnalyzerBase.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/SymbolAnalyzerBase.cs
@@ -27,7 +27,8 @@ namespace Azure.SdkAnalyzers
 
             return symbol.DeclaredAccessibility == Accessibility.NotApplicable ||
                    symbol.DeclaredAccessibility == Accessibility.Public ||
-                   symbol.DeclaredAccessibility == Accessibility.Protected;
+                   symbol.DeclaredAccessibility == Accessibility.Protected ||
+                   symbol.DeclaredAccessibility == Accessibility.ProtectedOrInternal;
         }
     }
 }

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
@@ -280,7 +280,7 @@ namespace Azure.Test
         }
 
         [Test]
-        public async Task AZC0040_NotProducedForMemberInPrivateType()
+        public async Task AZC0040_NotProducedForMemberInInternalType()
         {
             string code = @"
 using Apache.Arrow;

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Framework;
 using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.ArrowPublicApiAnalyzer>;
 
@@ -292,6 +294,52 @@ namespace Azure.Test
 }";
 
             await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ConstructorMessageUsesContainingTypeName()
+        {
+            const string code = @"
+using Apache.Arrow;
+
+namespace Apache.Arrow
+{
+    public class Table { }
+}
+
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        public TableModel(Table table) { }
+    }
+}";
+
+            var diagnostics = await GetAnalyzerDiagnosticsAsync(code);
+
+            Assert.That(diagnostics, Has.Count.EqualTo(1));
+            var message = diagnostics[0].GetMessage();
+            Assert.That(message, Does.Not.Contain(".ctor"), "Constructor diagnostics should not surface the '.ctor' symbol name.");
+            Assert.That(message, Does.Contain("TableModel"), "Constructor diagnostics should reference the containing type name.");
+        }
+
+        private static async Task<System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.Diagnostic>> GetAnalyzerDiagnosticsAsync(string source)
+        {
+            var refAssemblies = await AzureTestReferences.DefaultReferenceAssemblies.ResolveAsync(
+                Microsoft.CodeAnalysis.LanguageNames.CSharp, System.Threading.CancellationToken.None);
+
+            var syntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source);
+            var compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+                "TestAssembly",
+                new[] { syntaxTree },
+                refAssemblies,
+                new Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary));
+
+            var withAnalyzers = ((Microsoft.CodeAnalysis.Compilation)compilation).WithAnalyzers(
+                System.Collections.Immutable.ImmutableArray.Create<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer>(new ArrowPublicApiAnalyzer()));
+
+            var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync(System.Threading.CancellationToken.None);
+            return diagnostics.Where(d => d.Id == "AZC0040").ToList();
         }
 
         [Test]

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
@@ -261,6 +261,40 @@ namespace Azure.Test
         }
 
         [Test]
+        public async Task AZC0040_ProducedForProtectedInternalMember()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        protected internal Table {|AZC0040:Data|} { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_NotProducedForPrivateProtectedMember()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        private protected Table Data { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
         public async Task AZC0040_NotProducedForInternalMember()
         {
             string code = @"

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
@@ -211,6 +211,56 @@ namespace Azure.Test
         }
 
         [Test]
+        public async Task AZC0040_ProducedForArrowTypeParameterConstraintOnType()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class {|AZC0040:CustomContainer|}<T> where T : Table
+    {
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowTypeParameterConstraintOnMethod()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableClient
+    {
+        public void {|AZC0040:Process|}<T>(T item) where T : Table { }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_NotProducedForNonArrowTypeParameterConstraint()
+        {
+            string code = @"
+using System;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class CustomContainer<T> where T : IDisposable
+    {
+        public void Process<TItem>(TItem item) where TItem : class { }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
         public async Task AZC0040_NotProducedForInternalMember()
         {
             string code = @"

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
@@ -1,0 +1,285 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.ArrowPublicApiAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0040Tests
+    {
+        private const string ArrowStub = @"
+namespace Apache.Arrow
+{
+    public class Table { }
+    public class RecordBatch { }
+}
+
+namespace Apache.Arrow.Types
+{
+    public class Schema { }
+}
+";
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowReturnType()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableClient
+    {
+        public Table {|AZC0040:GetTable|}() => null;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowParameter()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableClient
+    {
+        public void Upload(Table {|AZC0040:table|}) { }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowProperty()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        public Table {|AZC0040:Data|} { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowField()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        public Table {|AZC0040:Data|};
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowEvent()
+        {
+            string code = @"
+using System;
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        public event Action<Table> {|AZC0040:Updated|};
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowGenericTypeArgument()
+        {
+            string code = @"
+using System.Collections.Generic;
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableClient
+    {
+        public IReadOnlyList<Table> {|AZC0040:GetTables|}() => null;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowArrayElement()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableClient
+    {
+        public Table[] {|AZC0040:GetTables|}() => null;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowSubNamespaceType()
+        {
+            string code = @"
+using Apache.Arrow.Types;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        public Schema {|AZC0040:Schema|} { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowBaseType()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class {|AZC0040:CustomTable|} : Table
+    {
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForProtectedMember()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        protected Table {|AZC0040:Data|} { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowConstructorParameter()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        public TableModel(Table {|AZC0040:table|}) { }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_NotProducedForInternalMember()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        internal Table Data { get; set; }
+        private Table OtherData { get; set; }
+        public string Name { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_NotProducedForMemberInPrivateType()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    internal class TableModel
+    {
+        public Table Data { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_NotProducedForNonArrowTypes()
+        {
+            string code = @"
+using System.Collections.Generic;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public class TableModel
+    {
+        public string Name { get; set; }
+        public IReadOnlyList<int> Values { get; set; }
+        public int[] Numbers { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_NotProducedForAzureCoreNamespace()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Core
+{
+    public class TableModel
+    {
+        public Table Data { get; set; }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0040Tests.cs
@@ -343,6 +343,34 @@ namespace Azure.Test
         }
 
         [Test]
+        public async Task AZC0040_ProducedForArrowDelegateReturnType()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public delegate Table {|AZC0040:TableProvider|}();
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0040_ProducedForArrowDelegateParameter()
+        {
+            string code = @"
+using Apache.Arrow;
+" + ArrowStub + @"
+namespace Azure.Test
+{
+    public delegate void {|AZC0040:TableHandler|}(Table table);
+}";
+
+            await Verifier.CreateAnalyzer(code).RunAsync();
+        }
+
+        [Test]
         public async Task AZC0040_NotProducedForInternalMember()
         {
             string code = @"


### PR DESCRIPTION
Adds a new Roslyn analyzer, **AZC0040**, to `Azure.SdkAnalyzers` that warns when a public or protected API member exposes a type from the `Apache.Arrow` library on the public API surface.

## Motivation

Exposing `Apache.Arrow` types on the public API surface couples SDK consumers to a third-party dependency whose versioning and breaking-change cadence are outside the SDK's control. Once an `Apache.Arrow` type is part of the public contract it cannot be changed without a breaking change.

## What it checks

For public/protected members of public types in Azure SDK namespaces (`Azure.*`, excluding `Azure.Core.*`), the analyzer flags any exposed `Apache.Arrow` type across:

- Method return types and parameters (including constructors and delegate signatures)
- Property types (including indexer parameters)
- Field and event types
- Base types and implemented interfaces
- Generic type arguments and array element types (e.g. `IReadOnlyList<RecordBatch>`, `Table[]`)

Detection is by namespace root: a type is treated as Apache.Arrow when its containing namespace is `Apache.Arrow` or begins with `Apache.Arrow.`. This is consistent with how existing analyzers/tests in the package detect framework types. The assumption was verified against the current `Apache.Arrow` package (v23): 100% of public top-level types live under `Apache.Arrow.*`.

## Changes

- `src/ArrowPublicApiAnalyzer.cs` - new analyzer (extends `SymbolAnalyzerBase`)
- `src/Descriptors.cs` - new `AZC0040` descriptor (Usage, Warning)
- `docs/AZC0040.md` - rule documentation
- `docs/list-of-diagnostics.md`, `README.md`, `CHANGELOG.md` - updated
- `tests/.../AZC0040Tests.cs` - 15 tests (positive and negative cases)

## Validation

Full suite passes: 157 tests across net462/net8.0/net9.0/net10.0, including the 15 new AZC0040 tests.
