### PR TITLE
Fix request path equality and hash code

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathPattern.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathPattern.cs
@@ -198,21 +198,12 @@ namespace Azure.Generator.Management.Models
 
         /// <inheritdoc />
         public bool Equals(RequestPathPattern? other)
-            => Equals(other, strict: false);
-
-        /// <summary>
-        /// Determines whether this path pattern equals another path pattern.
-        /// </summary>
-        /// <param name="other">The other path pattern to compare.</param>
-        /// <param name="strict">Whether variable segment names must match exactly.</param>
-        /// <returns><c>true</c> if the path patterns are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(RequestPathPattern? other, bool strict)
         {
             if (Count != other?.Count)
                 return false;
             for (int i = 0; i < Count; i++)
             {
-                if (!this[i].Equals(other[i], strict))
+                if (!this[i].Equals(other[i]))
                     return false;
             }
             return true;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathPattern.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathPattern.cs
@@ -198,12 +198,21 @@ namespace Azure.Generator.Management.Models
 
         /// <inheritdoc />
         public bool Equals(RequestPathPattern? other)
+            => Equals(other, strict: false);
+
+        /// <summary>
+        /// Determines whether this path pattern equals another path pattern.
+        /// </summary>
+        /// <param name="other">The other path pattern to compare.</param>
+        /// <param name="strict">Whether variable segment names must match exactly.</param>
+        /// <returns><c>true</c> if the path patterns are equal; otherwise, <c>false</c>.</returns>
+        public bool Equals(RequestPathPattern? other, bool strict)
         {
             if (Count != other?.Count)
                 return false;
             for (int i = 0; i < Count; i++)
             {
-                if (!this[i].Equals(other[i]))
+                if (!this[i].Equals(other[i], strict))
                     return false;
             }
             return true;
@@ -213,7 +222,15 @@ namespace Azure.Generator.Management.Models
         public override bool Equals(object? obj) => obj is RequestPathPattern other && Equals(other);
 
         /// <inheritdoc />
-        public override int GetHashCode() => _path.GetHashCode();
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (var segment in _segments)
+            {
+                hash.Add(segment);
+            }
+            return hash.ToHashCode();
+        }
 
         /// <inheritdoc />
         public override string ToString() => _path;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathSegment.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathSegment.cs
@@ -25,15 +25,6 @@ namespace Azure.Generator.Management.Models
 
         /// <inheritdoc />
         public bool Equals(RequestPathSegment? other)
-            => Equals(other, strict: false);
-
-        /// <summary>
-        /// Determines whether this segment equals another segment.
-        /// </summary>
-        /// <param name="other">The other segment to compare.</param>
-        /// <param name="strict">Whether variable segment names must match exactly.</param>
-        /// <returns><c>true</c> if the segments are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(RequestPathSegment? other, bool strict)
         {
             if (other is null)
                 return false;
@@ -41,7 +32,9 @@ namespace Azure.Generator.Management.Models
                 return false;
             if (IsConstant)
                 return string.Equals(_value, other._value, StringComparison.OrdinalIgnoreCase);
-            return strict ? string.Equals(_value, other._value, StringComparison.Ordinal) : true;
+
+            // Variable segment names are placeholders only; {resourceGroupName} and {rgName} represent the same path shape.
+            return true;
         }
 
         /// <summary>
@@ -87,7 +80,7 @@ namespace Azure.Generator.Management.Models
         public override bool Equals(object? obj) => obj is RequestPathSegment other && Equals(other);
 
         /// <inheritdoc />
-        public override int GetHashCode() => IsConstant ? StringComparer.OrdinalIgnoreCase.GetHashCode(_value) : "{}".GetHashCode();
+        public override int GetHashCode() => IsConstant ? StringComparer.OrdinalIgnoreCase.GetHashCode(_value) : 0;
 
         /// <inheritdoc />
         public override string ToString() => _value;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathSegment.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/RequestPathSegment.cs
@@ -25,10 +25,23 @@ namespace Azure.Generator.Management.Models
 
         /// <inheritdoc />
         public bool Equals(RequestPathSegment? other)
+            => Equals(other, strict: false);
+
+        /// <summary>
+        /// Determines whether this segment equals another segment.
+        /// </summary>
+        /// <param name="other">The other segment to compare.</param>
+        /// <param name="strict">Whether variable segment names must match exactly.</param>
+        /// <returns><c>true</c> if the segments are equal; otherwise, <c>false</c>.</returns>
+        public bool Equals(RequestPathSegment? other, bool strict)
         {
             if (other is null)
                 return false;
-            return _value == other._value;
+            if (IsConstant != other.IsConstant)
+                return false;
+            if (IsConstant)
+                return string.Equals(_value, other._value, StringComparison.OrdinalIgnoreCase);
+            return strict ? string.Equals(_value, other._value, StringComparison.Ordinal) : true;
         }
 
         /// <summary>
@@ -51,7 +64,7 @@ namespace Azure.Generator.Management.Models
         /// <summary>
         /// Returns true if this segment is the "providers" segment.
         /// </summary>
-        public bool IsProvidersSegment => _value.Equals("providers");
+        public bool IsProvidersSegment => _value.Equals("providers", StringComparison.OrdinalIgnoreCase);
 
         private static void ParseValue(string value, ref bool isConstant, ref string? variableName)
         {
@@ -74,7 +87,7 @@ namespace Azure.Generator.Management.Models
         public override bool Equals(object? obj) => obj is RequestPathSegment other && Equals(other);
 
         /// <inheritdoc />
-        public override int GetHashCode() => _value.GetHashCode();
+        public override int GetHashCode() => IsConstant ? StringComparer.OrdinalIgnoreCase.GetHashCode(_value) : "{}".GetHashCode();
 
         /// <inheritdoc />
         public override string ToString() => _value;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ProviderConstantsProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ProviderConstantsProvider.cs
@@ -14,7 +14,7 @@ namespace Azure.Generator.Management.Providers
     {
         private const string DefaultProviderNamespaceName = "DefaultProviderNamespace";
 
-        public static ValueExpression DefaultProviderNamespace =>  Static(ManagementClientGenerator.Instance.OutputLibrary.ProviderConstants.Type).Property(DefaultProviderNamespaceName);
+        public static ValueExpression DefaultProviderNamespace => Static(ManagementClientGenerator.Instance.OutputLibrary.ProviderConstants.Type).Property(DefaultProviderNamespaceName);
 
         protected override string BuildName() => "ProviderConstants";
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -355,7 +355,7 @@ namespace Azure.Generator.Management.Providers
             var parentResourceCsharpType = GetParentResourceType(_resourceMetadata, _resource);
             if (_resourceMetadata.Scope.Kind != ResourceScope.Extension)
             {
-                methods.Add(ResourceMethodSnippets.BuildValidateResourceIdMethod(this,Static(parentResourceCsharpType!).As<ArmResource>().ResourceType()));
+                methods.Add(ResourceMethodSnippets.BuildValidateResourceIdMethod(this, Static(parentResourceCsharpType!).As<ArmResource>().ResourceType()));
             }
             // For extension resource with known parent resource type, we can also generate a ValidateResourceId method
             else if (_resourceMetadata.Scope.ScopeResourceType is { } parentResourceType)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/RestClientVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/RestClientVisitor.cs
@@ -84,7 +84,7 @@ internal class RestClientVisitor : ScmLibraryVisitor
             rootClient);
 
         rootClient.Update(
-            fields:[apiVersionField, endpointField],
+            fields: [apiVersionField, endpointField],
             methods: [.. rootClient.RestClient.Methods], // put create request methods to client directly
             modifiers: TransformPublicModifiersToInternal(rootClient),
             relativeFilePath: TransformRelativeFilePathForClient(rootClient),

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/OperationContextTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/OperationContextTests.cs
@@ -402,6 +402,36 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
+        public void ValidateParameterMapping_MatchesConstantSegmentsCaseInsensitive()
+        {
+            Assert.That(new RequestPathSegment("resourcegroups"), Is.EqualTo(new RequestPathSegment("resourceGroups")));
+
+            var contextualPathPattern = new RequestPathPattern("/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Insights/metricAlerts/{ruleName}");
+            var operationContext = OperationContext.Create(contextualPathPattern);
+            var operationPath = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Insights/metricAlerts/{ruleName}/status/{statusName}");
+
+            var registry = operationContext.BuildParameterMapping(operationPath);
+
+            Assert.That(registry.TryGetValue("subscriptionId", out var subscriptionMapping), Is.True);
+            Assert.That(subscriptionMapping!.ContextualParameter, Is.Not.Null);
+            Assert.That(subscriptionMapping.ContextualParameter!.Key, Is.EqualTo("subscriptions"));
+            Assert.That(subscriptionMapping.ContextualParameter.VariableName, Is.EqualTo("subscriptionId"));
+
+            Assert.That(registry.TryGetValue("resourceGroupName", out var resourceGroupMapping), Is.True);
+            Assert.That(resourceGroupMapping!.ContextualParameter, Is.Not.Null);
+            Assert.That(resourceGroupMapping.ContextualParameter!.Key, Is.EqualTo("resourcegroups"));
+            Assert.That(resourceGroupMapping.ContextualParameter.VariableName, Is.EqualTo("resourceGroupName"));
+
+            Assert.That(registry.TryGetValue("ruleName", out var ruleMapping), Is.True);
+            Assert.That(ruleMapping!.ContextualParameter, Is.Not.Null);
+            Assert.That(ruleMapping.ContextualParameter!.Key, Is.EqualTo("metricAlerts"));
+            Assert.That(ruleMapping.ContextualParameter.VariableName, Is.EqualTo("ruleName"));
+
+            Assert.That(registry.TryGetValue("statusName", out var statusMapping), Is.True);
+            Assert.That(statusMapping!.ContextualParameter, Is.Null);
+        }
+
+        [Test]
         public void ValidateParameterMapping_ChildResourceWithPassThroughParameter()
         {
             // Test case where operation path represents a child resource with an additional parameter

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
@@ -149,20 +149,17 @@ namespace Azure.Generator.Management.Tests
             var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
 
             Assert.That(first.Equals(second), Is.True);
-            Assert.That(first.Equals(second, strict: false), Is.True);
         }
 
         [Test]
-        public void Equals_StrictComparesVariableNames()
+        public void Equals_TreatsProviderSegmentCasingAsEqual()
         {
-            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
-            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
-            var same = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
-            var sameDifferentConstantCasing = new RequestPathPattern("/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}");
+            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}");
+            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}/Providers/Microsoft.Storage/storageAccounts/{name}");
 
-            Assert.That(first.Equals(second, strict: true), Is.False);
-            Assert.That(first.Equals(same, strict: true), Is.True);
-            Assert.That(first.Equals(sameDifferentConstantCasing, strict: true), Is.True);
+            Assert.That(first.Equals(second), Is.True);
+            Assert.That(first.GetHashCode(), Is.EqualTo(second.GetHashCode()));
+            Assert.That(new RequestPathSegment("Providers").IsProvidersSegment, Is.True);
         }
 
         [Test]

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/RequestPathPatternTests.cs
@@ -3,6 +3,8 @@
 
 using Azure.Generator.Management.Models;
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Azure.Generator.Management.Tests
 {
@@ -108,6 +110,73 @@ namespace Azure.Generator.Management.Tests
             Assert.That(
                 RequestPathPattern.GetMaximumSharingSegmentsCount(right, left),
                 Is.EqualTo(RequestPathPattern.GetMaximumSharingSegmentsCount(left, right)));
+        }
+
+        [Test]
+        public void GetHashCode_EqualPatternsUseEqualHashCodes()
+        {
+            var fromString = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var fromSegments = new RequestPathPattern(fromString.AsEnumerable());
+
+            Assert.That(fromSegments, Is.EqualTo(fromString));
+            Assert.That(fromSegments.GetHashCode(), Is.EqualTo(fromString.GetHashCode()));
+        }
+
+        [Test]
+        public void GetHashCode_EqualPatternsWithDifferentVariableNamesUseEqualHashCodes()
+        {
+            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
+
+            Assert.That(second, Is.EqualTo(first));
+            Assert.That(second.GetHashCode(), Is.EqualTo(first.GetHashCode()));
+        }
+
+        [Test]
+        public void GetHashCode_EqualPatternsWithDifferentConstantCasingUseEqualHashCodes()
+        {
+            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}");
+            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
+
+            Assert.That(second, Is.EqualTo(first));
+            Assert.That(second.GetHashCode(), Is.EqualTo(first.GetHashCode()));
+        }
+
+        [Test]
+        public void Equals_NonStrictTreatsVariableNamesAsEqual()
+        {
+            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
+
+            Assert.That(first.Equals(second), Is.True);
+            Assert.That(first.Equals(second, strict: false), Is.True);
+        }
+
+        [Test]
+        public void Equals_StrictComparesVariableNames()
+        {
+            var first = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var second = new RequestPathPattern("/subscriptions/{subId}/resourceGroups/{rgName}");
+            var same = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var sameDifferentConstantCasing = new RequestPathPattern("/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}");
+
+            Assert.That(first.Equals(second, strict: true), Is.False);
+            Assert.That(first.Equals(same, strict: true), Is.True);
+            Assert.That(first.Equals(sameDifferentConstantCasing, strict: true), Is.True);
+        }
+
+        [Test]
+        public void GetHashCode_DifferentPatternsCanCoexistInHashSet()
+        {
+            var resourceGroup = new RequestPathPattern("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}");
+            var subscription = new RequestPathPattern("/subscriptions/{subscriptionId}");
+
+            Assert.That(resourceGroup, Is.Not.EqualTo(subscription));
+
+            var set = new HashSet<RequestPathPattern> { resourceGroup, subscription };
+            Assert.That(set.Count, Is.EqualTo(2));
+            Assert.That(set.Contains(resourceGroup), Is.True);
+            Assert.That(set.Contains(subscription), Is.True);
         }
     }
 }


### PR DESCRIPTION
This PR fixes request path equality/hash-code semantics in the management generator.

Changes:
- Treat constant request path segments as case-insensitive.
- Treat variable request path segments as equivalent by default, with strict equality available for exact variable-name comparisons.
- Hash request path patterns by parsed segments so hash-based collections align with equality semantics.
- Add request-path and operation-context regression tests, including the Monitor resourceGroups casing scenario.

Validation:
- dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --filter "OperationContextTests|RequestPathPatternTests" -v minimal
