### PR TITLE
[EventGrid] Set release date for Azure.Messaging.EventGrid.SystemEvents 1.1.0-beta.1

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid.SystemEvents/CHANGELOG.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid.SystemEvents/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
+## 1.1.0-beta.1 (2026-06-25)
 
 ### Features Added
 
 - Implemented `IJsonModel` and `IPersistableModel` deserialization methods for events.
-
-### Bug Fixes
-
-### Other Changes
 
 ## 1.0.0 (2025-06-23)
 


### PR DESCRIPTION
Makes the `Azure.Messaging.EventGrid.SystemEvents` **1.1.0-beta.1** changelog entry release-ready so the release pipeline's `Verify-ChangeLogEntry` passes:
- Sets the release date (requires `yyyy-MM-dd`; rejects `(Unreleased)`).
- Removes the empty `Bug Fixes` and `Other Changes` sections (validation rejects empty sections).

### Change
- CHANGELOG.md: `## 1.1.0-beta.1 (Unreleased)` -> `## 1.1.0-beta.1 (2026-06-25)`; dropped empty `Bug Fixes` / `Other Changes` headers (kept `Features Added`).

> Note: the `net - eventgrid` build is currently failing on an unrelated `CloudNativeCloudEvents` compile error (`DiagnosticScope.cs` `isRemote`); that must be fixed before this package can be released. Update the date above to the actual release day if it slips.