### PR TITLE
[CODEOWNERS] Fixing ownership of .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1236,11 +1236,10 @@
 ################
 
 # GitHub integration, CODEOWNERS, and bot rules
-/.github/                                                          @jsquire @m-redding @ArthurMa1978
-/.github/workflows/                                                @jsquire @m-redding @Azure/azure-sdk-eng
-/.github/CODEOWNERS                                                @jsquire @m-redding @Azure/azure-sdk-eng
-/.github/copilot-instructions.md                                   @jsquire @m-redding @praveenkuttappan @maririos
-/.github/skills/                                                   @azure/azsdk-cli @m-nash @jsquire
+/.github/                                                          @jsquire @m-nash @JoshLove-msft @ArthurMa1978
+/.github/workflows/                                                @jsquire @m-nash @JoshLove-msft
+/.github/CODEOWNERS                                                @jsquire @m-nash @JoshLove-msft
+/.github/copilot-instructions.md                                   @jsquire @m-nash @JoshLove-msft
 
 ###########################
 # Repository configuration


### PR DESCRIPTION
# Summary

Removing some ownership permissions.  Nothing should be merged into the `.github` area without explicit sign-off from Azure SDK for .NET leadership as it has impact across the repository on development workflow for both our team and partners.    