### PR TITLE
Update http-client-csharp-mgmt emitter package

### DIFF
--- a/eng/azure-typespec-http-client-csharp-mgmt-emitter-package-lock.json
+++ b/eng/azure-typespec-http-client-csharp-mgmt-emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260617.3"
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260618.1"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.69.0",
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260617.3",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260617.3.tgz",
-      "integrity": "sha1-5dzPBVNilcTh3n+o91QeuKr1ElI=",
+      "version": "1.0.0-alpha.20260618.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260618.1.tgz",
+      "integrity": "sha1-9FaAdpWkPU1j/9G9AnOKnNtI6Rk=",
       "license": "MIT",
       "dependencies": {
         "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260613.3",

--- a/eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json
+++ b/eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json
@@ -1,7 +1,7 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260617.3"
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260618.1"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.69.0",


### PR DESCRIPTION
Split from #60038. This contains only the eng package updates for azure-typespec/http-client-csharp-mgmt 1.0.0-alpha.20260618.1. Changes were copied from the merged PR branch; no regeneration was run.