### PR TITLE
Support no-op for PR pipeline

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -9,6 +9,8 @@ pr:
   paths:
     include:
     - "*"
+    exclude:
+    - .github/skills/azsdk-common-*/**
 
 parameters:
   - name: Service

--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -14,6 +14,9 @@ parameters:
   - name: Service
     type: string
     default: auto
+  - name: SkipPrValidation
+    type: boolean
+    default: false
   # Switch to canary to test canary 1es branch. 1es template validation will set this parameter
   # to canary on run.
   - name: oneESTemplateTag
@@ -27,6 +30,7 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     oneESTemplateTag: ${{ parameters.oneESTemplateTag }}
+    SkipPrValidation: ${{ parameters.SkipPrValidation }}
     # Short term hack to get 1es canary validation working until we can fix manual runs with 'auto'
     ${{ if and(eq(parameters.oneESTemplateTag, 'canary'), eq(parameters.Service, 'auto')) }}:
       ServiceDirectory: template

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -14,6 +14,9 @@ parameters:
   - name: ServiceDirectory
     type: string
     default: not-specified
+  - name: SkipPrValidation
+    type: boolean
+    default: false
   - name: BuildSnippets
     type: boolean
     default: true
@@ -63,7 +66,26 @@ extends:
   parameters:
     oneESTemplateTag: ${{ parameters.oneESTemplateTag }}
     stages:
+      - ${{ if and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual')) }}:
+        - stage: NoOp
+          displayName: No-op
+          variables:
+            - template: /eng/pipelines/templates/variables/globals.yml
+            - template: /eng/pipelines/templates/variables/image.yml
+          jobs:
+            - job: NoOp
+              displayName: No-op
+              pool:
+                name: $(LINUXPOOL)
+                image: $(LINUXVMIMAGE)
+                os: linux
+              steps:
+                - checkout: none
+                - pwsh: Write-Host "PR validation skipped because SkipPrValidation was set to true for a manual run."
+                  displayName: Skip PR validation
+
       - stage: Build
+        condition: not(and(eq(${{ parameters.SkipPrValidation }}, true), eq(variables['Build.Reason'], 'Manual')))
         variables:
           - template: /eng/pipelines/templates/variables/globals.yml
           - template: /eng/pipelines/templates/variables/image.yml
@@ -94,7 +116,7 @@ extends:
               TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
 
       # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-      - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+      - ${{if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
 
         - template: archetype-net-release.yml
           parameters:
@@ -111,4 +133,3 @@ extends:
             ArtifactName: packages
             PublicFeed: ${{ parameters.PublicFeed }}
             PublicPublishEnvironment: ${{ parameters.PublicPublishEnvironment }}
-


### PR DESCRIPTION
Mirrors Azure/azure-sdk-for-java#49558 for the .NET PR pipeline.

- Adds a `SkipPrValidation` parameter to `eng/pipelines/pullrequest.yml`.
- Passes it through to `archetype-sdk-client.yml`.
- Adds a manual-run no-op stage and skips build/release validation when the flag is enabled.
- Excludes `.github/skills/azsdk-common-*/**` from the PR validation trigger so changes limited to common Azure SDK skill folders do not run this pipeline.

Validation:
- `git diff --check`
- Parsed changed YAML files with PyYAML