### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1230,6 +1230,7 @@
 /.github/workflows/                                                @jsquire @m-redding @Azure/azure-sdk-eng
 /.github/CODEOWNERS                                                @jsquire @m-redding @Azure/azure-sdk-eng
 /.github/copilot-instructions.md                                   @jsquire @m-redding @praveenkuttappan @maririos
+/.github/skills/                                                   @azure/azsdk-cli
 
 # PRLabel: %EngSys
 /sdk/template/                                                     @hallipr @weshaggard @benbp @jsquire

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1230,7 +1230,7 @@
 /.github/workflows/                                                @jsquire @m-redding @Azure/azure-sdk-eng
 /.github/CODEOWNERS                                                @jsquire @m-redding @Azure/azure-sdk-eng
 /.github/copilot-instructions.md                                   @jsquire @m-redding @praveenkuttappan @maririos
-/.github/skills/                                                   @azure/azsdk-cli
+/.github/skills/                                                   @azure/azsdk-cli @m-nash @jsquire
 
 # PRLabel: %EngSys
 /sdk/template/                                                     @hallipr @weshaggard @benbp @jsquire


### PR DESCRIPTION
Assigns ownership of skill definitions under `.github/skills/` to the `@azure/azsdk-cli` team.

The entry is grouped with the existing `.github/` automation entries in `.github/CODEOWNERS`.