### PR TITLE
Use authenticated npmrc

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -75,6 +75,8 @@ jobs:
           sbomEnabled: false
 
     steps:
+      - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+      
       - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:


### PR DESCRIPTION
This pull request adds steps to the CI test pipeline to ensure authenticated access to npm during test runs by generating a custom `.npmrc` file and configuring the environment accordingly.

**NPM Authentication Setup:**

* Added a step to generate an authenticated `.npmrc` file using the `create-authenticated-npmrc.yml` template, placing it in the agent's temporary test directory.
* Updated the environment configuration for the Azurite installation step to use the generated `.npmrc` file by setting the `npm_config_userconfig` environment variable.

[net - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6467200&view=results)
