### PR TITLE
Updated network isolation policy and overrode npm registry host by CFS

### DIFF
--- a/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -10,6 +10,9 @@ parameters:
   - name: ServiceConnection
     type: string
     default: ''
+  - name: ReplaceRegistryHost
+    type: string
+    default: ''
 
 steps:
 - pwsh: |
@@ -21,7 +24,10 @@ steps:
       New-Item -Path $parentFolder -ItemType Directory | Out-Null
     }
 
-    $content = "registry=${{ parameters.registryUrl }}"
+    $content = @("registry=${{ parameters.registryUrl }}")
+    if ('${{ parameters.ReplaceRegistryHost }}') {
+      $content += "replace-registry-host=${{ parameters.ReplaceRegistryHost }}"
+    }
     $content | Out-File '${{ parameters.npmrcPath }}'
   displayName: 'Create .npmrc'
   condition: ${{ parameters.CustomCondition }}

--- a/eng/pipelines/templates/jobs/batched-analyze.yml
+++ b/eng/pipelines/templates/jobs/batched-analyze.yml
@@ -33,6 +33,8 @@ jobs:
     displayName: "Analyze"
     dependsOn: ${{ parameters.DependsOn }}
     condition: and(succeededOrFailed(), ne(${{ parameters.Matrix }}, '{}'))
+    variables:
+      NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/analyze-job/.npmrc
 
     strategy:
       matrix: $[ ${{ parameters.Matrix }} ]

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -153,6 +153,8 @@ jobs:
     - job: "Analyze"
       timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
       condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
+      variables:
+        NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/analyze-job/.npmrc
       pool:
         name: $(LINUXPOOL)
         image: $(LINUXVMIMAGE)
@@ -186,9 +188,15 @@ jobs:
 
         - template: /eng/common/pipelines/templates/steps/validate-filename.yml
 
+        - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+          parameters:
+            npmrcPath: $(Agent.TempDirectory)/cspell/.npmrc
+            ReplaceRegistryHost: registry.npmjs.org
+
         - template: /eng/common/pipelines/templates/steps/check-spelling.yml
           parameters:
             ScriptToValidateUpgrade: eng/scripts/spell-check-public-api.ps1
+            NpmConfigUserConfig: $(Agent.TempDirectory)/cspell/.npmrc
 
         - template: /eng/common/pipelines/templates/steps/verify-links.yml
           parameters:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,7 +40,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -63,8 +63,8 @@ steps:
   # Authenticate npm to Azure Artifacts
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
     parameters:
-      npmrcPath: $(Agent.TempDirectory)/analyze-job/.npmrc
-      registryUrl: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
+      npmrcPath: $(NPM_CONFIG_USERCONFIG)
+      ReplaceRegistryHost: registry.npmjs.org
 
   - task: DotNetCoreCLI@2
     displayName: 'Install Snippet Generator Tool'
@@ -103,7 +103,6 @@ steps:
     displayName: Verify Generated Code
     env:
       EnableSourceLink: false
-      NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/analyze-job/.npmrc
 
   - pwsh: |
       $failed = $false


### PR DESCRIPTION
This pull request introduces several improvements to the Azure Pipelines configuration, primarily focused on enhancing npm authentication and configuration management for analysis and spell checking jobs. The main changes include parameterizing npm registry host replacement, ensuring consistent `.npmrc` usage across jobs, and updating network isolation policies.

* Added a new `ReplaceRegistryHost` parameter to the `create-authenticated-npmrc.yml` template, allowing dynamic replacement of the npm registry host in the generated `.npmrc` file.

* Updated `analysis` and `spell checking` jobs to consistently use a specified `.npmrc` file by setting the `NPM_CONFIG_USERCONFIG` variable and passing it to relevant steps and templates. 

* Expanded the `networkIsolationPolicy` setting in the `1es-redirect.yml` stage to include `CFSClean`, `CFSClean2`, and `CFSClean3` explicitly.