### PR TITLE
Foundry: align "agent endpoint" responses/conversations support with resolved protocol structures

### DIFF
--- a/sdk/ai/Azure.AI.Extensions.OpenAI/CHANGELOG.md
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `GetProjectConversationsClientForAgentEndpoint` on the `ProjectOpenAIClient`.
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -11,6 +13,9 @@
 - Fixed issue with stateless encrypted reasoning [issue](https://github.com/Azure/azure-sdk-for-net/issues/59967).
 
 ### Other Changes
+
+- Agent endpoint clients now target the `endpoint/protocols/openai/v1` route and no longer append an `api-version` query parameter.
+- Marked `GetProjectResponsesClientForAgent` as non-browsable in favor of `GetProjectResponsesClientForAgentEndpoint`.
 
 ## 2.1.0-beta.3 (2026-05-29)
 

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/CHANGELOG.md
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Other Changes
 
 - Agent endpoint clients now target the `endpoint/protocols/openai/v1` route and no longer append an `api-version` query parameter.
+- Hid the now-unused `ProjectOpenAIClientOptions.ApiVersion` property.
 - Marked `GetProjectResponsesClientForAgent` as non-browsable in favor of `GetProjectResponsesClientForAgentEndpoint`.
 
 ## 2.1.0-beta.3 (2026-05-29)

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/README.md
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/README.md
@@ -17,8 +17,6 @@ Develop Agents using the Azure AI Foundry platform, leveraging an extensive ecos
   - [Install the package](#install-the-package)
   - [Authenticate the client](#authenticate-the-client)
 - [Key concepts](#key-concepts)
-  - [Service API versions](#service-api-versions)
-  - [Select a service API version](#select-a-service-api-version)
 - [Additional concepts](#additional-concepts)
 - [Examples](#examples)
   - [Prompt Agents](#prompt-agents)
@@ -115,24 +113,6 @@ VectorStoreClient vectorStoreClient = projectClient.ProjectOpenAIClient.GetVecto
 ```
 
 ## Key concepts
-
-### Service API versions
-
-When clients send REST requests to the endpoint, one of the query parameters is `api-version`. It allows us to select the API versions supporting different features. The current stable version is `v1` (default).
-
-#### Select a service API version
-
-The API version may be set supplying `version` parameter to `ProjectOpenAIClientOptions` constructor as shown in the example code below.
-
-```C# Snippet:SelectAPIVersion
-ProjectOpenAIClientOptions option = new()
-{
-    ApiVersion = "2025-11-15-preview"
-};
-ProjectOpenAIClient projectClient = new(
-    projectEndpoint: new Uri("https://<RESOURCE>.services.ai.azure.com/api/projects/<PROJECT>"),
-    tokenProvider: new AzureCliCredential());
-```
 
 ### Additional concepts
 The Azure.AI.Extensions.OpenAI framework organized in a way that for each call, requiring the REST API request, there are synchronous and asynchronous counterparts where the letter has the "Async" suffix. For example, the following code demonstrates the creation of a `ResponseResult` object.

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/api/Azure.AI.Extensions.OpenAI.net10.0.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/api/Azure.AI.Extensions.OpenAI.net10.0.cs
@@ -977,6 +977,7 @@ namespace Azure.AI.Extensions.OpenAI
         public override OpenAI.Conversations.ConversationClient GetConversationClient() { throw null; }
         public override OpenAI.Files.OpenAIFileClient GetOpenAIFileClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectConversationsClient GetProjectConversationsClient() { throw null; }
+        public virtual Azure.AI.Extensions.OpenAI.ProjectConversationsClient GetProjectConversationsClientForAgentEndpoint(string agentName, Azure.AI.Extensions.OpenAI.ProjectOpenAIClientOptions options = null) { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectFilesClient GetProjectFilesClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectResponsesClient GetProjectResponsesClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectResponsesClient GetProjectResponsesClientForAgent(Azure.AI.Extensions.OpenAI.AgentReference defaultAgent, string defaultConversationId = null) { throw null; }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/api/Azure.AI.Extensions.OpenAI.net8.0.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/api/Azure.AI.Extensions.OpenAI.net8.0.cs
@@ -973,6 +973,7 @@ namespace Azure.AI.Extensions.OpenAI
         public override OpenAI.Conversations.ConversationClient GetConversationClient() { throw null; }
         public override OpenAI.Files.OpenAIFileClient GetOpenAIFileClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectConversationsClient GetProjectConversationsClient() { throw null; }
+        public virtual Azure.AI.Extensions.OpenAI.ProjectConversationsClient GetProjectConversationsClientForAgentEndpoint(string agentName, Azure.AI.Extensions.OpenAI.ProjectOpenAIClientOptions options = null) { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectFilesClient GetProjectFilesClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectResponsesClient GetProjectResponsesClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectResponsesClient GetProjectResponsesClientForAgent(Azure.AI.Extensions.OpenAI.AgentReference defaultAgent, string defaultConversationId = null) { throw null; }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/api/Azure.AI.Extensions.OpenAI.netstandard2.0.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/api/Azure.AI.Extensions.OpenAI.netstandard2.0.cs
@@ -972,6 +972,7 @@ namespace Azure.AI.Extensions.OpenAI
         public override OpenAI.Conversations.ConversationClient GetConversationClient() { throw null; }
         public override OpenAI.Files.OpenAIFileClient GetOpenAIFileClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectConversationsClient GetProjectConversationsClient() { throw null; }
+        public virtual Azure.AI.Extensions.OpenAI.ProjectConversationsClient GetProjectConversationsClientForAgentEndpoint(string agentName, Azure.AI.Extensions.OpenAI.ProjectOpenAIClientOptions options = null) { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectFilesClient GetProjectFilesClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectResponsesClient GetProjectResponsesClient() { throw null; }
         public virtual Azure.AI.Extensions.OpenAI.ProjectResponsesClient GetProjectResponsesClientForAgent(Azure.AI.Extensions.OpenAI.AgentReference defaultAgent, string defaultConversationId = null) { throw null; }

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClient.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClient.cs
@@ -93,6 +93,25 @@ public partial class ProjectOpenAIClient : OpenAIClient
             ?? _cachedConversationClient;
     }
 
+    /// <summary> Gets a project conversations client that sends requests to the specified agent endpoint. </summary>
+    /// <param name="agentName"> The name of the agent endpoint to use. </param>
+    /// <param name="options"> The options used to configure the project conversations client. </param>
+    /// <returns> The project conversations client configured for the agent endpoint. </returns>
+    public virtual ProjectConversationsClient GetProjectConversationsClientForAgentEndpoint(string agentName, ProjectOpenAIClientOptions options = null)
+    {
+        Argument.AssertNotNull(agentName, nameof(agentName));
+
+        options ??= new();
+        options.AgentName = agentName;
+        options.TokenProvider = _options.TokenProvider;
+        options.Endpoint = BuildAgentEndpoint(agentName);
+
+        // Reuse the pipeline already configured on this client rather than building a new one. This
+        // preserves policy continuity (authentication, telemetry, and any custom user policies) across
+        // every client derived from this ProjectOpenAIClient.
+        return new ProjectConversationsClient(Pipeline, options);
+    }
+
     /// <summary> Gets a client for project file operations. </summary>
     /// <returns> The project files client. </returns>
     public virtual ProjectFilesClient GetProjectFilesClient()
@@ -126,9 +145,14 @@ public partial class ProjectOpenAIClient : OpenAIClient
     }
 
     /// <summary> Gets a project responses client that uses a default agent. </summary>
+    /// <remarks>
+    /// Using an agent endpoint via <see cref="GetProjectResponsesClientForAgentEndpoint(string, string, ProjectOpenAIClientOptions)"/>
+    /// is the preferred way to target an agent for response requests.
+    /// </remarks>
     /// <param name="defaultAgent"> The default agent used for response requests. </param>
     /// <param name="defaultConversationId"> The default conversation ID used for response requests. </param>
     /// <returns> The project responses client configured with the default agent. </returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ProjectResponsesClient GetProjectResponsesClientForAgent(AgentReference defaultAgent, string defaultConversationId = null)
     {
         Argument.AssertNotNull(defaultAgent, nameof(defaultAgent));
@@ -147,17 +171,17 @@ public partial class ProjectOpenAIClient : OpenAIClient
     public virtual ProjectResponsesClient GetProjectResponsesClientForAgentEndpoint(string agentName, string defaultConversationId = null, ProjectOpenAIClientOptions options = null)
     {
         Argument.AssertNotNull(agentName, nameof(agentName));
+
         options ??= new();
         options.AgentName = agentName;
         options.TokenProvider = _options.TokenProvider;
-        options.Endpoint = null;
-        Match match = new Regex(@"(?<=/projects/)([^/]+)(?=[/?]|$)").Match(_options.Endpoint.LocalPath);
-        string project = string.IsNullOrEmpty(match.Value) ? "_default" : match.Value;
-        Uri projectEndpoint = new($"{_options.Endpoint.Scheme}://{_options.Endpoint.Host}/api/projects/{project}");
-        options = GetMergedOptions(projectEndpoint, _options.TokenProvider, options);
-        ClientPipeline endpointPipeline = CreatePipeline(CreateAuthenticationPolicy(options.TokenProvider, options), options);
+        options.Endpoint = BuildAgentEndpoint(agentName);
+
+        // Reuse the pipeline already configured on this client rather than building a new one. This
+        // preserves policy continuity (authentication, telemetry, and any custom user policies) across
+        // every client derived from this ProjectOpenAIClient.
         return new ProjectResponsesClient(
-            pipeline: endpointPipeline,
+            pipeline: Pipeline,
             options: options,
             defaultAgent: null,
             defaultConversationId: defaultConversationId
@@ -178,6 +202,13 @@ public partial class ProjectOpenAIClient : OpenAIClient
             defaultConversationId);
     }
 
+    private Uri BuildAgentEndpoint(string agentName)
+    {
+        Match match = new Regex(@"(?<=/projects/)([^/]+)(?=[/?]|$)").Match(_options.Endpoint.LocalPath);
+        string project = string.IsNullOrEmpty(match.Value) ? "_default" : match.Value;
+        return new Uri($"{_options.Endpoint.Scheme}://{_options.Endpoint.Host}/api/projects/{project}/agents/{agentName}/endpoint/protocols/openai/v1");
+    }
+
     internal static ClientPipeline CreatePipeline(AuthenticationPolicy authenticationPolicy, ProjectOpenAIClientOptions options)
     {
         options ??= new ProjectOpenAIClientOptions();
@@ -187,10 +218,6 @@ public partial class ProjectOpenAIClient : OpenAIClient
         if (!string.IsNullOrEmpty(options.UserAgentApplicationId))
         {
             prefix = $"{options.UserAgentApplicationId}-AIProjectClient";
-        }
-        if (!string.IsNullOrEmpty(options.AgentName))
-        {
-            PipelinePolicyHelpers.AddQueryParameterPolicy(options, "api-version", options.ApiVersion);
         }
         PipelinePolicyHelpers.AddRequestHeaderPolicy(options, "User-Agent", $"{prefix} {telemetryDetails.UserAgent}");
         PipelinePolicyHelpers.AddRequestHeaderPolicy(options, "x-ms-client-request-id", () => Guid.NewGuid().ToString().ToLowerInvariant());
@@ -214,7 +241,7 @@ public partial class ProjectOpenAIClient : OpenAIClient
         {
             return options;
         }
-        string path = string.IsNullOrEmpty(options?.AgentName) ? "/openai/v1" : $"/agents/{options.AgentName}/endpoint/protocols/openai";
+        string path = string.IsNullOrEmpty(options?.AgentName) ? "/openai/v1" : $"/agents/{options.AgentName}/endpoint/protocols/openai/v1";
         string rawTargetOpenAIEndpoint = projectEndpoint.AbsoluteUri.TrimEnd('/') + path;
         if (options?.Endpoint is not null && options?.Endpoint?.AbsoluteUri != rawTargetOpenAIEndpoint)
         {

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClient.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClient.cs
@@ -206,7 +206,8 @@ public partial class ProjectOpenAIClient : OpenAIClient
     {
         Match match = new Regex(@"(?<=/projects/)([^/]+)(?=[/?]|$)").Match(_options.Endpoint.LocalPath);
         string project = string.IsNullOrEmpty(match.Value) ? "_default" : match.Value;
-        return new Uri($"{_options.Endpoint.Scheme}://{_options.Endpoint.Host}/api/projects/{project}/agents/{agentName}/endpoint/protocols/openai/v1");
+        string authority = _options.Endpoint.GetLeftPart(UriPartial.Authority);
+        return new Uri($"{authority}/api/projects/{project}/agents/{Uri.EscapeDataString(agentName)}/endpoint/protocols/openai/v1");
     }
 
     internal static ClientPipeline CreatePipeline(AuthenticationPolicy authenticationPolicy, ProjectOpenAIClientOptions options)

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClientOptions.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/src/Custom/OpenAI/ProjectOpenAIClientOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ClientModel;
+using System.ComponentModel;
 using OpenAI;
 
 namespace Azure.AI.Extensions.OpenAI;
@@ -12,6 +13,7 @@ public partial class ProjectOpenAIClientOptions : OpenAIClientOptions
     private string _apiVersion;
 
     /// <summary> Gets or sets the API version used for project OpenAI requests. </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public string ApiVersion
     {
         get => _apiVersion;

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/tests/ProjectOpenAIClientSmokeTest.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/tests/ProjectOpenAIClientSmokeTest.cs
@@ -117,6 +117,42 @@ public class ProjectOpenAIClientSmokeTest : ProjectsOpenAITestBase
         VerifyCall(DoResponseAsync(responsesClientWithoutApp), "AIProjectClient.*");
     }
 
+    [Test]
+    public void TestConversationsAgentEndpointStructure()
+    {
+        const string host = "my-test-host.services.ai.azure.com";
+        const string project = "my-test-project";
+        const string agentName = "my-test-agent";
+
+        Uri capturedUri = null;
+        PipelinePolicy captureUriAndFailPolicy = new TestPipelinePolicy(
+            processMessageAction: (PipelineMessage message) =>
+            {
+                capturedUri = message.Request?.Uri;
+                throw new NotImplementedException("This exception is expected as this policy short-circuits the pipeline after capturing the request URI.");
+            });
+
+        ProjectOpenAIClientOptions options = new();
+        options.RetryPolicy = new ClientRetryPolicy(maxRetries: 0);
+        options.AddPolicy(captureUriAndFailPolicy, PipelinePosition.BeforeTransport);
+
+        ProjectOpenAIClient client = new(
+            projectEndpoint: new Uri($"https://{host}/api/projects/{project}"),
+            tokenProvider: new MockCredential(),
+            options: options);
+
+        // The agent-endpoint conversations client reuses the parent pipeline (policy continuity), so the
+        // capture policy registered above also observes its requests.
+        ProjectConversationsClient conversationsClient = client.GetProjectConversationsClientForAgentEndpoint(agentName);
+
+        Assert.ThrowsAsync<NotImplementedException>(async () => await conversationsClient.CreateProjectConversationAsync());
+
+        Assert.That(capturedUri, Is.Not.Null);
+        Assert.That(
+            capturedUri.AbsoluteUri,
+            Is.EqualTo($"https://{host}/api/projects/{project}/agents/{agentName}/endpoint/protocols/openai/v1/conversations"));
+    }
+
     [RecordedTest]
     public async Task TestFileUpload()
     {

--- a/sdk/ai/Azure.AI.Extensions.OpenAI/tests/Samples/ClientCreationAndAuthenticationSamples.cs
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/tests/Samples/ClientCreationAndAuthenticationSamples.cs
@@ -51,19 +51,5 @@ public class ClientCreationAndAuthenticationSamples : ProjectsOpenAITestBase
         #endregion
     }
 
-    [Test]
-    public void SelectClientVersion()
-    {
-        #region Snippet:SelectAPIVersion
-        ProjectOpenAIClientOptions option = new()
-        {
-            ApiVersion = "2025-11-15-preview"
-        };
-        ProjectOpenAIClient projectClient = new(
-            projectEndpoint: new Uri("https://<RESOURCE>.services.ai.azure.com/api/projects/<PROJECT>"),
-            tokenProvider: new AzureCliCredential());
-        #endregion
-    }
-
     public ClientCreationAndAuthenticationSamples(bool isAsync) : base(isAsync) { }
 }


### PR DESCRIPTION
## Background & Motivation

**Agent endpoints** have been introduced as an evolution of prior "agent applications."
https://learn.microsoft.com/azure/foundry/agents/how-to/migrate-agent-applications

These agent endpoints provide enhanced isolation and observability support while optimizing role-based access considerations for agent consumption. Moving forward, they're the preferred way to call `/responses` and `/conversations` when using an agent.

REST change:
| Before | After |
|---|---|
| `/api/projects/{project_name}/openai/v1` | `/api/projects/{project_name}/agents/{agent_name}/endpoint/protocols/openai/v1` |

## This PR

- Adds `GetProjectConversationsClientForAgentEndpoint(string agentName)`, yielding a configured client for conversations calls pointing to the route structure
- Applies hidden editor status to `GetProjectResponsesClientForAgent()`, as the (already existing) `GetProjectResponsesClientForAgentEndpoint()` is preferred
- Updates and standardizes endpoint update logic for agent-endpoint-based use, preserving pipeline continuity