### PR TITLE
Split 60248: update mgmt emitter package references

### DIFF
--- a/eng/azure-typespec-http-client-csharp-mgmt-emitter-package-lock.json
+++ b/eng/azure-typespec-http-client-csharp-mgmt-emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260624.4"
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260624.9"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.69.0",
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260624.4",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260624.4.tgz",
-      "integrity": "sha1-42zvJzb8H/3H4VTD8sR4seQ9yZw=",
+      "version": "1.0.0-alpha.20260624.9",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260624.9.tgz",
+      "integrity": "sha1-MT3UW8M6e2L/lu24vAQi4V3QuII=",
       "license": "MIT",
       "dependencies": {
         "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260623.2",

--- a/eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json
+++ b/eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json
@@ -1,7 +1,7 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260624.4"
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260624.9"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.69.0",


### PR DESCRIPTION
Split from #60248. This draft PR contains only the eng package reference updates for azure-typespec/http-client-csharp-mgmt.