### PR TITLE
Fix case-insensitive ARM parent path detection

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -35,6 +35,10 @@ export function getVariableSegmentName(segment: string): string {
   return segment.slice(1, -1);
 }
 
+function literalSegmentsEqual(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
 /**
  * Represents a parsed ARM request path with pre-computed segment information.
  *
@@ -107,7 +111,7 @@ export class RequestPath {
         isVariableSegment(other.segments[i])
       ) {
         count++;
-      } else if (this.segments[i] === other.segments[i]) {
+      } else if (literalSegmentsEqual(this.segments[i], other.segments[i])) {
         count++;
       } else {
         break;
@@ -143,7 +147,8 @@ export class RequestPath {
       ) {
         continue;
       }
-      if (this.segments[i] !== other.segments[i]) return false;
+      if (!literalSegmentsEqual(this.segments[i], other.segments[i]))
+        return false;
     }
     return true;
   }
@@ -1302,32 +1307,7 @@ function canBeListResourceScope(
   listPath: RequestPath,
   resourceInstancePath: RequestPath
 ): boolean {
-  // Check if resourceInstancePath is a prefix of listPath
-  if (listPath.length < resourceInstancePath.length) {
-    return false;
-  }
-  for (let i = 0; i < resourceInstancePath.length; i++) {
-    // if both segments are variables, we consider it as a match
-    if (
-      isVariableSegment(listPath.segments[i]) &&
-      isVariableSegment(resourceInstancePath.segments[i])
-    ) {
-      continue;
-    }
-    // if one of them is a variable, the other is not, we consider it as not a match
-    if (
-      isVariableSegment(listPath.segments[i]) ||
-      isVariableSegment(resourceInstancePath.segments[i])
-    ) {
-      return false;
-    }
-    // both are fixed strings, they must match
-    if (listPath.segments[i] !== resourceInstancePath.segments[i]) {
-      return false;
-    }
-  }
-  // here it means every segment in resourceInstancePath matches the corresponding segment in listPath
-  return true;
+  return resourceInstancePath.isPrefixOf(listPath);
 }
 
 /**

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -1207,7 +1207,7 @@ function postProcessExpandedArmResources(
     const validCandidates: RequestPath[] = [];
 
     for (const candidatePath of resourceInstancePaths) {
-      if (canBeListResourceScope(listOp.operationPath, candidatePath)) {
+      if (candidatePath.isPrefixOf(listOp.operationPath)) {
         validCandidates.push(candidatePath);
       }
     }
@@ -1297,17 +1297,6 @@ function postProcessExpandedArmResources(
   }
 
   return filteredResources;
-}
-
-/**
- * Helper function to determine if a resource path can be the scope for a list operation.
- * The resource path must be a prefix of the list operation path.
- */
-function canBeListResourceScope(
-  listPath: RequestPath,
-  resourceInstancePath: RequestPath
-): boolean {
-  return resourceInstancePath.isPrefixOf(listPath);
 }
 
 /**

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -195,7 +195,7 @@ export class RequestPath {
     return (
       this.length === 0 ||
       (this.length === 2 &&
-        this.segments[0] === "tenants" &&
+        literalSegmentsEqual(this.segments[0], "tenants") &&
         isVariableSegment(this.segments[1]))
     );
   }
@@ -203,7 +203,7 @@ export class RequestPath {
   isSubscriptionPath(): boolean {
     return (
       this.length === 2 &&
-      this.segments[0] === "subscriptions" &&
+      literalSegmentsEqual(this.segments[0], "subscriptions") &&
       isVariableSegment(this.segments[1])
     );
   }
@@ -211,9 +211,9 @@ export class RequestPath {
   isResourceGroupPath(): boolean {
     return (
       this.length === 4 &&
-      this.segments[0] === "subscriptions" &&
+      literalSegmentsEqual(this.segments[0], "subscriptions") &&
       isVariableSegment(this.segments[1]) &&
-      this.segments[2] === "resourceGroups" &&
+      literalSegmentsEqual(this.segments[2], "resourceGroups") &&
       isVariableSegment(this.segments[3])
     );
   }
@@ -221,9 +221,9 @@ export class RequestPath {
   isManagementGroupPath(): boolean {
     return (
       this.length === 4 &&
-      this.segments[0] === "providers" &&
-      this.segments[1] === "Microsoft.Management" &&
-      this.segments[2] === "managementGroups" &&
+      literalSegmentsEqual(this.segments[0], "providers") &&
+      literalSegmentsEqual(this.segments[1], "Microsoft.Management") &&
+      literalSegmentsEqual(this.segments[2], "managementGroups") &&
       isVariableSegment(this.segments[3])
     );
   }
@@ -278,7 +278,7 @@ export class RequestPath {
         return "Microsoft.Resources/subscriptions";
       } else if (this.isResourceGroupPath()) {
         return "Microsoft.Resources/resourceGroups";
-      } else if (this.segments[0] === "tenants") {
+      } else if (literalSegmentsEqual(this.segments[0], "tenants")) {
         return "Microsoft.Resources/tenants";
       }
       return undefined;
@@ -819,7 +819,10 @@ function operationPathEndsWithResourceType(
   const lastTypeSegment = resourceType.split("/").at(-1);
   return (
     lastTypeSegment !== undefined &&
-    operationPath.segments[operationPath.length - 1] === lastTypeSegment
+    literalSegmentsEqual(
+      operationPath.segments[operationPath.length - 1],
+      lastTypeSegment
+    )
   );
 }
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -817,12 +817,11 @@ function operationPathEndsWithResourceType(
   resourceType: string
 ): boolean {
   const lastTypeSegment = resourceType.split("/").at(-1);
+  const lastOperationSegment = operationPath.segments.at(-1);
   return (
     lastTypeSegment !== undefined &&
-    literalSegmentsEqual(
-      operationPath.segments[operationPath.length - 1],
-      lastTypeSegment
-    )
+    lastOperationSegment !== undefined &&
+    literalSegmentsEqual(lastOperationSegment, lastTypeSegment)
   );
 }
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/request-path.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/request-path.test.ts
@@ -55,6 +55,17 @@ describe("RequestPath", () => {
       ok(parent.isPrefixOf(child));
     });
 
+    it("should match fixed ARM path segments case-insensitively", () => {
+      const parent = new RequestPath(
+        "/subscriptions/{subscriptionId}/resourceGroups/{rg}/providers/Microsoft.Devices/IotHubs/{resourceName}"
+      );
+      const child = new RequestPath(
+        "/subscriptions/{subscriptionId}/resourceGroups/{rg}/providers/Microsoft.Devices/iotHubs/{resourceName}/privateLinkResources/{groupId}"
+      );
+
+      ok(parent.isPrefixOf(child));
+    });
+
     it("should return true when paths are equal", () => {
       const rp1 = new RequestPath("/a/{b}/c");
       const rp2 = new RequestPath("/a/{b}/c");
@@ -138,6 +149,17 @@ describe("RequestPath", () => {
       const rp2 = new RequestPath(
         "/providers/Microsoft.Management/managementGroups/{groupId}"
       );
+      ok(rp1.equals(rp2));
+    });
+
+    it("should return true when fixed ARM path segment casing differs", () => {
+      const rp1 = new RequestPath(
+        "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Devices/IotHubs/{resourceName}"
+      );
+      const rp2 = new RequestPath(
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/iotHubs/{hubName}"
+      );
+
       ok(rp1.equals(rp2));
     });
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/request-path.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/request-path.test.ts
@@ -200,6 +200,20 @@ describe("RequestPath", () => {
       );
     });
 
+    it("should recognize well-known resource paths case-insensitively", () => {
+      ok(new RequestPath("/Tenants/{tenantId}").isResourceInstancePath());
+      ok(
+        new RequestPath(
+          "/Subscriptions/{subscriptionId}"
+        ).isResourceInstancePath()
+      );
+      ok(
+        new RequestPath(
+          "/Subscriptions/{subscriptionId}/ResourceGroups/{resourceGroupName}"
+        ).isResourceInstancePath()
+      );
+    });
+
     it("should recognize generic provider resource paths", () => {
       ok(
         new RequestPath(
@@ -273,6 +287,23 @@ describe("RequestPath", () => {
     it("should return Microsoft.Resources/tenants for tenant path", () => {
       const rp = new RequestPath("/tenants/{tenantId}");
       strictEqual(rp.resourceType, "Microsoft.Resources/tenants");
+    });
+
+    it("should return well-known resource types for mixed-case scope paths", () => {
+      strictEqual(
+        new RequestPath(
+          "/Subscriptions/{subscriptionId}/ResourceGroups/{resourceGroupName}"
+        ).resourceType,
+        "Microsoft.Resources/resourceGroups"
+      );
+      strictEqual(
+        new RequestPath("/Subscriptions/{subscriptionId}").resourceType,
+        "Microsoft.Resources/subscriptions"
+      );
+      strictEqual(
+        new RequestPath("/Tenants/{tenantId}").resourceType,
+        "Microsoft.Resources/tenants"
+      );
     });
 
     it("should return undefined for path without determinable resource type", () => {
@@ -363,6 +394,27 @@ describe("RequestPath", () => {
         "/providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Edge/sites/{siteName}"
       );
       strictEqual(rp.operationScope, ResourceScopeKind.ManagementGroup);
+    });
+
+    it("should detect scope with mixed-case ARM literals", () => {
+      strictEqual(
+        new RequestPath(
+          "/Subscriptions/{subscriptionId}/ResourceGroups/{resourceGroupName}/Providers/Microsoft.Edge/sites/{siteName}"
+        ).operationScope,
+        ResourceScopeKind.ResourceGroup
+      );
+      strictEqual(
+        new RequestPath(
+          "/Subscriptions/{subscriptionId}/Providers/Microsoft.Edge/sites/{siteName}"
+        ).operationScope,
+        ResourceScopeKind.Subscription
+      );
+      strictEqual(
+        new RequestPath(
+          "/Providers/microsoft.management/ManagementGroups/{groupId}/Providers/Microsoft.Edge/sites/{siteName}"
+        ).operationScope,
+        ResourceScopeKind.ManagementGroup
+      );
     });
 
     it("should detect Tenant scope for single provider path", () => {

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -640,6 +640,120 @@ interface ChildResources {
     );
   });
 
+  it("legacy child resource parent detection ignores ARM type segment casing differences", async () => {
+    const program = await typeSpecCompile(
+      `
+model IotHubDescription is TrackedResource<IotHubDescriptionProperties> {
+  ...ResourceNameParameter<
+    Resource = IotHubDescription,
+    KeyName = "resourceName",
+    SegmentName = "IotHubs",
+    NamePattern = ""
+  >;
+}
+
+model IotHubDescriptionProperties {
+  description?: string;
+}
+
+@parentResource(IotHubDescription)
+model GroupIdInformation is ProxyResource<GroupIdInformationProperties, false> {
+  ...ResourceNameParameter<
+    Resource = GroupIdInformation,
+    KeyName = "groupId",
+    SegmentName = "privateLinkResources",
+    NamePattern = ""
+  >;
+}
+
+model GroupIdInformationProperties {
+  description?: string;
+}
+
+model GroupIdInformationList is GroupIdInformation[];
+
+alias GroupIdInformationOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+    ...ResourceGroupParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+
+    @path
+    @segment("iotHubs")
+    resourceName: string;
+  },
+  {
+    @path
+    @segment("privateLinkResources")
+    groupId: string;
+  }
+>;
+
+@armResourceOperations
+interface IotHubDescriptions {
+  get is ArmResourceRead<IotHubDescription>;
+}
+
+@armResourceOperations
+interface GroupIdInformations {
+  get is GroupIdInformationOps.Read<GroupIdInformation>;
+  list is GroupIdInformationOps.ListSinglePage<
+    GroupIdInformation,
+    Response = ArmResponse<GroupIdInformationList>
+  >;
+}
+`,
+      runner,
+      { providerNamespace: "Microsoft.Devices" }
+    );
+
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const [root] = createModel(sdkContext);
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+
+    const hubResource = armProviderSchema.resources.find(
+      (r) =>
+        r.metadata.resourceIdPattern.path ===
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}"
+    );
+    ok(hubResource);
+
+    const groupIdResource = armProviderSchema.resources.find(
+      (r) =>
+        r.metadata.resourceType ===
+        "Microsoft.Devices/iotHubs/privateLinkResources"
+    );
+    ok(groupIdResource);
+    strictEqual(
+      groupIdResource.metadata.resourceIdPattern.path,
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/iotHubs/{resourceName}/privateLinkResources/{groupId}"
+    );
+    strictEqual(
+      groupIdResource.metadata.parentResourceId?.path,
+      hubResource.metadata.resourceIdPattern.path
+    );
+
+    const readMethod = groupIdResource.metadata.methods.find(
+      (m: any) => m.kind === "Read"
+    );
+    ok(readMethod);
+    strictEqual(
+      readMethod.operationPath.path,
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/iotHubs/{resourceName}/privateLinkResources/{groupId}"
+    );
+
+    const listMethod = groupIdResource.metadata.methods.find(
+      (m: any) => m.kind === "List"
+    );
+    ok(listMethod);
+    strictEqual(
+      listMethod.scope.scopeIdPattern?.path,
+      hubResource.metadata.resourceIdPattern.path
+    );
+  });
+
   it("resource with grand parent under a resource group", async () => {
     const program = await typeSpecCompile(
       `


### PR DESCRIPTION
## Description
Fixes #59538.

This updates management emitter ARM request path structural matching so literal path segments are compared case-insensitively. That keeps the generated wire/resource path casing intact while allowing SDK resource parent detection to match existing GA hierarchy for mixed-case ARM type segments such as IoTHub's `IotHubs` resource and lowercase `iotHubs` child operation paths.

## Validation
- `npm run prettier`
- `npm run lint`
- `npm run test:emitter`
- `npm run build:emitter`
- `.\eng\scripts\Generate.ps1`
