### PR TITLE
allow publish to docs to run without dependancy

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -206,10 +206,9 @@ stages:
                   condition: >-
                     and(
                       succeeded(),
-                       ne(variables['Skip.PublishDocs'], 'true'), 
+                       ne(variables['Skip.PublishDocs'], 'true'),
                        ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr')
                     )
-                  dependsOn: PublishPackage
 
                   pool:
                     name: $(LINUXPOOL)
@@ -240,10 +239,10 @@ stages:
               - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
                 - job: PublishDocs
                   displayName: Publish Docs to GitHub pages
-                  condition: >- 
+                  condition: >-
                     and(
-                      succeeded(), 
-                      ne(variables['Skip.PublishDocs'], 'true'), 
+                      succeeded(),
+                      ne(variables['Skip.PublishDocs'], 'true'),
                       ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr')
                     )
                   dependsOn: PublishPackage
@@ -320,9 +319,9 @@ stages:
           os: windows
 
         templateContext:
-          type: releaseJob 
+          type: releaseJob
           isProduction: true
-          inputs: 
+          inputs:
             - input: pipelineArtifact
               artifactName: ${{parameters.ArtifactName}}-signed
               targetPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
@@ -348,19 +347,19 @@ stages:
                       packageParentPath: '$(Pipeline.Workspace)'
                       packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                       publishVstsFeed: $(DevOpsFeedID)
-                
+
       - job: PublishDocsToNightlyBranch
         dependsOn: PublishPackages
         condition: >-
           and(
-            succeeded(), 
+            succeeded(),
             or(
-              eq(variables['SetDevVersion'], 'true'), 
+              eq(variables['SetDevVersion'], 'true'),
               and(
-                eq(variables['Build.Reason'],'Schedule'), 
+                eq(variables['Build.Reason'],'Schedule'),
                 eq(variables['System.TeamProject'], 'internal')
               )
-            ), 
+            ),
             ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr')
           )
         pool:

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -209,7 +209,6 @@ stages:
                        ne(variables['Skip.PublishDocs'], 'true'), 
                        ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr')
                     )
-                  dependsOn: PublishPackage
 
                   pool:
                     name: $(LINUXPOOL)

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -206,9 +206,10 @@ stages:
                   condition: >-
                     and(
                       succeeded(),
-                       ne(variables['Skip.PublishDocs'], 'true'),
+                       ne(variables['Skip.PublishDocs'], 'true'), 
                        ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr')
                     )
+                  dependsOn: PublishPackage
 
                   pool:
                     name: $(LINUXPOOL)
@@ -239,10 +240,10 @@ stages:
               - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
                 - job: PublishDocs
                   displayName: Publish Docs to GitHub pages
-                  condition: >-
+                  condition: >- 
                     and(
-                      succeeded(),
-                      ne(variables['Skip.PublishDocs'], 'true'),
+                      succeeded(), 
+                      ne(variables['Skip.PublishDocs'], 'true'), 
                       ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr')
                     )
                   dependsOn: PublishPackage
@@ -319,9 +320,9 @@ stages:
           os: windows
 
         templateContext:
-          type: releaseJob
+          type: releaseJob 
           isProduction: true
-          inputs:
+          inputs: 
             - input: pipelineArtifact
               artifactName: ${{parameters.ArtifactName}}-signed
               targetPath: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
@@ -347,19 +348,19 @@ stages:
                       packageParentPath: '$(Pipeline.Workspace)'
                       packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
                       publishVstsFeed: $(DevOpsFeedID)
-
+                
       - job: PublishDocsToNightlyBranch
         dependsOn: PublishPackages
         condition: >-
           and(
-            succeeded(),
+            succeeded(), 
             or(
-              eq(variables['SetDevVersion'], 'true'),
+              eq(variables['SetDevVersion'], 'true'), 
               and(
-                eq(variables['Build.Reason'],'Schedule'),
+                eq(variables['Build.Reason'],'Schedule'), 
                 eq(variables['System.TeamProject'], 'internal')
               )
-            ),
+            ), 
             ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr')
           )
         pool:

--- a/sdk/voicelive/ci.yml
+++ b/sdk/voicelive/ci.yml
@@ -18,3 +18,8 @@ extends:
     Artifacts:
     - name: Azure.AI.VoiceLive
       safeName: AzureAIVoiceLive
+      skipTagRepository: true
+      skipPublishPackage: true
+      skipSymbolsUpload: true
+      skipPublishDocGithubIo: true
+      skipUpdatePackageVersion: true


### PR DESCRIPTION
NOT to be merged!!

This is so only the publish to docs task will be run in the release pipeline for 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6414478&view=results

The pipeline will be run on the commit 417fcda771947522cad1c7df788b5b56cc0ac293