### PR TITLE
[http-client-csharp] Fix credential/instanceId swap in generated settings constructor

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/ClientSettingsVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/ClientSettingsVisitor.cs
@@ -97,19 +97,24 @@ namespace Azure.Generator.Visitors
                 if (ctor.Signature.Parameters.Count == 1 &&
                     ctor.Signature.Parameters[0].Type.Equals(clientProvider.ClientSettings?.Type))
                 {
-                    bool hasTokenCredCtor = constructors.Any(c =>
+                    // The Settings constructor chains to the internal constructor whose first
+                    // argument is the authentication policy. Match the public credential
+                    // constructor by argument count so the chained call maps argument-for-argument.
+                    int chainedArgCount = ctor.Signature.Initializer?.Arguments.Count ?? 0;
+
+                    var tokenCredCtor = constructors.FirstOrDefault(c =>
                         c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public) &&
                         c.Signature.Parameters.Any(p => p.Type.Equals(typeof(TokenCredential))) &&
-                        c.Signature.Parameters.Count >= 3);
+                        c.Signature.Parameters.Count == chainedArgCount);
 
-                    bool hasKeyCredCtor = constructors.Any(c =>
+                    var keyCredCtor = constructors.FirstOrDefault(c =>
                         c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public) &&
                         c.Signature.Parameters.Any(p => p.Type.Equals(typeof(AzureKeyCredential))) &&
-                        c.Signature.Parameters.Count >= 3);
+                        c.Signature.Parameters.Count == chainedArgCount);
 
-                    if (hasTokenCredCtor || hasKeyCredCtor)
+                    if (tokenCredCtor != null || keyCredCtor != null)
                     {
-                        UpdateSettingsConstructor(ctor, hasTokenCredCtor, hasKeyCredCtor);
+                        UpdateSettingsConstructor(ctor, tokenCredCtor, keyCredCtor);
                     }
                     else
                     {
@@ -119,12 +124,11 @@ namespace Azure.Generator.Visitors
             }
         }
 
-        private static void UpdateSettingsConstructor(ConstructorProvider settingsCtor, bool hasTokenCredCtor, bool hasKeyCredCtor)
+        private static void UpdateSettingsConstructor(ConstructorProvider settingsCtor, ConstructorProvider? tokenCredCtor, ConstructorProvider? keyCredCtor)
         {
-            var existingArgs = settingsCtor.Signature.Initializer!.Arguments;
             var settingsParam = settingsCtor.Signature.Parameters[0];
 
-            if (hasTokenCredCtor)
+            if (tokenCredCtor != null)
             {
                 // Build: settings?.CredentialProvider as TokenCredential
 #pragma warning disable SCME0002
@@ -132,17 +136,9 @@ namespace Azure.Generator.Visitors
 #pragma warning restore SCME0002
                 var tokenCredentialArg = new AsExpression(credentialProviderAccess, TokenCredentialType);
 
-                var newArgs = new List<ValueExpression>();
-                newArgs.Add(existingArgs[1]); // endpoint
-                newArgs.Add(tokenCredentialArg); // credential
-                for (int i = 2; i < existingArgs.Count; i++)
-                {
-                    newArgs.Add(existingArgs[i]);
-                }
-
-                settingsCtor.Signature.Update(initializer: new ConstructorInitializer(false, newArgs));
+                BuildSettingsInitializer(settingsCtor, tokenCredCtor, tokenCredentialArg, TokenCredentialType);
             }
-            else if (hasKeyCredCtor)
+            else if (keyCredCtor != null)
             {
                 // Key-credential only library.
                 // Build a ternary: check CredentialSource == "apikeycredential" (case-insensitive),
@@ -167,16 +163,41 @@ namespace Azure.Generator.Visitors
                     newKeyCredential,
                     Null);
 
-                var newArgs = new List<ValueExpression>();
-                newArgs.Add(existingArgs[1]); // endpoint
-                newArgs.Add(keyCredentialArg); // credential
-                for (int i = 2; i < existingArgs.Count; i++)
-                {
-                    newArgs.Add(existingArgs[i]);
-                }
-
-                settingsCtor.Signature.Update(initializer: new ConstructorInitializer(false, newArgs));
+                BuildSettingsInitializer(settingsCtor, keyCredCtor, keyCredentialArg, AzureKeyCredentialType);
             }
+        }
+
+        // Rebuilds the Settings constructor's chained initializer to target the public credential
+        // constructor. The credential argument is placed at the position of the credential parameter
+        // in the target constructor (which is not necessarily index 1 — e.g. when a parameter such as
+        // an instanceId has been hoisted onto the client via @clientInitialization). All other
+        // arguments are taken, in order, from the original chained arguments (skipping the leading
+        // authentication-policy argument), since the non-credential parameters keep their relative order.
+        private static void BuildSettingsInitializer(
+            ConstructorProvider settingsCtor,
+            ConstructorProvider targetCtor,
+            ValueExpression credentialArg,
+            CSharpType credentialType)
+        {
+            var existingArgs = settingsCtor.Signature.Initializer!.Arguments;
+            var restArgs = new Queue<ValueExpression>(existingArgs.Skip(1));
+
+            var newArgs = new List<ValueExpression>();
+            bool credentialPlaced = false;
+            foreach (var param in targetCtor.Signature.Parameters)
+            {
+                if (!credentialPlaced && param.Type.Equals(credentialType))
+                {
+                    newArgs.Add(credentialArg);
+                    credentialPlaced = true;
+                }
+                else
+                {
+                    newArgs.Add(restArgs.Dequeue());
+                }
+            }
+
+            settingsCtor.Signature.Update(initializer: new ConstructorInitializer(false, newArgs));
         }
 
         private static void UpdateSettingsConstructorForNoAuth(ConstructorProvider settingsCtor)

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/ClientSettingsVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/ClientSettingsVisitorTests.cs
@@ -190,6 +190,71 @@ namespace Azure.Generator.Tests.Visitors
         }
 
         [Test]
+        public void SettingsConstructorPlacesCredentialAfterHoistedClientParameter()
+        {
+            // Reproduces the case where an additional client-level parameter (e.g. an
+            // instanceId hoisted onto the client via @clientInitialization) appears before
+            // the credential in the public credential constructor. The Settings constructor
+            // must place the credential argument at the credential parameter's actual
+            // position, not hard-coded at index 1, otherwise the credential and the hoisted
+            // parameter are passed into each other's slots and the code fails to compile.
+            var endpointParam = InputFactory.EndpointParameter(
+                "endpoint",
+                InputPrimitiveType.String,
+                isRequired: true,
+                isEndpoint: true);
+            var instanceIdParam = InputFactory.PathParameter(
+                "instanceId",
+                InputPrimitiveType.String,
+                isRequired: true,
+                scope: InputParameterScope.Client);
+            var client = InputFactory.Client(
+                "TestClient",
+                parameters: [endpointParam, instanceIdParam]);
+
+            MockHelpers.LoadMockGenerator(
+                oauth2Auth: () => new InputOAuth2Auth([new InputOAuth2Flow(["https://test.azure.com/.default"], null, null, null)]),
+                clients: () => [client]);
+
+            var clientProvider = AzureClientGenerator.Instance.OutputLibrary.TypeProviders
+                .OfType<ClientProvider>().FirstOrDefault();
+            Assert.IsNotNull(clientProvider);
+            Assert.IsNotNull(clientProvider!.ClientSettings,
+                "Client should have ClientSettings");
+
+            var settingsCtor = clientProvider.Constructors.FirstOrDefault(c =>
+                c.Signature.Parameters.Count == 1 &&
+                c.Signature.Parameters[0].Type.Equals(clientProvider.ClientSettings!.Type));
+            Assert.IsNotNull(settingsCtor, "Client should have a Settings constructor");
+
+            var initializer = settingsCtor!.Signature.Initializer;
+            Assert.IsNotNull(initializer, "Settings constructor should have an initializer");
+
+            // Find the public credential constructor the Settings constructor chains to.
+            var credentialCtor = clientProvider.Constructors.FirstOrDefault(c =>
+                c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public) &&
+                c.Signature.Parameters.Count == initializer!.Arguments.Count &&
+                c.Signature.Parameters.Any(p => p.Type.Equals(typeof(TokenCredential))));
+            Assert.IsNotNull(credentialCtor,
+                "Client should have a public TokenCredential constructor matching the Settings chain arity");
+
+            int credentialIndex = credentialCtor!.Signature.Parameters
+                .ToList().FindIndex(p => p.Type.Equals(typeof(TokenCredential)));
+            Assert.Greater(credentialIndex, 1,
+                "With a hoisted client parameter, the credential is not the second parameter");
+
+            // The credential argument must be at the credential parameter's actual position.
+            var credentialArgDisplay = initializer!.Arguments[credentialIndex].ToDisplayString();
+            Assert.IsTrue(credentialArgDisplay.Contains("CredentialProvider"),
+                $"Credential argument should be at index {credentialIndex}. Found: {credentialArgDisplay}");
+
+            // The hoisted parameter's slot (index 1) must NOT receive the credential.
+            var hoistedArgDisplay = initializer.Arguments[1].ToDisplayString();
+            Assert.IsFalse(hoistedArgDisplay.Contains("CredentialProvider"),
+                $"The hoisted parameter slot should not receive the credential. Found: {hoistedArgDisplay}");
+        }
+
+        [Test]
         public void SettingsConstructorChainsToTokenCredentialConstructor()
         {
             var endpointParam = InputFactory.EndpointParameter(


### PR DESCRIPTION
## Summary

Fixes a bug in the Azure C# emitter (`@azure-typespec/http-client-csharp`) where the generated settings-object constructor swaps the credential and a hoisted client parameter, producing non-compiling code (CS1503).

This was reported for the `Azure.IoT.DeviceUpdate` data-plane SDK after its Swagger → TypeSpec migration. The spec uses `@@clientInitialization` to hoist `instanceId` onto the main client, which places `instanceId` ahead of the credential in the client constructor.

## Root cause

`ClientSettingsVisitor` rewrites the settings-object constructor to chain into the Azure credential constructor. The old logic hard-coded the credential argument at index 1:

```csharp
newArgs.Add(existingArgs[1]);     // assumed slot 0 was the credential's predecessor
newArgs.Add(tokenCredentialArg);  // credential forced to index 1
```

When `@@clientInitialization` hoists an extra client parameter (here `instanceId`) ahead of the credential, the credential parameter no longer lives at index 1. The result was the credential and `instanceId` being emitted into each other's parameter slots:

```csharp
// BEFORE (broken) — instanceId where the credential is expected, credential where a string is expected
: this(settings?.Endpoint, settings?.CredentialProvider as TokenCredential, settings?.InstanceId, settings?.Options)
```

## Fix

The visitor now captures the actual target credential constructor and places the credential argument at the credential parameter's real index in that constructor, filling the remaining slots from the existing arguments in order. The generated chain is now correct regardless of how many client parameters are hoisted:

```csharp
// AFTER (correct)
: this(settings?.Endpoint, settings?.InstanceId, settings?.CredentialProvider as TokenCredential, settings?.Options)
```

## Validation

- `ClientSettingsVisitorTests` — 9/9 pass (8 existing + 1 new regression test `SettingsConstructorPlacesCredentialAfterHoistedClientParameter` covering the hoisted-parameter ordering).
- End-to-end: regenerated the DeviceUpdate-style spec and confirmed the settings constructor now compiles.

## Notes

This PR addresses only the Azure-owned issue. The same spec surfaces two other issues that are **not** in scope here:
- Sub-client `Uri _endpoint` field vs `string endpoint` constructor parameter mismatch — reproduces in the core/unbranded `@typespec/http-client-csharp` emitter, so it is being fixed upstream in `microsoft/typespec`.
- The `Azure.IoT._DeviceUpdate` namespace underscore is by-design TCGC disambiguation (a client named `DeviceUpdate` collides with the namespace tail) and is resolved by renaming the colliding client.
