### PR TITLE
Fix NuGet version publish check

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -149,7 +149,8 @@ function IsNugetPackageVersionPublished ($pkgId, $pkgVersion)
     return $False
   }
 
-  return $existingVersions.Contains($pkgVersion)
+  # Normalize to an array so a single returned version is checked as an exact item, not a substring.
+  return @($existingVersions).Contains($pkgVersion)
 }
 
 # Parse out package publishing information given a nupkg ZIP format.
@@ -344,7 +345,7 @@ function GetExistingPackageVersions ($PackageName, $GroupId=$null)
     $PackageName = $PackageName.ToLower()
     $uri = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/flat2/${PackageName}/index.json"
     $existingVersion = Invoke-RestMethod -MaximumRetryCount 3 -RetryIntervalSec 10 -Method GET -Uri $uri
-    return $existingVersion.versions
+    return @($existingVersion.versions)
   }
   catch {
     if ($_.Exception.Response.StatusCode -notin (401, 404))


### PR DESCRIPTION
## Description
- Preserve array semantics when reading existing NuGet package versions from the dev feed.
- Force exact array membership checks so a single alpha version does not substring-match a GA version.

## Validation
- Verified locally that a single existing version of \1.0.0-alpha.20260624.2\ no longer matches release version 1.0.0, while the exact alpha version still matches.