### PR TITLE
Add auto-build-repair skill for cloud-agent custom-code build repair (#59697)

### DIFF
--- a/.github/skills/auto-build-repair/SKILL.md
+++ b/.github/skills/auto-build-repair/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: auto-build-repair
-description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in repair mode. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
+description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in custom-code-only (editScope=CustomCode) scope. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
 ---
 # Auto Build Repair
 
 Purpose-built, **headless** skill that repairs an **already-generated Azure SDK pull request** whose build fails because of **custom (non-generated) code** that has drifted from the regenerated surface.
 
-This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **repair** mode — until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix loop in this one shared tool.
+This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix loop in this one shared tool.
 
 ## When Invoked
 
@@ -18,7 +18,7 @@ The Copilot cloud agent runs this skill on an **Auto SDK PR** created by the rel
 
 This skill is a **thin wrapper**. All classification → fix → regenerate → rebuild logic lives inside the shared `azure-sdk-mcp:azsdk_customized_code_update` tool, which already handles .NET (partial classes / `[CodeGen*]`), Python (`_patch.py`), and Java (`*Customization.java`). Do **not** replicate its behavior by editing files yourself, and do **not** invoke a per-language generator-agent — the design deliberately uses this single shared engine.
 
-Invoke it in **`repair` mode**, which:
+Invoke it with **`editScope: CustomCode`** (custom-code-only), which:
 - operates against `packagePath` with the TypeSpec source pulled at the **pinned `tsp-location.yaml` commit** (no manual spec checkout);
 - **forbids spec-input edits** — never edits `client.tsp` / `tspconfig.yaml` and never moves the pinned commit;
 - **allows regeneration**, so a custom-code fix may deterministically change `Generated/`;
@@ -29,7 +29,7 @@ Invoke it in **`repair` mode**, which:
 
 ```
 azure-sdk-mcp:azsdk_customized_code_update(
-  mode:                 "repair",        // forbids spec-input edits, keeps regeneration
+  editScope:            "CustomCode",    // custom-code-only: forbids spec-input edits, keeps regeneration
   packagePath:          "<failing SDK package dir>",
   customizationRequest: "<the build errors / failure context from the PR>",
   // tspProjectPath resolves from the pinned tsp-location.yaml commit; do not point it at an edited spec.
@@ -40,13 +40,13 @@ azure-sdk-mcp:azsdk_customized_code_update(
 
 Pass the **build error output** as `customizationRequest`. Pass `packagePath` for the single failing package (it is already scoped — do not widen to other packages). Supply `maxIterations` / `wallClockBudget` from the repair flow's bounds; otherwise rely on the tool defaults.
 
-> The repair-specific inputs (`mode: "repair"`, `maxIterations`, `wallClockBudget`, structured result, diff manifest) are the additive, backward-compatible changes proposed for the shared tool in the design (§6). Until they ship, invoke the closest available form and still honor the scope rules below.
+> Some repair-specific inputs (`maxIterations`, `wallClockBudget`, structured result, diff manifest) are additive, backward-compatible changes still proposed for the shared tool in the design (§6); `editScope` ships first. Until the rest land, invoke the closest available form and still honor the scope rules below.
 
 ## Scope — read this first
 
 | Allowed | Forbidden |
 |---------|-----------|
-| Drive `azsdk_customized_code_update` (repair mode) to patch the failing package's **custom (non-generated) code**. | Edit any **spec input**: `client.tsp`, `tspconfig.yaml`, `main.tsp`, or any TypeSpec source. |
+| Drive `azsdk_customized_code_update` (editScope: CustomCode) to patch the failing package's **custom (non-generated) code**. | Edit any **spec input**: `client.tsp`, `tspconfig.yaml`, `main.tsp`, or any TypeSpec source. |
 | Let the tool **regenerate** `Generated/` from the **unchanged pinned** commit, and **commit** the deterministic result. | **Move the pinned spec commit** in `tsp-location.yaml` (the `commit`/`repo`/`directory` fields). |
 | Commit the tool's custom-code changes + regenerated output as reviewable commits. | Hand-edit code (custom or generated) to "help" the tool; let the engine own the edits. |
 | Re-invoke the tool on an already-partially-repaired branch (it is idempotent). | Touch `.github/`, `eng/`, shared props/targets, pipeline files, package metadata, or secrets. |
@@ -66,7 +66,7 @@ Pass the **build error output** as `customizationRequest`. Pass `packagePath` fo
 ```
 1. Identify the failing `packagePath` and collect the build-error output from the PR.
 2. Call azure-sdk-mcp:azsdk_customized_code_update with:
-      mode = "repair", packagePath, customizationRequest = <build errors>, plus bounds.
+      editScope = "CustomCode", packagePath, customizationRequest = <build errors>, plus bounds.
    The tool classifies, patches ONLY custom code, regenerates from the pinned commit, and rebuilds.
 3. Inspect the tool's structured result:
       - SUCCESS (build green) → ensure custom-code edits AND regenerated Generated/ are committed. Go to 5.
@@ -81,6 +81,7 @@ Pass the **build error output** as `customizationRequest`. Pass `packagePath` fo
 When the tool returns one of these, **surface its structured guidance** and stop — do not keep retrying or escalate to a human prompt:
 
 - **Out of scope (spec change required)** — the only real fix is a `client.tsp`/`tspconfig.yaml` decorator or spec edit (e.g. `@@clientName`, `@@access`, `AZC0030`/`AZC0012` naming). Report "requires a spec-repo PR" with the offending errors. Leave the PR red for a human to route.
+- **Regeneration fails at the pinned commit (spec-side error)** — the tool's regeneration step (e.g. `/t:GenerateCode`) fails because of a spec-side problem at the **unchanged** pinned `tsp-location.yaml` commit: invalid `tspconfig.yaml`, missing/renamed spec files, or a broken TypeSpec source. Because this skill must never move the pinned commit or edit spec inputs, treat this as an **immediate stop** — report "spec-side generation failure at the pinned commit; requires a spec-repo fix" with the generation error. Do **not** attempt to fix the spec or bump the commit.
 - **Suspected generator bug** — `Generated/` has structural errors that persist after the tool removes custom-code influence and regenerates from the unchanged pinned commit. Do NOT suppress; report with the minimal repro.
 - **Bounds exhausted** — `maxIterations` / `wallClockBudget` reached without a green build. Commit progress and report remaining errors.
 
@@ -88,7 +89,7 @@ On success, summarize from the tool's structured result: errors fixed (determini
 
 ## Hard Rules (recap)
 
-1. Drive **`azure-sdk-mcp:azsdk_customized_code_update`** in `repair` mode; do not hand-edit code and do not use any other fix engine.
+1. Drive **`azure-sdk-mcp:azsdk_customized_code_update`** with `editScope: CustomCode`; do not hand-edit code and do not use any other fix engine.
 2. Never edit `client.tsp`, `tspconfig.yaml`, or any TypeSpec/spec input; never move the pinned spec commit in `tsp-location.yaml`.
 3. Commit the tool's regenerated `Generated/` alongside the custom-code edits (the guard is reproducibility, not freezing).
 4. Never touch `.github/`, `eng/`, shared props/targets, pipelines, metadata, or secrets.

--- a/.github/skills/auto-build-repair/SKILL.md
+++ b/.github/skills/auto-build-repair/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: auto-build-repair
+description: Headless, bounded repair of custom-code build failures in an already-generated Azure SDK for .NET PR. Patches ONLY custom (non-generated) code until the package builds, using the generator-agent MCP build-fix tools. Used by the Copilot cloud agent on release-planner-created "Auto SDK PRs" labeled `auto-sdk-build-fix`. Never edits spec inputs (client.tsp/tspconfig.yaml) and never moves the pinned spec commit.
+---
+# Auto Build Repair
+
+Purpose-built, **headless** skill that repairs an **already-generated Azure SDK for .NET pull request** whose build fails because of **custom (non-generated) code** that has drifted from the regenerated surface.
+
+This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to patch the package's **custom code** (and commit any deterministic regenerated `Generated/` output) until the package builds — then stop.
+
+## When Invoked
+
+The Copilot cloud agent runs this skill on an **Auto SDK PR** created by the release-planner generation flow and labeled `auto-sdk-build-fix`. Trigger phrases: "auto build repair", "repair build", "fix the SDK PR build", "auto-sdk-build-fix", "custom-code build repair".
+
+**This skill runs non-interactively in an ephemeral environment. Never prompt the user for input** (no spec repo path, no confirmations). If you cannot proceed within scope, stop and emit structured guidance (see [Stop Conditions](#stop-conditions)).
+
+## Scope — read this first
+
+| Allowed | Forbidden |
+|---------|-----------|
+| Edit the failing package's **custom (non-generated) code** (`.cs` partial classes, `[CodeGen*]` attributes, backward-compat shims). | Edit any **spec input**: `client.tsp`, `tspconfig.yaml`, `main.tsp`, or any TypeSpec source. |
+| **Regenerate** `Generated/` from the **unchanged pinned** `tsp-location.yaml` commit, and **commit** the deterministic result. | **Move the pinned spec commit** in `tsp-location.yaml` (the `commit`/`repo`/`directory` fields). |
+| Add/adjust customization files under the package's `Custom/` (or equivalent) folders. | Hand-edit files under `Generated/`. |
+| Add backward-compat shims for ApiCompat breaks. | Touch `.github/`, `eng/`, shared props/targets, pipeline files, package metadata, or secrets. |
+
+**Custom code only.** If the only viable fix is a spec/decorator (Phase-A) change — e.g. a naming fix that must live in `client.tsp` via `@@clientName`, or `@@access` — that belongs in a **separate spec-repo PR** and is **out of scope**. Stop and report (see [Stop Conditions](#stop-conditions)); do not attempt it.
+
+**Regeneration is expected, not a violation.** Fixing custom code that carries generator signals (`[CodeGenType]`, `[CodeGenSuppress]`, `[CodeGenMember]`, `[CodeGenSerialization]`) legitimately changes `Generated/` as a deterministic downstream effect. You **must commit** the regenerated `Generated/` so the repo's existing generated-code-diff check (`eng/scripts/CodeChecks.ps1` → `/t:GenerateCode` + `git diff --exit-code`) stays green. The guard is "`Generated/` is *reproducible from unchanged inputs*", not "`Generated/` is frozen".
+
+## MCP Server (generator-agent)
+
+This skill uses the deterministic build-fix tools from the `generator-agent` MCP server (`sdk/tools/Azure.GeneratorAgent`), already provisioned in the cloud-agent environment. Use **only** the build-fix-loop subset below — do not invoke migration-only tools (`pregen_cleanup`, `migrate_test_samples`, `finalize_migration`, `commit_iteration`, `validate_tsp_config`).
+
+| Tool | When to Use | What It Does |
+|------|-------------|--------------|
+| `discover_project` | First step — to resolve package paths and `tsp-location.yaml` fields | Returns project context (plane, package/service name, custom code folder, Generated/ paths, pinned commit). Ignore any spec-repo prompt — this flow never needs a local spec checkout. |
+| `snapshot_generated` | Immediately after the first regeneration, before the fix loop | SHA-256 snapshot of `Generated/`, enabling auto-verification in later `build_and_classify` calls. |
+| `build_and_classify` | First step of **every** iteration | Runs `dotnet build`, classifies each error as deterministic vs requires-reasoning. |
+| `classify_errors` | Re-classify after partial fixes | Classifies errors against the deterministic fix registry. |
+| `batch_fix` | After deterministic errors are identified | Applies multiple deterministic fixes in one call. |
+| `add_using_directive` | `CS0246`/`CS0103` for a known type | Adds a missing `using`. |
+| `remove_using_directive` | `CS0246` for stale `*.Rest.*` / `Autorest.*` namespaces | Removes matching `using` directives. |
+| `nullable_annotation_fix` | `CS8625`/`CS8600` | Adds `?` nullable annotation. |
+| `rename_codegen_type` | `CS0246` for a `[CodeGenType]` that no longer matches the generated name | Updates `[CodeGenType]` to match generated type. |
+| `add_codegen_suppress` | `CS0111` (custom + generated member clash) | Adds `[CodeGenSuppress]` to the custom partial. |
+| `fetch_to_fromlro` | `CS0103`/`CS1061` for custom LRO `Fetch` calls | Replaces `Fetch(response)` with `Model.FromLroResponse(response)`. |
+| `verify_generated_unchanged` | After the fix loop completes | Confirms no `Generated/` files were hand-modified outside regeneration. |
+
+Prefer MCP tools for deterministic fixes; only hand-edit custom code for errors classified as requires-reasoning.
+
+## Bounds
+
+- **Max 10 build-fix iterations.** If the error count is not decreasing after 3 consecutive iterations, stop and report.
+- Stay within the cloud-agent wall-clock budget. If exhausted, commit progress made so far and report remaining errors.
+- Do not expand scope to other packages — `discover_project` already targets the single failing package.
+
+## Repair Loop
+
+```
+SETUP:
+  0. Call `discover_project` to resolve the package path, custom-code folder, and pinned tsp-location.yaml fields.
+  1. Regenerate once from the PINNED commit:  dotnet build /t:GenerateCode
+     (remote mode — uses the commit already in tsp-location.yaml; do NOT pass a local spec repo,
+      do NOT change tsp-location.yaml).
+  2. Call `snapshot_generated` to lock down Generated/.
+
+LOOP (max 10 iterations):
+  3. Call `build_and_classify`.
+  4. IF zero errors → EXIT LOOP (go to FINALIZE).
+  5. IF error count not decreasing after 3 iterations → STOP and report (see Stop Conditions).
+  6. Split errors into deterministic vs requires-reasoning.
+  7. Apply ALL deterministic fixes via `batch_fix` / targeted fixers.
+  8. For requires-reasoning errors, edit ONLY custom code (see Drift & ApiCompat patterns below).
+     IF the only viable fix is a spec/decorator change → STOP and report (out of scope).
+  9. IF you changed any `[CodeGen*]` attribute or added/removed/renamed a custom file carrying
+     generator signals → regenerate:  dotnet build /t:GenerateCode  (pinned commit, no spec edits).
+     Customization-only `.cs` edits with no generator attributes → no regeneration needed.
+ 10. GOTO 3.
+
+FINALIZE:
+ 11. Call `verify_generated_unchanged` to confirm no hand edits leaked into Generated/.
+ 12. Ensure the regenerated Generated/ is committed alongside the custom-code edits.
+```
+
+> **Generated/ auto-guard**: once a snapshot exists, every `build_and_classify` verifies that no `Generated/` files were hand-modified; the deterministic fixers also refuse to write inside `Generated/`. Let regeneration (`/t:GenerateCode`) — not manual edits — produce any `Generated/` change.
+
+## Customization-drift patterns (custom code only)
+
+These are the common drift failures. All fixes live in the package's custom code; never edit `Generated/` or the spec.
+
+- **Stale reference to a renamed/removed generated symbol** — custom code references a model/property/method that the new surface renamed or dropped. Update the custom reference to the new name, or delete the custom member if the generated type no longer exists, then regenerate if a `[CodeGen*]` attribute was involved.
+- **`[CodeGenType]` name mismatch** — the value must exactly match the generated class name (use `rename_codegen_type`); a mismatch silently breaks partial-class merging and produces spurious "missing member" errors.
+- **Duplicate member (`CS0111`)** — custom partial and generated code both define a member; add `[CodeGenSuppress("Member")]` to the custom partial (use `add_codegen_suppress`).
+- **Stale `using` / namespace** — add the missing `using` (`add_using_directive`) or remove obsolete `*.Rest.*` / `Autorest.*` usings (`remove_using_directive`).
+- **LRO `Fetch`** — replace with `Model.FromLroResponse(response)` (`fetch_to_fromlro`).
+- **Stale custom file** — a custom `FooResource.cs` exists but `Generated/FooResource.cs` was renamed/removed: rename the custom file to match, or remove it, then regenerate.
+
+## ApiCompat breaks (GA libraries)
+
+ApiCompat surfaces breaking changes vs the last shipped API. Fix with backward-compat shims in custom code (e.g. `Custom/BackwardCompat/<Type>.cs`), each marked `[EditorBrowsable(EditorBrowsableState.Never)]` with a comment explaining the shim. For async forwarding overloads, always `await ... .ConfigureAwait(false)`.
+
+**Hard rules — no exceptions:**
+- ⛔ NEVER create or modify `ApiCompatBaseline.txt` to suppress ApiCompat errors.
+- ⛔ NEVER remove or change `ApiCompatVersion` in the `.csproj`.
+
+(For detailed shim recipes, the `dpg-migration` / `mitigate-breaking-changes` skills document the per-rule patterns; reuse those recipes but stay within custom-code scope.)
+
+## Stop Conditions
+
+Stop and emit a **structured, machine-readable summary** (do not keep retrying or escalate to a human prompt) when any of these hold:
+
+- **Out of scope (spec change required)** — the only real fix is a `client.tsp`/`tspconfig.yaml` decorator or spec edit (e.g. `@@clientName`, `@@access`, `AZC0030`/`AZC0012` naming). Report: "requires a spec-repo PR" with the offending errors. Leave the PR red for a human to route.
+- **Suspected generator bug** — `Generated/` has structural errors that persist after removing all custom-code influence and regenerating from the unchanged pinned commit. Do NOT suppress; report with the minimal repro.
+- **Bounds exhausted** — 10 iterations reached, or error count not decreasing after 3 iterations, or wall-clock budget hit. Commit progress and report remaining errors.
+
+On success, summarize: errors fixed (with deterministic-vs-reasoning split), files changed (generated-vs-custom split), final build status, and confirmation that no spec inputs or the pinned commit were touched.
+
+## Hard Rules (recap)
+
+1. Never edit `client.tsp`, `tspconfig.yaml`, or any TypeSpec/spec input.
+2. Never move the pinned spec commit in `tsp-location.yaml`.
+3. Never hand-edit `Generated/`; only `/t:GenerateCode` may change it, and you must commit that result.
+4. Never touch `.github/`, `eng/`, shared props/targets, pipelines, metadata, or secrets.
+5. Never prompt the user; run fully headless.
+6. Never auto-merge — fixes land as reviewable commits for human review.

--- a/.github/skills/auto-build-repair/SKILL.md
+++ b/.github/skills/auto-build-repair/SKILL.md
@@ -18,6 +18,8 @@ The Copilot cloud agent runs this skill on an **Auto SDK PR** created by the rel
 
 This skill is a **thin wrapper**. All classification → fix → regenerate → rebuild logic lives inside the shared `azure-sdk-mcp:azsdk_customized_code_update` tool, which already handles .NET (partial classes / `[CodeGen*]`), Python (`_patch.py`), and Java (`*Customization.java`). Do **not** replicate its behavior by editing files yourself, and do **not** invoke a per-language generator-agent — the design deliberately uses this single shared engine.
 
+> **Requires azsdk ≥ 0.6.22** — the `editScope` parameter (and optional `tspProjectPath`) used below shipped in azsdk-cli `0.6.22`. The cloud agent installs the MCP tool via `eng/common/mcp/azure-sdk-mcp.ps1`, which defaults to the latest release, so this is satisfied automatically; no version pin needs bumping.
+
 Given the failing package and the **build errors** (passed as `customizationRequest`), invoked with **`editScope: CustomCode`**, the tool:
 - **regenerates** the client from the **pinned `tsp-location.yaml` commit** (omit `tspProjectPath` — it resolves from the pinned commit, so no manual spec checkout);
 - in `CustomCode` scope, **only patches custom (non-generated) code** and reports anything that would need a spec change as out of scope (`SpecChangeRequired`) instead of applying it;

--- a/.github/skills/auto-build-repair/SKILL.md
+++ b/.github/skills/auto-build-repair/SKILL.md
@@ -6,7 +6,7 @@ description: "Headless, bounded repair of custom-code build failures in an alrea
 
 Purpose-built, **headless** skill that repairs an **already-generated Azure SDK pull request** whose build fails because of **custom (non-generated) code** that has drifted from the regenerated surface.
 
-This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — re-invoking it up to **`maxIterations`** times until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix logic in this one shared tool.
+This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — re-invoking it up to **`maxIterations` = 3** times (a cap this skill defines; see [Bounds](#bounds)) until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix logic in this one shared tool.
 
 ## When Invoked
 
@@ -56,10 +56,10 @@ Pass the **build error output** as `customizationRequest`. Pass `packagePath` fo
 
 ## Bounds
 
-Each call performs **one repair attempt**; the skill owns the iterate-until-green loop and caps it with **`maxIterations`** (default **3** if not configured):
+Each call performs **one repair attempt**; the skill owns the iterate-until-green loop and caps it at **`maxIterations` = 3** attempts (this skill defines the value — it is not a tool parameter or external input):
 
-- Re-invoke the tool at most `maxIterations` times (it is idempotent on an already-partially-repaired branch); do not loop it unbounded. Re-invoke only while the build error set is still shrinking — stop early if an attempt makes no progress.
-- If `maxIterations` is reached without a green build, **commit progress made so far and report** — do not switch to manual fixing.
+- Re-invoke the tool at most 3 times (it is idempotent on an already-partially-repaired branch); do not loop it unbounded. Re-invoke only while the build error set is still shrinking — stop early if an attempt makes no progress.
+- If 3 attempts are reached without a green build, **commit progress made so far and report** — do not switch to manual fixing.
 - Do not expand scope to other packages — `packagePath` already targets the single failing package.
 
 ## Workflow

--- a/.github/skills/auto-build-repair/SKILL.md
+++ b/.github/skills/auto-build-repair/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: auto-build-repair
-description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in custom-code-only (editScope=CustomCode) scope. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
+description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in custom-code-only scope (editScope: CustomCode); the skill owns the iterate-until-green budget. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
 ---
 # Auto Build Repair
 
 Purpose-built, **headless** skill that repairs an **already-generated Azure SDK pull request** whose build fails because of **custom (non-generated) code** that has drifted from the regenerated surface.
 
-This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix loop in this one shared tool.
+This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — looping it under a skill-owned budget until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix logic in this one shared tool.
 
 ## When Invoked
 
@@ -18,29 +18,26 @@ The Copilot cloud agent runs this skill on an **Auto SDK PR** created by the rel
 
 This skill is a **thin wrapper**. All classification → fix → regenerate → rebuild logic lives inside the shared `azure-sdk-mcp:azsdk_customized_code_update` tool, which already handles .NET (partial classes / `[CodeGen*]`), Python (`_patch.py`), and Java (`*Customization.java`). Do **not** replicate its behavior by editing files yourself, and do **not** invoke a per-language generator-agent — the design deliberately uses this single shared engine.
 
-Invoke it with **`editScope: CustomCode`** (custom-code-only), which:
-- operates against `packagePath` with the TypeSpec source pulled at the **pinned `tsp-location.yaml` commit** (no manual spec checkout);
-- **forbids spec-input edits** — never edits `client.tsp` / `tspconfig.yaml` and never moves the pinned commit;
-- **allows regeneration**, so a custom-code fix may deterministically change `Generated/`;
-- runs **fully non-interactively** (no prompts) and returns a **structured result**;
-- if the only viable fix is a spec/decorator change, **stops and returns guidance** rather than attempting it.
+Given the failing package and the **build errors** (passed as `customizationRequest`), invoked with **`editScope: CustomCode`**, the tool:
+- **regenerates** the client from the **pinned `tsp-location.yaml` commit** (omit `tspProjectPath` — it resolves from the pinned commit, so no manual spec checkout);
+- in `CustomCode` scope, **only patches custom (non-generated) code** and reports anything that would need a spec change as out of scope (`SpecChangeRequired`) instead of applying it;
+- **allows regeneration**, so reconciling a custom-code fix may deterministically change `Generated/`;
+- runs **fully non-interactively** (no prompts) and returns a structured `CustomizedCodeUpdateResponse` (build success/failure + `BuildResult`, plus `ResponseError` / `ErrorCode`).
 
 ### Call shape
 
 ```
 azure-sdk-mcp:azsdk_customized_code_update(
-  editScope:            "CustomCode",    // custom-code-only: forbids spec-input edits, keeps regeneration
-  packagePath:          "<failing SDK package dir>",
-  customizationRequest: "<the build errors / failure context from the PR>",
-  // tspProjectPath resolves from the pinned tsp-location.yaml commit; do not point it at an edited spec.
-  maxIterations:        <bound>,         // pass the configured iteration bound (default if absent)
-  wallClockBudget:      <bound>          // pass the configured time budget (default if absent)
+  editScope:            "CustomCode",   // custom-code-only: never edits spec inputs / the pinned commit
+  packagePath:          "<failing SDK package dir>",   // the single failing package; do not widen
+  customizationRequest: "<the build errors / failure context from the PR>"
+  // tspProjectPath: OMIT for CustomCode — regeneration resolves the spec from the pinned tsp-location.yaml commit.
 )
 ```
 
-Pass the **build error output** as `customizationRequest`. Pass `packagePath` for the single failing package (it is already scoped — do not widen to other packages). Supply `maxIterations` / `wallClockBudget` from the repair flow's bounds; otherwise rely on the tool defaults.
+Pass the **build error output** as `customizationRequest`. Pass `packagePath` for the single failing package — it is already scoped; do not widen. Use **`editScope: CustomCode`** so the tool never edits `client.tsp` / `tspconfig.yaml` and never moves the pinned commit. **Omit `tspProjectPath`** (required only for `SpecInputs`/`All` scope).
 
-> Some repair-specific inputs (`maxIterations`, `wallClockBudget`, structured result, diff manifest) are additive, backward-compatible changes still proposed for the shared tool in the design (§6); `editScope` ships first. Until the rest land, invoke the closest available form and still honor the scope rules below.
+> The tool runs **one bounded repair attempt per call** (regenerate → classify → build → a second classifier pass enriched with the build error → build) and returns a terminal build result. It has **no `maxIterations` / `wallClockBudget`** and no open-ended internal retry loop, so **the iterate-until-green-or-budget loop lives in this skill** (see [Bounds](#bounds)): re-invoke the idempotent tool while it makes progress, under a skill-owned cap + wall-clock budget. A richer structured result / diff manifest is additive and still proposed in the design (§6); until it lands, drive the call above and read `BuildResult` / `ResponseError`.
 
 ## Scope — read this first
 
@@ -57,8 +54,10 @@ Pass the **build error output** as `customizationRequest`. Pass `packagePath` fo
 
 ## Bounds
 
-- Pass the configured `maxIterations` / `wallClockBudget` to the tool; do not loop the tool unbounded yourself.
-- If the tool reports it is still failing after exhausting bounds, **commit progress made so far and report** — do not switch to manual fixing.
+The tool runs **one bounded repair attempt per call** and has **no `maxIterations` / `wallClockBudget`** — so the skill owns the budget and the loop:
+
+- Re-invoke the tool only a small, fixed number of times (it is idempotent on an already-partially-repaired branch); do not loop it unbounded. Re-invoke only while the build error set is still shrinking.
+- Track wall-clock yourself; if the configured budget is exhausted without a green build, **commit progress made so far and report** — do not switch to manual fixing.
 - Do not expand scope to other packages — `packagePath` already targets the single failing package.
 
 ## Workflow
@@ -66,32 +65,32 @@ Pass the **build error output** as `customizationRequest`. Pass `packagePath` fo
 ```
 1. Identify the failing `packagePath` and collect the build-error output from the PR.
 2. Call azure-sdk-mcp:azsdk_customized_code_update with:
-      editScope = "CustomCode", packagePath, customizationRequest = <build errors>, plus bounds.
-   The tool classifies, patches ONLY custom code, regenerates from the pinned commit, and rebuilds.
-3. Inspect the tool's structured result:
-      - SUCCESS (build green) → ensure custom-code edits AND regenerated Generated/ are committed. Go to 5.
-      - STILL FAILING but progressing and bounds remain → re-invoke (step 2) with the updated error context (idempotent).
-      - OUT OF SCOPE / generator bug / bounds exhausted → STOP (see Stop Conditions).
+      editScope = "CustomCode", packagePath, customizationRequest = <build errors>  (omit tspProjectPath).
+   The tool regenerates from the pinned commit, patches ONLY custom code, rebuilds, and returns a build result.
+3. Inspect the structured result (build success/failure + BuildResult, plus ResponseError / ErrorCode):
+      - Build green → ensure custom-code edits AND regenerated Generated/ are committed. Go to 5.
+      - Still failing but the error set shrank and budget remains → re-invoke (step 2) with the updated build errors; it is idempotent.
+      - SpecChangeRequired / RegenerateFailed at the pinned commit / no further progress → STOP (see Stop Conditions).
 4. Never hand-edit to finish the job; if the tool cannot, it is a stop condition.
 5. Summarize the result (see below). Fixes land as reviewable commits — no auto-merge.
 ```
 
 ## Stop Conditions
 
-When the tool returns one of these, **surface its structured guidance** and stop — do not keep retrying or escalate to a human prompt:
+When the tool returns one of these, **surface its guidance (`ResponseError` / `BuildResult`)** and stop — do not keep retrying or escalate to a human prompt:
 
-- **Out of scope (spec change required)** — the only real fix is a `client.tsp`/`tspconfig.yaml` decorator or spec edit (e.g. `@@clientName`, `@@access`, `AZC0030`/`AZC0012` naming). Report "requires a spec-repo PR" with the offending errors. Leave the PR red for a human to route.
-- **Regeneration fails at the pinned commit (spec-side error)** — the tool's regeneration step (e.g. `/t:GenerateCode`) fails because of a spec-side problem at the **unchanged** pinned `tsp-location.yaml` commit: invalid `tspconfig.yaml`, missing/renamed spec files, or a broken TypeSpec source. Because this skill must never move the pinned commit or edit spec inputs, treat this as an **immediate stop** — report "spec-side generation failure at the pinned commit; requires a spec-repo fix" with the generation error. Do **not** attempt to fix the spec or bump the commit.
-- **Suspected generator bug** — `Generated/` has structural errors that persist after the tool removes custom-code influence and regenerates from the unchanged pinned commit. Do NOT suppress; report with the minimal repro.
-- **Bounds exhausted** — `maxIterations` / `wallClockBudget` reached without a green build. Commit progress and report remaining errors.
+- **Out of scope (spec change required)** — the tool reports `SpecChangeRequired`: the only real fix is a `client.tsp`/`tspconfig.yaml` decorator or spec edit (e.g. `@@clientName`, `@@access`, `AZC0030`/`AZC0012` naming). Because the call uses `editScope: CustomCode`, the tool reports these instead of applying them. Report "requires a spec-repo PR" with the offending errors. Leave the PR red for a human to route.
+- **Regeneration fails at the pinned commit (spec-side error)** — the tool returns `ErrorCode: RegenerateFailed` because of a spec-side problem at the **unchanged** pinned `tsp-location.yaml` commit: invalid `tspconfig.yaml`, missing/renamed spec files, or a broken TypeSpec source. Because this skill must never move the pinned commit or edit spec inputs, treat this as an **immediate stop** — report "spec-side generation failure at the pinned commit; requires a spec-repo fix" with the generation error. Do **not** attempt to fix the spec or bump the commit.
+- **Suspected generator bug** — `Generated/` has structural errors that persist after the tool reconciles customizations and regenerates from the unchanged pinned commit. Do NOT suppress; report with the minimal repro.
+- **Budget exhausted** — the skill's re-invocation count / wall-clock budget is reached without a green build. Commit progress and report remaining errors.
 
-On success, summarize from the tool's structured result: errors fixed (deterministic-vs-reasoning split), files changed (generated-vs-custom split), final build status, and confirmation that no spec inputs or the pinned commit were touched.
+On success, summarize: errors fixed, files changed (generated-vs-custom split), final build status, and confirmation that no spec inputs or the pinned commit were touched.
 
 ## Hard Rules (recap)
 
-1. Drive **`azure-sdk-mcp:azsdk_customized_code_update`** with `editScope: CustomCode`; do not hand-edit code and do not use any other fix engine.
-2. Never edit `client.tsp`, `tspconfig.yaml`, or any TypeSpec/spec input; never move the pinned spec commit in `tsp-location.yaml`.
+1. Drive **`azure-sdk-mcp:azsdk_customized_code_update`** with `editScope: CustomCode` (+ the failing `packagePath` and the build errors as `customizationRequest`); do not hand-edit code and do not use any other fix engine.
+2. Never edit `client.tsp`, `tspconfig.yaml`, or any TypeSpec/spec input; never move the pinned spec commit in `tsp-location.yaml` (`editScope: CustomCode` enforces this — and omit `tspProjectPath`).
 3. Commit the tool's regenerated `Generated/` alongside the custom-code edits (the guard is reproducibility, not freezing).
 4. Never touch `.github/`, `eng/`, shared props/targets, pipelines, metadata, or secrets.
-5. Never prompt the user; run fully headless, honoring the configured bounds.
+5. Never prompt the user; run fully headless, honoring the skill-enforced budget.
 6. Never auto-merge — fixes land as reviewable commits for human review.

--- a/.github/skills/auto-build-repair/SKILL.md
+++ b/.github/skills/auto-build-repair/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: auto-build-repair
-description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in custom-code-only scope (editScope: CustomCode); the skill owns the iterate-until-green budget. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
+description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in custom-code-only scope (editScope: CustomCode); the skill owns the iterate-until-green loop, capped by maxIterations. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
 ---
 # Auto Build Repair
 
 Purpose-built, **headless** skill that repairs an **already-generated Azure SDK pull request** whose build fails because of **custom (non-generated) code** that has drifted from the regenerated surface.
 
-This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — looping it under a skill-owned budget until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix logic in this one shared tool.
+This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — re-invoking it up to **`maxIterations`** times until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix logic in this one shared tool.
 
 ## When Invoked
 
@@ -39,7 +39,7 @@ azure-sdk-mcp:azsdk_customized_code_update(
 
 Pass the **build error output** as `customizationRequest`. Pass `packagePath` for the single failing package — it is already scoped; do not widen. Use **`editScope: CustomCode`** so the tool never edits `client.tsp` / `tspconfig.yaml` and never moves the pinned commit. **Omit `tspProjectPath`** (required only for `SpecInputs`/`All` scope).
 
-> The tool runs **one bounded repair attempt per call** (regenerate → classify → build → a second classifier pass enriched with the build error → build) and returns a terminal build result. It has **no `maxIterations` / `wallClockBudget`** and no open-ended internal retry loop, so **the iterate-until-green-or-budget loop lives in this skill** (see [Bounds](#bounds)): re-invoke the idempotent tool while it makes progress, under a skill-owned cap + wall-clock budget. A richer structured result / diff manifest is additive and still proposed in the design (§6); until it lands, drive the call above and read `BuildResult` / `ResponseError`.
+> Each call performs **one repair attempt** (regenerate → classify → build → a second classifier pass enriched with the build error → build) and returns a terminal build result. The **iterate-until-green loop lives in this skill** (see [Bounds](#bounds)): re-invoke the idempotent tool while it makes progress, up to **`maxIterations`** attempts. A richer structured result / diff manifest is additive and still proposed in the design (§6); until it lands, drive the call above and read `BuildResult` / `ResponseError`.
 
 ## Scope — read this first
 
@@ -56,10 +56,10 @@ Pass the **build error output** as `customizationRequest`. Pass `packagePath` fo
 
 ## Bounds
 
-The tool runs **one bounded repair attempt per call** and has **no `maxIterations` / `wallClockBudget`** — so the skill owns the budget and the loop:
+Each call performs **one repair attempt**; the skill owns the iterate-until-green loop and caps it with **`maxIterations`** (default **3** if not configured):
 
-- Re-invoke the tool only a small, fixed number of times (it is idempotent on an already-partially-repaired branch); do not loop it unbounded. Re-invoke only while the build error set is still shrinking.
-- Track wall-clock yourself; if the configured budget is exhausted without a green build, **commit progress made so far and report** — do not switch to manual fixing.
+- Re-invoke the tool at most `maxIterations` times (it is idempotent on an already-partially-repaired branch); do not loop it unbounded. Re-invoke only while the build error set is still shrinking — stop early if an attempt makes no progress.
+- If `maxIterations` is reached without a green build, **commit progress made so far and report** — do not switch to manual fixing.
 - Do not expand scope to other packages — `packagePath` already targets the single failing package.
 
 ## Workflow
@@ -71,7 +71,7 @@ The tool runs **one bounded repair attempt per call** and has **no `maxIteration
    The tool regenerates from the pinned commit, patches ONLY custom code, rebuilds, and returns a build result.
 3. Inspect the structured result (build success/failure + BuildResult, plus ResponseError / ErrorCode):
       - Build green → ensure custom-code edits AND regenerated Generated/ are committed. Go to 5.
-      - Still failing but the error set shrank and budget remains → re-invoke (step 2) with the updated build errors; it is idempotent.
+      - Still failing but the error set shrank and attempts remain (< `maxIterations`) → re-invoke (step 2) with the updated build errors; it is idempotent.
       - SpecChangeRequired / RegenerateFailed at the pinned commit / no further progress → STOP (see Stop Conditions).
 4. Never hand-edit to finish the job; if the tool cannot, it is a stop condition.
 5. Summarize the result (see below). Fixes land as reviewable commits — no auto-merge.
@@ -84,7 +84,7 @@ When the tool returns one of these, **surface its guidance (`ResponseError` / `B
 - **Out of scope (spec change required)** — the tool reports `SpecChangeRequired`: the only real fix is a `client.tsp`/`tspconfig.yaml` decorator or spec edit (e.g. `@@clientName`, `@@access`, `AZC0030`/`AZC0012` naming). Because the call uses `editScope: CustomCode`, the tool reports these instead of applying them. Report "requires a spec-repo PR" with the offending errors. Leave the PR red for a human to route.
 - **Regeneration fails at the pinned commit (spec-side error)** — the tool returns `ErrorCode: RegenerateFailed` because of a spec-side problem at the **unchanged** pinned `tsp-location.yaml` commit: invalid `tspconfig.yaml`, missing/renamed spec files, or a broken TypeSpec source. Because this skill must never move the pinned commit or edit spec inputs, treat this as an **immediate stop** — report "spec-side generation failure at the pinned commit; requires a spec-repo fix" with the generation error. Do **not** attempt to fix the spec or bump the commit.
 - **Suspected generator bug** — `Generated/` has structural errors that persist after the tool reconciles customizations and regenerates from the unchanged pinned commit. Do NOT suppress; report with the minimal repro.
-- **Budget exhausted** — the skill's re-invocation count / wall-clock budget is reached without a green build. Commit progress and report remaining errors.
+- **`maxIterations` reached** — the skill's re-invocation cap is reached without a green build. Commit progress and report remaining errors.
 
 On success, summarize: errors fixed, files changed (generated-vs-custom split), final build status, and confirmation that no spec inputs or the pinned commit were touched.
 
@@ -94,5 +94,5 @@ On success, summarize: errors fixed, files changed (generated-vs-custom split), 
 2. Never edit `client.tsp`, `tspconfig.yaml`, or any TypeSpec/spec input; never move the pinned spec commit in `tsp-location.yaml` (`editScope: CustomCode` enforces this — and omit `tspProjectPath`).
 3. Commit the tool's regenerated `Generated/` alongside the custom-code edits (the guard is reproducibility, not freezing).
 4. Never touch `.github/`, `eng/`, shared props/targets, pipelines, metadata, or secrets.
-5. Never prompt the user; run fully headless, honoring the skill-enforced budget.
+5. Never prompt the user; run fully headless, honoring `maxIterations`.
 6. Never auto-merge — fixes land as reviewable commits for human review.

--- a/.github/skills/auto-build-repair/SKILL.md
+++ b/.github/skills/auto-build-repair/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: auto-build-repair
-description: Headless, bounded repair of custom-code build failures in an already-generated Azure SDK for .NET PR. Patches ONLY custom (non-generated) code until the package builds, using the generator-agent MCP build-fix tools. Used by the Copilot cloud agent on release-planner-created "Auto SDK PRs" labeled `auto-sdk-build-fix`. Never edits spec inputs (client.tsp/tspconfig.yaml) and never moves the pinned spec commit.
+description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in repair mode. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
 ---
 # Auto Build Repair
 
-Purpose-built, **headless** skill that repairs an **already-generated Azure SDK for .NET pull request** whose build fails because of **custom (non-generated) code** that has drifted from the regenerated surface.
+Purpose-built, **headless** skill that repairs an **already-generated Azure SDK pull request** whose build fails because of **custom (non-generated) code** that has drifted from the regenerated surface.
 
-This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to patch the package's **custom code** (and commit any deterministic regenerated `Generated/` output) until the package builds — then stop.
+This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **repair** mode — until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix loop in this one shared tool.
 
 ## When Invoked
 
@@ -14,112 +14,83 @@ The Copilot cloud agent runs this skill on an **Auto SDK PR** created by the rel
 
 **This skill runs non-interactively in an ephemeral environment. Never prompt the user for input** (no spec repo path, no confirmations). If you cannot proceed within scope, stop and emit structured guidance (see [Stop Conditions](#stop-conditions)).
 
+## The engine: `azure-sdk-mcp:azsdk_customized_code_update`
+
+This skill is a **thin wrapper**. All classification → fix → regenerate → rebuild logic lives inside the shared `azure-sdk-mcp:azsdk_customized_code_update` tool, which already handles .NET (partial classes / `[CodeGen*]`), Python (`_patch.py`), and Java (`*Customization.java`). Do **not** replicate its behavior by editing files yourself, and do **not** invoke a per-language generator-agent — the design deliberately uses this single shared engine.
+
+Invoke it in **`repair` mode**, which:
+- operates against `packagePath` with the TypeSpec source pulled at the **pinned `tsp-location.yaml` commit** (no manual spec checkout);
+- **forbids spec-input edits** — never edits `client.tsp` / `tspconfig.yaml` and never moves the pinned commit;
+- **allows regeneration**, so a custom-code fix may deterministically change `Generated/`;
+- runs **fully non-interactively** (no prompts) and returns a **structured result**;
+- if the only viable fix is a spec/decorator change, **stops and returns guidance** rather than attempting it.
+
+### Call shape
+
+```
+azure-sdk-mcp:azsdk_customized_code_update(
+  mode:                 "repair",        // forbids spec-input edits, keeps regeneration
+  packagePath:          "<failing SDK package dir>",
+  customizationRequest: "<the build errors / failure context from the PR>",
+  // tspProjectPath resolves from the pinned tsp-location.yaml commit; do not point it at an edited spec.
+  maxIterations:        <bound>,         // pass the configured iteration bound (default if absent)
+  wallClockBudget:      <bound>          // pass the configured time budget (default if absent)
+)
+```
+
+Pass the **build error output** as `customizationRequest`. Pass `packagePath` for the single failing package (it is already scoped — do not widen to other packages). Supply `maxIterations` / `wallClockBudget` from the repair flow's bounds; otherwise rely on the tool defaults.
+
+> The repair-specific inputs (`mode: "repair"`, `maxIterations`, `wallClockBudget`, structured result, diff manifest) are the additive, backward-compatible changes proposed for the shared tool in the design (§6). Until they ship, invoke the closest available form and still honor the scope rules below.
+
 ## Scope — read this first
 
 | Allowed | Forbidden |
 |---------|-----------|
-| Edit the failing package's **custom (non-generated) code** (`.cs` partial classes, `[CodeGen*]` attributes, backward-compat shims). | Edit any **spec input**: `client.tsp`, `tspconfig.yaml`, `main.tsp`, or any TypeSpec source. |
-| **Regenerate** `Generated/` from the **unchanged pinned** `tsp-location.yaml` commit, and **commit** the deterministic result. | **Move the pinned spec commit** in `tsp-location.yaml` (the `commit`/`repo`/`directory` fields). |
-| Add/adjust customization files under the package's `Custom/` (or equivalent) folders. | Hand-edit files under `Generated/`. |
-| Add backward-compat shims for ApiCompat breaks. | Touch `.github/`, `eng/`, shared props/targets, pipeline files, package metadata, or secrets. |
+| Drive `azsdk_customized_code_update` (repair mode) to patch the failing package's **custom (non-generated) code**. | Edit any **spec input**: `client.tsp`, `tspconfig.yaml`, `main.tsp`, or any TypeSpec source. |
+| Let the tool **regenerate** `Generated/` from the **unchanged pinned** commit, and **commit** the deterministic result. | **Move the pinned spec commit** in `tsp-location.yaml` (the `commit`/`repo`/`directory` fields). |
+| Commit the tool's custom-code changes + regenerated output as reviewable commits. | Hand-edit code (custom or generated) to "help" the tool; let the engine own the edits. |
+| Re-invoke the tool on an already-partially-repaired branch (it is idempotent). | Touch `.github/`, `eng/`, shared props/targets, pipeline files, package metadata, or secrets. |
 
-**Custom code only.** If the only viable fix is a spec/decorator (Phase-A) change — e.g. a naming fix that must live in `client.tsp` via `@@clientName`, or `@@access` — that belongs in a **separate spec-repo PR** and is **out of scope**. Stop and report (see [Stop Conditions](#stop-conditions)); do not attempt it.
+**Custom code only.** If the only viable fix is a spec/decorator (Phase-A) change — e.g. a naming fix that must live in `client.tsp` via `@@clientName`, or `@@access` — that belongs in a **separate spec-repo PR** and is **out of scope**. The tool will stop and return guidance; surface it (see [Stop Conditions](#stop-conditions)) and do not attempt it.
 
-**Regeneration is expected, not a violation.** Fixing custom code that carries generator signals (`[CodeGenType]`, `[CodeGenSuppress]`, `[CodeGenMember]`, `[CodeGenSerialization]`) legitimately changes `Generated/` as a deterministic downstream effect. You **must commit** the regenerated `Generated/` so the repo's existing generated-code-diff check (`eng/scripts/CodeChecks.ps1` → `/t:GenerateCode` + `git diff --exit-code`) stays green. The guard is "`Generated/` is *reproducible from unchanged inputs*", not "`Generated/` is frozen".
-
-## MCP Server (generator-agent)
-
-This skill uses the deterministic build-fix tools from the `generator-agent` MCP server (`sdk/tools/Azure.GeneratorAgent`), already provisioned in the cloud-agent environment. Use **only** the build-fix-loop subset below — do not invoke migration-only tools (`pregen_cleanup`, `migrate_test_samples`, `finalize_migration`, `commit_iteration`, `validate_tsp_config`).
-
-| Tool | When to Use | What It Does |
-|------|-------------|--------------|
-| `discover_project` | First step — to resolve package paths and `tsp-location.yaml` fields | Returns project context (plane, package/service name, custom code folder, Generated/ paths, pinned commit). Ignore any spec-repo prompt — this flow never needs a local spec checkout. |
-| `snapshot_generated` | Immediately after the first regeneration, before the fix loop | SHA-256 snapshot of `Generated/`, enabling auto-verification in later `build_and_classify` calls. |
-| `build_and_classify` | First step of **every** iteration | Runs `dotnet build`, classifies each error as deterministic vs requires-reasoning. |
-| `classify_errors` | Re-classify after partial fixes | Classifies errors against the deterministic fix registry. |
-| `batch_fix` | After deterministic errors are identified | Applies multiple deterministic fixes in one call. |
-| `add_using_directive` | `CS0246`/`CS0103` for a known type | Adds a missing `using`. |
-| `remove_using_directive` | `CS0246` for stale `*.Rest.*` / `Autorest.*` namespaces | Removes matching `using` directives. |
-| `nullable_annotation_fix` | `CS8625`/`CS8600` | Adds `?` nullable annotation. |
-| `rename_codegen_type` | `CS0246` for a `[CodeGenType]` that no longer matches the generated name | Updates `[CodeGenType]` to match generated type. |
-| `add_codegen_suppress` | `CS0111` (custom + generated member clash) | Adds `[CodeGenSuppress]` to the custom partial. |
-| `fetch_to_fromlro` | `CS0103`/`CS1061` for custom LRO `Fetch` calls | Replaces `Fetch(response)` with `Model.FromLroResponse(response)`. |
-| `verify_generated_unchanged` | After the fix loop completes | Confirms no `Generated/` files were hand-modified outside regeneration. |
-
-Prefer MCP tools for deterministic fixes; only hand-edit custom code for errors classified as requires-reasoning.
+**Regeneration is expected, not a violation.** Fixing custom code that carries generator signals legitimately changes `Generated/` as a deterministic downstream effect. The regenerated `Generated/` **must be committed** so the repo's existing generated-code-diff check (.NET: `eng/scripts/CodeChecks.ps1` → `/t:GenerateCode` + `git diff --exit-code`) stays green. The guard is "`Generated/` is *reproducible from unchanged inputs*", not "`Generated/` is frozen".
 
 ## Bounds
 
-- **Max 10 build-fix iterations.** If the error count is not decreasing after 3 consecutive iterations, stop and report.
-- Stay within the cloud-agent wall-clock budget. If exhausted, commit progress made so far and report remaining errors.
-- Do not expand scope to other packages — `discover_project` already targets the single failing package.
+- Pass the configured `maxIterations` / `wallClockBudget` to the tool; do not loop the tool unbounded yourself.
+- If the tool reports it is still failing after exhausting bounds, **commit progress made so far and report** — do not switch to manual fixing.
+- Do not expand scope to other packages — `packagePath` already targets the single failing package.
 
-## Repair Loop
+## Workflow
 
 ```
-SETUP:
-  0. Call `discover_project` to resolve the package path, custom-code folder, and pinned tsp-location.yaml fields.
-  1. Regenerate once from the PINNED commit:  dotnet build /t:GenerateCode
-     (remote mode — uses the commit already in tsp-location.yaml; do NOT pass a local spec repo,
-      do NOT change tsp-location.yaml).
-  2. Call `snapshot_generated` to lock down Generated/.
-
-LOOP (max 10 iterations):
-  3. Call `build_and_classify`.
-  4. IF zero errors → EXIT LOOP (go to FINALIZE).
-  5. IF error count not decreasing after 3 iterations → STOP and report (see Stop Conditions).
-  6. Split errors into deterministic vs requires-reasoning.
-  7. Apply ALL deterministic fixes via `batch_fix` / targeted fixers.
-  8. For requires-reasoning errors, edit ONLY custom code (see Drift & ApiCompat patterns below).
-     IF the only viable fix is a spec/decorator change → STOP and report (out of scope).
-  9. IF you changed any `[CodeGen*]` attribute or added/removed/renamed a custom file carrying
-     generator signals → regenerate:  dotnet build /t:GenerateCode  (pinned commit, no spec edits).
-     Customization-only `.cs` edits with no generator attributes → no regeneration needed.
- 10. GOTO 3.
-
-FINALIZE:
- 11. Call `verify_generated_unchanged` to confirm no hand edits leaked into Generated/.
- 12. Ensure the regenerated Generated/ is committed alongside the custom-code edits.
+1. Identify the failing `packagePath` and collect the build-error output from the PR.
+2. Call azure-sdk-mcp:azsdk_customized_code_update with:
+      mode = "repair", packagePath, customizationRequest = <build errors>, plus bounds.
+   The tool classifies, patches ONLY custom code, regenerates from the pinned commit, and rebuilds.
+3. Inspect the tool's structured result:
+      - SUCCESS (build green) → ensure custom-code edits AND regenerated Generated/ are committed. Go to 5.
+      - STILL FAILING but progressing and bounds remain → re-invoke (step 2) with the updated error context (idempotent).
+      - OUT OF SCOPE / generator bug / bounds exhausted → STOP (see Stop Conditions).
+4. Never hand-edit to finish the job; if the tool cannot, it is a stop condition.
+5. Summarize the result (see below). Fixes land as reviewable commits — no auto-merge.
 ```
-
-> **Generated/ auto-guard**: once a snapshot exists, every `build_and_classify` verifies that no `Generated/` files were hand-modified; the deterministic fixers also refuse to write inside `Generated/`. Let regeneration (`/t:GenerateCode`) — not manual edits — produce any `Generated/` change.
-
-## Customization-drift patterns (custom code only)
-
-These are the common drift failures. All fixes live in the package's custom code; never edit `Generated/` or the spec.
-
-- **Stale reference to a renamed/removed generated symbol** — custom code references a model/property/method that the new surface renamed or dropped. Update the custom reference to the new name, or delete the custom member if the generated type no longer exists, then regenerate if a `[CodeGen*]` attribute was involved.
-- **`[CodeGenType]` name mismatch** — the value must exactly match the generated class name (use `rename_codegen_type`); a mismatch silently breaks partial-class merging and produces spurious "missing member" errors.
-- **Duplicate member (`CS0111`)** — custom partial and generated code both define a member; add `[CodeGenSuppress("Member")]` to the custom partial (use `add_codegen_suppress`).
-- **Stale `using` / namespace** — add the missing `using` (`add_using_directive`) or remove obsolete `*.Rest.*` / `Autorest.*` usings (`remove_using_directive`).
-- **LRO `Fetch`** — replace with `Model.FromLroResponse(response)` (`fetch_to_fromlro`).
-- **Stale custom file** — a custom `FooResource.cs` exists but `Generated/FooResource.cs` was renamed/removed: rename the custom file to match, or remove it, then regenerate.
-
-## ApiCompat breaks (GA libraries)
-
-ApiCompat surfaces breaking changes vs the last shipped API. Fix with backward-compat shims in custom code (e.g. `Custom/BackwardCompat/<Type>.cs`), each marked `[EditorBrowsable(EditorBrowsableState.Never)]` with a comment explaining the shim. For async forwarding overloads, always `await ... .ConfigureAwait(false)`.
-
-**Hard rules — no exceptions:**
-- ⛔ NEVER create or modify `ApiCompatBaseline.txt` to suppress ApiCompat errors.
-- ⛔ NEVER remove or change `ApiCompatVersion` in the `.csproj`.
-
-(For detailed shim recipes, the `dpg-migration` / `mitigate-breaking-changes` skills document the per-rule patterns; reuse those recipes but stay within custom-code scope.)
 
 ## Stop Conditions
 
-Stop and emit a **structured, machine-readable summary** (do not keep retrying or escalate to a human prompt) when any of these hold:
+When the tool returns one of these, **surface its structured guidance** and stop — do not keep retrying or escalate to a human prompt:
 
-- **Out of scope (spec change required)** — the only real fix is a `client.tsp`/`tspconfig.yaml` decorator or spec edit (e.g. `@@clientName`, `@@access`, `AZC0030`/`AZC0012` naming). Report: "requires a spec-repo PR" with the offending errors. Leave the PR red for a human to route.
-- **Suspected generator bug** — `Generated/` has structural errors that persist after removing all custom-code influence and regenerating from the unchanged pinned commit. Do NOT suppress; report with the minimal repro.
-- **Bounds exhausted** — 10 iterations reached, or error count not decreasing after 3 iterations, or wall-clock budget hit. Commit progress and report remaining errors.
+- **Out of scope (spec change required)** — the only real fix is a `client.tsp`/`tspconfig.yaml` decorator or spec edit (e.g. `@@clientName`, `@@access`, `AZC0030`/`AZC0012` naming). Report "requires a spec-repo PR" with the offending errors. Leave the PR red for a human to route.
+- **Suspected generator bug** — `Generated/` has structural errors that persist after the tool removes custom-code influence and regenerates from the unchanged pinned commit. Do NOT suppress; report with the minimal repro.
+- **Bounds exhausted** — `maxIterations` / `wallClockBudget` reached without a green build. Commit progress and report remaining errors.
 
-On success, summarize: errors fixed (with deterministic-vs-reasoning split), files changed (generated-vs-custom split), final build status, and confirmation that no spec inputs or the pinned commit were touched.
+On success, summarize from the tool's structured result: errors fixed (deterministic-vs-reasoning split), files changed (generated-vs-custom split), final build status, and confirmation that no spec inputs or the pinned commit were touched.
 
 ## Hard Rules (recap)
 
-1. Never edit `client.tsp`, `tspconfig.yaml`, or any TypeSpec/spec input.
-2. Never move the pinned spec commit in `tsp-location.yaml`.
-3. Never hand-edit `Generated/`; only `/t:GenerateCode` may change it, and you must commit that result.
+1. Drive **`azure-sdk-mcp:azsdk_customized_code_update`** in `repair` mode; do not hand-edit code and do not use any other fix engine.
+2. Never edit `client.tsp`, `tspconfig.yaml`, or any TypeSpec/spec input; never move the pinned spec commit in `tsp-location.yaml`.
+3. Commit the tool's regenerated `Generated/` alongside the custom-code edits (the guard is reproducibility, not freezing).
 4. Never touch `.github/`, `eng/`, shared props/targets, pipelines, metadata, or secrets.
-5. Never prompt the user; run fully headless.
+5. Never prompt the user; run fully headless, honoring the configured bounds.
 6. Never auto-merge — fixes land as reviewable commits for human review.

--- a/.github/skills/auto-build-repair/SKILL.md
+++ b/.github/skills/auto-build-repair/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: auto-build-repair
-description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in custom-code-only scope (editScope: CustomCode); the skill owns the iterate-until-green loop, capped by maxIterations. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
+description: "Headless, bounded repair of custom-code build failures in an already-generated Azure SDK PR. Thin wrapper over the shared azure-sdk-mcp:azsdk_customized_code_update engine in custom-code-only scope (editScope: CustomCode); the skill owns the iterate-until-green loop, capped by a per-language `maxIterations` read from repair-config.yml. WHEN: Copilot cloud agent runs on a release-planner Auto SDK PR labeled `auto-sdk-build-fix` that fails to build because of custom (non-generated) code. DO NOT USE FOR: full TypeSpec migrations, spec edits, API design review, manual fixing. INVOKES: azure-sdk-mcp:azsdk_customized_code_update."
 ---
 # Auto Build Repair
 
 Purpose-built, **headless** skill that repairs an **already-generated Azure SDK pull request** whose build fails because of **custom (non-generated) code** that has drifted from the regenerated surface.
 
-This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — re-invoking it up to **`maxIterations` = 3** times (a cap this skill defines; see [Bounds](#bounds)) until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix logic in this one shared tool.
+This is NOT a migration. The SDK PR already exists, the TypeSpec source is already pinned via `tsp-location.yaml`, and most of the diff is generated code. Your only job is to drive the shared **`azure-sdk-mcp:azsdk_customized_code_update`** engine — in **custom-code-only** scope (`editScope: CustomCode`) — re-invoking it up to **`maxIterations`** times (a cross-language repair bound; its per-language value is read from [`repair-config.yml`](#configuration), see [Bounds](#bounds)) until the package builds, then stop. **Do not hand-edit code and do not use any other fix engine** (e.g. the per-language generator-agent); the cross-language design centralizes the fix logic in this one shared tool.
 
 ## When Invoked
 
@@ -54,17 +54,28 @@ Pass the **build error output** as `customizationRequest`. Pass `packagePath` fo
 
 **Regeneration is expected, not a violation.** Fixing custom code that carries generator signals legitimately changes `Generated/` as a deterministic downstream effect. The regenerated `Generated/` **must be committed** so the repo's existing generated-code-diff check (.NET: `eng/scripts/CodeChecks.ps1` → `/t:GenerateCode` + `git diff --exit-code`) stays green. The guard is "`Generated/` is *reproducible from unchanged inputs*", not "`Generated/` is frozen".
 
+## Configuration
+
+`maxIterations` is a **cross-language repair concept**: every language repo's auto-build-repair skill bounds its repair loop by the same `maxIterations` key, but the **value is tunable per language** (build + regeneration cost differs across .NET / Python / Java). This skill reads it from the co-located per-language config file:
+
+- File: [`repair-config.yml`](repair-config.yml) (next to this `SKILL.md`).
+- Key: `maxIterations` — max number of times the skill re-invokes `azsdk_customized_code_update` before committing progress and stopping.
+- If the file or key is absent, fall back to the cross-language default **3**.
+
+To tune this repo, edit `maxIterations` in `repair-config.yml`; do not hardcode a different number in the skill body. Other language repos carry their own `repair-config.yml` with their own value.
+
 ## Bounds
 
-Each call performs **one repair attempt**; the skill owns the iterate-until-green loop and caps it at **`maxIterations` = 3** attempts (this skill defines the value — it is not a tool parameter or external input):
+Each call performs **one repair attempt**; the skill owns the iterate-until-green loop and caps it at **`maxIterations`** attempts (read from [`repair-config.yml`](#configuration); default 3):
 
-- Re-invoke the tool at most 3 times (it is idempotent on an already-partially-repaired branch); do not loop it unbounded. Re-invoke only while the build error set is still shrinking — stop early if an attempt makes no progress.
-- If 3 attempts are reached without a green build, **commit progress made so far and report** — do not switch to manual fixing.
+- Re-invoke the tool at most `maxIterations` times (it is idempotent on an already-partially-repaired branch); do not loop it unbounded. Re-invoke only while the build error set is still shrinking — stop early if an attempt makes no progress.
+- If `maxIterations` attempts are reached without a green build, **commit progress made so far and report** — do not switch to manual fixing.
 - Do not expand scope to other packages — `packagePath` already targets the single failing package.
 
 ## Workflow
 
 ```
+0. Read `maxIterations` from repair-config.yml (next to this SKILL.md); default to 3 if absent.
 1. Identify the failing `packagePath` and collect the build-error output from the PR.
 2. Call azure-sdk-mcp:azsdk_customized_code_update with:
       editScope = "CustomCode", packagePath, customizationRequest = <build errors>  (omit tspProjectPath).

--- a/.github/skills/auto-build-repair/evals/eval.yaml
+++ b/.github/skills/auto-build-repair/evals/eval.yaml
@@ -1,0 +1,83 @@
+name: auto-build-repair-eval
+description: Evaluation suite for the auto-build-repair skill
+
+type: capability
+
+environment: azsdk-mcp-mock
+
+tags:
+  area: auto-build-repair
+  type: ci-gate
+
+config:
+  runs: 1
+  timeout: "90s"
+  model: claude-opus-4.6
+  executor: copilot-sdk
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  # Happy path: a custom-code build failure on an Auto SDK PR should drive the
+  # shared engine with editScope CustomCode.
+  - name: repair-basic-001
+    prompt: >-
+      This Auto SDK PR is labeled auto-sdk-build-fix. The package at
+      sdk/contoso/Azure.Contoso.Widgets fails to build because a custom partial
+      class references a generated member that was renamed during regeneration.
+      Repair the build.
+    graders:
+      - type: tool-calls
+        config:
+          required:
+            - name: azure-sdk-mcp-azsdk_customized_code_update
+      - type: output-contains
+        config:
+          substring: "custom"
+
+  # Scope: the skill must stay in custom-code-only scope and must not edit spec
+  # inputs or move the pinned commit.
+  - name: repair-scope-001
+    prompt: >-
+      The Auto SDK PR for sdk/contoso/Azure.Contoso.Widgets is failing to build
+      after regeneration. Fix the build, but explain what you are and are not
+      allowed to change.
+    graders:
+      - type: tool-calls
+        config:
+          required:
+            - name: azure-sdk-mcp-azsdk_customized_code_update
+      - type: output-not-contains
+        config:
+          substring: "edit client.tsp"
+      - type: output-not-contains
+        config:
+          substring: "move the pinned commit"
+
+  # Stop condition: when the only viable fix is a spec/decorator change, the
+  # skill must report it as out of scope (a separate spec-repo PR), not attempt it.
+  - name: repair-stop-specchange-001
+    prompt: >-
+      The Auto SDK PR for sdk/contoso/Azure.Contoso.Widgets fails because a
+      client method name violates AZC0030 and the only correct fix is an
+      @@clientName rename in client.tsp. Repair the build.
+    graders:
+      - type: output-contains
+        config:
+          substring: "spec"
+      - type: output-contains
+        config:
+          substring: "out of scope"
+
+  # Negative: a brand-new TypeSpec authoring request must not drive the repair engine.
+  - name: repair-negative-001
+    prompt: "How do I define a new REST operation in my TypeSpec project?"
+    graders:
+      - type: tool-calls
+        config:
+          disallowed:
+            - name: azure-sdk-mcp-azsdk_customized_code_update
+      - type: output-not-contains
+        config:
+          substring: "auto-sdk-build-fix"

--- a/.github/skills/auto-build-repair/evals/trigger.eval.yaml
+++ b/.github/skills/auto-build-repair/evals/trigger.eval.yaml
@@ -1,0 +1,88 @@
+name: auto-build-repair-trigger-eval
+description: Trigger and anti-trigger tests for the auto-build-repair skill
+
+type: capability
+
+environment: azsdk-mcp-mock
+
+tags:
+  area: auto-build-repair
+  type: ci-gate
+
+config:
+  runs: 1
+  timeout: "90s"
+  model: claude-opus-4.6
+  executor: copilot-sdk
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  - name: trigger-fix-the-sdk-pr-build
+    prompt: "fix the SDK PR build"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["auto-build-repair"]
+  - name: trigger-auto-build-repair
+    prompt: "auto build repair"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["auto-build-repair"]
+  - name: trigger-auto-sdk-build-fix-label
+    prompt: "This Auto SDK PR is labeled auto-sdk-build-fix and the build is red. Repair it."
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["auto-build-repair"]
+  - name: trigger-custom-code-build-repair
+    prompt: "custom-code build repair on the generated SDK PR"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["auto-build-repair"]
+  - name: trigger-generated-pr-custom-code-drift
+    prompt: "The generated SDK PR fails to build because the custom code drifted from the regenerated surface. Fix it."
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["auto-build-repair"]
+
+  - name: anti-trigger-write-unit-tests
+    prompt: "write unit tests"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["auto-build-repair"]
+  - name: anti-trigger-create-a-new-typespec-definition
+    prompt: "create a new TypeSpec definition"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["auto-build-repair"]
+  - name: anti-trigger-migrate-swagger-to-typespec
+    prompt: "migrate my SDK from Swagger to TypeSpec"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["auto-build-repair"]
+  - name: anti-trigger-resolve-apiview-feedback
+    prompt: "resolve APIView feedback"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["auto-build-repair"]
+  - name: anti-trigger-debug-ci-pipeline
+    prompt: "my CI pipeline failed, help me debug it"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["auto-build-repair"]
+  - name: anti-trigger-release-my-sdk-package
+    prompt: "release my SDK package"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["auto-build-repair"]

--- a/.github/skills/auto-build-repair/repair-config.yml
+++ b/.github/skills/auto-build-repair/repair-config.yml
@@ -1,0 +1,11 @@
+# Per-language tuning for the cross-language auto-build-repair flow.
+#
+# These values configure the shared repair concept (driving
+# azure-sdk-mcp:azsdk_customized_code_update) for THIS language repo. The keys and
+# their meaning are standardized across languages; the values are tunable per repo,
+# so each language can pick a bound appropriate to its build/regeneration cost.
+#
+# maxIterations: maximum number of times the auto-build-repair skill re-invokes
+#   azsdk_customized_code_update (one repair attempt per call) before it commits the
+#   progress made so far and stops. Cross-language default is 3.
+maxIterations: 3


### PR DESCRIPTION
Part of epic #59658 — **Auto-repair custom-code build failures in generated SDK PRs**. Closes #59697.

Implements the **repair skill** component of the [cross-language design](https://gist.github.com/JoshLove-msft/9dce73ac374598523b9c46a49192784d) (source of truth): a thin, purpose-built skill the Copilot cloud agent runs on a release-planner-created **Auto SDK PR** (labeled uto-sdk-build-fix) whose build fails because of **custom (non-generated) code** drift.

## Why a new skill
The existing dpg-migration / mpg-migration skills are built for full Swagger->TypeSpec migrations: they require a local spec checkout, *prompt the user* for it, edit client.tsp/	spconfig.yaml, and run migration-only phases. None of that fits a headless, bounded, custom-code-only PR repair.

## Engine: the shared zsdk_customized_code_update tool (not the generator-agent)
Per the gist (§5.6/§6), the repair flow reuses the **single shared** `azure-sdk-mcp:azsdk_customized_code_update` engine in a new **`repair` mode** — *not* the per-language generator-agent. This skill is a **thin wrapper**: it hands the build errors to that tool and surfaces its structured result. All classify -> fix -> regenerate -> rebuild logic stays in the shared tool (which already covers .NET / Python / Java).

> The `repair` mode + bounds/structured-result/diff-manifest inputs are additive tool changes proposed in gist §6 and tracked separately. The skill notes this and uses the closest available form while still enforcing the scope rules.

## What the skill enforces
- **Headless** — never prompts; TypeSpec resolves from the pinned `tsp-location.yaml` commit.
- **Custom-code only** — never edits `client.tsp`/`tspconfig.yaml` and never moves the pinned commit.
- **Regeneration allowed & committed** — `Generated/` may change as a deterministic effect of a custom-code fix; commit it so the existing generated-code-diff check (`CodeChecks.ps1`) stays green. Reproducible, not frozen.
- **No hand-editing / no other fix engine** — drive the shared tool only.
- **Bounded** — pass `maxIterations` / `wallClockBudget`; out-of-scope (spec change) / generator-bug / bounds-exhausted -> structured stop guidance.
- **No auto-merge** — fixes land as reviewable commits.

## Acceptance criteria (#59697)
- [x] New uto-build-repair skill, self-contained, no interactive prompts, no migration-only phases.
- [x] Thin wrapper over the shared `azsdk_customized_code_update` engine; enforces `Generated/` reproducibility and custom-code-only scope.
- [ ] #59653 to be updated to reference this skill + the single `azure-sdk-mcp` server (follow-up).

--generated by Copilot