### PR TITLE
Document LocalSpecRepo option for data plane code generation

### DIFF
--- a/doc/DataPlaneCodeGeneration/AzureSDKCodeGeneration_DataPlane_Quickstart.md
+++ b/doc/DataPlaneCodeGeneration/AzureSDKCodeGeneration_DataPlane_Quickstart.md
@@ -36,7 +36,7 @@ dotnet build /t:GenerateCode /p:Trace=true -v d
 
 #### Run against a local spec
 
-By default the generator syncs the TypeSpec from the remote `azure-rest-api-specs` repo using the `repo` and `commit`
+By default the generator syncs the TypeSpec from the remote repo specified by the `repo` and `commit`
 values in `tsp-location.yaml`. To generate against a local clone of the spec instead (for example, to test in-progress
 TypeSpec changes before they are merged), pass the `LocalSpecRepo` property.
 
@@ -45,7 +45,7 @@ TypeSpec changes before they are merged), pass the `LocalSpecRepo` property.
 `directory` property in `tsp-location.yaml`.
 
 ```dotnetcli
-dotnet build /t:GenerateCode /p:LocalSpecRepo="C:\src\azure-rest-api-specs\specification\anomalydetector\AnomalyDetector"
+dotnet build /t:GenerateCode /p:LocalSpecRepo="C:\src\azure-rest-api-specs\specification\cognitiveservices\AnomalyDetector"
 ```
 
 This maps to `tsp-client`'s `--local-spec-repo` argument.

--- a/doc/DataPlaneCodeGeneration/AzureSDKCodeGeneration_DataPlane_Quickstart.md
+++ b/doc/DataPlaneCodeGeneration/AzureSDKCodeGeneration_DataPlane_Quickstart.md
@@ -45,7 +45,7 @@ TypeSpec changes before they are merged), pass the `LocalSpecRepo` property.
 `directory` property in `tsp-location.yaml`.
 
 ```dotnetcli
-dotnet build /t:GenerateCode /p:LocalSpecRepo="C:\src\azure-rest-api-specs\specification\anomalydetector\AnomalyDetector"
+dotnet build /t:GenerateCode /p:LocalSpecRepo="C:\src\azure-rest-api-specs\specification\cognitiveservices\AnomalyDetector"
 ```
 
 This maps to `tsp-client`'s `--local-spec-repo` argument.

--- a/doc/DataPlaneCodeGeneration/AzureSDKCodeGeneration_DataPlane_Quickstart.md
+++ b/doc/DataPlaneCodeGeneration/AzureSDKCodeGeneration_DataPlane_Quickstart.md
@@ -34,6 +34,22 @@ dotnet build /t:GenerateCode
 dotnet build /t:GenerateCode /p:Trace=true -v d
 ```
 
+#### Run against a local spec
+
+By default the generator syncs the TypeSpec from the remote `azure-rest-api-specs` repo using the `repo` and `commit`
+values in `tsp-location.yaml`. To generate against a local clone of the spec instead (for example, to test in-progress
+TypeSpec changes before they are merged), pass the `LocalSpecRepo` property.
+
+`LocalSpecRepo` must point to the **TypeSpec project directory** — the folder that contains `tspconfig.yaml` and
+`main.tsp` — not the spec repo root and not the `main.tsp` file itself. This is the same folder referenced by the
+`directory` property in `tsp-location.yaml`.
+
+```dotnetcli
+dotnet build /t:GenerateCode /p:LocalSpecRepo="C:\src\azure-rest-api-specs\specification\anomalydetector\AnomalyDetector"
+```
+
+This maps to `tsp-client`'s `--local-spec-repo` argument.
+
 #### Run with additional emitter options
 Any of the [emitter options](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/packages/http-client-csharp/README.md#emitter-options) can be passed through to the build target
 as shown below:


### PR DESCRIPTION
## What

Adds a **Run against a local spec** section to the data plane code generation quickstart.

The section documents the `LocalSpecRepo` MSBuild property used with `dotnet build /t:GenerateCode` to generate against a local clone of the spec, and clarifies that the value must point to the **TypeSpec project directory** (the folder containing `tspconfig.yaml`/`main.tsp`) — not the spec repo root or the `main.tsp` file. It maps to `tsp-client`'s `--local-spec-repo` argument.

## Why

The `LocalSpecRepo` property (wired in `eng/CodeGeneration.targets`) was undocumented, and the expected path (project directory vs. repo root vs. main.tsp file) was a common point of confusion.