### PR TITLE
Reduce mgmt regeneration group size

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/ci.yml
+++ b/eng/packages/http-client-csharp-mgmt/ci.yml
@@ -85,7 +85,12 @@ extends:
         PublishDependsOnTest: false
         PublishPublic: ${{ and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
         HasNugetPackages: true
-      RegenerationJobCount: 5
+      # Workaround: keep regen groups small enough to avoid the public release
+      # pipeline's 1-hour timeout. Azure.ResourceManager.Network takes much
+      # longer than most packages and should be optimized eventually; the shared
+      # matrix generator only supports count-based batching, not per-package
+      # isolation.
+      RegenerationJobCount: 18
       MinimumPerJob: 10
       OnlyGenerateTypespec: true
       DirectoryFilterPattern: 'Azure.ResourceManager*,Azure.Provisioning*'


### PR DESCRIPTION
## Description

This is a workaround for the public release pipeline timeout during management emitter regeneration. Azure.ResourceManager.Network currently takes much longer than most packages, and the shared matrix generator only supports count-based batching rather than per-package isolation.

This increases the management emitter regeneration job count from 5 to 18 so regeneration groups stay around 10 packages each.

## Validation

Ran New-RegenerateMatrix.ps1 locally with the updated mgmt settings and confirmed 184 packages are split into 18 groups of approximately 10 packages each.