### PR TITLE
Update customer SDK stats dimension keys to camelCase

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Updated customer SDK stats dimension key names to use camelCase (`computeType`, `telemetryType`, `dropCode`, `dropReason`, `retryCode`, `retryReason`).
+
 ## 1.8.1 (2026-05-20)
 
 ### Features Added

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsDimensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsDimensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Diagnostics;
@@ -16,33 +16,33 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
         /// <summary>
         /// Gets base tags common to all customer SDK stats metrics.
         /// </summary>
-        /// <param name="telemetryType">The type of telemetry (REQUEST, DEPENDENCY, etc.)</param>
+        /// <param name="telemetryType">The type of telemetry.</param>
         /// <returns>TagList with common dimensions</returns>
-        public static TagList GetBaseTags(string telemetryType)
+        public static TagList GetBaseTags(TelemetryType telemetryType)
         {
             return new TagList
             {
                 { "language", "dotnet" },
                 { "version", SdkVersionUtils.ExtensionVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength) },
                 { "computeType", GetComputeType() },
-                { "telemetry_type", telemetryType }
+                { "telemetryType", ToDimensionValue(telemetryType) }
             };
         }
 
         /// <summary>
         /// Gets tags for dropped telemetry items.
         /// </summary>
-        /// <param name="telemetryType">The type of telemetry</param>
+        /// <param name="telemetryType">The type of telemetry.</param>
         /// <param name="dropCode">The drop code (status code or error category)</param>
         /// <param name="dropReason">Optional drop reason description</param>
         /// <returns>TagList with dropped item dimensions</returns>
-        public static TagList GetDroppedTags(string telemetryType, string dropCode, string? dropReason = null)
+        public static TagList GetDroppedTags(TelemetryType telemetryType, string dropCode, string? dropReason = null)
         {
             var tags = GetBaseTags(telemetryType);
-            tags.Add("drop.code", dropCode);
+            tags.Add("dropCode", dropCode);
             if (!string.IsNullOrEmpty(dropReason))
             {
-                tags.Add("drop.reason", dropReason);
+                tags.Add("dropReason", dropReason);
             }
             return tags;
         }
@@ -50,17 +50,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
         /// <summary>
         /// Gets tags for retried telemetry items.
         /// </summary>
-        /// <param name="telemetryType">The type of telemetry</param>
+        /// <param name="telemetryType">The type of telemetry.</param>
         /// <param name="retryCode">The retry code (status code or error category)</param>
         /// <param name="retryReason">Optional retry reason description</param>
         /// <returns>TagList with retry item dimensions</returns>
-        public static TagList GetRetryTags(string telemetryType, string retryCode, string? retryReason = null)
+        public static TagList GetRetryTags(TelemetryType telemetryType, string retryCode, string? retryReason = null)
         {
             var tags = GetBaseTags(telemetryType);
-            tags.Add("retry.code", retryCode);
+            tags.Add("retryCode", retryCode);
             if (!string.IsNullOrEmpty(retryReason))
             {
-                tags.Add("retry.reason", retryReason);
+                tags.Add("retryReason", retryReason);
             }
             return tags;
         }
@@ -73,6 +73,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
                 s_computeType = ResourceProviderHelper.DetermineResourceProvider(platform);
             }
             return s_computeType;
+        }
+
+        private static string ToDimensionValue(TelemetryType telemetryType)
+        {
+            return telemetryType switch
+            {
+                TelemetryType.Request => "REQUEST",
+                TelemetryType.Dependency => "DEPENDENCY",
+                TelemetryType.Exception => "EXCEPTION",
+                TelemetryType.CustomEvent => "CUSTOM_EVENT",
+                TelemetryType.CustomMetric => "CUSTOM_METRIC",
+                _ => "TRACE"
+            };
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -124,37 +124,37 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
             {
                 if (telemetrySchemaTypeCounter._requestCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetBaseTags("REQUEST");
+                    var tags = CustomerSdkStatsDimensions.GetBaseTags(TelemetryType.Request);
                     CustomerSdkStatsMeters.ItemSuccessCount.Add(telemetrySchemaTypeCounter._requestCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._dependencyCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetBaseTags("DEPENDENCY");
+                    var tags = CustomerSdkStatsDimensions.GetBaseTags(TelemetryType.Dependency);
                     CustomerSdkStatsMeters.ItemSuccessCount.Add(telemetrySchemaTypeCounter._dependencyCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._exceptionCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetBaseTags("EXCEPTION");
+                    var tags = CustomerSdkStatsDimensions.GetBaseTags(TelemetryType.Exception);
                     CustomerSdkStatsMeters.ItemSuccessCount.Add(telemetrySchemaTypeCounter._exceptionCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._eventCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetBaseTags("EVENT");
+                    var tags = CustomerSdkStatsDimensions.GetBaseTags(TelemetryType.CustomEvent);
                     CustomerSdkStatsMeters.ItemSuccessCount.Add(telemetrySchemaTypeCounter._eventCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._metricCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetBaseTags("METRIC");
+                    var tags = CustomerSdkStatsDimensions.GetBaseTags(TelemetryType.CustomMetric);
                     CustomerSdkStatsMeters.ItemSuccessCount.Add(telemetrySchemaTypeCounter._metricCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._traceCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetBaseTags("TRACE");
+                    var tags = CustomerSdkStatsDimensions.GetBaseTags(TelemetryType.Trace);
                     CustomerSdkStatsMeters.ItemSuccessCount.Add(telemetrySchemaTypeCounter._traceCount, tags);
                 }
             }
@@ -202,37 +202,37 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
 
                 if (telemetrySchemaTypeCounter._requestCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetDroppedTags("REQUEST", dropCodeString, dropReason);
+                    var tags = CustomerSdkStatsDimensions.GetDroppedTags(TelemetryType.Request, dropCodeString, dropReason);
                     CustomerSdkStatsMeters.ItemDroppedCount.Add(telemetrySchemaTypeCounter._requestCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._dependencyCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetDroppedTags("DEPENDENCY", dropCodeString, dropReason);
+                    var tags = CustomerSdkStatsDimensions.GetDroppedTags(TelemetryType.Dependency, dropCodeString, dropReason);
                     CustomerSdkStatsMeters.ItemDroppedCount.Add(telemetrySchemaTypeCounter._dependencyCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._exceptionCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetDroppedTags("EXCEPTION", dropCodeString, dropReason);
+                    var tags = CustomerSdkStatsDimensions.GetDroppedTags(TelemetryType.Exception, dropCodeString, dropReason);
                     CustomerSdkStatsMeters.ItemDroppedCount.Add(telemetrySchemaTypeCounter._exceptionCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._eventCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetDroppedTags("EVENT", dropCodeString, dropReason);
+                    var tags = CustomerSdkStatsDimensions.GetDroppedTags(TelemetryType.CustomEvent, dropCodeString, dropReason);
                     CustomerSdkStatsMeters.ItemDroppedCount.Add(telemetrySchemaTypeCounter._eventCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._metricCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetDroppedTags("METRIC", dropCodeString, dropReason);
+                    var tags = CustomerSdkStatsDimensions.GetDroppedTags(TelemetryType.CustomMetric, dropCodeString, dropReason);
                     CustomerSdkStatsMeters.ItemDroppedCount.Add(telemetrySchemaTypeCounter._metricCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._traceCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetDroppedTags("TRACE", dropCodeString, dropReason);
+                    var tags = CustomerSdkStatsDimensions.GetDroppedTags(TelemetryType.Trace, dropCodeString, dropReason);
                     CustomerSdkStatsMeters.ItemDroppedCount.Add(telemetrySchemaTypeCounter._traceCount, tags);
                 }
             }
@@ -267,37 +267,37 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
 
                 if (telemetrySchemaTypeCounter._requestCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetRetryTags("REQUEST", retryCodeString, retryReason);
+                    var tags = CustomerSdkStatsDimensions.GetRetryTags(TelemetryType.Request, retryCodeString, retryReason);
                     CustomerSdkStatsMeters.ItemRetryCount.Add(telemetrySchemaTypeCounter._requestCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._dependencyCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetRetryTags("DEPENDENCY", retryCodeString, retryReason);
+                    var tags = CustomerSdkStatsDimensions.GetRetryTags(TelemetryType.Dependency, retryCodeString, retryReason);
                     CustomerSdkStatsMeters.ItemRetryCount.Add(telemetrySchemaTypeCounter._dependencyCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._exceptionCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetRetryTags("EXCEPTION", retryCodeString, retryReason);
+                    var tags = CustomerSdkStatsDimensions.GetRetryTags(TelemetryType.Exception, retryCodeString, retryReason);
                     CustomerSdkStatsMeters.ItemRetryCount.Add(telemetrySchemaTypeCounter._exceptionCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._eventCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetRetryTags("EVENT", retryCodeString, retryReason);
+                    var tags = CustomerSdkStatsDimensions.GetRetryTags(TelemetryType.CustomEvent, retryCodeString, retryReason);
                     CustomerSdkStatsMeters.ItemRetryCount.Add(telemetrySchemaTypeCounter._eventCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._metricCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetRetryTags("METRIC", retryCodeString, retryReason);
+                    var tags = CustomerSdkStatsDimensions.GetRetryTags(TelemetryType.CustomMetric, retryCodeString, retryReason);
                     CustomerSdkStatsMeters.ItemRetryCount.Add(telemetrySchemaTypeCounter._metricCount, tags);
                 }
 
                 if (telemetrySchemaTypeCounter._traceCount != 0)
                 {
-                    var tags = CustomerSdkStatsDimensions.GetRetryTags("TRACE", retryCodeString, retryReason);
+                    var tags = CustomerSdkStatsDimensions.GetRetryTags(TelemetryType.Trace, retryCodeString, retryReason);
                     CustomerSdkStatsMeters.ItemRetryCount.Add(telemetrySchemaTypeCounter._traceCount, tags);
                 }
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/TelemetryType.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/TelemetryType.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
+{
+    internal enum TelemetryType
+    {
+        Request,
+        Dependency,
+        Exception,
+        CustomEvent,
+        CustomMetric,
+        Trace
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CustomerSdkStats/CustomerSdkStatsDimensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CustomerSdkStats/CustomerSdkStatsDimensionsTests.cs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats;
 using Xunit;
+using TelemetryType = Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats.TelemetryType;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CustomerSdkStats;
 
@@ -14,61 +15,63 @@ public class CustomerSdkStatsDimensionsTests
     public void GetBaseTags_IncludesAllRequiredDimensions()
     {
         // Act
-        var tags = CustomerSdkStatsDimensions.GetBaseTags("DEPENDENCY");
+        var tags = CustomerSdkStatsDimensions.GetBaseTags(TelemetryType.Dependency);
 
         // Assert
         Assert.Contains(tags, tag => tag.Key == "language");
         Assert.Contains(tags, tag => tag.Key == "version");
         Assert.Contains(tags, tag => tag.Key == "computeType");
-        Assert.Contains(tags, tag => tag.Key == "telemetry_type" && tag.Value?.Equals("DEPENDENCY") == true);
+        Assert.Contains(tags, tag => tag.Key == "telemetryType" && tag.Value?.Equals("DEPENDENCY") == true);
     }
 
     [Theory]
-    [InlineData("REQUEST", "200")]
-    [InlineData("DEPENDENCY", "404")]
-    [InlineData("EXCEPTION", "500")]
-    public void GetDroppedTags_IncludesDropCodeAndReason(string telemetryType, string dropCode)
+    [InlineData("Request", "200")]
+    [InlineData("Dependency", "404")]
+    [InlineData("Exception", "500")]
+    public void GetDroppedTags_IncludesDropCodeAndReason(string telemetryTypeName, string dropCode)
     {
         // Act
+        var telemetryType = (TelemetryType)Enum.Parse(typeof(TelemetryType), telemetryTypeName);
         var tags = CustomerSdkStatsDimensions.GetDroppedTags(telemetryType, dropCode, "Test reason");
 
         // Assert
-        Assert.Contains(tags, tag => tag.Key == "telemetry_type" && tag.Value?.Equals(telemetryType) == true);
-        Assert.Contains(tags, tag => tag.Key == "drop.code" && tag.Value?.Equals(dropCode) == true);
-        Assert.Contains(tags, tag => tag.Key == "drop.reason" && tag.Value?.Equals("Test reason") == true);
+        Assert.Contains(tags, tag => tag.Key == "telemetryType");
+        Assert.Contains(tags, tag => tag.Key == "dropCode" && tag.Value?.Equals(dropCode) == true);
+        Assert.Contains(tags, tag => tag.Key == "dropReason" && tag.Value?.Equals("Test reason") == true);
     }
 
     [Theory]
-    [InlineData("REQUEST", "429")]
-    [InlineData("DEPENDENCY", "503")]
-    public void GetRetryTags_IncludesRetryCodeAndReason(string telemetryType, string retryCode)
+    [InlineData("Request", "429")]
+    [InlineData("Dependency", "503")]
+    public void GetRetryTags_IncludesRetryCodeAndReason(string telemetryTypeName, string retryCode)
     {
         // Act
+        var telemetryType = (TelemetryType)Enum.Parse(typeof(TelemetryType), telemetryTypeName);
         var tags = CustomerSdkStatsDimensions.GetRetryTags(telemetryType, retryCode, "Test retry");
 
         // Assert
-        Assert.Contains(tags, tag => tag.Key == "telemetry_type" && tag.Value?.Equals(telemetryType) == true);
-        Assert.Contains(tags, tag => tag.Key == "retry.code" && tag.Value?.Equals(retryCode) == true);
-        Assert.Contains(tags, tag => tag.Key == "retry.reason" && tag.Value?.Equals("Test retry") == true);
+        Assert.Contains(tags, tag => tag.Key == "telemetryType");
+        Assert.Contains(tags, tag => tag.Key == "retryCode" && tag.Value?.Equals(retryCode) == true);
+        Assert.Contains(tags, tag => tag.Key == "retryReason" && tag.Value?.Equals("Test retry") == true);
     }
 
     [Fact]
     public void GetDroppedTags_WithoutReason_DoesNotIncludeReasonTag()
     {
         // Act
-        var tags = CustomerSdkStatsDimensions.GetDroppedTags("REQUEST", "200");
+        var tags = CustomerSdkStatsDimensions.GetDroppedTags(TelemetryType.Request, "200");
 
         // Assert
-        Assert.DoesNotContain(tags, tag => tag.Key == "drop.reason");
+        Assert.DoesNotContain(tags, tag => tag.Key == "dropReason");
     }
 
     [Fact]
     public void GetRetryTags_WithoutReason_DoesNotIncludeReasonTag()
     {
         // Act
-        var tags = CustomerSdkStatsDimensions.GetRetryTags("REQUEST", "429");
+        var tags = CustomerSdkStatsDimensions.GetRetryTags(TelemetryType.Request, "429");
 
         // Assert
-        Assert.DoesNotContain(tags, tag => tag.Key == "retry.reason");
+        Assert.DoesNotContain(tags, tag => tag.Key == "retryReason");
     }
 }


### PR DESCRIPTION
Rename dimension keys to use camelCase format:
- compute.type -> computeType
- telemetry_type -> telemetryType
- drop.code -> dropCode
- drop.reason -> dropReason
- retry.code -> retryCode
- retry.reason -> retryReason
Also fixes

TelemetryType.CustomEvent => "EVENT", -> "CUSTOM_EVENT"
TelemetryType.CustomMetric => "METRIC" -> "CUSTOM_METRIC"

This is consistent with the [spec](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/blob/main/ApplicationInsights/sdkstats/customer_facing_sdk_stats.md)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
