### PR TITLE
Split 60256: update mgmt emitter package references

### DIFF
--- a/eng/azure-typespec-http-client-csharp-mgmt-emitter-package-lock.json
+++ b/eng/azure-typespec-http-client-csharp-mgmt-emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260624.9"
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260625.1"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.69.0",
@@ -132,22 +132,22 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260623.2",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260623.2.tgz",
-      "integrity": "sha1-sC1MhujsxJemj8t7zOocMMa5IGk=",
+      "version": "1.0.0-alpha.20260624.5",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260624.5.tgz",
+      "integrity": "sha1-0pWKO4PfXPzwhwEV6ai8ll7rfvc=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260622.6"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260624.10"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260624.9",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260624.9.tgz",
-      "integrity": "sha1-MT3UW8M6e2L/lu24vAQi4V3QuII=",
+      "version": "1.0.0-alpha.20260625.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260625.1.tgz",
+      "integrity": "sha1-WOvulewmIEdRZK6Kksia8q9xhiM=",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260623.2",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260622.6"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260624.5",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260624.10"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -733,16 +733,16 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260622.6",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260622.6.tgz",
-      "integrity": "sha1-mf1JDuEAIr8RDqnPsp+qNnm4rwY=",
+      "version": "1.0.0-alpha.20260624.10",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260624.10.tgz",
+      "integrity": "sha1-XoeSNqiOIxYrNXLgRLBBybAHib4=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.69.1 <0.70.0 || ~0.70.0-0",
         "@typespec/compiler": "^1.13.0",
         "@typespec/http": "^1.13.0",
         "@typespec/openapi": "^1.13.0",

--- a/eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json
+++ b/eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json
@@ -1,7 +1,7 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260624.9"
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260625.1"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.69.0",


### PR DESCRIPTION
Split from #60256. This draft PR contains only the eng package reference updates for azure-typespec/http-client-csharp-mgmt.