### PR TITLE
Document custom code file organization

### DIFF
--- a/.github/skills/mitigate-breaking-changes/SKILL.md
+++ b/.github/skills/mitigate-breaking-changes/SKILL.md
@@ -18,6 +18,7 @@ Use **Custom/*.cs** or **Customization/*.cs** partial classes (follow the packag
 Keep custom code types split into separate files:
 - Put each custom type/partial type in its own `.cs` file.
 - Name the file after the class it contains, for example `src/Custom/Models/MyModel.cs` for `public partial class MyModel`.
+- Align the custom code folder structure with the generated code structure, such as using `Models/` for model customizations and `Extensions/` for extension customizations when those folders exist.
 - Do not group multiple compatibility types in a single broad file such as `Compatibility.cs`; split them so each file name aligns with the class name.
 
 ### Partial class (add members, suppress generated members)

--- a/.github/skills/mitigate-breaking-changes/SKILL.md
+++ b/.github/skills/mitigate-breaking-changes/SKILL.md
@@ -14,6 +14,12 @@ Trigger phrases: "mitigate breaking changes", "fix breaking change", "customizat
 
 Use **Custom/*.cs** or **Customization/*.cs** partial classes (follow the package's existing structure) for .NET-side fixes.
 
+### Custom code file organization
+Keep custom code types split into separate files:
+- Put each custom type/partial type in its own `.cs` file.
+- Name the file after the class it contains, for example `src/Custom/Models/MyModel.cs` for `public partial class MyModel`.
+- Do not group multiple compatibility types in a single broad file such as `Compatibility.cs`; split them so each file name aligns with the class name.
+
 ### Partial class (add members, suppress generated members)
 ```csharp
 // src/Custom/MyModel.cs (or src/Customization/MyModel.cs — follow the package's existing convention)

--- a/.github/skills/mitigate-breaking-changes/SKILL.md
+++ b/.github/skills/mitigate-breaking-changes/SKILL.md
@@ -23,7 +23,7 @@ Keep custom code types split into separate files:
 
 ### Partial class (add members, suppress generated members)
 ```csharp
-// src/Custom/MyModel.cs (or src/Customization/MyModel.cs — follow the package's existing convention)
+// src/Custom/Models/MyModel.cs (or src/Customization/Models/MyModel.cs — follow the package's existing convention)
 namespace Azure.ResourceManager.<Service>.Models
 {
     public partial class MyModel


### PR DESCRIPTION
## Summary
- Add guidance to the mitigate-breaking-changes skill for custom code file organization.
- Document that each custom type/partial type should live in its own file named after the class.

## Validation
- Documentation-only change.
