### PR TITLE
[Identity] Prevent DefaultAzureCredential from aborting on Managed identity probe failures

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bugs Fixed
 
+- Fixed a regression (introduced with managed identity host capability detection) where `DefaultAzureCredential` could throw an `AuthenticationFailedException` and stop evaluating the credential chain on hosts without a managed identity — for example, a developer machine running in Visual Studio where the IMDS endpoint (169.254.169.254) is unreachable. When `ManagedIdentityCredential` is part of a chain, a failure to detect the managed identity source/capabilities is now surfaced as a `CredentialUnavailableException`, allowing the chain to continue to the next credential.
+
 ### Other Changes
 
 ## 1.59.0 (2026-06-09)

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -84,7 +84,7 @@ namespace Azure.Identity
             {
                 throw;
             }
-            catch (Exception e) when (_isChainedCredential && e is not OperationCanceledException && !cancellationToken.IsCancellationRequested)
+            catch (Exception e) when (_isChainedCredential && e is not OperationCanceledException)
             {
                 // IMDS probing can fail on hosts without a managed identity. When chained, surface a CredentialUnavailableException so the chain continues.
                 AzureIdentityEventSource.Singleton.ImdsEndpointUnavailable(ImdsManagedIdentityProbeSource.GetImdsUri(), e);

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -87,7 +87,7 @@ namespace Azure.Identity
             catch (Exception e) when (_isChainedCredential && e is not OperationCanceledException && !cancellationToken.IsCancellationRequested)
             {
                 // IMDS probing can fail on hosts without a managed identity. When chained, surface a CredentialUnavailableException so the chain continues.
-                AzureIdentityEventSource.Singleton.ImdsEndpointUnavailable(ImdsManagedIdentityProbeSource.s_imdsEndpoint, e);
+                AzureIdentityEventSource.Singleton.ImdsEndpointUnavailable(ImdsManagedIdentityProbeSource.GetImdsUri(), e);
                 throw new CredentialUnavailableException(MsiUnavailableError, e);
             }
 

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -72,9 +72,24 @@ namespace Azure.Identity
         public async ValueTask<AccessToken> AuthenticateAsync(bool async, TokenRequestContext context, CancellationToken cancellationToken)
         {
             AuthenticationResult result;
+
+            MSAL.ManagedIdentityCapabilities capabilities;
+            try
+            {
 #pragma warning disable AZC0106 // Non-public asynchronous method needs 'async' parameter.
-            MSAL.ManagedIdentityCapabilities capabilities = await _msalManagedIdentityClient.GetManagedIdentityCapabilitiesCoreAsync(async, context, cancellationToken).ConfigureAwait(false);
+                capabilities = await _msalManagedIdentityClient.GetManagedIdentityCapabilitiesCoreAsync(async, context, cancellationToken).ConfigureAwait(false);
 #pragma warning restore AZC0106 // Non-public asynchronous method needs 'async' parameter.
+            }
+            catch (CredentialUnavailableException)
+            {
+                throw;
+            }
+            catch (Exception e) when (_isChainedCredential && e is not OperationCanceledException && !cancellationToken.IsCancellationRequested)
+            {
+                // IMDS probing can fail on hosts without a managed identity. When chained, surface a CredentialUnavailableException so the chain continues.
+                AzureIdentityEventSource.Singleton.ImdsEndpointUnavailable(ImdsManagedIdentityProbeSource.s_imdsEndpoint, e);
+                throw new CredentialUnavailableException(MsiUnavailableError, e);
+            }
 
             AzureIdentityEventSource.Singleton.ManagedIdentityCredentialSelected(capabilities.Source.ToString(), _options.ManagedIdentityId.ToString());
 

--- a/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
@@ -243,6 +243,54 @@ namespace Azure.Core.Tests.Identity
             ApplicationBase.ResetStateForTest();
         }
 
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/issues/59961
+        // When the MSAL-based managed identity source/capability detection fails (for example, because the
+        // IMDS endpoint is unreachable on a developer machine running in Visual Studio), a chained
+        // ManagedIdentityCredential must surface a CredentialUnavailableException so that DefaultAzureCredential
+        // continues to the next credential in the chain instead of aborting with an AuthenticationFailedException.
+        [NonParallelizable]
+        [Test]
+        public void ChainedManagedIdentitySourceDetectionFailureThrowsCredentialUnavailable()
+        {
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
+
+            var probeFailure = new MsalClientException(
+                "managed_identity_request_failed",
+                "All Managed Identity sources are unavailable. The Azure Instance Metadata Service (IMDS) that runs on VMs was not detected: IMDSv2: IMDSv2 probe failed. Exception: Retry failed after 6 tries.");
+
+            var credential = BuildManagedIdentityCredential(
+                new TokenCredentialOptions { Transport = new MockTransport(_ => CreateSuccessResponse(ExpectedToken)), IsChainedCredential = true },
+                ManagedIdentityId.SystemAssigned,
+                configureMockMsal: mock => mock.GetManagedIdentityCapabilitiesFactory = (_, _) => throw probeFailure);
+
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.AreSame(probeFailure, ex.InnerException);
+        }
+
+        // Companion to the regression test above: a standalone (non-chained) ManagedIdentityCredential keeps
+        // surfacing AuthenticationFailedException when source/capability detection fails, preserving the
+        // documented single-credential behavior (only chained credentials downgrade to CredentialUnavailableException).
+        [NonParallelizable]
+        [Test]
+        public void StandaloneManagedIdentitySourceDetectionFailureThrowsAuthenticationFailed()
+        {
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
+
+            var probeFailure = new MsalClientException(
+                "managed_identity_request_failed",
+                "All Managed Identity sources are unavailable. The Azure Instance Metadata Service (IMDS) that runs on VMs was not detected: IMDSv2: IMDSv2 probe failed. Exception: Retry failed after 6 tries.");
+
+            var credential = BuildManagedIdentityCredential(
+                new TokenCredentialOptions { Transport = new MockTransport(_ => CreateSuccessResponse(ExpectedToken)), IsChainedCredential = false },
+                ManagedIdentityId.SystemAssigned,
+                configureMockMsal: mock => mock.GetManagedIdentityCapabilitiesFactory = (_, _) => throw probeFailure);
+
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.IsNotInstanceOf<CredentialUnavailableException>(ex);
+        }
+
         [NonParallelizable]
         [Test]
         public async Task VerifyImdsRequestWithClientIdMock()

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
@@ -81,7 +81,9 @@ namespace Azure.Core.Tests.Identity.Mock
             {
                 // Allows tests to simulate the MSAL source/capability probe (which throws when IMDS is
                 // unreachable). The factory may return a value or throw.
-                return new ValueTask<ManagedIdentityCapabilities>(GetManagedIdentityCapabilitiesFactory(context, cancellationToken));
+                ManagedIdentityCapabilities capabilities = GetManagedIdentityCapabilitiesFactory(context, cancellationToken);
+                _detectedSource = capabilities.Source;
+                return new ValueTask<ManagedIdentityCapabilities>(capabilities);
             }
 
             // Use the static method to avoid real network probing in tests.

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
@@ -19,6 +19,13 @@ namespace Azure.Core.Tests.Identity.Mock
         public Func<CancellationToken, IManagedIdentityApplication> ClientAppFactory { get; set; }
         public Func<TokenRequestContext, CancellationToken, AuthenticationResult> AcquireTokenForManagedIdentityAsyncFactory { get; set; }
 
+        /// <summary>
+        /// When set, this is invoked by <see cref="GetManagedIdentityCapabilitiesAsync"/> to produce the
+        /// capabilities result (or throw). Tests use this to simulate the MSAL IMDS source/capability probe
+        /// failing — for example, when the IMDS endpoint is unreachable on a developer machine.
+        /// </summary>
+        public Func<TokenRequestContext, CancellationToken, ManagedIdentityCapabilities> GetManagedIdentityCapabilitiesFactory { get; set; }
+
         private Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource _detectedSource;
         private ManagedIdentityId _azureManagedIdentityId;
 
@@ -70,6 +77,13 @@ namespace Azure.Core.Tests.Identity.Mock
 
         public override ValueTask<ManagedIdentityCapabilities> GetManagedIdentityCapabilitiesAsync(TokenRequestContext context, CancellationToken cancellationToken)
         {
+            if (GetManagedIdentityCapabilitiesFactory != null)
+            {
+                // Allows tests to simulate the MSAL source/capability probe (which throws when IMDS is
+                // unreachable). The factory may return a value or throw.
+                return new ValueTask<ManagedIdentityCapabilities>(GetManagedIdentityCapabilitiesFactory(context, cancellationToken));
+            }
+
             // Use the static method to avoid real network probing in tests.
 #pragma warning disable CS0618 // GetManagedIdentitySource is obsolete
             _detectedSource = ManagedIdentityApplication.GetManagedIdentitySource();


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/59961

This pull request fixes a regression in `DefaultAzureCredential` related to managed identity capability detection, ensuring that when the managed identity probe fails on hosts without a managed identity (such as developer machines), the credential chain continues as expected. It also adds comprehensive regression tests and improves the test infrastructure to simulate these scenarios.

**Bug fix for managed identity detection in credential chain:**

* Updated `ManagedIdentityClient.AuthenticateAsync` to surface a `CredentialUnavailableException` (instead of `AuthenticationFailedException`) when managed identity detection fails and the credential is part of a chain, allowing `DefaultAzureCredential` to continue to the next credential. This prevents authentication failures on hosts without managed identity, such as local development machines.

**Testing improvements:**

* Added regression tests to verify that a chained `ManagedIdentityCredential` throws `CredentialUnavailableException` on source detection failure (allowing fallback), while a standalone credential still throws `AuthenticationFailedException`, preserving documented behavior.
* Enhanced the `MockMsalManagedIdentityClient` with a `GetManagedIdentityCapabilitiesFactory` to simulate managed identity probe failures in tests, enabling accurate regression testing of these scenarios. [[1]](diffhunk://#diff-feebe6aed9aed7a18ad5f0ea2fb1c76ce310b44e6684ea10a48220f88324c068R22-R28) [[2]](diffhunk://#diff-feebe6aed9aed7a18ad5f0ea2fb1c76ce310b44e6684ea10a48220f88324c068R80-R86)

**Documentation:**

* Updated the `CHANGELOG.md` to document the bug fix and clarify the improved behavior for managed identity detection in chained credentials.