### PR TITLE
Bumping BCL dependencies to resove CVE-2026-26127 in System.Bcl.Memory

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -17,21 +17,21 @@
     <MicrosoftAspNetCoreHttpVersion>2.3.0</MicrosoftAspNetCoreHttpVersion>
     <MicrosoftAspNetCoreVersion>2.3.0</MicrosoftAspNetCoreVersion>
     <MicrosoftExtensionsAzureVersion>1.14.0</MicrosoftExtensionsAzureVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.3</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationBinderVersion>10.0.3</MicrosoftExtensionsConfigurationBinderVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>10.0.3</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.3</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.3</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationUserSecretsVersion>10.0.3</MicrosoftExtensionsConfigurationUserSecretsVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.3</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.3</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsHostingVersion>10.0.3</MicrosoftExtensionsHostingVersion>
-    <MicrosoftExtensionsHttpVersion>10.0.3</MicrosoftExtensionsHttpVersion>
-    <MicrosoftExtensionsLoggingConfigurationVersion>10.0.3</MicrosoftExtensionsLoggingConfigurationVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.3</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.3</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.3</MicrosoftExtensionsPrimitivesVersion>
-    <SystemIOPipelinesVersion>10.0.3</SystemIOPipelinesVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.9</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationBinderVersion>10.0.9</MicrosoftExtensionsConfigurationBinderVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>10.0.9</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.9</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.9</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationUserSecretsVersion>10.0.9</MicrosoftExtensionsConfigurationUserSecretsVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.9</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.9</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsHostingVersion>10.0.9</MicrosoftExtensionsHostingVersion>
+    <MicrosoftExtensionsHttpVersion>10.0.9</MicrosoftExtensionsHttpVersion>
+    <MicrosoftExtensionsLoggingConfigurationVersion>10.0.9</MicrosoftExtensionsLoggingConfigurationVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.9</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.9</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.9</MicrosoftExtensionsPrimitivesVersion>
+    <SystemIOPipelinesVersion>10.0.9</SystemIOPipelinesVersion>
     <MicrosoftSpatialVersion>7.5.3</MicrosoftSpatialVersion>
     <NewtonsoftJsonVersion>13.0.4</NewtonsoftJsonVersion>
     <MSTestVersion>1.3.2</MSTestVersion>
@@ -77,26 +77,26 @@
       or '$(IsStressProject)' == 'true'">
 
     <!-- BCL packages -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.ClientModel" Version="1.14.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.9" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Memory.Data" Version="10.0.3" />
+    <PackageVersion Include="System.Memory.Data" Version="10.0.9" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.3" />
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.9" />
     <PackageVersion Include="System.Numerics.Vectors" Version="4.6.1" />
     <PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageVersion Include="System.Security.Cryptography.Cose" Version="10.0.3" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.3" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.3" />
-    <PackageVersion Include="System.Threading.Channels" Version="10.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Cose" Version="10.0.9" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.9" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
+    <PackageVersion Include="System.Threading.Channels" Version="10.0.9" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
 
@@ -182,7 +182,7 @@
     <PackageVersion Include="Azure.Provisioning.Network" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.Storage" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.Bcl.Numerics" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Bcl.Numerics" Version="10.0.9" />
 
     <!-- Other approved packages -->
     <PackageVersion Include="Microsoft.Azure.Amqp" Version="2.7.0" />
@@ -201,8 +201,8 @@
     <PackageVersion Include="CoreWCF.Queue" Version="1.7.0" />
     <PackageVersion Include="CoreWCF.Primitives" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="$(MicrosoftExtensionsConfigurationUserSecretsVersion)" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.1" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.1" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="6.2.0" />
     <PackageVersion Update="Azure.Storage.Files.Shares" Version="12.21.0" />
     <PackageVersion Update="Azure.Storage.Queues" Version="12.21.0" />

--- a/eng/centralpackagemanagement/Directory.Support.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Support.Packages.props
@@ -126,7 +126,7 @@
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
-    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.1" />
+    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.9" />
     <PackageVersion Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Runtime.InteropServices" Version="4.3.0" />


### PR DESCRIPTION
 ## Summary
 
 Resolves **CVE-2026-26127** (GHSA-73j8-2gch-69rq), a High-severity .NET Denial of Service vulnerability in `Microsoft.Bcl.Memory`.
 
 `Microsoft.Bcl.Memory` is a transitive-only dependency in this repository (it has no direct `PackageReference` or `PackageVersion` entries anywhere). The vulnerable range is `>= 10.0.0, <= 10.0.3`, patched in `10.0.4`. Our centrally-managed .NET base class library (BCL) packages were pinned to `10.0.3`, which flowed a vulnerable `Microsoft.Bcl.Memory` transitively.
 
 This PR bumps every dotnet/runtime BCL package currently on the 10.x line to the latest 10.x patch, **`10.0.9`**, which transitively raises `Microsoft.Bcl.Memory` past the patched `10.0.4`.
 
 ## Advisory details
 
 | Field | Value |
 |-------|-------|
 | CVE | CVE-2026-26127 |
 | GitHub Advisory | GHSA-73j8-2gch-69rq |
 | Severity | High |
 | Type | .NET Denial of Service |
 | Affected (`Microsoft.Bcl.Memory`) | `>= 10.0.0, <= 10.0.3` |
 | First patched | `10.0.4` |
 
 Source: GitHub Advisory Database (`/advisories/GHSA-73j8-2gch-69rq`).
 
 ## Scope
 
 - Only dotnet/runtime BCL packages already on the 10.x line were bumped, all to `10.0.9` (the latest 10.x patch, verified on NuGet for every package).
 - Packages **not** on the 10.x line were intentionally left unchanged (for example `System.Memory` 4.6.3, `System.Buffers` 4.6.1, `System.Numerics.Vectors` 4.6.1, `System.Threading.Tasks.Extensions` 4.6.3, `System.ValueTuple` 4.6.2).
 - Non-BCL packages that happen to be on 10.x were excluded: `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.AspNetCore.DataProtection` (ASP.NET Core), `Asp.Versioning.Mvc` (third-party), and `Microsoft.CodeAnalysis.NetAnalyzers` (Roslyn analyzer).
 - No `overrides/*.Packages.props` file references any BCL package, so there were no override edits.
 
 ## Changes
 
 All versions managed centrally under `eng/centralpackagemanagement`. 31 version bumps across 2 files.
 
 ### `eng/centralpackagemanagement/Directory.Packages.props`
 
 Shared version-stamp properties (`10.0.3` to `10.0.9`):
 
 | Property |
 |----------|
 | `MicrosoftExtensionsConfigurationAbstractionsVersion` |
 | `MicrosoftExtensionsConfigurationBinderVersion` |
 | `MicrosoftExtensionsConfigurationEnvironmentVariablesVersion` |
 | `MicrosoftExtensionsConfigurationJsonVersion` |
 | `MicrosoftExtensionsConfigurationVersion` |
 | `MicrosoftExtensionsConfigurationUserSecretsVersion` |
 | `MicrosoftExtensionsDependencyInjectionAbstractionsVersion` |
 | `MicrosoftExtensionsDependencyInjectionVersion` |
 | `MicrosoftExtensionsHostingVersion` |
 | `MicrosoftExtensionsHttpVersion` |
 | `MicrosoftExtensionsLoggingConfigurationVersion` |
 | `MicrosoftExtensionsLoggingConsoleVersion` |
 | `MicrosoftExtensionsLoggingVersion` |
 | `MicrosoftExtensionsPrimitivesVersion` |
 | `SystemIOPipelinesVersion` |
 
 BCL `PackageVersion` items (`10.0.3` to `10.0.9`):
 
 | Package |
 |---------|
 | `Microsoft.Bcl.AsyncInterfaces` |
 | `Microsoft.Bcl.Numerics` |
 | `Microsoft.Extensions.Configuration.Abstractions` |
 | `Microsoft.Extensions.Hosting.Abstractions` |
 | `Microsoft.Extensions.Logging.Abstractions` |
 | `System.Diagnostics.DiagnosticSource` |
 | `System.IO.Hashing` |
 | `System.Memory.Data` |
 | `System.Net.ServerSentEvents` |
 | `System.Security.Cryptography.Cose` |
 | `System.Text.Encodings.Web` |
 | `System.Text.Json` |
 | `System.Threading.Channels` |
 
 WCF-scoped `PackageVersion` items, `IsWcfLibrary` (`10.0.1` to `10.0.9`):
 
 | Package |
 |---------|
 | `System.Formats.Asn1` |
 | `System.Security.Cryptography.Pkcs` |
 
 ### `eng/centralpackagemanagement/Directory.Support.Packages.props`
 
 | Package | Old | New |
 |---------|-----|-----|
 | `System.Linq.AsyncEnumerable` | 10.0.1 | 10.0.9 |
 
 (`System.IO.Pipelines` in this file references `$(SystemIOPipelinesVersion)` and picks up the stamp bump automatically.)