### PR TITLE
[Monitor Exporter] Add Network SDK Stats Request_Success_Count

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -9,6 +9,7 @@ using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
@@ -51,12 +52,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             _fileBlobProvider = InitializeOfflineStorage(platform, _connectionVars, options.DisableOfflineStorage, options.StorageDirectory);
 
+            _statsbeat = InitializeStatsbeat(options, _connectionVars, platform);
+
             if (_fileBlobProvider != null)
             {
-                _transmitFromStorageHandler = new TransmitFromStorageHandler(_applicationInsightsRestClient, _fileBlobProvider, _transmissionStateManager, _connectionVars, _isAadEnabled);
+                _transmitFromStorageHandler = new TransmitFromStorageHandler(_applicationInsightsRestClient, _fileBlobProvider, _transmissionStateManager, _connectionVars, _isAadEnabled, _statsbeat?.NetworkSdkStatsManager);
             }
-
-            _statsbeat = InitializeStatsbeat(options, _connectionVars, platform);
         }
 
         internal static ConnectionVars InitializeConnectionVars(AzureMonitorExporterOptions options, IPlatform platform)
@@ -167,6 +168,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 return result;
             }
 
+            var networkSdkStats = _statsbeat?.NetworkSdkStatsManager;
+
             try
             {
                 if (_transmissionStateManager.State == TransmissionState.Closed)
@@ -177,10 +180,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
                     result = HttpPipelineHelper.IsSuccess(httpMessage, telemetrySchemaTypeCounter);
 
+                    if (result == ExportResult.Success && networkSdkStats != null)
+                    {
+                        // Record Network SDKStats Request_Success_Count for HTTP 200.
+                        // request.Uri reflects any redirect followed by IngestionRedirectPolicy,
+                        // so the host recorded matches the stamp that returned the response.
+                        networkSdkStats.TrackSuccess(httpMessage.Request.Uri.Host);
+                    }
+
                     if (result == ExportResult.Failure && _fileBlobProvider != null)
                     {
                         _transmissionStateManager.EnableBackOff(httpMessage.HasResponse ? httpMessage.Response : null);
-                        var transmissionResult = HttpPipelineHelper.ProcessTransmissionResult(httpMessage, _fileBlobProvider, null, _connectionVars, origin, _isAadEnabled, telemetrySchemaTypeCounter);
+                        var transmissionResult = HttpPipelineHelper.ProcessTransmissionResult(httpMessage, _fileBlobProvider, null, _connectionVars, origin, _isAadEnabled, telemetrySchemaTypeCounter, networkSdkStats);
                         result = transmissionResult.ExportResult;
                     }
                     else

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -477,7 +477,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         [NonEvent]
         public void CustomerSdkStatsInitializationFailed(Exception ex)
         {
-            if (IsEnabled(EventLevel.Warning))
+            if (IsEnabled(EventLevel.Informational))
             {
                 CustomerSdkStatsInitializationFailed(ex.FlattenException().ToInvariantString());
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -483,7 +483,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
             }
         }
 
-        [Event(48, Message = "Customer SDK stats initialization failed due to an exception. This is only for internal telemetry and can safely be ignored. {0}", Level = EventLevel.Warning)]
+        [Event(48, Message = "Customer SDK stats initialization failed due to an exception. This is only for internal telemetry and can safely be ignored. {0}", Level = EventLevel.Informational)]
         public void CustomerSdkStatsInitializationFailed(string exceptionMessage) => WriteEvent(48, exceptionMessage);
 
         [Event(49, Message = "Invalid sampler type '{0}'. Supported values: microsoft.rate_limited, microsoft.fixed_percentage", Level = EventLevel.Warning)]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -477,13 +477,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         [NonEvent]
         public void CustomerSdkStatsInitializationFailed(Exception ex)
         {
-            if (IsEnabled(EventLevel.Informational))
+            if (IsEnabled(EventLevel.Warning))
             {
                 CustomerSdkStatsInitializationFailed(ex.FlattenException().ToInvariantString());
             }
         }
 
-        [Event(48, Message = "Customer SDK stats initialization failed due to an exception. This is only for internal telemetry and can safely be ignored. {0}", Level = EventLevel.Informational)]
+        [Event(48, Message = "Customer SDK stats initialization failed due to an exception. This is only for internal telemetry and can safely be ignored. {0}", Level = EventLevel.Warning)]
         public void CustomerSdkStatsInitializationFailed(string exceptionMessage) => WriteEvent(48, exceptionMessage);
 
         [Event(49, Message = "Invalid sampler type '{0}'. Supported values: microsoft.rate_limited, microsoft.fixed_percentage", Level = EventLevel.Warning)]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -368,7 +368,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             result.ItemsAccepted = trackResponse.ItemsAccepted;
 
-            // ASccepted envelopes within a 206 response are
+            // Accepted envelopes within a 206 response are
             // counted toward Request_Success_Count.
             if (networkSdkStatsManager != null && trackResponse.ItemsAccepted is int acceptedCount && acceptedCount > 0)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -12,6 +12,7 @@ using Azure.Core;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry;
@@ -231,8 +232,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// <param name="origin">Origin of telemetry (Exporter vs Storage).</param>
         /// <param name="isAadEnabled">If AAD auth is enabled.</param>
         /// <param name="telemetrySchemaTypeCounter">Telemetry counter for tracking metrics.</param>
+        /// <param name="networkSdkStatsManager">Optional Network SDKStats manager for per-envelope tracking on 206 partial success responses.</param>
         /// <returns>TransmissionResult describing actions taken.</returns>
-        internal static TransmissionResult ProcessTransmissionResult(HttpMessage httpMessage, PersistentBlobProvider? blobProvider, PersistentBlob? blob, ConnectionVars connectionVars, TelemetryItemOrigin origin, bool isAadEnabled, TelemetrySchemaTypeCounter? telemetrySchemaTypeCounter = null)
+        internal static TransmissionResult ProcessTransmissionResult(HttpMessage httpMessage, PersistentBlobProvider? blobProvider, PersistentBlob? blob, ConnectionVars connectionVars, TelemetryItemOrigin origin, bool isAadEnabled, TelemetrySchemaTypeCounter? telemetrySchemaTypeCounter = null, NetworkSdkStatsManager? networkSdkStatsManager = null)
         {
             var result = CreateTransmissionResult();
 
@@ -268,7 +270,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             if (result.StatusCode == ResponseStatusCodes.PartialSuccess)
             {
-                HandlePartialSuccess(httpMessage, blobProvider, blob, origin, ref result, telemetrySchemaTypeCounter);
+                HandlePartialSuccess(httpMessage, blobProvider, blob, origin, ref result, telemetrySchemaTypeCounter, networkSdkStatsManager);
             }
             else if (IsRetriableStatus(result.StatusCode))
             {
@@ -357,7 +359,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
         }
 
-        private static void HandlePartialSuccess(HttpMessage httpMessage, PersistentBlobProvider? blobProvider, PersistentBlob? blob, TelemetryItemOrigin origin, ref TransmissionResult result, TelemetrySchemaTypeCounter? telemetrySchemaTypeCounter)
+        private static void HandlePartialSuccess(HttpMessage httpMessage, PersistentBlobProvider? blobProvider, PersistentBlob? blob, TelemetryItemOrigin origin, ref TransmissionResult result, TelemetrySchemaTypeCounter? telemetrySchemaTypeCounter, NetworkSdkStatsManager? networkSdkStatsManager)
         {
             if (!TryGetTrackResponse(httpMessage, out TrackResponse? trackResponse))
             {
@@ -365,6 +367,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
 
             result.ItemsAccepted = trackResponse.ItemsAccepted;
+
+            // ASccepted envelopes within a 206 response are
+            // counted toward Request_Success_Count.
+            if (networkSdkStatsManager != null && trackResponse.ItemsAccepted is int acceptedCount && acceptedCount > 0)
+            {
+                networkSdkStatsManager.TrackPartialSuccessAccepted(httpMessage.Request.Uri.Host, acceptedCount);
+            }
 
             var (partialContent, successCounter, retryCounter, droppedCounter) = ProcessPartialSuccessWithCounting(trackResponse, httpMessage.Request.Content, telemetrySchemaTypeCounter);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsHelper.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
+{
+    /// <summary>
+    /// Stateless helpers for Network SDKStats. Initial scope only exposes host extraction;
+    /// the response-status classification helpers required by the failure / retry / throttle
+    /// / exception instruments will be added alongside those instruments in a follow-up.
+    /// </summary>
+    internal static class NetworkSdkStatsHelper
+    {
+        /// <summary>
+        /// Extract the stamp-specific host segment from an ingestion endpoint host name.
+        /// </summary>
+        public static string ExtractStampHost(string? requestHost)
+        {
+            if (string.IsNullOrEmpty(requestHost))
+            {
+                return "unknown";
+            }
+
+            // Strip a leading "www." if present, then return everything up to the first '.'.
+            const string wwwPrefix = "www.";
+            string host = requestHost!;
+            if (host.StartsWith(wwwPrefix, System.StringComparison.OrdinalIgnoreCase))
+            {
+                host = host.Substring(wwwPrefix.Length);
+            }
+
+            int firstDot = host.IndexOf('.');
+            return firstDot > 0 ? host.Substring(0, firstDot) : host;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsManager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsManager.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
+{
+    /// <summary>
+    /// Records short-interval Network SDKStats metrics for a single Azure Monitor exporter
+    /// transmitter. Initial scope only emits <c>Request_Success_Count</c>; additional
+    /// instruments (failure / retry / throttle / exception / duration) will be added in
+    /// follow-up changes.
+    /// </summary>
+    /// <remarks>
+    /// One <see cref="NetworkSdkStatsManager"/> is created per <see cref="Statsbeat.AzureMonitorStatsbeat"/>
+    /// instance. The dimensions <c>rp</c>, <c>attach</c>, <c>cikey</c>, <c>runtimeVersion</c>,
+    /// <c>os</c>, <c>language</c>, <c>version</c>, and <c>endpoint</c> are captured at
+    /// initialization time; the <c>host</c> dimension is added per recorded measurement.
+    /// </remarks>
+    internal sealed class NetworkSdkStatsManager
+    {
+        private const string Language = "dotnet";
+
+        private readonly string _customerIkey;
+        private readonly IPlatform _platform;
+        private string? _resourceProvider;
+
+        internal NetworkSdkStatsManager(ConnectionVars connectionVars, IPlatform platform)
+        {
+            _platform = platform;
+            _customerIkey = string.IsNullOrEmpty(connectionVars?.InstrumentationKey) ? "N/A" : connectionVars!.InstrumentationKey;
+        }
+
+        /// <summary>
+        /// Record a successful HTTP 200 transmission to the ingestion endpoint.
+        /// </summary>
+        /// <param name="requestHost">Host portion of the request URI (e.g. <c>westus-0.in.applicationinsights.azure.com</c>).</param>
+        public void TrackSuccess(string? requestHost)
+        {
+            try
+            {
+                NetworkSdkStatsMeters.RequestSuccessCount.Add(1, BuildBaseTags(NetworkSdkStatsHelper.ExtractStampHost(requestHost)));
+            }
+            catch
+            {
+                // Network SDK stats are internal telemetry; never let a recording failure
+                // propagate or emit log noise that customers might mistake for an exporter
+                // issue.
+            }
+        }
+
+        /// <summary>
+        /// Record accepted envelopes from a 206 Partial Success response. Per the Network
+        /// SDKStats specification, accepted envelopes within a 206 response are counted
+        /// toward <c>Request_Success_Count</c>.
+        /// </summary>
+        public void TrackPartialSuccessAccepted(string? requestHost, int count)
+        {
+            if (count <= 0)
+            {
+                return;
+            }
+
+            try
+            {
+                NetworkSdkStatsMeters.RequestSuccessCount.Add(count, BuildBaseTags(NetworkSdkStatsHelper.ExtractStampHost(requestHost)));
+            }
+            catch
+            {
+                // See TrackSuccess for rationale.
+            }
+        }
+
+        internal TagList BuildBaseTags(string host)
+        {
+            // Resource provider can require an Azure Instance Metadata Service probe; defer
+            // until the first measurement is recorded (matches AzureMonitorStatsbeat).
+            _resourceProvider ??= ResourceProviderHelper.DetermineResourceProvider(_platform);
+
+            return new TagList
+            {
+                { "rp", _resourceProvider },
+                { "attach", SdkVersionUtils.SdkVersionPrefix != null ? "IntegratedAuto" : "Manual" },
+                { "cikey", _customerIkey },
+                { "runtimeVersion", SdkVersionUtils.GetVersion(typeof(object)) },
+                { "os", _platform.GetOSPlatformName() },
+                { "language", Language },
+                // Read on every recording so the exporter version reflects any late hydration
+                // performed by ResourceExtensions (similar to AzureMonitorStatsbeat).
+                { "version", SdkVersionUtils.GetVersion() },
+                { "endpoint", StatsbeatConstants.NetworkSdkStatsEndpointBreeze },
+                { "host", host },
+            };
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsManager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsManager.cs
@@ -27,12 +27,22 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
 
         private readonly string _customerIkey;
         private readonly IPlatform _platform;
+        private readonly string _attach;
+        private readonly string? _runtimeVersion;
+        private readonly string _operatingSystem;
         private string? _resourceProvider;
 
         internal NetworkSdkStatsManager(ConnectionVars connectionVars, IPlatform platform)
         {
             _platform = platform;
             _customerIkey = string.IsNullOrEmpty(connectionVars?.InstrumentationKey) ? "N/A" : connectionVars!.InstrumentationKey;
+
+            // These dimensions are invariant for the process lifetime, so capture them
+            // once instead of recomputing on every recorded measurement (matches
+            // AzureMonitorStatsbeat, which caches the OS name at construction).
+            _attach = SdkVersionUtils.SdkVersionPrefix != null ? "IntegratedAuto" : "Manual";
+            _runtimeVersion = SdkVersionUtils.GetVersion(typeof(object));
+            _operatingSystem = platform.GetOSPlatformName();
         }
 
         /// <summary>
@@ -84,10 +94,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
             return new TagList
             {
                 { "rp", _resourceProvider },
-                { "attach", SdkVersionUtils.SdkVersionPrefix != null ? "IntegratedAuto" : "Manual" },
+                { "attach", _attach },
                 { "cikey", _customerIkey },
-                { "runtimeVersion", SdkVersionUtils.GetVersion(typeof(object)) },
-                { "os", _platform.GetOSPlatformName() },
+                { "runtimeVersion", _runtimeVersion },
+                { "os", _operatingSystem },
                 { "language", Language },
                 // Read on every recording so the exporter version reflects any late hydration
                 // performed by ResourceExtensions (similar to AzureMonitorStatsbeat).

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsMeters.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsMeters.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics.Metrics;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
+{
+    /// <summary>
+    /// Provides the OpenTelemetry <see cref="Meter"/> and instruments used to publish
+    /// short-interval Network SDKStats. Metric names follow the SDKStats specification.
+    /// </summary>
+    /// <remarks>
+    /// The meter is process-static (matching the existing Statsbeat meters); per-instance
+    /// dimension context is added by <see cref="NetworkSdkStatsManager"/> at recording time.
+    /// </remarks>
+    internal static class NetworkSdkStatsMeters
+    {
+        public static readonly Meter Meter = new(StatsbeatConstants.NetworkSdkStatsMeterName, "1.0.0");
+
+        public static readonly Counter<long> RequestSuccessCount = Meter.CreateCounter<long>(
+            "Request_Success_Count",
+            description: "Count of requests accepted by the destination ingestion endpoint.");
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
@@ -39,12 +41,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
 
         internal MeterProvider? _statsbeatMeterProvider;
 
-        internal MeterProvider? _networkSdkStatsMeterProvider;
+        // Wall-clock throttle for the Attach observable gauge so it emits at most once per
+        // AttachEmissionInterval even though the shared reader collects every 15 min.
+        private long _lastAttachEmissionTicks;
 
         /// <summary>
-        /// Records short-interval Network SDKStats (request success / failure / retry /
-        /// throttle / exception counts and request duration). Shares the SDK Stats
-        /// ingestion endpoint but uses a 15-minute export interval.
+        /// Records Network SDKStats on the shared statsbeat <see cref="MeterProvider"/>.
         /// </summary>
         internal NetworkSdkStatsManager? NetworkSdkStatsManager { get; }
 
@@ -66,49 +68,37 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
 
             _customer_Ikey = connectionStringVars.InstrumentationKey;
 
-            s_myMeter.CreateObservableGauge(StatsbeatConstants.AttachStatsbeatMetricName, () => GetAttachStatsbeat());
+            // IEnumerable<Measurement<T>> overload lets the callback yield zero
+            // measurements while throttled - see GetAttachStatsbeat.
+            s_myMeter.CreateObservableGauge(StatsbeatConstants.AttachStatsbeatMetricName, GetAttachStatsbeat);
 
-            // Configure for attach statsbeat which has collection
-            // schedule of 24 hrs == 86400000 milliseconds.
+            try
+            {
+                NetworkSdkStatsManager = new NetworkSdkStatsManager(connectionStringVars, platform);
+            }
+            catch
+            {
+                // Internal telemetry - swallow.
+            }
+
+            // One MeterProvider for both long and short-interval stats. The reader runs
+            // at the Network (15 min) cadence. Delta temporality + the Attach throttle
+            // keep the long-interval instruments on their native 24 hr cadence.
             var exporterOptions = new AzureMonitorExporterOptions
             {
                 DisableOfflineStorage = true,
                 ConnectionString = _statsbeat_ConnectionString,
-                EnableStatsbeat = false, // to avoid recursive Statsbeat.
+                EnableStatsbeat = false, // avoid recursive SDK Stats.
             };
 
             _statsbeatMeterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(StatsbeatConstants.AttachStatsbeatMeterName)
                 .AddMeter(StatsbeatConstants.FeatureStatsbeatMeterName)
                 .AddMeter(StatsbeatConstants.DistroFeatureSdkStatsMeterName)
-                .AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions), StatsbeatConstants.GeneralStatsbeatInterval)
+                .AddMeter(StatsbeatConstants.NetworkSdkStatsMeterName)
+                .AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions), StatsbeatConstants.NetworkStatsbeatInterval)
                 { TemporalityPreference = MetricReaderTemporalityPreference.Delta })
                 .Build();
-
-            // Short-interval (15 min) Network SDKStats use the same ingestion
-            // endpoint as long-interval stats but a separate MeterProvider so they can be
-            // flushed independently on the short cadence required by the SDKStats spec.
-            try
-            {
-                NetworkSdkStatsManager = new NetworkSdkStatsManager(connectionStringVars, platform);
-
-                _networkSdkStatsMeterProvider = Sdk.CreateMeterProviderBuilder()
-                    .AddMeter(StatsbeatConstants.NetworkSdkStatsMeterName)
-                    .AddReader(new PeriodicExportingMetricReader(
-                        new AzureMonitorMetricExporter(new AzureMonitorExporterOptions
-                        {
-                            DisableOfflineStorage = true,
-                            ConnectionString = _statsbeat_ConnectionString,
-                            EnableStatsbeat = false, // avoid recursive Statsbeat.
-                        }),
-                        StatsbeatConstants.NetworkStatsbeatInterval)
-                        { TemporalityPreference = MetricReaderTemporalityPreference.Delta })
-                    .Build();
-            }
-            catch
-            {
-                // Network SDK stats are internal telemetry; do not surface initialization errors.
-            }
 
             // Wait 1 minute before sending the startup SDK stats attach signal to ensure we don't collect data from very short-lived apps that could spam the stats.
             // If the version information is not yet available, wait up to five minutes - it really should be done in one minute or less
@@ -170,8 +160,25 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
                 : null;
         }
 
-        private Measurement<int> GetAttachStatsbeat()
+        private IEnumerable<Measurement<int>> GetAttachStatsbeat()
         {
+            // Emit at most once per AttachEmissionInterval. Delta temporality means
+            // skipped intervals don't produce an exported metric point.
+            long previousTicks = Volatile.Read(ref _lastAttachEmissionTicks);
+            long nowTicks = DateTime.UtcNow.Ticks;
+            if (previousTicks != 0
+                && nowTicks - previousTicks < StatsbeatConstants.AttachEmissionInterval.Ticks)
+            {
+                yield break;
+            }
+
+            // CAS before doing any work so a racing reader can't double-emit.
+            if (Interlocked.CompareExchange(ref _lastAttachEmissionTicks, nowTicks, previousTicks) != previousTicks)
+            {
+                yield break;
+            }
+
+            Measurement<int> measurement;
             try
             {
                 if (_resourceProvider == null)
@@ -179,23 +186,26 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
                     SetResourceProviderDetails(_platform);
                 }
 
-                return
-                    new Measurement<int>(1,
-                        new("rp", _resourceProvider),
-                        new("rpId", _resourceProviderId),
-                        new("attach", s_attachMode),
-                        new("cikey", _customer_Ikey),
-                        new("runtimeVersion", s_runtimeVersion),
-                        new("language", "dotnet"),
-                        // We don't memoize this version because it can be updated up to a minute into the application startup
-                        new("version", SdkVersionUtils.GetVersion()),
-                        new("os", _operatingSystem));
+                measurement = new Measurement<int>(1,
+                    new("rp", _resourceProvider),
+                    new("rpId", _resourceProviderId),
+                    new("attach", s_attachMode),
+                    new("cikey", _customer_Ikey),
+                    new("runtimeVersion", s_runtimeVersion),
+                    new("language", "dotnet"),
+                    // We don't memoize this version because it can be updated up to a minute into the application startup
+                    new("version", SdkVersionUtils.GetVersion()),
+                    new("os", _operatingSystem));
             }
             catch (Exception ex)
             {
                 AzureMonitorExporterEventSource.Log.StatsbeatFailed(ex);
-                return new Measurement<int>();
+                // Rewind the throttle so we retry on the next collection.
+                Volatile.Write(ref _lastAttachEmissionTicks, previousTicks);
+                yield break;
             }
+
+            yield return measurement;
         }
 
         internal static VmMetadataResponse? GetVmMetadataResponse()
@@ -281,7 +291,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
         public void Dispose()
         {
             _statsbeatMeterProvider?.Dispose();
-            _networkSdkStatsMeterProvider?.Dispose();
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -37,6 +38,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
         private readonly IPlatform _platform;
 
         internal MeterProvider? _statsbeatMeterProvider;
+
+        internal MeterProvider? _networkSdkStatsMeterProvider;
+
+        /// <summary>
+        /// Records short-interval Network SDKStats (request success / failure / retry /
+        /// throttle / exception counts and request duration). Shares the SDK Stats
+        /// ingestion endpoint but uses a 15-minute export interval.
+        /// </summary>
+        internal NetworkSdkStatsManager? NetworkSdkStatsManager { get; }
 
         internal static Regex s_endpoint_pattern => new("^https?://(?:www\\.)?([^/.-]+)");
 
@@ -74,6 +84,31 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
                 .AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions), StatsbeatConstants.GeneralStatsbeatInterval)
                 { TemporalityPreference = MetricReaderTemporalityPreference.Delta })
                 .Build();
+
+            // Short-interval (15 min) Network SDKStats use the same ingestion
+            // endpoint as long-interval stats but a separate MeterProvider so they can be
+            // flushed independently on the short cadence required by the SDKStats spec.
+            try
+            {
+                NetworkSdkStatsManager = new NetworkSdkStatsManager(connectionStringVars, platform);
+
+                _networkSdkStatsMeterProvider = Sdk.CreateMeterProviderBuilder()
+                    .AddMeter(StatsbeatConstants.NetworkSdkStatsMeterName)
+                    .AddReader(new PeriodicExportingMetricReader(
+                        new AzureMonitorMetricExporter(new AzureMonitorExporterOptions
+                        {
+                            DisableOfflineStorage = true,
+                            ConnectionString = _statsbeat_ConnectionString,
+                            EnableStatsbeat = false, // avoid recursive Statsbeat.
+                        }),
+                        StatsbeatConstants.NetworkStatsbeatInterval)
+                        { TemporalityPreference = MetricReaderTemporalityPreference.Delta })
+                    .Build();
+            }
+            catch
+            {
+                // Network SDK stats are internal telemetry; do not surface initialization errors.
+            }
 
             // Wait 1 minute before sending the startup SDK stats attach signal to ensure we don't collect data from very short-lived apps that could spam the stats.
             // If the version information is not yet available, wait up to five minutes - it really should be done in one minute or less
@@ -246,6 +281,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
         public void Dispose()
         {
             _statsbeatMeterProvider?.Dispose();
+            _networkSdkStatsMeterProvider?.Dispose();
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/StatsbeatConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/StatsbeatConstants.cs
@@ -108,11 +108,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
         internal const string AMS_Url = "http://169.254.169.254/metadata/instance/compute?api-version=2017-08-01&format=json";
 
         /// <summary>
-        /// 24 hrs == 86400000 milliseconds.
-        /// </summary>
-        internal const int GeneralStatsbeatInterval = 86400000;
-
-        /// <summary>
         /// 15 min == 900000 milliseconds. Cadence of the shared statsbeat reader.
         /// </summary>
         internal const int NetworkStatsbeatInterval = 900000;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/StatsbeatConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/StatsbeatConstants.cs
@@ -111,11 +111,29 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
         /// </summary>
         internal const int GeneralStatsbeatInterval = 86400000;
 
+        /// <summary>
+        /// 15 min == 900000 milliseconds. Short interval for Network SDKStats.
+        /// </summary>
+        internal const int NetworkStatsbeatInterval = 900000;
+
         internal const string AttachStatsbeatMeterName = "AttachStatsbeatMeter";
         internal const string AttachStatsbeatMetricName = "Attach";
 
         internal const string FeatureStatsbeatMeterName = "FeatureStatsbeatMeter";
         internal const string FeatureStatsbeatMetricName = "Feature";
+
+        /// <summary>
+        /// Meter name for Network SDKStats (short interval - 15 min). Tracks request success,
+        /// failure, retry, throttle, exception counts and request duration for outbound
+        /// transmissions to the configured ingestion endpoint.
+        /// </summary>
+        internal const string NetworkSdkStatsMeterName = "NetworkSdkStatsMeter";
+
+        /// <summary>
+        /// Value of the <c>endpoint</c> dimension on Network SDKStats metrics published by the
+        /// Azure Monitor / Application Insights exporter (Breeze ingestion).
+        /// </summary>
+        internal const string NetworkSdkStatsEndpointBreeze = "breeze";
 
         /// <summary>
         /// Meter name used by the Microsoft OpenTelemetry distro to publish distro-owned Feature

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/StatsbeatConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/StatsbeatConstants.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
@@ -112,9 +113,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
         internal const int GeneralStatsbeatInterval = 86400000;
 
         /// <summary>
-        /// 15 min == 900000 milliseconds. Short interval for Network SDKStats.
+        /// 15 min == 900000 milliseconds. Cadence of the shared statsbeat reader.
         /// </summary>
         internal const int NetworkStatsbeatInterval = 900000;
+
+        /// <summary>
+        /// Min time between Attach observable gauge emissions (long-interval cadence
+        /// while sharing the 15-min reader).
+        /// </summary>
+        internal static readonly TimeSpan AttachEmissionInterval = TimeSpan.FromHours(24);
 
         internal const string AttachStatsbeatMeterName = "AttachStatsbeatMeter";
         internal const string AttachStatsbeatMetricName = "Attach";

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -8,6 +8,7 @@ using System.Timers;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats;
 using OpenTelemetry;
 using OpenTelemetry.PersistentStorage.Abstractions;
 
@@ -21,15 +22,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private readonly TransmissionStateManager _transmissionStateManager;
         private readonly System.Timers.Timer _transmitFromStorageTimer;
         private readonly bool _isAadEnabled;
+        private readonly NetworkSdkStatsManager? _networkSdkStatsManager;
         private bool _disposed;
 
-        internal TransmitFromStorageHandler(ApplicationInsightsRestClient applicationInsightsRestClient, PersistentBlobProvider blobProvider, TransmissionStateManager transmissionStateManager, ConnectionVars connectionVars, bool isAadEnabled)
+        internal TransmitFromStorageHandler(ApplicationInsightsRestClient applicationInsightsRestClient, PersistentBlobProvider blobProvider, TransmissionStateManager transmissionStateManager, ConnectionVars connectionVars, bool isAadEnabled, NetworkSdkStatsManager? networkSdkStatsManager = null)
         {
             _applicationInsightsRestClient = applicationInsightsRestClient;
             _connectionVars = connectionVars;
             _isAadEnabled = isAadEnabled;
             _blobProvider = blobProvider;
             _transmissionStateManager = transmissionStateManager;
+            _networkSdkStatsManager = networkSdkStatsManager;
             _transmitFromStorageTimer = new System.Timers.Timer();
             _transmitFromStorageTimer.Elapsed += TransmitFromStorage;
             _transmitFromStorageTimer.AutoReset = true;
@@ -78,10 +81,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         }
 
                         using var httpMessage = _applicationInsightsRestClient.InternalTrackAsync(data, CancellationToken.None).Result;
+
                         var result = HttpPipelineHelper.IsSuccess(httpMessage, telemetrySchemaTypeCounter);
 
                         if (result == ExportResult.Success)
                         {
+                            _networkSdkStatsManager?.TrackSuccess(httpMessage.Request.Uri.Host);
+
                             _transmissionStateManager.ResetConsecutiveErrors();
                             _transmissionStateManager.CloseTransmission();
 
@@ -98,7 +104,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         else
                         {
                             _transmissionStateManager.EnableBackOff(httpMessage.HasResponse ? httpMessage.Response : null);
-                            HttpPipelineHelper.ProcessTransmissionResult(httpMessage, _blobProvider, blob, _connectionVars, TelemetryItemOrigin.Storage, _isAadEnabled, telemetrySchemaTypeCounter);
+                            HttpPipelineHelper.ProcessTransmissionResult(httpMessage, _blobProvider, blob, _connectionVars, TelemetryItemOrigin.Storage, _isAadEnabled, telemetrySchemaTypeCounter, _networkSdkStatsManager);
                             break;
                         }
                     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/NetworkSdkStats/NetworkSdkStatsManagerTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/NetworkSdkStats/NetworkSdkStatsManagerTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/NetworkSdkStats/NetworkSdkStatsManagerTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/NetworkSdkStats/NetworkSdkStatsManagerTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.NetworkSdkStats
+{
+    public class NetworkSdkStatsManagerTests
+    {
+        [Theory]
+        [InlineData("westus-0.in.applicationinsights.azure.com", "westus-0")]
+        [InlineData("westus2-1.in.applicationinsights.azure.com", "westus2-1")]
+        [InlineData("eastus", "eastus")]
+        [InlineData("www.westeurope-5.in.applicationinsights.azure.com", "westeurope-5")]
+        [InlineData("", "unknown")]
+        [InlineData(null, "unknown")]
+        public void ExtractStampHost_ReturnsStampSpecificRegion(string? input, string expected)
+        {
+            Assert.Equal(expected, NetworkSdkStatsHelper.ExtractStampHost(input));
+        }
+
+        [Fact]
+        public void BuildBaseTags_IncludesAllRequiredDimensions()
+        {
+            var connectionVars = ConnectionStringParser.GetValues(
+                "InstrumentationKey=00000000-0000-0000-0000-000000000001;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/");
+
+            var manager = new NetworkSdkStatsManager(connectionVars, new MockPlatform());
+
+            var tags = manager.BuildBaseTags("westus-0");
+
+            // All dimensions required by the Network SDKStats spec for Request_Success_Count.
+            Assert.Contains(tags, t => t.Key == "rp");
+            Assert.Contains(tags, t => t.Key == "attach");
+            Assert.Contains(tags, t => t.Key == "cikey" && (string?)t.Value == "00000000-0000-0000-0000-000000000001");
+            Assert.Contains(tags, t => t.Key == "runtimeVersion");
+            Assert.Contains(tags, t => t.Key == "os");
+            Assert.Contains(tags, t => t.Key == "language" && (string?)t.Value == "dotnet");
+            Assert.Contains(tags, t => t.Key == "version");
+            Assert.Contains(tags, t => t.Key == "endpoint" && (string?)t.Value == StatsbeatConstants.NetworkSdkStatsEndpointBreeze);
+            Assert.Contains(tags, t => t.Key == "host" && (string?)t.Value == "westus-0");
+        }
+
+        [Fact]
+        public void TrackSuccess_RecordsRequestSuccessCount()
+        {
+            var connectionVars = ConnectionStringParser.GetValues(
+                "InstrumentationKey=00000000-0000-0000-0000-000000000002;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/");
+            var manager = new NetworkSdkStatsManager(connectionVars, new MockPlatform());
+
+            long recorded = 0;
+            string? observedHost = null;
+
+            using var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == StatsbeatConstants.NetworkSdkStatsMeterName
+                        && instrument.Name == "Request_Success_Count")
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+            {
+                recorded += value;
+                foreach (var t in tags)
+                {
+                    if (t.Key == "host")
+                    {
+                        observedHost = t.Value as string;
+                    }
+                }
+            });
+            listener.Start();
+
+            manager.TrackSuccess("westus-0.in.applicationinsights.azure.com");
+
+            Assert.Equal(1, recorded);
+            Assert.Equal("westus-0", observedHost);
+        }
+
+        [Fact]
+        public void TrackPartialSuccessAccepted_RecordsRequestSuccessCountWithAcceptedCount()
+        {
+            var connectionVars = ConnectionStringParser.GetValues(
+                "InstrumentationKey=00000000-0000-0000-0000-000000000003;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/");
+            var manager = new NetworkSdkStatsManager(connectionVars, new MockPlatform());
+
+            long recorded = 0;
+            using var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == StatsbeatConstants.NetworkSdkStatsMeterName
+                        && instrument.Name == "Request_Success_Count")
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            listener.SetMeasurementEventCallback<long>((_, value, _, _) => recorded += value);
+            listener.Start();
+
+            manager.TrackPartialSuccessAccepted("westus-0.in.applicationinsights.azure.com", 7);
+
+            Assert.Equal(7, recorded);
+        }
+
+        [Fact]
+        public void TrackPartialSuccessAccepted_ZeroOrNegativeCount_DoesNotRecord()
+        {
+            var connectionVars = ConnectionStringParser.GetValues(
+                "InstrumentationKey=00000000-0000-0000-0000-000000000004;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/");
+            var manager = new NetworkSdkStatsManager(connectionVars, new MockPlatform());
+
+            long recorded = 0;
+            using var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == StatsbeatConstants.NetworkSdkStatsMeterName
+                        && instrument.Name == "Request_Success_Count")
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            listener.SetMeasurementEventCallback<long>((_, value, _, _) => recorded += value);
+            listener.Start();
+
+            manager.TrackPartialSuccessAccepted("westus-0.in.applicationinsights.azure.com", 0);
+            manager.TrackPartialSuccessAccepted("westus-0.in.applicationinsights.azure.com", -3);
+
+            Assert.Equal(0, recorded);
+        }
+    }
+}


### PR DESCRIPTION
Implements the short-interval Network SDKStats path defined in the Application Insights SDKStats spec, scoped to `Request_Success_Count` only for this first PR. Additional instruments (Request_Failure_Count, Request_Duration, Retry_Count, Throttle_Count, Exception_Count) and the per-envelope retry/failure classification on 206 responses will land in a follow-up.

What's new
- src/Internals/NetworkSdkStats/NetworkSdkStatsMeters.cs - static Meter with a single `Request_Success_Count` counter.
- src/Internals/NetworkSdkStats/NetworkSdkStatsHelper.cs - helper to extract the stamp-specific host (e.g. westus2-1.in.applicationinsights .azure.com -> westus2-1) per spec.
- src/Internals/NetworkSdkStats/NetworkSdkStatsManager.cs - per-Statsbeat instance that records TrackSuccess(host) and TrackPartialSuccessAccepted (host, count) using the full spec dimensions: rp, attach, cikey, runtimeVersion, os, language, version, endpoint=breeze, host.

Wiring
- StatsbeatConstants gains `NetworkSdkStatsMeterName`, `NetworkStatsbeatInterval` (900000 ms = 15 min), and `NetworkSdkStatsEndpointBreeze`.
- AzureMonitorStatsbeat creates a second MeterProvider with a 15-minute PeriodicExportingMetricReader against the same Statsbeat connection string used by long-interval stats, so Network SDKStats land on the same Statsbeat ingestion resource (or stats.monitor / eu.stats.monitor when the Microsoft OpenTelemetry distro's RouteSdkStatsToDistroEndpoint AppContext switch is on).
- AzureMonitorTransmitter and TransmitFromStorageHandler call NetworkSdkStatsManager.TrackSuccess on HTTP 200 responses.
- HttpPipelineHelper.ProcessTransmissionResult / HandlePartialSuccess accept the manager and call TrackPartialSuccessAccepted with trackResponse.ItemsAccepted on 206 partial-success responses.

Design notes
- Internal Network SDKStats failures are silently swallowed (no EventSource log). They are internal telemetry; surfacing failures via log noise could be mistaken for an exporter issue.

Tests
- New NetworkSdkStats/NetworkSdkStatsManagerTests.cs covers host extraction, base-tag construction, and counter recording for TrackSuccess and TrackPartialSuccessAccepted.
- Full Azure.Monitor.OpenTelemetry.Exporter test suite passes (730 tests on net10.0).

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

<img width="883" height="642" alt="image" src="https://github.com/user-attachments/assets/bd8a50a2-a928-43bc-a891-8fb5c35cdf5b" />

