### PR TITLE
Fix AsPages() continuation token off-by-one in data-plane generator

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/AzureCollectionResultDefinition.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/AzureCollectionResultDefinition.cs
@@ -131,6 +131,11 @@ namespace Azure.Generator.Providers
                 Declare("result", ResponseModelType, responseVariable.CastTo(ResponseModelType), out var resultVariable),
             };
 
+            // Determine the next page link/token from the current response BEFORE yielding, so that the
+            // page's continuation token points to the NEXT page rather than the page just returned.
+            // See https://github.com/Azure/azure-sdk-for-net/issues/60274.
+            whileStatement.Add(AssignNextPageVariable(responseVariable, resultVariable, nextPageVariable));
+
             ValueExpression nextPageExpression = _paging.NextLink != null
                 ? new TernaryConditionalExpression(
                     nextPageVariable.NullConditional().Property(nameof(Uri.IsAbsoluteUri)).Equal(True),
@@ -151,11 +156,66 @@ namespace Azure.Generator.Providers
                 whileStatement.Add(YieldReturn(Static(new CSharpType(typeof(Page<>), [_itemModelType])).Invoke("FromValues", [BuildGetPropertyExpression(Paging.ItemPropertySegments, resultVariable).CastTo(new CSharpType(typeof(IReadOnlyList<>), _itemModelType)), nextPageExpression, responseVariable])));
             }
 
-            // Extract next page
-            whileStatement.Add(AssignAndCheckNextPageVariable(responseVariable.ToApi<ClientResponseApi>(), resultVariable, nextPageVariable));
+            // Stop paging once there is no next page. Checked AFTER the yield so the final page is still returned.
+            whileStatement.Add(CheckNextPageVariable(nextPageVariable));
 
             statements.Add(whileStatement);
             return [.. statements];
+        }
+
+        // Assigns the next page link/token from the current response into <paramref name="nextPageVariable"/>
+        // without breaking out of the paging loop. This mirrors the assignment portion of the base
+        // AssignAndCheckNextPageVariable, but the null check is performed separately (after the yield) by
+        // CheckNextPageVariable so that the continuation token of the current page reflects the next page.
+        private MethodBodyStatement[] AssignNextPageVariable(VariableExpression responseVariable, VariableExpression resultVariable, VariableExpression nextPageVariable)
+        {
+            switch (NextPageLocation)
+            {
+                case InputResponseLocation.Body:
+                    var resultExpression = BuildGetPropertyExpression(NextPagePropertySegments, resultVariable);
+                    if (Paging.ContinuationToken != null || NextPagePropertyType.Equals(typeof(Uri)))
+                    {
+                        // The next link (Uri) or continuation token can be assigned directly.
+                        return [nextPageVariable.Assign(resultExpression).Terminate()];
+                    }
+
+                    // The next link is a string property; materialize it into a Uri (or null when empty).
+                    return
+                    [
+                        Declare("nextPageString", resultExpression.As<string>(), out ScopedApi<string> nextPageString),
+                        nextPageVariable.Assign(
+                            new TernaryConditionalExpression(
+                                Static<string>().Invoke(nameof(string.IsNullOrEmpty), nextPageString),
+                                Null,
+                                New.Instance<Uri>(nextPageString, FrameworkEnumValue(UriKind.RelativeOrAbsolute)))).Terminate()
+                    ];
+                case InputResponseLocation.Header:
+                    return
+                    [
+                        new IfElseStatement(
+                            new IfStatement(responseVariable.ToApi<ClientResponseApi>().GetRawResponse()
+                                .TryGetHeader(NextPagePropertySegments[0], out var nextLinkHeader)
+                                .And(Not(Static<string>().Invoke(nameof(string.IsNullOrEmpty), nextLinkHeader!))))
+                            {
+                                nextPageVariable.Type.Equals(typeof(Uri))
+                                    ? nextPageVariable.Assign(New.Instance<Uri>(nextLinkHeader!, FrameworkEnumValue(UriKind.RelativeOrAbsolute))).Terminate()
+                                    : nextPageVariable.Assign(nextLinkHeader!).Terminate(),
+                            },
+                            nextPageVariable.Assign(Null).Terminate())
+                    ];
+                default:
+                    // Invalid location is logged by the emitter.
+                    return [];
+            }
+        }
+
+        // Breaks out of the paging loop when there is no next page. Performed after the page has been yielded.
+        private MethodBodyStatement CheckNextPageVariable(VariableExpression nextPageVariable)
+        {
+            ValueExpression condition = nextPageVariable.Type.Equals(typeof(Uri))
+                ? nextPageVariable.Equal(Null)
+                : Static<string>().Invoke(nameof(string.IsNullOrEmpty), nextPageVariable);
+            return new IfStatement(condition) { new YieldBreakStatement() };
         }
 
         private MethodBodyStatement[] ConvertItemsToListOfBinaryData(VariableExpression responseVariable, out VariableExpression itemsVariable)

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBody.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBody.cs
@@ -50,14 +50,14 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                nextPage = result.NextPage;
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
-                nextPage = result.NextPage;
-                if ((nextPage == null))
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyAsync.cs
@@ -51,14 +51,14 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                nextPage = result.NextPage;
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
-                nextPage = result.NextPage;
-                if ((nextPage == null))
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyOfT.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyOfT.cs
@@ -49,9 +49,9 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), nextPage, response);
                 nextPage = result.NextPage;
-                if ((nextPage == null))
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), nextPage, response);
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyOfTAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyOfTAsync.cs
@@ -50,9 +50,9 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), nextPage, response);
                 nextPage = result.NextPage;
-                if ((nextPage == null))
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), nextPage, response);
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeader.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeader.cs
@@ -50,17 +50,21 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                if ((response.Headers.TryGetValue("nextPage", out string value) && !string.IsNullOrEmpty(value)))
+                {
+                    nextPage = value;
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
-                if ((response.Headers.TryGetValue("nextPage", out string value) && !string.IsNullOrEmpty(value)))
-                {
-                    nextPage = value;
-                }
-                else
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderAsync.cs
@@ -51,17 +51,21 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                if ((response.Headers.TryGetValue("nextPage", out string value) && !string.IsNullOrEmpty(value)))
+                {
+                    nextPage = value;
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
-                if ((response.Headers.TryGetValue("nextPage", out string value) && !string.IsNullOrEmpty(value)))
-                {
-                    nextPage = value;
-                }
-                else
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderOfT.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderOfT.cs
@@ -49,12 +49,16 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), nextPage, response);
                 if ((response.Headers.TryGetValue("nextPage", out string value) && !string.IsNullOrEmpty(value)))
                 {
                     nextPage = value;
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), nextPage, response);
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderOfTAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderOfTAsync.cs
@@ -50,12 +50,16 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), nextPage, response);
                 if ((response.Headers.TryGetValue("nextPage", out string value) && !string.IsNullOrEmpty(value)))
                 {
                     nextPage = value;
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), nextPage, response);
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/MaxPageSizePassedToNextRequest.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/MaxPageSizePassedToNextRequest.cs
@@ -53,14 +53,14 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                nextPage = result.NextPage;
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
-                nextPage = result.NextPage;
-                if ((nextPage == null))
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/MaxPageSizeRequiredPassedToNextRequest.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/MaxPageSizeRequiredPassedToNextRequest.cs
@@ -53,14 +53,14 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                nextPage = result.NextPage;
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
-                nextPage = result.NextPage;
-                if ((nextPage == null))
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/MaxPageSizePassedToNextRequest.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/MaxPageSizePassedToNextRequest.cs
@@ -50,13 +50,13 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                nextPage = result.NextCat;
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                nextPage = result.NextCat;
                 if ((nextPage == null))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/MaxPageSizeRequiredPassedToNextRequest.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/MaxPageSizeRequiredPassedToNextRequest.cs
@@ -50,13 +50,13 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                nextPage = result.NextCat;
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                nextPage = result.NextCat;
                 if ((nextPage == null))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBody.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBody.cs
@@ -47,13 +47,13 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                nextPage = result.NextCat;
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                nextPage = result.NextCat;
                 if ((nextPage == null))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyAsync.cs
@@ -48,13 +48,13 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                nextPage = result.NextCat;
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                nextPage = result.NextCat;
                 if ((nextPage == null))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyOfT.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyOfT.cs
@@ -46,8 +46,8 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 nextPage = result.NextCat;
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyOfTAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyOfTAsync.cs
@@ -47,8 +47,8 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 nextPage = result.NextCat;
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyOfTWithStringProperty.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyOfTWithStringProperty.cs
@@ -46,13 +46,13 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 string nextPageString = result.NextCat;
-                if (string.IsNullOrEmpty(nextPageString))
+                nextPage = string.IsNullOrEmpty(nextPageString) ? null : new global::System.Uri(nextPageString, global::System.UriKind.RelativeOrAbsolute);
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if ((nextPage == null))
                 {
                     yield break;
                 }
-                nextPage = new global::System.Uri(nextPageString, global::System.UriKind.RelativeOrAbsolute);
             }
         }
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyWithStringProperty.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyWithStringProperty.cs
@@ -47,18 +47,18 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                string nextPageString = result.NextCat;
+                nextPage = string.IsNullOrEmpty(nextPageString) ? null : new global::System.Uri(nextPageString, global::System.UriKind.RelativeOrAbsolute);
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                string nextPageString = result.NextCat;
-                if (string.IsNullOrEmpty(nextPageString))
+                if ((nextPage == null))
                 {
                     yield break;
                 }
-                nextPage = new global::System.Uri(nextPageString, global::System.UriKind.RelativeOrAbsolute);
             }
         }
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeader.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeader.cs
@@ -47,17 +47,21 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                if ((response.Headers.TryGetValue("nextCat", out string value) && !string.IsNullOrEmpty(value)))
+                {
+                    nextPage = new global::System.Uri(value, global::System.UriKind.RelativeOrAbsolute);
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                if ((response.Headers.TryGetValue("nextCat", out string value) && !string.IsNullOrEmpty(value)))
-                {
-                    nextPage = new global::System.Uri(value, global::System.UriKind.RelativeOrAbsolute);
-                }
-                else
+                if ((nextPage == null))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeaderAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeaderAsync.cs
@@ -48,17 +48,21 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
+                if ((response.Headers.TryGetValue("nextCat", out string value) && !string.IsNullOrEmpty(value)))
+                {
+                    nextPage = new global::System.Uri(value, global::System.UriKind.RelativeOrAbsolute);
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
                     items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                if ((response.Headers.TryGetValue("nextCat", out string value) && !string.IsNullOrEmpty(value)))
-                {
-                    nextPage = new global::System.Uri(value, global::System.UriKind.RelativeOrAbsolute);
-                }
-                else
+                if ((nextPage == null))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeaderOfT.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeaderOfT.cs
@@ -46,12 +46,16 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((response.Headers.TryGetValue("nextCat", out string value) && !string.IsNullOrEmpty(value)))
                 {
                     nextPage = new global::System.Uri(value, global::System.UriKind.RelativeOrAbsolute);
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if ((nextPage == null))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeaderOfTAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeaderOfTAsync.cs
@@ -47,12 +47,16 @@ namespace Samples
                     yield break;
                 }
                 global::Samples.Models.Page result = ((global::Samples.Models.Page)response);
-                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((response.Headers.TryGetValue("nextCat", out string value) && !string.IsNullOrEmpty(value)))
                 {
                     nextPage = new global::System.Uri(value, global::System.UriKind.RelativeOrAbsolute);
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return global::Azure.Page<global::Samples.Models.Cat>.FromValues(((global::System.Collections.Generic.IReadOnlyList<global::Samples.Models.Cat>)result.Cats), (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if ((nextPage == null))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenAsyncCollectionResult.cs
@@ -50,13 +50,13 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenResponse result = (ListWithContinuationTokenResponse)response;
+                nextPage = result.NextToken;
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
-                nextPage = result.NextToken;
                 if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenAsyncCollectionResultOfT.cs
@@ -49,8 +49,8 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenResponse result = (ListWithContinuationTokenResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 nextPage = result.NextToken;
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenCollectionResult.cs
@@ -49,13 +49,13 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenResponse result = (ListWithContinuationTokenResponse)response;
+                nextPage = result.NextToken;
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
-                nextPage = result.NextToken;
                 if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenCollectionResultOfT.cs
@@ -48,8 +48,8 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenResponse result = (ListWithContinuationTokenResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 nextPage = result.NextToken;
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResult.cs
@@ -50,17 +50,21 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenHeaderResponseResponse result = (ListWithContinuationTokenHeaderResponseResponse)response;
+                if (response.Headers.TryGetValue("next-token", out string value) && !string.IsNullOrEmpty(value))
+                {
+                    nextPage = value;
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
-                if (response.Headers.TryGetValue("next-token", out string value) && !string.IsNullOrEmpty(value))
-                {
-                    nextPage = value;
-                }
-                else
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResultOfT.cs
@@ -49,12 +49,16 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenHeaderResponseResponse result = (ListWithContinuationTokenHeaderResponseResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 if (response.Headers.TryGetValue("next-token", out string value) && !string.IsNullOrEmpty(value))
                 {
                     nextPage = value;
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResult.cs
@@ -49,17 +49,21 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenHeaderResponseResponse result = (ListWithContinuationTokenHeaderResponseResponse)response;
+                if (response.Headers.TryGetValue("next-token", out string value) && !string.IsNullOrEmpty(value))
+                {
+                    nextPage = value;
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
-                if (response.Headers.TryGetValue("next-token", out string value) && !string.IsNullOrEmpty(value))
-                {
-                    nextPage = value;
-                }
-                else
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResultOfT.cs
@@ -48,12 +48,16 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenHeaderResponseResponse result = (ListWithContinuationTokenHeaderResponseResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 if (response.Headers.TryGetValue("next-token", out string value) && !string.IsNullOrEmpty(value))
                 {
                     nextPage = value;
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
+                if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageAsyncCollectionResult.cs
@@ -53,13 +53,13 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenWithMaxPageResponse result = (ListWithContinuationTokenWithMaxPageResponse)response;
+                nextPage = result.NextToken;
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
-                nextPage = result.NextToken;
                 if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageAsyncCollectionResultOfT.cs
@@ -52,8 +52,8 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenWithMaxPageResponse result = (ListWithContinuationTokenWithMaxPageResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 nextPage = result.NextToken;
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageCollectionResult.cs
@@ -52,13 +52,13 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenWithMaxPageResponse result = (ListWithContinuationTokenWithMaxPageResponse)response;
+                nextPage = result.NextToken;
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
-                nextPage = result.NextToken;
                 if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageCollectionResultOfT.cs
@@ -51,8 +51,8 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithContinuationTokenWithMaxPageResponse result = (ListWithContinuationTokenWithMaxPageResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 nextPage = result.NextToken;
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkAsyncCollectionResult.cs
@@ -47,17 +47,21 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithHeaderNextLinkResponse result = (ListWithHeaderNextLinkResponse)response;
+                if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
+                {
+                    nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
-                {
-                    nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
-                }
-                else
+                if (nextPage == null)
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkAsyncCollectionResultOfT.cs
@@ -46,12 +46,16 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithHeaderNextLinkResponse result = (ListWithHeaderNextLinkResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
                 {
                     nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if (nextPage == null)
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkCollectionResult.cs
@@ -46,17 +46,21 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithHeaderNextLinkResponse result = (ListWithHeaderNextLinkResponse)response;
+                if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
+                {
+                    nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
-                {
-                    nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
-                }
-                else
+                if (nextPage == null)
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkCollectionResultOfT.cs
@@ -45,12 +45,16 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithHeaderNextLinkResponse result = (ListWithHeaderNextLinkResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
                 {
                     nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if (nextPage == null)
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageAsyncCollectionResult.cs
@@ -50,17 +50,21 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithHeaderNextLinkWithMaxPageResponse result = (ListWithHeaderNextLinkWithMaxPageResponse)response;
+                if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
+                {
+                    nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
-                {
-                    nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
-                }
-                else
+                if (nextPage == null)
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageAsyncCollectionResultOfT.cs
@@ -49,12 +49,16 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithHeaderNextLinkWithMaxPageResponse result = (ListWithHeaderNextLinkWithMaxPageResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
                 {
                     nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if (nextPage == null)
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageCollectionResult.cs
@@ -49,17 +49,21 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithHeaderNextLinkWithMaxPageResponse result = (ListWithHeaderNextLinkWithMaxPageResponse)response;
+                if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
+                {
+                    nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
+                }
+                else
+                {
+                    nextPage = null;
+                }
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
-                {
-                    nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
-                }
-                else
+                if (nextPage == null)
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageCollectionResultOfT.cs
@@ -48,12 +48,16 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithHeaderNextLinkWithMaxPageResponse result = (ListWithHeaderNextLinkWithMaxPageResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (response.Headers.TryGetValue("next", out string value) && !string.IsNullOrEmpty(value))
                 {
                     nextPage = new Uri(value, UriKind.RelativeOrAbsolute);
                 }
                 else
+                {
+                    nextPage = null;
+                }
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if (nextPage == null)
                 {
                     yield break;
                 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkAsyncCollectionResult.cs
@@ -47,13 +47,13 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithNextLinkResponse result = (ListWithNextLinkResponse)response;
+                nextPage = result.Next;
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                nextPage = result.Next;
                 if (nextPage == null)
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkAsyncCollectionResultOfT.cs
@@ -46,8 +46,8 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithNextLinkResponse result = (ListWithNextLinkResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 nextPage = result.Next;
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkCollectionResult.cs
@@ -46,13 +46,13 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithNextLinkResponse result = (ListWithNextLinkResponse)response;
+                nextPage = result.Next;
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                nextPage = result.Next;
                 if (nextPage == null)
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkCollectionResultOfT.cs
@@ -45,8 +45,8 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithNextLinkResponse result = (ListWithNextLinkResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 nextPage = result.Next;
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)
                 {
                     yield break;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkAsyncCollectionResult.cs
@@ -47,18 +47,18 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithStringNextLinkResponse result = (ListWithStringNextLinkResponse)response;
+                string nextPageString = result.Next;
+                nextPage = string.IsNullOrEmpty(nextPageString) ? null : new Uri(nextPageString, UriKind.RelativeOrAbsolute);
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                string nextPageString = result.Next;
-                if (string.IsNullOrEmpty(nextPageString))
+                if (nextPage == null)
                 {
                     yield break;
                 }
-                nextPage = new Uri(nextPageString, UriKind.RelativeOrAbsolute);
             }
         }
 

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkAsyncCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkAsyncCollectionResultOfT.cs
@@ -46,13 +46,13 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithStringNextLinkResponse result = (ListWithStringNextLinkResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 string nextPageString = result.Next;
-                if (string.IsNullOrEmpty(nextPageString))
+                nextPage = string.IsNullOrEmpty(nextPageString) ? null : new Uri(nextPageString, UriKind.RelativeOrAbsolute);
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if (nextPage == null)
                 {
                     yield break;
                 }
-                nextPage = new Uri(nextPageString, UriKind.RelativeOrAbsolute);
             }
         }
 

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkCollectionResult.cs
@@ -46,18 +46,18 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithStringNextLinkResponse result = (ListWithStringNextLinkResponse)response;
+                string nextPageString = result.Next;
+                nextPage = string.IsNullOrEmpty(nextPageString) ? null : new Uri(nextPageString, UriKind.RelativeOrAbsolute);
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
                     items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
-                string nextPageString = result.Next;
-                if (string.IsNullOrEmpty(nextPageString))
+                if (nextPage == null)
                 {
                     yield break;
                 }
-                nextPage = new Uri(nextPageString, UriKind.RelativeOrAbsolute);
             }
         }
 

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkCollectionResultOfT.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkCollectionResultOfT.cs
@@ -45,13 +45,13 @@ namespace BasicTypeSpec
                     yield break;
                 }
                 ListWithStringNextLinkResponse result = (ListWithStringNextLinkResponse)response;
-                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 string nextPageString = result.Next;
-                if (string.IsNullOrEmpty(nextPageString))
+                nextPage = string.IsNullOrEmpty(nextPageString) ? null : new Uri(nextPageString, UriKind.RelativeOrAbsolute);
+                yield return Page<ThingModel>.FromValues((IReadOnlyList<ThingModel>)result.Things, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
+                if (nextPage == null)
                 {
                     yield break;
                 }
-                nextPage = new Uri(nextPageString, UriKind.RelativeOrAbsolute);
             }
         }
 

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Pageable/NextLinkPaginationTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Pageable/NextLinkPaginationTests.cs
@@ -112,6 +112,42 @@ namespace TestProjects.Spector.Tests.Http.Payload.Pageable
         });
 
         [SpectorTest]
+        public Task ContinuationTokenResumesFromNextPage() => Test(async (host) =>
+        {
+            var client = new PageableClient(host, null);
+
+            // Capture the continuation token exposed by the first page.
+            string? firstPageToken = null;
+            await foreach (var page in client.GetServerDrivenPaginationClient().LinkAsync(new RequestContext()).AsPages())
+            {
+                firstPageToken = page.ContinuationToken;
+                break;
+            }
+
+            // The first page must expose the token needed to fetch the NEXT page. Regression test for
+            // https://github.com/Azure/azure-sdk-for-net/issues/60274, where the token pointed at the
+            // current page (or was null) rather than the next one.
+            Assert.IsNotNull(firstPageToken);
+
+            // Resuming from the captured token should return the remaining pages only (pets 3 and 4).
+            var resumedIds = new List<string>();
+            string? lastPageToken = "unset";
+            await foreach (var page in client.GetServerDrivenPaginationClient().LinkAsync(new RequestContext()).AsPages(firstPageToken))
+            {
+                lastPageToken = page.ContinuationToken;
+                var pageResult = JsonNode.Parse(page.GetRawResponse().Content.ToString())!;
+                foreach (var pet in (pageResult["pets"] as JsonArray)!)
+                {
+                    resumedIds.Add(pet!["id"]!.ToString());
+                }
+            }
+            CollectionAssert.AreEqual(new[] { "3", "4" }, resumedIds);
+
+            // The final page must expose a null continuation token to signal the end of the collection.
+            Assert.IsNull(lastPageToken);
+        });
+
+        [SpectorTest]
         public Task ConvenienceMethodNested() => Test(async (host) =>
         {
             var client = new PageableClient(host, null);


### PR DESCRIPTION
## Summary
Fixes #60274. The generated *CollectionResult.AsPages(continuationToken, pageSizeHint) loop exposed the wrong continuation token: it passed the URI used to fetch the **current** page as that page's `Page<T>.ContinuationToken`, instead of the link to the **next** page. This broke resume-from-token scenarios (resume was always one page behind) and left the final page with a non-null token.

## Fix
In `AzureCollectionResultDefinition.BuildAsPagesMethodBody` (data-plane core generator), the coupled "assign next link + null-check yield-break" was split:
- `AssignNextPageVariable` reads the next link/token from the response **before** the `yield`, so the page's `ContinuationToken` points to the **next** page.
- `CheckNextPageVariable` performs the `yield break` **after** the `yield`, so the final page is still returned (with a `null` token).

Covers all pagination shapes: NextLink in body (Uri and string property), NextLink in header, ContinuationToken in body, and ContinuationToken in header — both protocol and convenience methods.

## Validation
- Regenerated 22 snapshot test-data files and 28 Local Basic-TypeSpec generated `CollectionResults` files.
- Full `Azure.Generator.Tests` suite: 235 passed, 0 failed.
- Added Spector regression test `ContinuationTokenResumesFromNextPage` that captures page 1's continuation token, resumes via `AsPages(token)`, and asserts only the remaining items are returned and the last page's token is `null`.

## Follow-up
The KeyVault `Internalize-Generated.ps1` Patch 6 workaround can be removed once this ships.

---
*--generated by Copilot*