### PR TITLE
Refine ResourceCollection recognition logic in hierarchy tool

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/eng/scripts/ResourceHierarchyTool/Program.cs
+++ b/eng/packages/http-client-csharp-mgmt/eng/scripts/ResourceHierarchyTool/Program.cs
@@ -233,10 +233,12 @@ internal static class Program
                 info.IsTrackedResource = IsAssignableTo(dataProp.PropertyType, trackedResourceDataType);
             }
 
-            var expectedCollName = resType.Name.EndsWith("Resource")
-                ? resType.Name.Substring(0, resType.Name.Length - "Resource".Length) + "Collection"
-                : resType.Name + "Collection";
-            var collType = collectionTypes.FirstOrDefault(c => c.Name == expectedCollName);
+            var expectedCollNames = resType.Name.EndsWith("Resource")
+                ? new[] { resType.Name.Substring(0, resType.Name.Length - "Resource".Length) + "Collection", resType.Name + "Collection" }
+                : new[] { resType.Name + "Collection" };
+            var collType = expectedCollNames
+                .Select(name => collectionTypes.FirstOrDefault(c => c.Name == name))
+                .FirstOrDefault(c => c != null);
             if (collType != null) info.CollectionType = collType.Name;
             else                  info.IsSingleton    = true;
 


### PR DESCRIPTION
## Description

Updates the management resource hierarchy reflection helper to recognize `FooResourceCollection` as the collection type for `FooResource`, after checking the existing `FooCollection` convention.

This prevents resources from being incorrectly reported as singleton when a GA SDK uses the newer `*ResourceCollection` naming convention.

## Validation

- `dotnet build eng\packages\http-client-csharp-mgmt\eng\scripts\ResourceHierarchyTool\ResourceHierarchyTool.csproj -c Release --nologo`
- Reran Monitor GA hierarchy extraction and comparison against current migration artifacts; structural mismatches dropped to 0, leaving only the expected missing-resource compatibility items.