### PR TITLE
Add github workflow for verifyin links

### DIFF
--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -1,0 +1,90 @@
+name: Verify Links
+
+# Runs the link verification check (eng/common/scripts/Verify-Links.ps1) that
+# previously lived as a step in the Azure DevOps "Compliance" job in
+# eng/pipelines/templates/jobs/ci.yml.
+#
+# Triggers:
+#   - pull_request: runs on every PR, scanning only changed *.md files (matches
+#     the prior Compliance-job behavior for PR builds).
+#   - check_run completed: fires when the Azure DevOps "net - pullrequest"
+#     pipeline (which owns the Compliance job) reports back to GitHub, so it
+#     effectively runs after the Compliance job. Same scanning behavior as PR.
+#   - workflow_dispatch: manual runs.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - hotfix/*
+  check_run:
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-links:
+    name: Verify Links
+    # When fired via check_run, only run after the Azure DevOps Compliance
+    # job in the Azure/azure-sdk-for-net repo completes.
+    if: >-
+      github.event_name != 'check_run' ||
+      (github.repository == 'Azure/azure-sdk-for-net' &&
+       contains(github.event.check_run.name, 'Compliance'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.check_run.head_sha || github.sha }}
+          # Need history so get-markdown-files-from-changed-files.ps1 can diff
+          # against the target branch.
+          fetch-depth: 0
+
+      - name: Fetch target branch
+        if: github.base_ref != ''
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+        shell: bash
+
+      - name: Resolve default branch
+        id: default-branch
+        shell: pwsh
+        run: |
+          $defaultBranch = (git remote show origin | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($defaultBranch)) {
+            Write-Host "Could not detect default branch from origin; falling back to 'main'."
+            $defaultBranch = 'main'
+          }
+          Write-Host "DefaultBranch=$defaultBranch"
+          "default-branch=$defaultBranch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Link verification check
+        shell: pwsh
+        run: |
+          $urls = & ./eng/common/scripts/get-markdown-files-from-changed-files.ps1 `
+            -targetBranch "origin/${{ github.base_ref }}"
+          if (-not $urls -or $urls.Count -eq 0) {
+            Write-Host "No changed markdown files; nothing to verify."
+            exit 0
+          }
+
+          $sourceRepoUri  = '${{ github.event.pull_request.head.repo.html_url }}'
+          $defaultBranch  = '${{ steps.default-branch.outputs.default-branch }}'
+          $branchReplaceRegex = "^($sourceRepoUri(?:\.git)?/(?:blob|tree)/)$defaultBranch(/.*)$"
+
+          ./eng/common/scripts/Verify-Links.ps1 `
+            -urls $urls `
+            -rootUrl "file://$env:GITHUB_WORKSPACE/" `
+            -recursive:$false `
+            -ignoreLinksFile "$env:GITHUB_WORKSPACE/eng/ignore-links.txt" `
+            -branchReplaceRegex $branchReplaceRegex `
+            -branchReplacementName '${{ github.event.pull_request.head.sha }}' `
+            -checkLinkGuidance:$true `
+            -localBuildRepoName '${{ github.repository }}' `
+            -localBuildRepoPath $env:GITHUB_WORKSPACE `
+            -inputCacheFile "https://azuresdkartifacts.blob.core.windows.net/verify-links-cache/verify-links-cache.txt" `
+            -allowRelativeLinksFile "$env:GITHUB_WORKSPACE/eng/common/scripts/allow-relative-links.txt"

--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -41,39 +41,29 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.check_run.head_sha || github.sha }}
-          # Need history so get-markdown-files-from-changed-files.ps1 can diff
-          # against the target branch.
+          # Need full history so get-markdown-files-from-changed-files.ps1 can
+          # diff against the target branch (origin/<base>) that checkout sets up.
           fetch-depth: 0
-
-      - name: Fetch target branch
-        if: github.base_ref != ''
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
-        shell: bash
-
-      - name: Resolve default branch
-        id: default-branch
-        shell: pwsh
-        run: |
-          $defaultBranch = (git remote show origin | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
-          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($defaultBranch)) {
-            Write-Host "Could not detect default branch from origin; falling back to 'main'."
-            $defaultBranch = 'main'
-          }
-          Write-Host "DefaultBranch=$defaultBranch"
-          "default-branch=$defaultBranch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Link verification check
         shell: pwsh
+        # The shared scripts read these Azure DevOps-style variables to compute
+        # the git diff range used by Get-ChangedFiles. Setting them lets the
+        # script's defaults work:
+        #   $TargetCommittish = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
+        #   $SourceCommittish = "${env:SYSTEM_PULLREQUEST_SOURCECOMMITID}"
+        env:
+          SYSTEM_PULLREQUEST_TARGETBRANCH: ${{ github.base_ref }}
+          SYSTEM_PULLREQUEST_SOURCECOMMITID: ${{ github.event.pull_request.head.sha }}
         run: |
-          $urls = & ./eng/common/scripts/get-markdown-files-from-changed-files.ps1 `
-            -targetBranch "origin/${{ github.base_ref }}"
+          $urls = & ./eng/common/scripts/get-markdown-files-from-changed-files.ps1
           if (-not $urls -or $urls.Count -eq 0) {
             Write-Host "No changed markdown files; nothing to verify."
             exit 0
           }
 
           $sourceRepoUri  = '${{ github.event.pull_request.head.repo.html_url }}'
-          $defaultBranch  = '${{ steps.default-branch.outputs.default-branch }}'
+          $defaultBranch  = '${{ github.event.repository.default_branch }}'
           $branchReplaceRegex = "^($sourceRepoUri(?:\.git)?/(?:blob|tree)/)$defaultBranch(/.*)$"
 
           ./eng/common/scripts/Verify-Links.ps1 `

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ We would love to incorporate the community's input into our library design proce
 ## Contributing
 For details on contributing to this repository, see the [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).
 
-For AI agents and automated tools working with this repository, see [AGENTS.md](https://github.com/Azure/azure-sdk-for-net/blob/main/AGENTS.md) for guidelines on safe and effective automation patterns.
+For AI agents and automated tools working with this repository, see [AGENTS.md](https://github.com/Azure/azure-sdk-for-net/blob/main/AGENT.md) for guidelines on safe and effective automation patterns.
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit
 https://cla.microsoft.com.
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofonduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faqq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate link verification for markdown files. The workflow replicates the previous Azure DevOps Compliance job behavior, ensuring that links in changed `.md` files are checked automatically on pull requests and other triggers.

**New workflow for link verification:**

* Added `.github/workflows/verify-links.yml` to automate the running of `Verify-Links.ps1` on changed markdown files during pull requests, check runs, and manual dispatches. This workflow ensures link compliance checks are consistently applied and integrates with existing CI processes.