### PR TITLE
Fix MPG resource data customization namespace

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ResourceVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ResourceVisitor.cs
@@ -124,13 +124,14 @@ internal class ResourceVisitor : ScmLibraryVisitor
     {
         if (type is ModelProvider model && ManagementClientGenerator.Instance.OutputLibrary.IsResourceModelType(model.Type))
         {
-            type.Update(@namespace: ManagementClientGenerator.Instance.TypeFactory.PrimaryNamespace);
+            var resourceNamespace = model.CustomCodeView?.Type.Namespace ?? ManagementClientGenerator.Instance.TypeFactory.PrimaryNamespace;
+            type.Update(@namespace: resourceNamespace);
 
             foreach (var serialization in type.SerializationProviders)
             {
                 serialization.Update(
                     relativeFilePath: Path.Combine("src", "Generated", $"{model.Name}.Serialization.cs"),
-                    @namespace: ManagementClientGenerator.Instance.TypeFactory.PrimaryNamespace);
+                    @namespace: resourceNamespace);
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ResourceDataModelProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ResourceDataModelProviderTests.cs
@@ -175,6 +175,24 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
+        public void ResourceDataModelUsesCustomizationNamespace()
+        {
+            var (client, models) = InputResourceData.ClientWithResource();
+            var resourceModel = models.Single();
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => models,
+                clients: () => [client]);
+
+            var modelProvider = plugin.Object.TypeFactory.CreateModel(resourceModel)!;
+            ManagementMockHelpers.SetCustomCodeView(modelProvider, new ModelsNamespaceCustomCodeView());
+
+            var visitor = new TestableResourceVisitor();
+            var result = visitor.InvokeVisitType(modelProvider);
+
+            Assert.That(result!.Type.Namespace, Is.EqualTo("Samples.Models"));
+        }
+
+        [Test]
         public void DerivedSerializationFromResponseHidesBaseWithNewModifier()
         {
             var baseModel = InputFactory.Model(
@@ -244,6 +262,13 @@ namespace Azure.Generator.Mgmt.Tests
             {
                 return base.VisitMethod(method);
             }
+        }
+
+        private class ModelsNamespaceCustomCodeView : TypeProvider
+        {
+            protected override string BuildName() => "ResponseTypeData";
+            protected override string BuildNamespace() => "Samples.Models";
+            protected override string BuildRelativeFilePath() => "ResponseTypeData.cs";
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ResourceDataModelProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ResourceDataModelProviderTests.cs
@@ -190,6 +190,7 @@ namespace Azure.Generator.Mgmt.Tests
             var result = visitor.InvokeVisitType(modelProvider);
 
             Assert.That(result!.Type.Namespace, Is.EqualTo("Samples.Models"));
+            Assert.That(result.SerializationProviders.Select(s => s.Type.Namespace), Is.All.EqualTo("Samples.Models"));
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Fixes #59888.

Preserves the namespace from a customization partial for MPG resource data models instead of forcing those models back to the package root namespace.

## Changes

- Use `CustomCodeView.Type.Namespace` when transforming customized resource data models.
- Keep resource data serialization providers in the same namespace as the resource data model.
- Add a regression test for a customized resource data model under `.Models`.

## Verification

- `dotnet test "eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj" --filter "FullyQualifiedName~ResourceDataModelProviderTests"`
- `pwsh -NoLogo -NoProfile -File "eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1"`