### PR TITLE
Prepare for Patch Release, Cherry-pick SasBuilder.DeepCopy preserve fix and Structured Message empty content fix

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Release History
 
-## 12.30.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 12.29.1 (2026-06-23)
 
 ### Bugs Fixed
 - Fixed an issue where the `GenerateSasUri` and `GenerateUserDelegationSasUri` convenience methods on blob clients did not honor the `RequestHeaders` and `RequestQueryParameters` properties, and where `GenerateUserDelegationSasUri` did not honor `DelegatedUserObjectId`, set on the supplied `BlobSasBuilder`.
-
-### Other Changes
+- Fixed an issue where structured-message Uploads with checksum validation could fail with a `ArgumentOutOfRangeException` for empty content
 
 ## 12.29.0 (2026-06-04)
 

--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 12.30.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+- Fixed an issue where the `GenerateSasUri` and `GenerateUserDelegationSasUri` convenience methods on blob clients did not honor the `RequestHeaders` and `RequestQueryParameters` properties, and where `GenerateUserDelegationSasUri` did not honor `DelegatedUserObjectId`, set on the supplied `BlobSasBuilder`.
+
+### Other Changes
+
 ## 12.29.0 (2026-06-04)
 
 ### Features Added

--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_632dc57c2e"
+  "Tag": "net/storage/Azure.Storage.Blobs_7f8d728759"
 }

--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_7f8d728759"
+  "Tag": "net/storage/Azure.Storage.Blobs_addee1eaff"
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.Blobs client library</AssemblyTitle>
-    <Version>12.29.0</Version>
+    <Version>12.29.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>12.28.0</ApiCompatVersion>
     <DefineConstants>BlobSDK;$(DefineConstants)</DefineConstants>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -887,10 +887,12 @@ namespace Azure.Storage.Blobs.Specialized
                     Errors.VerifyStreamPosition(content, nameof(content));
 
                     ContentHasher.GetHashResult hashResult = null;
+                    // length of the raw stream
                     long contentLength = (content?.Length - content?.Position) ?? 0;
+                    // length of content within a structured message wrapper
                     long? structuredContentLength = default;
                     string structuredBodyType = null;
-                    if (content != null &&
+                    if (contentLength > 0 &&
                         validationOptions != null &&
                         validationOptions.ChecksumAlgorithm.ResolveAuto() == StorageChecksumAlgorithm.StorageCrc64 &&
                         ClientSideEncryption == null) // don't allow feature combination

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -702,7 +702,14 @@ namespace Azure.Storage.Sas
                 ContentType = originalBlobSasBuilder.ContentType,
                 PreauthorizedAgentObjectId = originalBlobSasBuilder.PreauthorizedAgentObjectId,
                 CorrelationId = originalBlobSasBuilder.CorrelationId,
-                EncryptionScope = originalBlobSasBuilder.EncryptionScope
+                EncryptionScope = originalBlobSasBuilder.EncryptionScope,
+                DelegatedUserObjectId = originalBlobSasBuilder.DelegatedUserObjectId,
+                RequestHeaders = originalBlobSasBuilder.RequestHeaders == null
+                    ? null
+                    : new Dictionary<string, string>(originalBlobSasBuilder.RequestHeaders),
+                RequestQueryParameters = originalBlobSasBuilder.RequestQueryParameters == null
+                    ? null
+                    : new Dictionary<string, string>(originalBlobSasBuilder.RequestQueryParameters)
             };
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTransferValidationTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTransferValidationTests.cs
@@ -187,6 +187,22 @@ namespace Azure.Storage.Blobs.Tests
             Assert.That(response.Value.Details.ContentCrc, Is.EqualTo(dataCrc));
             Assert.That(response.Value.Content.ToArray(), Is.EqualTo(data));
         }
+
+        [TestCaseSource(nameof(GetValidationAlgorithms))]
+        public virtual async Task ParallelUploadEmptySuccess(StorageChecksumAlgorithm algorithm)
+        {
+            await using IDisposingContainer<BlobContainerClient> disposingContainer = await GetDisposingContainerAsync();
+
+            var validationOptions = new UploadTransferValidationOptions
+            {
+                ChecksumAlgorithm = algorithm
+            };
+            var client = await GetResourceClientAsync(disposingContainer.Container, resourceLength: 0, createResource: false, options: ClientBuilder.GetOptions());
+
+            await ParallelUploadAsync(client, new MemoryStream(), validationOptions, default);
+
+            Assert.That((await client.ExistsAsync()).Value);
+        }
         #endregion
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -306,6 +306,85 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2026_04_06)]
+        public void GenerateUserDelegationSasUri_Blob_PreservesIdentityBindingAndRequestPins()
+        {
+            // Arrange
+            TestConstants constants = TestConstants.Create(this);
+            string containerName = GetNewContainerName();
+            string blobName = GetNewBlobName();
+            Uri blobUri = new BlobUriBuilder(new Uri($"https://{constants.Sas.Account}.blob.core.windows.net"))
+            {
+                BlobContainerName = containerName,
+                BlobName = blobName,
+            }.ToUri();
+            BlobClient blobClient = InstrumentClient(new BlobClient(blobUri, GetOptions()));
+            UserDelegationKey userDelegationKey = GetUserDelegationKey(constants);
+
+            BlobSasBuilder builder = new BlobSasBuilder(BlobSasPermissions.Read, constants.Sas.ExpiryTime)
+            {
+                BlobContainerName = containerName,
+                BlobName = blobName,
+                DelegatedUserObjectId = constants.Sas.DelegatedObjectId,        // sduoid
+                RequestHeaders = constants.Sas.RequestHeaders,                  // srh
+                RequestQueryParameters = constants.Sas.RequestQueryParameters,  // srq
+            };
+
+            // Act
+            string viaClient = blobClient.GenerateUserDelegationSasUri(builder, userDelegationKey).Query.TrimStart('?');
+            string viaDirect = builder.ToSasQueryParameters(userDelegationKey, blobClient.AccountName).ToString();
+
+            // Assert
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestHeaders, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestQueryParameters, viaDirect);
+
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaClient);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestHeaders, viaClient);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestQueryParameters, viaClient);
+
+            Assert.AreEqual(viaDirect, viaClient);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2026_04_06)]
+        public void GenerateUserDelegationSasUri_Container_PreservesIdentityBindingAndRequestPins()
+        {
+            // Arrange
+            TestConstants constants = TestConstants.Create(this);
+            string containerName = GetNewContainerName();
+            Uri containerUri = new BlobUriBuilder(new Uri($"https://{constants.Sas.Account}.blob.core.windows.net"))
+            {
+                BlobContainerName = containerName,
+            }.ToUri();
+            BlobContainerClient containerClient = InstrumentClient(new BlobContainerClient(containerUri, GetOptions()));
+            UserDelegationKey userDelegationKey = GetUserDelegationKey(constants);
+
+            BlobSasBuilder builder = new BlobSasBuilder(BlobContainerSasPermissions.Read, constants.Sas.ExpiryTime)
+            {
+                BlobContainerName = containerName,
+                DelegatedUserObjectId = constants.Sas.DelegatedObjectId,        // sduoid
+                RequestHeaders = constants.Sas.RequestHeaders,                  // srh
+                RequestQueryParameters = constants.Sas.RequestQueryParameters,  // srq
+            };
+
+            // Act
+            string viaClient = containerClient.GenerateUserDelegationSasUri(builder, userDelegationKey).Query.TrimStart('?');
+            string viaDirect = builder.ToSasQueryParameters(userDelegationKey, containerClient.AccountName).ToString();
+
+            // Assert
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestHeaders, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestQueryParameters, viaDirect);
+
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaClient);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestHeaders, viaClient);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestQueryParameters, viaClient);
+
+            Assert.AreEqual(viaDirect, viaClient);
+        }
+
+        [RecordedTest]
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_12_06)]
         public void ToSasQueryParameters_SnapshotTest()
         {

--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 12.28.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+- Fixed an issue where the `GenerateSasUri` and `GenerateUserDelegationSasUri` convenience methods on Data Lake clients did not honor the `RequestHeaders` and `RequestQueryParameters` properties, and where `GenerateUserDelegationSasUri` did not honor `DelegatedUserObjectId`, set on the supplied `DataLakeSasBuilder`.
+
+### Other Changes
+
 ## 12.27.0 (2026-06-04)
 
 ### Features Added

--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Release History
 
-## 12.28.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 12.27.1 (2026-06-23)
 
 ### Bugs Fixed
 - Fixed an issue where the `GenerateSasUri` and `GenerateUserDelegationSasUri` convenience methods on Data Lake clients did not honor the `RequestHeaders` and `RequestQueryParameters` properties, and where `GenerateUserDelegationSasUri` did not honor `DelegatedUserObjectId`, set on the supplied `DataLakeSasBuilder`.
-
-### Other Changes
 
 ## 12.27.0 (2026-06-04)
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/assets.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.DataLake",
-  "Tag": "net/storage/Azure.Storage.Files.DataLake_ec34697db4"
+  "Tag": "net/storage/Azure.Storage.Files.DataLake_972c21694c"
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.Files.DataLake client library</AssemblyTitle>
-    <Version>12.27.0</Version>
+    <Version>12.27.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>12.26.0</ApiCompatVersion>
     <DefineConstants>DataLakeSDK;$(DefineConstants)</DefineConstants>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
@@ -702,7 +702,14 @@ namespace Azure.Storage.Sas
                 PreauthorizedAgentObjectId = originalDataLakeSasBuilder.PreauthorizedAgentObjectId,
                 AgentObjectId = originalDataLakeSasBuilder.AgentObjectId,
                 CorrelationId = originalDataLakeSasBuilder.CorrelationId,
-                EncryptionScope = originalDataLakeSasBuilder.EncryptionScope
+                EncryptionScope = originalDataLakeSasBuilder.EncryptionScope,
+                DelegatedUserObjectId = originalDataLakeSasBuilder.DelegatedUserObjectId,
+                RequestHeaders = originalDataLakeSasBuilder.RequestHeaders == null
+                    ? null
+                    : new Dictionary<string, string>(originalDataLakeSasBuilder.RequestHeaders),
+                RequestQueryParameters = originalDataLakeSasBuilder.RequestQueryParameters == null
+                    ? null
+                    : new Dictionary<string, string>(originalDataLakeSasBuilder.RequestQueryParameters)
             };
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
@@ -813,6 +813,79 @@ namespace Azure.Storage.Files.DataLake.Tests
             AssertResponseHeaders(constants, sasQueryParameters);
         }
 
+        [RecordedTest]
+        [ServiceVersion(Min = DataLakeClientOptions.ServiceVersion.V2026_02_06)]
+        public void GenerateUserDelegationSasUri_Path_PreservesIdentityBindingAndRequestPins()
+        {
+            // Arrange
+            var constants = TestConstants.Create(this);
+            string fileSystemName = GetNewFileSystemName();
+            string fileName = GetNewFileName();
+            Uri pathUri = new Uri("https://" + constants.Sas.Account + ".dfs.core.windows.net/" + fileSystemName + "/" + fileName);
+            DataLakePathClient pathClient = InstrumentClient(new DataLakePathClient(pathUri, GetOptions()));
+            UserDelegationKey userDelegationKey = GetUserDelegationKey(constants);
+
+            DataLakeSasBuilder builder = BuildDataLakeSasBuilder(
+                includePath: true,
+                includeDelegatedObjectId: true,        // sduoid
+                includeRequestHeaders: true,           // srh
+                includeRequestQueryParameters: true,   // srq
+                fileSystemName: fileSystemName,
+                path: fileName,
+                constants);
+
+            // Act
+            string viaClient = pathClient.GenerateUserDelegationSasUri(builder, userDelegationKey).Query.TrimStart('?');
+            string viaDirect = builder.ToSasQueryParameters(userDelegationKey, pathClient.AccountName).ToString();
+
+            // Assert
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestHeaders, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestQueryParameters, viaDirect);
+
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaClient);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestHeaders, viaClient);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestQueryParameters, viaClient);
+
+            Assert.AreEqual(viaDirect, viaClient);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = DataLakeClientOptions.ServiceVersion.V2026_02_06)]
+        public void GenerateUserDelegationSasUri_FileSystem_PreservesIdentityBindingAndRequestPins()
+        {
+            // Arrange
+            var constants = TestConstants.Create(this);
+            string fileSystemName = GetNewFileSystemName();
+            Uri fileSystemUri = new Uri("https://" + constants.Sas.Account + ".dfs.core.windows.net/" + fileSystemName);
+            DataLakeFileSystemClient fileSystemClient = InstrumentClient(new DataLakeFileSystemClient(fileSystemUri, GetOptions()));
+            UserDelegationKey userDelegationKey = GetUserDelegationKey(constants);
+
+            DataLakeSasBuilder builder = BuildDataLakeSasBuilder(
+                includePath: false,
+                includeDelegatedObjectId: true,        // sduoid
+                includeRequestHeaders: true,           // srh
+                includeRequestQueryParameters: true,   // srq
+                fileSystemName: fileSystemName,
+                path: null,
+                constants);
+
+            // Act
+            string viaClient = fileSystemClient.GenerateUserDelegationSasUri(builder, userDelegationKey).Query.TrimStart('?');
+            string viaDirect = builder.ToSasQueryParameters(userDelegationKey, fileSystemClient.AccountName).ToString();
+
+            // Assert
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestHeaders, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestQueryParameters, viaDirect);
+
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaClient);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestHeaders, viaClient);
+            StringAssert.Contains(Constants.Sas.Parameters.RequestQueryParameters, viaClient);
+
+            Assert.AreEqual(viaDirect, viaClient);
+        }
+
         private DataLakeSasBuilder BuildDataLakeSasBuilder(
             bool includePath,
             bool includeDelegatedObjectId,

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Release History
 
-## 12.28.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 12.27.1 (2026-06-23)
 
 ### Bugs Fixed
 - Fixed an issue where the `GenerateUserDelegationSasUri` convenience methods on Share clients did not honor the `DelegatedUserObjectId` property set on the supplied `ShareSasBuilder`.
-
-### Other Changes
 
 ## 12.27.0 (2026-06-04)
 

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 12.28.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+- Fixed an issue where the `GenerateUserDelegationSasUri` convenience methods on Share clients did not honor the `DelegatedUserObjectId` property set on the supplied `ShareSasBuilder`.
+
+### Other Changes
+
 ## 12.27.0 (2026-06-04)
 
 ### Features Added

--- a/sdk/storage/Azure.Storage.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.Files.Shares_1d0ea2e2cf"
+  "Tag": "net/storage/Azure.Storage.Files.Shares_ad48ad8a9e"
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.Files.Shares client library</AssemblyTitle>
-    <Version>12.27.0</Version>
+    <Version>12.27.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>12.26.0</ApiCompatVersion>
     <DefineConstants>FileSDK;$(DefineConstants)</DefineConstants>

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
@@ -548,7 +548,8 @@ namespace Azure.Storage.Sas
                 ContentDisposition = originalShareSasBuilder.ContentDisposition,
                 ContentEncoding = originalShareSasBuilder.ContentEncoding,
                 ContentLanguage = originalShareSasBuilder.ContentLanguage,
-                ContentType = originalShareSasBuilder.ContentType
+                ContentType = originalShareSasBuilder.ContentType,
+                DelegatedUserObjectId = originalShareSasBuilder.DelegatedUserObjectId
             };
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -330,6 +330,63 @@ namespace Azure.Storage.Files.Shares.Tests
             Assert.IsNotNull(stringToSign);
         }
 
+        [RecordedTest]
+        [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2026_02_06)]
+        public void GenerateUserDelegationSasUri_File_PreservesIdentityBinding()
+        {
+            // Arrange
+            var constants = TestConstants.Create(this);
+            string shareName = GetNewShareName();
+            string filePath = GetNewDirectoryName();
+            Uri fileUri = new Uri("https://" + constants.Sas.Account + ".file.core.windows.net/" + shareName + "/" + filePath);
+            ShareFileClient fileClient = InstrumentClient(new ShareFileClient(fileUri, GetOptions()));
+            UserDelegationKey userDelegationKey = GetUserDelegationKey(constants);
+
+            ShareSasBuilder builder = BuildFileSasBuilder(
+                includeFilePath: true,
+                constants,
+                shareName,
+                filePath,
+                includeDelegatedUserObjectId: true);
+
+            // Act
+            string viaClient = fileClient.GenerateUserDelegationSasUri(builder, userDelegationKey).Query.TrimStart('?');
+            string viaDirect = builder.ToSasQueryParameters(userDelegationKey, fileClient.AccountName).ToString();
+
+            // Assert
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaClient);
+            Assert.AreEqual(viaDirect, viaClient);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2026_02_06)]
+        public void GenerateUserDelegationSasUri_Share_PreservesIdentityBinding()
+        {
+            // Arrange
+            var constants = TestConstants.Create(this);
+            string shareName = GetNewShareName();
+            Uri shareUri = new Uri("https://" + constants.Sas.Account + ".file.core.windows.net/" + shareName);
+            ShareClient shareClient = InstrumentClient(new ShareClient(shareUri, GetOptions()));
+            UserDelegationKey userDelegationKey = GetUserDelegationKey(constants);
+
+            ShareSasBuilder builder = BuildFileSasBuilder(
+                includeFilePath: false,
+                constants,
+                shareName,
+                filePath: null,
+                includeDelegatedUserObjectId: true);
+
+            // Act
+            string viaClient = shareClient.GenerateUserDelegationSasUri(builder, userDelegationKey).Query.TrimStart('?');
+            string viaDirect = builder.ToSasQueryParameters(userDelegationKey, shareClient.AccountName).ToString();
+
+            // Assert
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaClient);
+            Assert.AreEqual(viaDirect, viaClient);
+        }
+
         private ShareSasBuilder BuildFileSasBuilder(
             bool includeFilePath,
             TestConstants constants,

--- a/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 12.28.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+- Fixed an issue where the `GenerateUserDelegationSasUri` convenience methods on the `QueueClient` did not honor the `DelegatedUserObjectId` property set on the supplied `QueueSasBuilder`.
+
+### Other Changes
+
 ## 12.27.0 (2026-06-04)
 
 ### Features Added

--- a/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Release History
 
-## 12.28.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 12.27.1 (2026-06-23)
 
 ### Bugs Fixed
 - Fixed an issue where the `GenerateUserDelegationSasUri` convenience methods on the `QueueClient` did not honor the `DelegatedUserObjectId` property set on the supplied `QueueSasBuilder`.
-
-### Other Changes
 
 ## 12.27.0 (2026-06-04)
 

--- a/sdk/storage/Azure.Storage.Queues/assets.json
+++ b/sdk/storage/Azure.Storage.Queues/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Queues",
-  "Tag": "net/storage/Azure.Storage.Queues_e74c0f8142"
+  "Tag": "net/storage/Azure.Storage.Queues_d8369ae518"
 }

--- a/sdk/storage/Azure.Storage.Queues/src/Azure.Storage.Queues.csproj
+++ b/sdk/storage/Azure.Storage.Queues/src/Azure.Storage.Queues.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.Queues client library</AssemblyTitle>
-    <Version>12.27.0</Version>
+    <Version>12.27.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>12.26.0</ApiCompatVersion>
     <DefineConstants>QueueSDK;$(DefineConstants)</DefineConstants>

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
@@ -474,7 +474,8 @@ namespace Azure.Storage.Sas
                 Permissions = originalQueueSasBuilder.Permissions,
                 IPRange = originalQueueSasBuilder.IPRange,
                 Identifier = originalQueueSasBuilder.Identifier,
-                QueueName = originalQueueSasBuilder.QueueName
+                QueueName = originalQueueSasBuilder.QueueName,
+                DelegatedUserObjectId = originalQueueSasBuilder.DelegatedUserObjectId
             };
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
@@ -61,6 +61,29 @@ namespace Azure.Storage.Queues.Test
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2026_02_06)]
+        public void GenerateUserDelegationSasUri_PreservesIdentityBinding()
+        {
+            // Arrange
+            var constants = TestConstants.Create(this);
+            string queueName = GetNewQueueName();
+            Uri queueUri = new Uri("https://" + constants.Sas.Account + ".queue.core.windows.net/" + queueName);
+            QueueClient queueClient = InstrumentClient(new QueueClient(queueUri, GetOptions()));
+            UserDelegationKey userDelegationKey = GetUserDelegationKey(constants);
+
+            QueueSasBuilder builder = BuildQueueSasBuilder(constants, queueName);
+
+            // Act
+            string viaClient = queueClient.GenerateUserDelegationSasUri(builder, userDelegationKey).Query.TrimStart('?');
+            string viaDirect = builder.ToSasQueryParameters(userDelegationKey, queueClient.AccountName).ToString();
+
+            // Assert
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaDirect);
+            StringAssert.Contains(Constants.Sas.Parameters.DelegatedUserObjectId, viaClient);
+            Assert.AreEqual(viaDirect, viaClient);
+        }
+
+        [RecordedTest]
         public void QueueSasBuilder_ToSasQueryParameters_VersionTest()
         {
             // Arrange


### PR DESCRIPTION
Preparing for a patch release for Azure.Storage.Blobs, Azure.Storage.Files.Shares, Azure.Storage.Files.DataLake, and Azure.Storage.Queues.

Cherry picked the SasBuilder.DeepCopy Fix (See https://github.com/Azure/azure-sdk-for-net/pull/59974)
Cherry picked the Structured Message empty context Fix (See https://github.com/Azure/azure-sdk-for-net/pull/60073)
Updated changelogs dates and format
