### PR TITLE
Align mgmt TypeSpec Azure dependencies

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -14,10 +14,10 @@
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
-        "@azure-tools/typespec-autorest": "0.69.0",
+        "@azure-tools/typespec-autorest": "0.69.1",
         "@azure-tools/typespec-azure-core": "0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.69.0",
-        "@azure-tools/typespec-azure-rulesets": "0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.69.1",
+        "@azure-tools/typespec-azure-rulesets": "0.69.1",
         "@azure-tools/typespec-client-generator-core": "0.69.1",
         "@azure-tools/typespec-liftr-base": "0.14.0",
         "@eslint/js": "^9.2.0",
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.69.0.tgz",
-      "integrity": "sha512-6lOOe3NWfLI8M5NGLM1ZzIFRe34gVPj2GXzti9ag6o3fVpC6eMUfacv1sU4zmz9dkpKTdOUXNO5qm3DvqPRC8Q==",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.69.1.tgz",
+      "integrity": "sha512-nbAsTagr4pyBO0ajlRnE5TW4tAXrYKFYSoWD+8bevXpe23bkVIJkDUJCZPSgWE7CBf3kxfw53lAb70a50oJmRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -152,7 +152,7 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.1",
         "@azure-tools/typespec-client-generator-core": "^0.69.0",
         "@typespec/compiler": "^1.13.0",
         "@typespec/http": "^1.13.0",
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.69.0.tgz",
-      "integrity": "sha512-q/kdsGhVpvn2wb3OedxFHg7hp+al3FynUAPsz2gwqJx62z6UGOEJhtYCWP3osatVgxvKRhhh8uYl5mHRMDFi3g==",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.69.1.tgz",
+      "integrity": "sha512-NF7fqmPwaQbywcxGhH+v9qPYtIrPRR5MncXmeml6Kf9WLeqQj0rJt76KZCsZ8zwj58ZVbTNFPKcjsTQ00yQupA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.69.0.tgz",
-      "integrity": "sha512-+7KThtfHupWBDSwDR9rRHNmBb15gxACH8iPOOohRr1J28Gu25YWlz1G00r62X9VUBFLZTxYc4rQ2QCxPFT0uFw==",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.69.1.tgz",
+      "integrity": "sha512-vRvO8MoO4dwHdOKCFUB0IZkwf5AFGW92PP+48GKDYSNVFA7mwKVlbAlRa0rU6yURsUppAT6BPEurtau3FR+N0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -214,7 +214,7 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.1",
         "@azure-tools/typespec-client-generator-core": "^0.69.0",
         "@typespec/compiler": "^1.13.0"
       }

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -43,10 +43,10 @@
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
-    "@azure-tools/typespec-autorest": "0.69.0",
+    "@azure-tools/typespec-autorest": "0.69.1",
     "@azure-tools/typespec-azure-core": "0.69.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.69.0",
-    "@azure-tools/typespec-azure-rulesets": "0.69.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.69.1",
+    "@azure-tools/typespec-azure-rulesets": "0.69.1",
     "@azure-tools/typespec-client-generator-core": "0.69.1",
     "@azure-tools/typespec-liftr-base": "0.14.0",
     "@eslint/js": "^9.2.0",


### PR DESCRIPTION
Updates `eng/packages/http-client-csharp-mgmt` TypeSpec Azure dev dependencies to align with the current Azure generator package.

Changes:
- @azure-tools/typespec-autorest: 0.69.0 -> 0.69.1
- @azure-tools/typespec-azure-resource-manager: 0.69.0 -> 0.69.1
- @azure-tools/typespec-azure-rulesets: 0.69.0 -> 0.69.1

`@azure-tools/typespec-client-generator-core` remains at 0.69.1, matching the Azure generator.

Validation:
- npm run build:emitter --prefix eng/packages/http-client-csharp-mgmt
- npm run prettier --prefix eng/packages/http-client-csharp-mgmt
- npm run lint --prefix eng/packages/http-client-csharp-mgmt