### PR TITLE
Fix mgmt mocking cref model qualification

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/CSharpTypeExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/CSharpTypeExtensions.cs
@@ -63,12 +63,24 @@ namespace Azure.Generator.Management.Utilities
 
         public static string GetXmlDocTypeName(this CSharpType type)
         {
+            var typeName = GetTypeName(type);
+
             // For nullable value types, we need to append '?' to the type name for XML documentation
             if (type.IsValueType && type.IsNullable)
             {
-                return $"{type.Name}?";
+                return $"{typeName}?";
             }
-            return type.Name;
+            return typeName;
+        }
+
+        private static string GetTypeName(CSharpType type)
+        {
+            if (string.IsNullOrEmpty(type.Namespace))
+            {
+                return type.Name;
+            }
+
+            return $"{type.Namespace}.{type.Name}";
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ExtensionProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ExtensionProviderTests.cs
@@ -4,6 +4,7 @@
 using Azure.Generator.Management.Providers;
 using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
+using Azure.Generator.Management.Utilities;
 using Humanizer;
 using NUnit.Framework;
 
@@ -88,6 +89,17 @@ namespace Azure.Generator.Management.Tests.Providers
                 Assert.That(mockableResource.Methods.Count, Is.GreaterThan(0),
                     $"MockableResourceProvider '{mockableResource.Name}' should have at least one method to be included in the output.");
             }
+        }
+
+        [TestCase]
+        public void Verify_MockingCrefQualifiesModelParameters()
+        {
+            var model = InputFactory.Model("ResponseType", clientNamespace: "Samples.Models");
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [model]);
+            var modelType = plugin.Object.TypeFactory.CreateCSharpType(model);
+            Assert.That(modelType, Is.Not.Null);
+
+            Assert.That(modelType!.GetXmlDocTypeName(), Is.EqualTo("Samples.Models.ResponseType"));
         }
     }
 }


### PR DESCRIPTION
# Summary

Fixes #60030.

Updates the management generator mocking XML documentation so method `cref` parameter types are qualified consistently with generated method signatures. Model parameters now emit `Models.<TypeName>` instead of always using the bare type name, avoiding collisions with same-namespace generated REST operation clients.

# Validation

- `npm install` in `eng/packages/http-client-csharp-mgmt`
- `eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1`
- `npm run lint`
- `npm run prettier`
- `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --no-restore --nologo`
- Minimal compiler repro confirms `Models.DataConnectorsCheckRequirements` avoids CS1574
