### PR TITLE
Peel 8 high-activity packages off the NoWarn skip-list

### DIFF
--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -32,7 +32,6 @@ Azure.Developer.DevCenter
 Azure.Health.Insights.CancerProfiling
 Azure.Health.Insights.ClinicalMatching
 Azure.Identity
-Azure.Identity.Broker
 Azure.Maps.Common
 Azure.Maps.Geolocation
 Azure.Maps.Rendering
@@ -96,15 +95,8 @@ Azure.Provisioning.Storage
 Azure.Provisioning.WebPubSub
 Azure.ResourceManager.AppService
 Azure.ResourceManager.Compute
-Azure.ResourceManager.CosmosDB
-Azure.ResourceManager.EdgeActions
 Azure.ResourceManager.InformaticaDataManagement
-Azure.ResourceManager.KubernetesConfiguration.Extensions
-Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes
 Azure.ResourceManager.MachineLearning
-Azure.ResourceManager.Network
-Azure.Security.KeyVault.Certificates
-Azure.Security.KeyVault.Secrets
 Azure.Storage.Blobs
 Azure.Storage.Blobs.Batch
 Azure.Storage.Blobs.ChangeFeed

--- a/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/src/Azure.ResourceManager.CosmosDB.csproj
+++ b/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/src/Azure.ResourceManager.CosmosDB.csproj
@@ -8,8 +8,6 @@
     <Description>Microsoft Azure management client SDK for Azure resource provider Microsoft.CosmosDB.</Description>
     <PackageTags>azure;management;arm;resource manager;cosmosdb</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
-    <NoWarn>$(NoWarn);CS1591;</NoWarn>
-
   </PropertyGroup>
 
 </Project>

--- a/sdk/edgeactions/Azure.ResourceManager.EdgeActions/src/Azure.ResourceManager.EdgeActions.csproj
+++ b/sdk/edgeactions/Azure.ResourceManager.EdgeActions/src/Azure.ResourceManager.EdgeActions.csproj
@@ -5,6 +5,5 @@
     <Description>Microsoft Azure Resource Manager client SDK for Azure resource provider Microsoft.Cdn EdgeActions.</Description>
     <PackageTags>azure;management;arm;resource manager;edgeactions;frontdoor</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
-    <NoWarn>$(NoWarn);CS1591;</NoWarn>
   </PropertyGroup>
 </Project>

--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -8,7 +8,6 @@
     <PackageTags>Microsoft Azure Identity Broker;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);$(NetFxTargetFramework)</TargetFrameworks>
-    <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -8,11 +8,8 @@
     <ApiCompatVersion>4.9.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Certificates;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -9,7 +9,6 @@
     <PackageTags>Microsoft Azure Key Vault Secrets;$(PackageCommonTags)</PackageTags>
 
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>

--- a/sdk/kubernetesconfiguration/Azure.ResourceManager.KubernetesConfiguration.Extensions/src/Azure.ResourceManager.KubernetesConfiguration.Extensions.csproj
+++ b/sdk/kubernetesconfiguration/Azure.ResourceManager.KubernetesConfiguration.Extensions/src/Azure.ResourceManager.KubernetesConfiguration.Extensions.csproj
@@ -6,6 +6,5 @@
     <PackageId>Azure.ResourceManager.KubernetesConfiguration.Extensions</PackageId>
     <Description>Microsoft Azure Resource Manager client SDK for Azure resource provider Microsoft.KubernetesConfiguration Extensions.</Description>
     <PackageTags>azure;management;arm;resource manager;kubernetesconfiguration;extensions</PackageTags>
-    <NoWarn>$(NoWarn);SA1402;CS1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/sdk/kubernetesconfiguration/Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes/src/Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes.csproj
+++ b/sdk/kubernetesconfiguration/Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes/src/Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes.csproj
@@ -4,6 +4,5 @@
     <PackageId>Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes</PackageId>
     <Description>Microsoft Azure Resource Manager client SDK for Azure resource provider Microsoft.KubernetesConfiguration PrivateLinkScopes.</Description>
     <PackageTags>azure;management;arm;resource manager;kubernetesconfiguration;privatelinkscopes</PackageTags>
-    <NoWarn>$(NoWarn);SA1402;CS1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/sdk/network/Azure.ResourceManager.Network/src/Azure.ResourceManager.Network.csproj
+++ b/sdk/network/Azure.ResourceManager.Network/src/Azure.ResourceManager.Network.csproj
@@ -7,8 +7,6 @@
     <Description>Microsoft Azure management client SDK for Azure resource provider Microsoft.Network.</Description>
     <PackageTags>azure;management;network</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
-    <!-- CA1708 cannot be suppress through #pragma. So we suppress it here. -->
-    <NoWarn>$(NoWarn);CA1708</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- TODO: Remove when https://github.com/Azure/azure-sdk-for-net/issues/60023 is fixed. -->


### PR DESCRIPTION
## Summary

Continues draining `eng/NoWarnSkipValidation.txt`, this time targeting the **highest-activity** packages still on the skip list. Removes **8 packages** whose `<NoWarn>` codes turned out to be **dead** — they suppressed no diagnostics, verified by building each package with the suppression removed.

## What changed

| Package | Stale code removed |
|---|---|
| `Azure.ResourceManager.CosmosDB` | CS1591 |
| `Azure.ResourceManager.EdgeActions` | CS1591 |
| `Azure.ResourceManager.KubernetesConfiguration.Extensions` | SA1402, CS1591 |
| `Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes` | SA1402, CS1591 |
| `Azure.ResourceManager.Network` | CA1708 |
| `Azure.Identity.Broker` | CS3021 |
| `Azure.Security.KeyVault.Secrets` | CS3021 |
| `Azure.Security.KeyVault.Certificates` | CS3021, CS1591 |

Each dead `<NoWarn>` line is removed from the csproj, and two now-stale explanatory comments are dropped (the `CA1708` note in Network and the xml-doc note in Certificates).

## Validation

Every package builds clean after removal (no `AZSDK0002`, no resurfaced warning-as-error). Because shared `Directory.Build.props` can contribute `<NoWarn>` codes that a csproj text search misses, each removal here is build-verified rather than inferred from the csproj.
