### PR TITLE
[Monitor Exporter] Add remaining Network SDK Stats signals

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -174,18 +174,46 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             {
                 if (_transmissionStateManager.State == TransmissionState.Closed)
                 {
+                    var stopwatch = networkSdkStats != null ? System.Diagnostics.Stopwatch.StartNew() : null;
+
                     using var httpMessage = async ?
                     await _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).ConfigureAwait(false) :
                     _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).Result;
 
+                    stopwatch?.Stop();
+
                     result = HttpPipelineHelper.IsSuccess(httpMessage, telemetrySchemaTypeCounter);
 
-                    if (result == ExportResult.Success && networkSdkStats != null)
+                    if (networkSdkStats != null)
                     {
-                        // Record Network SDKStats Request_Success_Count for HTTP 200.
-                        // request.Uri reflects any redirect followed by IngestionRedirectPolicy,
-                        // so the host recorded matches the stamp that returned the response.
-                        networkSdkStats.TrackSuccess(httpMessage.Request.Uri.Host);
+                        var requestHost = httpMessage.Request.Uri.Host;
+
+                        if (httpMessage.HasResponse)
+                        {
+                            // Request_Duration is recorded for every request that received a
+                            // response, regardless of outcome.
+                            networkSdkStats.TrackDuration(requestHost, stopwatch!.Elapsed.TotalMilliseconds);
+                        }
+
+                        if (result == ExportResult.Success)
+                        {
+                            // Record Network SDKStats Request_Success_Count for HTTP 200.
+                            // request.Uri reflects any redirect followed by IngestionRedirectPolicy,
+                            // so the host recorded matches the stamp that returned the response.
+                            networkSdkStats.TrackSuccess(requestHost);
+                        }
+                        else if (httpMessage.HasResponse)
+                        {
+                            // Classify the top-level non-success response as retry / throttle /
+                            // failure. 206 partial-success per-envelope handling happens in
+                            // HttpPipelineHelper.HandlePartialSuccess.
+                            networkSdkStats.TrackResponseFailure(requestHost, httpMessage.Response.Status);
+                        }
+                        else
+                        {
+                            // No response code received: count as an exception.
+                            networkSdkStats.TrackException(requestHost, exceptionType: null);
+                        }
                     }
 
                     if (result == ExportResult.Failure && _fileBlobProvider != null)
@@ -221,6 +249,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
             catch (Exception ex)
             {
+                networkSdkStats?.TrackException(requestHost: null, exceptionType: ex.GetType().FullName);
                 AzureMonitorExporterEventSource.Log.TransmitterFailed(origin, _isAadEnabled, _connectionVars.InstrumentationKey, ex);
                 CustomerSdkStatsHelper.TrackDropped(telemetrySchemaTypeCounter, (int)DropCode.ClientException, CustomerSdkStatsHelper.GetDropReason(ex));
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -375,6 +375,30 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 networkSdkStatsManager.TrackPartialSuccessAccepted(httpMessage.Request.Uri.Host, acceptedCount);
             }
 
+            // Per the Network SDKStats spec, rejected envelopes within a 206 response are
+            // classified per-envelope: retryable status codes increment Retry_Count, and
+            // non-retryable status codes increment Exception_Count.
+            if (networkSdkStatsManager != null && trackResponse.Errors != null)
+            {
+                var partialHost = httpMessage.Request.Uri.Host;
+                foreach (var error in trackResponse.Errors)
+                {
+                    if (error?.StatusCode is not int envelopeStatusCode)
+                    {
+                        continue;
+                    }
+
+                    if (NetworkSdkStatsHelper.IsRetryable(envelopeStatusCode))
+                    {
+                        networkSdkStatsManager.TrackRetry(partialHost, envelopeStatusCode);
+                    }
+                    else
+                    {
+                        networkSdkStatsManager.TrackException(partialHost, exceptionType: envelopeStatusCode.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                    }
+                }
+            }
+
             var (partialContent, successCounter, retryCounter, droppedCounter) = ProcessPartialSuccessWithCounting(trackResponse, httpMessage.Request.Content, telemetrySchemaTypeCounter);
 
             if (successCounter != null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsHelper.cs
@@ -4,9 +4,9 @@
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
 {
     /// <summary>
-    /// Stateless helpers for Network SDKStats. Initial scope only exposes host extraction;
-    /// the response-status classification helpers required by the failure / retry / throttle
-    /// / exception instruments will be added alongside those instruments in a follow-up.
+    /// Stateless helpers for Network SDKStats: stamp-host extraction and the breeze
+    /// response-status classification (retryable / throttling) used by the failure /
+    /// retry / throttle / exception instruments.
     /// </summary>
     internal static class NetworkSdkStatsHelper
     {
@@ -31,5 +31,27 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
             int firstDot = host.IndexOf('.');
             return firstDot > 0 ? host.Substring(0, firstDot) : host;
         }
+
+        /// <summary>
+        /// Whether a breeze (HTTP) status code is retryable per the Network SDKStats spec:
+        /// 401, 403, 408, 429, 500, 502, 503, or 504.
+        /// </summary>
+        public static bool IsRetryable(int statusCode) =>
+            statusCode == ResponseStatusCodes.Unauthorized
+            || statusCode == ResponseStatusCodes.Forbidden
+            || statusCode == ResponseStatusCodes.RequestTimeout
+            || statusCode == ResponseStatusCodes.ResponseCodeTooManyRequests
+            || statusCode == ResponseStatusCodes.InternalServerError
+            || statusCode == ResponseStatusCodes.BadGateway
+            || statusCode == ResponseStatusCodes.ServiceUnavailable
+            || statusCode == ResponseStatusCodes.GatewayTimeout;
+
+        /// <summary>
+        /// Whether a breeze (HTTP) status code is a throttling response per the Network SDKStats
+        /// spec: 402 or 439.
+        /// </summary>
+        public static bool IsThrottle(int statusCode) =>
+            statusCode == ResponseStatusCodes.PaymentRequired
+            || statusCode == ResponseStatusCodes.ResponseCodeTooManyRequestsAndRefreshCache;
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsManager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsManager.cs
@@ -11,15 +11,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
 {
     /// <summary>
     /// Records short-interval Network SDKStats metrics for a single Azure Monitor exporter
-    /// transmitter. Initial scope only emits <c>Request_Success_Count</c>; additional
-    /// instruments (failure / retry / throttle / exception / duration) will be added in
-    /// follow-up changes.
+    /// transmitter: <c>Request_Success_Count</c>, <c>Request_Failure_Count</c>,
+    /// <c>Request_Duration</c>, <c>Retry_Count</c>, <c>Throttle_Count</c>, and
+    /// <c>Exception_Count</c>.
     /// </summary>
     /// <remarks>
     /// One <see cref="NetworkSdkStatsManager"/> is created per <see cref="Statsbeat.AzureMonitorStatsbeat"/>
     /// instance. The dimensions <c>rp</c>, <c>attach</c>, <c>cikey</c>, <c>runtimeVersion</c>,
     /// <c>os</c>, <c>language</c>, <c>version</c>, and <c>endpoint</c> are captured at
-    /// initialization time; the <c>host</c> dimension is added per recorded measurement.
+    /// initialization time; the <c>host</c> dimension is added per recorded measurement, and
+    /// <c>statusCode</c> / <c>exceptionType</c> are added for the relevant instruments.
     /// </remarks>
     internal sealed class NetworkSdkStatsManager
     {
@@ -30,12 +31,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
         private readonly string _attach;
         private readonly string? _runtimeVersion;
         private readonly string _operatingSystem;
+        private readonly string? _ingestionHost;
         private string? _resourceProvider;
 
         internal NetworkSdkStatsManager(ConnectionVars connectionVars, IPlatform platform)
         {
             _platform = platform;
             _customerIkey = string.IsNullOrEmpty(connectionVars?.InstrumentationKey) ? "N/A" : connectionVars!.InstrumentationKey;
+
+            // Configured ingestion host, used as a best-effort host dimension when an exception
+            // prevents us from observing the actual (possibly redirected) request host.
+            if (connectionVars != null && Uri.TryCreate(connectionVars.IngestionEndpoint, UriKind.Absolute, out Uri? ingestionUri))
+            {
+                _ingestionHost = ingestionUri.Host;
+            }
 
             // These dimensions are invariant for the process lifetime, so capture them
             // once instead of recomputing on every recorded measurement (matches
@@ -85,6 +94,116 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
             }
         }
 
+        /// <summary>
+        /// Record the duration of a request that received a response from the ingestion
+        /// endpoint, regardless of outcome. Backs the <c>Request_Duration</c> (avg) metric.
+        /// </summary>
+        public void TrackDuration(string? requestHost, double durationMs)
+        {
+            try
+            {
+                NetworkSdkStatsMeters.RequestDuration.Record(durationMs, BuildBaseTags(NetworkSdkStatsHelper.ExtractStampHost(requestHost)));
+            }
+            catch
+            {
+                // See TrackSuccess for rationale.
+            }
+        }
+
+        /// <summary>
+        /// Classify a non-success top-level response and record the matching Network SDKStats
+        /// instrument (<c>Retry_Count</c>, <c>Throttle_Count</c>, or <c>Request_Failure_Count</c>).
+        /// HTTP 200 / 206 and 307 / 308 redirects are handled elsewhere and ignored here.
+        /// </summary>
+        public void TrackResponseFailure(string? requestHost, int statusCode)
+        {
+            // 200 (success) and 206 (partial success - per-envelope handling) are tracked
+            // elsewhere. Redirects are followed by the pipeline and are not a terminal outcome.
+            if (statusCode == ResponseStatusCodes.Success
+                || statusCode == ResponseStatusCodes.PartialSuccess
+                || statusCode == ResponseStatusCodes.TemporaryRedirect
+                || statusCode == ResponseStatusCodes.PermanentRedirect)
+            {
+                return;
+            }
+
+            if (NetworkSdkStatsHelper.IsRetryable(statusCode))
+            {
+                TrackRetry(requestHost, statusCode);
+            }
+            else if (NetworkSdkStatsHelper.IsThrottle(statusCode))
+            {
+                TrackThrottle(requestHost, statusCode);
+            }
+            else
+            {
+                TrackFailure(requestHost, statusCode);
+            }
+        }
+
+        /// <summary>
+        /// Record a non-retryable, non-throttling failure response. Backs <c>Request_Failure_Count</c>.
+        /// </summary>
+        public void TrackFailure(string? requestHost, int statusCode)
+        {
+            try
+            {
+                NetworkSdkStatsMeters.RequestFailureCount.Add(1, BuildStatusCodeTags(NetworkSdkStatsHelper.ExtractStampHost(requestHost), statusCode));
+            }
+            catch
+            {
+                // See TrackSuccess for rationale.
+            }
+        }
+
+        /// <summary>
+        /// Record a retryable response. Backs <c>Retry_Count</c>.
+        /// </summary>
+        public void TrackRetry(string? requestHost, int statusCode)
+        {
+            try
+            {
+                NetworkSdkStatsMeters.RetryCount.Add(1, BuildStatusCodeTags(NetworkSdkStatsHelper.ExtractStampHost(requestHost), statusCode));
+            }
+            catch
+            {
+                // See TrackSuccess for rationale.
+            }
+        }
+
+        /// <summary>
+        /// Record a throttling response. Backs <c>Throttle_Count</c>.
+        /// </summary>
+        public void TrackThrottle(string? requestHost, int statusCode)
+        {
+            try
+            {
+                NetworkSdkStatsMeters.ThrottleCount.Add(1, BuildStatusCodeTags(NetworkSdkStatsHelper.ExtractStampHost(requestHost), statusCode));
+            }
+            catch
+            {
+                // See TrackSuccess for rationale.
+            }
+        }
+
+        /// <summary>
+        /// Record an exception that occurred during the HTTP call (no response code received).
+        /// Backs <c>Exception_Count</c>. When <paramref name="requestHost"/> is <c>null</c> the
+        /// configured ingestion host is used as a best-effort value.
+        /// </summary>
+        public void TrackException(string? requestHost, string? exceptionType)
+        {
+            try
+            {
+                string host = NetworkSdkStatsHelper.ExtractStampHost(requestHost ?? _ingestionHost);
+                NetworkSdkStatsMeters.ExceptionCount.Add(1, BuildExceptionTags(host, exceptionType));
+            }
+            catch
+            {
+                // See TrackSuccess for rationale.
+            }
+        }
+
         internal TagList BuildBaseTags(string host)
         {
             // Resource provider can require an Azure Instance Metadata Service probe; defer
@@ -105,6 +224,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
                 { "endpoint", StatsbeatConstants.NetworkSdkStatsEndpointBreeze },
                 { "host", host },
             };
+        }
+
+        private TagList BuildStatusCodeTags(string host, int statusCode)
+        {
+            var tags = BuildBaseTags(host);
+            tags.Add("statusCode", statusCode);
+            return tags;
+        }
+
+        private TagList BuildExceptionTags(string host, string? exceptionType)
+        {
+            var tags = BuildBaseTags(host);
+            tags.Add("exceptionType", exceptionType ?? "unknown");
+            return tags;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsMeters.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NetworkSdkStats/NetworkSdkStatsMeters.cs
@@ -8,7 +8,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
 {
     /// <summary>
     /// Provides the OpenTelemetry <see cref="Meter"/> and instruments used to publish
-    /// short-interval Network SDKStats. Metric names follow the SDKStats specification.
+    /// short-interval Network SDKStats (request success / failure / retry / throttle /
+    /// exception counts and request duration). Metric names follow the SDKStats specification.
     /// </summary>
     /// <remarks>
     /// The meter is process-static (matching the existing Statsbeat meters); per-instance
@@ -21,5 +22,26 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats
         public static readonly Counter<long> RequestSuccessCount = Meter.CreateCounter<long>(
             "Request_Success_Count",
             description: "Count of requests accepted by the destination ingestion endpoint.");
+
+        public static readonly Counter<long> RequestFailureCount = Meter.CreateCounter<long>(
+            "Request_Failure_Count",
+            description: "Count of requests that returned a non-retryable, non-throttling failure from the destination ingestion endpoint.");
+
+        public static readonly Histogram<double> RequestDuration = Meter.CreateHistogram<double>(
+            "Request_Duration",
+            unit: "ms",
+            description: "Duration of requests to the destination ingestion endpoint.");
+
+        public static readonly Counter<long> RetryCount = Meter.CreateCounter<long>(
+            "Retry_Count",
+            description: "Count of requests for which the destination ingestion endpoint returned a retryable response.");
+
+        public static readonly Counter<long> ThrottleCount = Meter.CreateCounter<long>(
+            "Throttle_Count",
+            description: "Count of requests for which the destination ingestion endpoint returned a quota / rate-limit response.");
+
+        public static readonly Counter<long> ExceptionCount = Meter.CreateCounter<long>(
+            "Exception_Count",
+            description: "Count of requests that failed with an exception (no response code received).");
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResponseStatusCodes.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResponseStatusCodes.cs
@@ -7,7 +7,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     {
         public const int Success = 200;
         public const int PartialSuccess = 206;
+        public const int TemporaryRedirect = 307;
+        public const int PermanentRedirect = 308;
         public const int Unauthorized = 401;
+        public const int PaymentRequired = 402;
         public const int Forbidden = 403;
         public const int RequestTimeout = 408;
         public const int ResponseCodeTooManyRequests = 429;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -80,9 +80,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             }
                         }
 
+                        var stopwatch = _networkSdkStatsManager != null ? System.Diagnostics.Stopwatch.StartNew() : null;
+
                         using var httpMessage = _applicationInsightsRestClient.InternalTrackAsync(data, CancellationToken.None).Result;
 
+                        stopwatch?.Stop();
+
                         var result = HttpPipelineHelper.IsSuccess(httpMessage, telemetrySchemaTypeCounter);
+
+                        if (_networkSdkStatsManager != null && httpMessage.HasResponse)
+                        {
+                            _networkSdkStatsManager.TrackDuration(httpMessage.Request.Uri.Host, stopwatch!.Elapsed.TotalMilliseconds);
+                        }
 
                         if (result == ExportResult.Success)
                         {
@@ -103,6 +112,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         }
                         else
                         {
+                            if (_networkSdkStatsManager != null)
+                            {
+                                if (httpMessage.HasResponse)
+                                {
+                                    // 206 partial-success per-envelope handling happens in
+                                    // HttpPipelineHelper.HandlePartialSuccess.
+                                    _networkSdkStatsManager.TrackResponseFailure(httpMessage.Request.Uri.Host, httpMessage.Response.Status);
+                                }
+                                else
+                                {
+                                    _networkSdkStatsManager.TrackException(httpMessage.Request.Uri.Host, exceptionType: null);
+                                }
+                            }
+
                             _transmissionStateManager.EnableBackOff(httpMessage.HasResponse ? httpMessage.Response : null);
                             HttpPipelineHelper.ProcessTransmissionResult(httpMessage, _blobProvider, blob, _connectionVars, TelemetryItemOrigin.Storage, _isAadEnabled, telemetrySchemaTypeCounter, _networkSdkStatsManager);
                             break;
@@ -110,6 +133,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     }
                     catch (Exception ex)
                     {
+                        _networkSdkStatsManager?.TrackException(requestHost: null, exceptionType: ex.GetType().FullName);
                         AzureMonitorExporterEventSource.Log.FailedToTransmitFromStorage(_isAadEnabled, _connectionVars.InstrumentationKey, ex);
                         CustomerSdkStatsHelper.TrackDropped(telemetrySchemaTypeCounter, (int)DropCode.ClientException, CustomerSdkStatsHelper.GetDropReason(ex));
                     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/NetworkSdkStats/NetworkSdkStatsManagerTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/NetworkSdkStats/NetworkSdkStatsManagerTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.NetworkSdkStats;
@@ -139,6 +141,254 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.NetworkSdkStats
             manager.TrackPartialSuccessAccepted("westus-0.in.applicationinsights.azure.com", -3);
 
             Assert.Equal(0, recorded);
+        }
+
+        [Theory]
+        [InlineData(401, true)]
+        [InlineData(403, true)]
+        [InlineData(408, true)]
+        [InlineData(429, true)]
+        [InlineData(500, true)]
+        [InlineData(502, true)]
+        [InlineData(503, true)]
+        [InlineData(504, true)]
+        [InlineData(402, false)]
+        [InlineData(439, false)]
+        [InlineData(400, false)]
+        [InlineData(404, false)]
+        [InlineData(200, false)]
+        public void IsRetryable_MatchesBreezeSpec(int statusCode, bool expected)
+        {
+            Assert.Equal(expected, NetworkSdkStatsHelper.IsRetryable(statusCode));
+        }
+
+        [Theory]
+        [InlineData(402, true)]
+        [InlineData(439, true)]
+        [InlineData(429, false)]
+        [InlineData(503, false)]
+        [InlineData(400, false)]
+        [InlineData(200, false)]
+        public void IsThrottle_MatchesBreezeSpec(int statusCode, bool expected)
+        {
+            Assert.Equal(expected, NetworkSdkStatsHelper.IsThrottle(statusCode));
+        }
+
+        [Fact]
+        public void TrackDuration_RecordsRequestDuration()
+        {
+            var manager = CreateManager("00000000-0000-0000-0000-000000000010");
+
+            double recorded = 0;
+            string? observedHost = null;
+            using var listener = CreateHistogramListener("Request_Duration", (value, tags) =>
+            {
+                recorded += value;
+                observedHost = GetTag(tags, "host");
+            });
+            listener.Start();
+
+            manager.TrackDuration("westus-0.in.applicationinsights.azure.com", 123.5);
+
+            Assert.Equal(123.5, recorded);
+            Assert.Equal("westus-0", observedHost);
+        }
+
+        [Fact]
+        public void TrackResponseFailure_NonRetriableStatus_RecordsRequestFailureCountWithStatusCode()
+        {
+            var manager = CreateManager("00000000-0000-0000-0000-000000000011");
+
+            long recorded = 0;
+            int? observedStatusCode = null;
+            using var listener = CreateCounterListener("Request_Failure_Count", (value, tags) =>
+            {
+                recorded += value;
+                observedStatusCode = GetIntTag(tags, "statusCode");
+            });
+            listener.Start();
+
+            manager.TrackResponseFailure("westus-0.in.applicationinsights.azure.com", 404);
+
+            Assert.Equal(1, recorded);
+            Assert.Equal(404, observedStatusCode);
+        }
+
+        [Fact]
+        public void TrackResponseFailure_RetriableStatus_RecordsRetryCount()
+        {
+            var manager = CreateManager("00000000-0000-0000-0000-000000000012");
+
+            long recorded = 0;
+            int? observedStatusCode = null;
+            using var listener = CreateCounterListener("Retry_Count", (value, tags) =>
+            {
+                recorded += value;
+                observedStatusCode = GetIntTag(tags, "statusCode");
+            });
+            listener.Start();
+
+            manager.TrackResponseFailure("westus-0.in.applicationinsights.azure.com", 503);
+
+            Assert.Equal(1, recorded);
+            Assert.Equal(503, observedStatusCode);
+        }
+
+        [Fact]
+        public void TrackResponseFailure_ThrottleStatus_RecordsThrottleCount()
+        {
+            var manager = CreateManager("00000000-0000-0000-0000-000000000013");
+
+            long recorded = 0;
+            int? observedStatusCode = null;
+            using var listener = CreateCounterListener("Throttle_Count", (value, tags) =>
+            {
+                recorded += value;
+                observedStatusCode = GetIntTag(tags, "statusCode");
+            });
+            listener.Start();
+
+            manager.TrackResponseFailure("westus-0.in.applicationinsights.azure.com", 439);
+
+            Assert.Equal(1, recorded);
+            Assert.Equal(439, observedStatusCode);
+        }
+
+        [Theory]
+        [InlineData(200)]
+        [InlineData(206)]
+        [InlineData(307)]
+        [InlineData(308)]
+        public void TrackResponseFailure_SuccessPartialOrRedirect_DoesNotRecord(int statusCode)
+        {
+            var manager = CreateManager("00000000-0000-0000-0000-000000000014");
+
+            long recorded = 0;
+            using var failureListener = CreateCounterListener("Request_Failure_Count", (value, _) => recorded += value);
+            using var retryListener = CreateCounterListener("Retry_Count", (value, _) => recorded += value);
+            using var throttleListener = CreateCounterListener("Throttle_Count", (value, _) => recorded += value);
+            failureListener.Start();
+            retryListener.Start();
+            throttleListener.Start();
+
+            manager.TrackResponseFailure("westus-0.in.applicationinsights.azure.com", statusCode);
+
+            Assert.Equal(0, recorded);
+        }
+
+        [Fact]
+        public void TrackException_RecordsExceptionCountWithExceptionType()
+        {
+            var manager = CreateManager("00000000-0000-0000-0000-000000000015");
+
+            long recorded = 0;
+            string? observedExceptionType = null;
+            using var listener = CreateCounterListener("Exception_Count", (value, tags) =>
+            {
+                recorded += value;
+                observedExceptionType = GetTag(tags, "exceptionType");
+            });
+            listener.Start();
+
+            manager.TrackException("westus-0.in.applicationinsights.azure.com", "System.Net.Http.HttpRequestException");
+
+            Assert.Equal(1, recorded);
+            Assert.Equal("System.Net.Http.HttpRequestException", observedExceptionType);
+        }
+
+        [Fact]
+        public void TrackException_NullExceptionType_RecordsUnknown()
+        {
+            var manager = CreateManager("00000000-0000-0000-0000-000000000016");
+
+            string? observedExceptionType = null;
+            using var listener = CreateCounterListener("Exception_Count", (_, tags) => observedExceptionType = GetTag(tags, "exceptionType"));
+            listener.Start();
+
+            manager.TrackException("westus-0.in.applicationinsights.azure.com", exceptionType: null);
+
+            Assert.Equal("unknown", observedExceptionType);
+        }
+
+        [Fact]
+        public void TrackException_NullHost_FallsBackToConfiguredIngestionHost()
+        {
+            var manager = CreateManager("00000000-0000-0000-0000-000000000017");
+
+            string? observedHost = null;
+            using var listener = CreateCounterListener("Exception_Count", (_, tags) => observedHost = GetTag(tags, "host"));
+            listener.Start();
+
+            manager.TrackException(requestHost: null, exceptionType: "System.TimeoutException");
+
+            Assert.Equal("westus-0", observedHost);
+        }
+
+        private static NetworkSdkStatsManager CreateManager(string instrumentationKey)
+        {
+            var connectionVars = ConnectionStringParser.GetValues(
+                $"InstrumentationKey={instrumentationKey};IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/");
+            return new NetworkSdkStatsManager(connectionVars, new MockPlatform());
+        }
+
+        private static MeterListener CreateCounterListener(string instrumentName, Action<long, KeyValuePair<string, object?>[]> onMeasurement)
+        {
+            var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == StatsbeatConstants.NetworkSdkStatsMeterName
+                        && instrument.Name == instrumentName)
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            listener.SetMeasurementEventCallback<long>((_, value, tags, _) => onMeasurement(value, tags.ToArray()));
+            return listener;
+        }
+
+        private static MeterListener CreateHistogramListener(string instrumentName, Action<double, KeyValuePair<string, object?>[]> onMeasurement)
+        {
+            var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == StatsbeatConstants.NetworkSdkStatsMeterName
+                        && instrument.Name == instrumentName)
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            listener.SetMeasurementEventCallback<double>((_, value, tags, _) => onMeasurement(value, tags.ToArray()));
+            return listener;
+        }
+
+        private static string? GetTag(KeyValuePair<string, object?>[] tags, string key)
+        {
+            foreach (var t in tags)
+            {
+                if (t.Key == key)
+                {
+                    return t.Value as string;
+                }
+            }
+
+            return null;
+        }
+
+        private static int? GetIntTag(KeyValuePair<string, object?>[] tags, string key)
+        {
+            foreach (var t in tags)
+            {
+                if (t.Key == key && t.Value is int value)
+                {
+                    return value;
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements the remaining short-interval **Network SDKStats** signals defined in the [Application Insights SDKStats spec](https://github.com/microsoft/Telemetry-Collection-Spec/blob/main/ApplicationInsights/sdkstats/sdkstats.md#network-sdkstats), building on the `Request_Success_Count` path added in #59909.

## New signals

| Metric | Unit | Extra dimension | Definition (breeze) |
| ------ | ---- | --------------- | ------------------- |
| `Request_Failure_Count` | Count | `statusCode` | Non-retryable, non-throttling response codes |
| `Request_Duration` | avg (histogram) | — | Duration of every request that received a response |
| `Retry_Count` | Count | `statusCode` | 401 / 403 / 408 / 429 / 500 / 502 / 503 / 504 |
| `Throttle_Count` | Count | `statusCode` | 402 / 439 |
| `Exception_Count` | Count | `exceptionType` | HTTP-call exceptions / no response received |

## Changes

- **NetworkSdkStatsMeters** — added the five instruments (4 counters + 1 histogram).
- **NetworkSdkStatsHelper** — added `IsRetryable` / `IsThrottle` breeze classification.
- **NetworkSdkStatsManager** — added `TrackDuration`, `TrackResponseFailure` (retry/throttle/failure dispatch; skips 200/206/307/308), `TrackFailure`/`TrackRetry`/`TrackThrottle`/`TrackException`, `statusCode` / `exceptionType` tag builders, and an ingestion-host fallback for exceptions.
- **ResponseStatusCodes** — added 402, 307, 308.
- **AzureMonitorTransmitter** / **TransmitFromStorageHandler** — wired stopwatch duration, top-level failure/retry/throttle classification, and exception tracking (catch + no-response paths), independent of offline storage.
- **HttpPipelineHelper** — 206 per-envelope handling: retryable envelopes → `Retry_Count`, non-retryable → `Exception_Count` (accepted → `Request_Success_Count` was already wired).

## Tests

- Extended `NetworkSdkStatsManagerTests` covering each track method, the classification helpers, `statusCode` / `exceptionType` dimensions, and the host fallback.
- Full `Azure.Monitor.OpenTelemetry.Exporter` suite passes (762/762 on net10.0 and net8.0).

## End-to-end validation

Verified against a live stamp (`westus2-2`) that all six Network SDKStats instruments export to the Statsbeat ingestion resource (ikey `c4a29126-...`) with the expected dimensions (`language=dotnet`, `endpoint=breeze`, `host`, `statusCode`/`exceptionType`, etc.).