### PR TITLE
fix: add ServiceLabel for Azure.Communication.CallAutomation in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -218,6 +218,9 @@
 # PRLabel: %Communication - Call Automation
 /sdk/communication/Azure.Communication.CallAutomation/    @juntuchen-msft @minwoolee-msft
 
+# ServiceLabel: %Communication - Call Automation
+# ServiceOwners: @juntuchen-msft @minwoolee-msft
+
 # PRLabel: %Communication - Chat
 /sdk/communication/Azure.Communication.Chat/    @LuChen-Microsoft
 


### PR DESCRIPTION
## Summary

The `check-package` CI check was failing for `/sdk/communication/Azure.Communication.CallAutomation/` with:

```
No service label entry found whose labels are fully contained within PR labels [Communication - Call Automation].
```

## Root Cause

The CODEOWNERS entry for `Azure.Communication.CallAutomation` had a `# PRLabel: %Communication - Call Automation` block but was missing the corresponding `# ServiceLabel` + `# ServiceOwners` block. The `check-package` tool requires a service label entry whose label matches the PR labels.

## Fix

Added the missing service label block:

```
# ServiceLabel: %Communication - Call Automation
# ServiceOwners: @juntuchen-msft @minwoolee-msft
```

This follows the same pattern used by all other packages with specific service labels (e.g., `Cognitive - Translator`, `Communication - Chat`, etc.).

The GitHub label `Communication - Call Automation` was confirmed to exist in the repository.