### PR TITLE
Reduce data-plane emitter regeneration group size

### DIFF
--- a/eng/packages/http-client-csharp/ci.yml
+++ b/eng/packages/http-client-csharp/ci.yml
@@ -77,7 +77,11 @@ extends:
         PublishDependsOnTest: false
         PublishPublic: ${{ and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
         HasNugetPackages: true
-      RegenerationJobCount: 5
+      # Workaround: keep regen groups small enough to avoid the public release
+      # pipeline's 1-hour timeout. Some packages take much longer than most
+      # packages and should be optimized eventually; the shared matrix generator
+      # only supports count-based batching, not per-package isolation.
+      RegenerationJobCount: 18
       MinimumPerJob: 10
       OnlyGenerateTypespec: true
     TestMatrix:


### PR DESCRIPTION
## Description

This is a workaround for the public release pipeline timeout during data-plane emitter regeneration. Some packages take much longer than most packages, and the shared matrix generator only supports count-based batching rather than per-package isolation.

This increases the data-plane emitter regeneration job count from 5 to 18 so regeneration groups stay around 12-13 packages each.

## Validation

Ran New-RegenerateMatrix.ps1 locally with the updated data-plane settings and confirmed 229 packages are split into 18 groups of approximately 12 packages each.