### PR TITLE
[Mgmt] Fix duplicate WirePath attributes on shared properties

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/WirePathVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/WirePathVisitor.cs
@@ -31,6 +31,12 @@ namespace Azure.Generator.Management.Visitors
             // add WirePathAttribute
             // first get out its previous attributes
             var attributes = property.Attributes;
+            // skip if a WirePathAttribute has already been added (the same PropertyProvider
+            // instance may be visited more than once when shared across models, e.g. via hierarchyBuilding)
+            if (attributes.Any(a => a.Type.Equals(WirePathAttributeType)))
+            {
+                return base.VisitProperty(property);
+            }
             // get the wire path
             var wirePath = GetWirePath(property);
             // add WirePathAttribute to the list

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/WirePathVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/WirePathVisitor.cs
@@ -33,14 +33,15 @@ namespace Azure.Generator.Management.Visitors
             var attributes = property.Attributes;
             // skip if a WirePathAttribute has already been added (the same PropertyProvider
             // instance may be visited more than once when shared across models, e.g. via hierarchyBuilding)
-            if (attributes.Any(a => a.Type.Equals(WirePathAttributeType)))
+            var wirePathType = WirePathAttributeType;
+            if (attributes.Any(a => FlattenPropertyVisitor.IsWirePathAttribute(a, wirePathType)))
             {
                 return base.VisitProperty(property);
             }
             // get the wire path
             var wirePath = GetWirePath(property);
             // add WirePathAttribute to the list
-            var wirePathAttribute = new AttributeStatement(WirePathAttributeType,
+            var wirePathAttribute = new AttributeStatement(wirePathType,
                 [
                     Literal(wirePath),
                 ]);

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -14,10 +14,10 @@
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
-        "@azure-tools/typespec-autorest": "0.69.0",
+        "@azure-tools/typespec-autorest": "0.69.1",
         "@azure-tools/typespec-azure-core": "0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.69.0",
-        "@azure-tools/typespec-azure-rulesets": "0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.69.1",
+        "@azure-tools/typespec-azure-rulesets": "0.69.1",
         "@azure-tools/typespec-client-generator-core": "0.69.1",
         "@azure-tools/typespec-liftr-base": "0.14.0",
         "@eslint/js": "^9.2.0",
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.69.0.tgz",
-      "integrity": "sha512-6lOOe3NWfLI8M5NGLM1ZzIFRe34gVPj2GXzti9ag6o3fVpC6eMUfacv1sU4zmz9dkpKTdOUXNO5qm3DvqPRC8Q==",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.69.1.tgz",
+      "integrity": "sha512-nbAsTagr4pyBO0ajlRnE5TW4tAXrYKFYSoWD+8bevXpe23bkVIJkDUJCZPSgWE7CBf3kxfw53lAb70a50oJmRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -152,7 +152,7 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.1",
         "@azure-tools/typespec-client-generator-core": "^0.69.0",
         "@typespec/compiler": "^1.13.0",
         "@typespec/http": "^1.13.0",
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.69.0.tgz",
-      "integrity": "sha512-q/kdsGhVpvn2wb3OedxFHg7hp+al3FynUAPsz2gwqJx62z6UGOEJhtYCWP3osatVgxvKRhhh8uYl5mHRMDFi3g==",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.69.1.tgz",
+      "integrity": "sha512-NF7fqmPwaQbywcxGhH+v9qPYtIrPRR5MncXmeml6Kf9WLeqQj0rJt76KZCsZ8zwj58ZVbTNFPKcjsTQ00yQupA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.69.0.tgz",
-      "integrity": "sha512-+7KThtfHupWBDSwDR9rRHNmBb15gxACH8iPOOohRr1J28Gu25YWlz1G00r62X9VUBFLZTxYc4rQ2QCxPFT0uFw==",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.69.1.tgz",
+      "integrity": "sha512-vRvO8MoO4dwHdOKCFUB0IZkwf5AFGW92PP+48GKDYSNVFA7mwKVlbAlRa0rU6yURsUppAT6BPEurtau3FR+N0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -214,7 +214,7 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.1",
         "@azure-tools/typespec-client-generator-core": "^0.69.0",
         "@typespec/compiler": "^1.13.0"
       }

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -43,10 +43,10 @@
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
-    "@azure-tools/typespec-autorest": "0.69.0",
+    "@azure-tools/typespec-autorest": "0.69.1",
     "@azure-tools/typespec-azure-core": "0.69.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.69.0",
-    "@azure-tools/typespec-azure-rulesets": "0.69.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.69.1",
+    "@azure-tools/typespec-azure-rulesets": "0.69.1",
     "@azure-tools/typespec-client-generator-core": "0.69.1",
     "@azure-tools/typespec-liftr-base": "0.14.0",
     "@eslint/js": "^9.2.0",


### PR DESCRIPTION
## Summary
Fix duplicate [WirePath] attributes emitted on shared model properties.

## Root cause
WirePathVisitor.VisitProperty unconditionally appended a WirePathAttribute on every visit. When @@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding reparents many models to a common base (e.g. Azure.ResourceManager.CommonTypes.ProxyResource), the same inherited PropertyProvider instance (such as `Kind`) is encountered once per descendant model during the visitor traversal. Each visit mutated the shared property by appending another `WirePathAttribute`, producing dozens of `[WirePath("kind")]` attributes on a single property.

## Fix
Guard the append by checking whether a `WirePathAttribute` of the expected type is already present on the property.

## Validation
Regenerated `Azure.ResourceManager.AppService` (which now uses `hierarchyBuilding` for 50+ models extending `ProxyOnlyResource`). The duplicate `[WirePath("kind")]` attributes are gone — a single attribute is emitted as expected.