### PR TITLE
Recognize inherited custom ARM resources

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -57,6 +57,7 @@ import {
   getMinLength,
   getMaxLength
 } from "@typespec/compiler";
+import { isCustomAzureResource } from "@azure-tools/typespec-azure-resource-manager";
 import { resolveArmResources } from "./resolve-arm-resources-converter.js";
 import { AzureMgmtEmitterOptions } from "./options.js";
 import { getAllSdkClients, traverseClient } from "./sdk-client-utils.js";
@@ -101,7 +102,7 @@ export function buildArmProviderSchema(
   );
 
   // Step 1: candidate resource models.
-  const resourceModels = getAllResourceModels(codeModel);
+  const resourceModels = getAllResourceModels(sdkContext, codeModel);
   const resourceModelMap = new Map<string, InputModelType>(
     resourceModels.map((m) => [m.crossLanguageDefinitionId, m])
   );
@@ -752,7 +753,10 @@ export function getAllClients(codeModel: CodeModel): InputClient[] {
  * @param model - The model to check for @customAzureResource decorator
  * @returns true if the model or any ancestor has @customAzureResource decorator
  */
-function hasCustomAzureResourceInHierarchy(model: InputModelType): boolean {
+function hasCustomAzureResourceInHierarchy(
+  sdkContext: CSharpEmitterContext,
+  model: InputModelType
+): boolean {
   let current: InputModelType | undefined = model;
   while (current) {
     if (current.decorators?.some((d) => d.name === customAzureResource)) {
@@ -760,7 +764,11 @@ function hasCustomAzureResourceInHierarchy(model: InputModelType): boolean {
     }
     current = current.baseModel;
   }
-  return false;
+
+  const rawModel = sdkContext.sdkPackage.models.find(
+    (m) => m.crossLanguageDefinitionId === model.crossLanguageDefinitionId
+  )?.__raw as Model | undefined;
+  return rawModel ? isCustomAzureResource(sdkContext.program, rawModel) : false;
 }
 
 /**
@@ -779,7 +787,10 @@ function hasCustomAzureResourceInHierarchy(model: InputModelType): boolean {
  * @param codeModel - The code model containing all models
  * @returns Array of resource models
  */
-function getAllResourceModels(codeModel: CodeModel): InputModelType[] {
+function getAllResourceModels(
+  sdkContext: CSharpEmitterContext,
+  codeModel: CodeModel
+): InputModelType[] {
   const resourceModels: InputModelType[] = [];
 
   for (const model of codeModel.models) {
@@ -794,7 +805,7 @@ function getAllResourceModels(codeModel: CodeModel): InputModelType[] {
     }
     // 2. Custom Azure resources: Models inheriting from a @customAzureResource base model
     //    Used by legacy services like TrafficManager that don't use standard ARM templates
-    else if (hasCustomAzureResourceInHierarchy(model)) {
+    else if (hasCustomAzureResourceInHierarchy(sdkContext, model)) {
       resourceModels.push(model);
     }
   }

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -2920,6 +2920,86 @@ interface TrafficEndpoints {
     );
   });
 
+  it("custom Azure resource inheritance survives alternateType on base model", async () => {
+    const program = await typeSpecCompile(
+      `
+using Azure.ResourceManager.Legacy;
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Testing custom resource pattern"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-no-key" "Testing custom resource pattern"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "Testing custom resource pattern"
+@Azure.ResourceManager.Legacy.customAzureResource(#{ isAzureResource: true })
+model Resource {
+  @visibility(Lifecycle.Read)
+  id?: string;
+
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  @visibility(Lifecycle.Read)
+  type?: string;
+}
+
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Testing custom resource pattern"
+model FrontDoor extends Resource {
+  properties?: FrontDoorProperties;
+}
+
+model FrontDoorProperties {
+  friendlyName?: string;
+}
+
+@@alternateType(
+  Resource,
+  Azure.ResourceManager.Foundations.TrackedResource,
+  "csharp"
+);
+
+alias FrontDoorOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+    ...ResourceGroupParameter;
+    ...Azure.ResourceManager.Legacy.Provider<FrontDoor>;
+  },
+  {
+    @path
+    @segment("frontDoors")
+    frontDoorName: string;
+  },
+  ErrorResponse,
+  "FrontDoor"
+>;
+
+@armResourceOperations
+interface FrontDoors {
+  get is FrontDoorOps.Read<FrontDoor>;
+  createOrUpdate is FrontDoorOps.CreateOrUpdateSync<FrontDoor>;
+  delete is FrontDoorOps.DeleteSync<FrontDoor>;
+  list is FrontDoorOps.List<FrontDoor>;
+}
+`,
+      runner
+    );
+
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const [root] = createModel(sdkContext);
+
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+    const frontDoorResource = armProviderSchema.resources.find(
+      (r) =>
+        r.metadata.resourceType === "Microsoft.ContosoProviderHub/frontDoors"
+    );
+
+    ok(frontDoorResource, "FrontDoor resource should be detected");
+    strictEqual(
+      frontDoorResource.resourceModelId,
+      "Microsoft.ContosoProviderHub.FrontDoor"
+    );
+    strictEqual(frontDoorResource.metadata.methods.length, 4);
+  });
+
   it("builtInResourceOperation - NspConfiguration pattern", async () => {
     const program = await typeSpecCompile(
       `


### PR DESCRIPTION
## Summary

- Honor inherited `@customAzureResource` metadata using the raw TypeSpec model when SDK model conversion has changed the input model base type.
- Add a regression test for the Front Door-style `@@alternateType` on a decorated base resource model.

## Validation

- `npm run build:emitter`
- `npm run test:emitter`
- `npm run lint`
- `npm run prettier`
- `RegenSdkLocal.ps1 -Services Azure.ResourceManager.FrontDoor -LocalSpecRepoPath C:\Users\dapzhang\Documents\workspace\azure-rest-api-specs-provisioning -SaveInputs`
- `dotnet build sdk\frontdoor\Azure.ResourceManager.FrontDoor\src\Azure.ResourceManager.FrontDoor.csproj --no-restore`

Fixes #60126
