### PR TITLE
Fix Azure generator LRO diagnostic scope name to strip Async suffix

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Extensions/ClientProviderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Extensions/ClientProviderExtensions.cs
@@ -14,7 +14,17 @@ namespace Azure.Generator.Extensions
     {
         public static ClientProvider GetClient(this ScmMethodProvider method) => (ClientProvider)method.EnclosingType;
 
-        public static string GetScopeName(this ScmMethodProvider method) => $"{method.EnclosingType.Name}.{method.Signature.Name}";
+        public static string GetScopeName(this ScmMethodProvider method)
+        {
+            const string asyncSuffix = "Async";
+            var methodName = method.Signature.Name;
+            if (methodName.EndsWith(asyncSuffix, System.StringComparison.Ordinal))
+            {
+                methodName = methodName[..^asyncSuffix.Length];
+            }
+
+            return $"{method.EnclosingType.Name}.{methodName}";
+        }
 
         public static string GetScopeName(this ClientProvider client, InputOperation operation) => $"{client.Name}.{operation.Name.ToIdentifierName()}";
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/LroVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/LroVisitorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
@@ -476,15 +475,11 @@ namespace Azure.Generator.Tests.Visitors
             Assert.IsNotNull(asyncProtocolMethod);
             var actual = asyncProtocolMethod!.BodyStatements!.ToDisplayString();
 
-            // The outer scope (DistributedTracingVisitor) must be present and use the stripped name.
-            Assert.IsTrue(actual.Contains("CreateScope(\"TestClient.Foo\")"), actual);
-            // The async protocol method must call ProcessMessageAsync (LroVisitor rewrite).
-            Assert.IsTrue(actual.Contains("ProcessMessageAsync"), actual);
-            // Both the outer scope and the ProcessMessageAsync scope argument must use the
-            // stripped literal, so it should appear at least twice.
-            Assert.GreaterOrEqual(Regex.Matches(actual, "\"TestClient\\.Foo\"").Count, 2, actual);
-            // The Async suffix must not leak into either scope name.
-            Assert.IsFalse(actual.Contains("TestClient.FooAsync"), actual);
+            // The expected snapshot captures both the outer scope (added by
+            // DistributedTracingVisitor) and the ProcessMessageAsync scope argument (added by
+            // LroVisitor), both of which must use the stripped scope name "TestClient.Foo"
+            // rather than the Async-suffixed "TestClient.FooAsync".
+            Assert.AreEqual(Helpers.GetExpectedFromFile(), actual);
         }
 
         private class TestLroVisitor : LroVisitor

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/LroVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/LroVisitorTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
@@ -430,6 +431,62 @@ namespace Azure.Generator.Tests.Visitors
             Assert.AreEqual(Helpers.GetExpectedFromFile(), actual);
         }
 
+        // Regression test for the Async-suffix scope-name bug: when both visitors run
+        // (DistributedTracingVisitor adds the outer client-method scope, LroVisitor rewrites
+        // the ProcessMessage call and injects the polling scope argument), the async protocol
+        // method must use the stripped scope name ("TestClient.Foo") in BOTH places, never
+        // "TestClient.FooAsync".
+        [Test]
+        public void AsyncProtocolMethodUsesStrippedScopeNameForOuterScopeAndScopeArg()
+        {
+            var lroVisitor = new TestLroVisitor();
+            var tracingVisitor = new TestDistributedTracingVisitor();
+            List<InputParameter> parameters =
+            [
+                InputFactory.BodyParameter("p1", InputPrimitiveType.String)
+            ];
+            List<InputMethodParameter> methodParameters =
+            [
+                InputFactory.MethodParameter("p1", InputPrimitiveType.String)
+            ];
+            var lro = InputFactory.Operation(
+                "foo",
+                parameters: parameters);
+            var responseModel = InputFactory.Model("foo");
+            var lroServiceMethod = InputFactory.LongRunningServiceMethod(
+                "foo",
+                lro, parameters: methodParameters,
+                response: InputFactory.ServiceMethodResponse(responseModel, ["result"]));
+            var inputClient = InputFactory.Client("TestClient", methods: [lroServiceMethod]);
+            var plugin = MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+            var outputLibrary = plugin.Object.OutputLibrary;
+
+            // Run the visitors in the same order as the real generation pipeline:
+            // DistributedTracingVisitor wraps the body with the outer scope first,
+            // then LroVisitor rewrites the inner ProcessMessage call / scope argument.
+            tracingVisitor.InvokeVisitLibrary(outputLibrary);
+            lroVisitor.InvokeVisitLibrary(outputLibrary);
+
+            var clientProvider = outputLibrary.TypeProviders.OfType<ClientProvider>().FirstOrDefault();
+            Assert.IsNotNull(clientProvider);
+            var asyncProtocolMethod = clientProvider!.Methods
+                .FirstOrDefault(m => m.Signature.Name == "FooAsync"
+                    && m.Signature.Parameters.Any(p => p.Name == "context"));
+
+            Assert.IsNotNull(asyncProtocolMethod);
+            var actual = asyncProtocolMethod!.BodyStatements!.ToDisplayString();
+
+            // The outer scope (DistributedTracingVisitor) must be present and use the stripped name.
+            Assert.IsTrue(actual.Contains("CreateScope(\"TestClient.Foo\")"), actual);
+            // The async protocol method must call ProcessMessageAsync (LroVisitor rewrite).
+            Assert.IsTrue(actual.Contains("ProcessMessageAsync"), actual);
+            // Both the outer scope and the ProcessMessageAsync scope argument must use the
+            // stripped literal, so it should appear at least twice.
+            Assert.GreaterOrEqual(Regex.Matches(actual, "\"TestClient\\.Foo\"").Count, 2, actual);
+            // The Async suffix must not leak into either scope name.
+            Assert.IsFalse(actual.Contains("TestClient.FooAsync"), actual);
+        }
+
         private class TestLroVisitor : LroVisitor
         {
             public MethodProvider? InvokeVisitMethod(MethodProvider method)
@@ -445,6 +502,14 @@ namespace Azure.Generator.Tests.Visitors
                 return base.Visit(serviceMethod, client, methodCollection);
             }
 
+            public void InvokeVisitLibrary(OutputLibrary library)
+            {
+                base.VisitLibrary(library);
+            }
+        }
+
+        private class TestDistributedTracingVisitor : DistributedTracingVisitor
+        {
             public void InvokeVisitLibrary(OutputLibrary library)
             {
                 base.VisitLibrary(library);

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/AsyncProtocolMethodUsesStrippedScopeNameForOuterScopeAndScopeArg.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/AsyncProtocolMethodUsesStrippedScopeNameForOuterScopeAndScopeArg.cs
@@ -1,0 +1,12 @@
+using global::Azure.Core.Pipeline.DiagnosticScope scope = ClientDiagnostics.CreateScope("TestClient.Foo");
+scope.Start();
+try
+{
+    using global::Azure.Core.HttpMessage message = this.CreateFooRequest(content, context);
+    return await global::Azure.Core.ProtocolOperationHelpers.ProcessMessageAsync(Pipeline, message, ClientDiagnostics, "TestClient.Foo", global::Azure.Core.OperationFinalStateVia.Location, context, waitUntil).ConfigureAwait(false);
+}
+catch (global::System.Exception e)
+{
+    scope.Failed(e);
+    throw;
+}

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesAsyncConvenienceMethodBodyWithResultPath.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesAsyncConvenienceMethodBodyWithResultPath.cs
@@ -1,3 +1,3 @@
 ﻿using global::Azure.Core.RequestContent content = global::Azure.Core.RequestContent.Create(global::System.BinaryData.FromString(p1));
 global::Azure.Operation<global::System.BinaryData> result = await this.FooAsync(waitUntil, content, cancellationToken.ToRequestContext()).ConfigureAwait(false);
-return global::Azure.Core.ProtocolOperationHelpers.Convert(result, response => global::Samples.Models.Foo.FromLroResponse(response), ClientDiagnostics, "TestClient.FooAsync");
+return global::Azure.Core.ProtocolOperationHelpers.Convert(result, response => global::Samples.Models.Foo.FromLroResponse(response), ClientDiagnostics, "TestClient.Foo");


### PR DESCRIPTION
## Problem

For long-running operations, the Azure generator's async method passes the method's signature name — including the `Async` suffix — as the scope name to `ProtocolOperationHelpers.ProcessMessageAsync`/`Convert`. That scope name is stored on the returned `Operation` and used to name its polling scopes (`UpdateStatus`/`WaitForCompletion`).

As a result, async LRO polling scopes were named `<Client>.<Operation>OperationAsync` instead of `<Client>.<Operation>Operation`. This is:
- inconsistent with the **sync** path (no suffix), and
- inconsistent with the **outer** client-method scope, which `DistributedTracingVisitor` already strips, and
- a violation of the Azure SDK convention that diagnostic scope names must not contain the `Async` suffix (the test framework's `DiagnosticScopeValidatingInterceptor` strips `Async` to compute the expected name).

The outer client-method scope itself is correct and intentional — it is the only method-level span covering the initial LRO request.

## Fix

Strip the `Async` suffix inside `GetScopeName(ScmMethodProvider)` so every caller (`LroVisitor` for the `ProcessMessage`/`Convert` scope name, and `DistributedTracingVisitor` for the outer scope) emits consistent, correctly named scopes.

## Validation

- Updated the `LroVisitor` async convenience-method test data (`TestClient.FooAsync` → `TestClient.Foo`).
- All 111 `Visitors` unit tests pass.
- Regenerated the generator test projects: no other generated output changed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>