### PR TITLE
fix(eventhubs): surface masked partition steal to avoid re-steal loop

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -956,5 +956,16 @@ namespace Azure.Messaging.EventHubs
                 return ResourceManager.GetString("LongLastEnqueuedOffsetOffsetUnsupported", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The consumer was disconnected by a connection-level fault, which may mask a partition steal; the consumer will be invalidated so that ownership can be re-arbitrated..
+        /// </summary>
+        internal static string ConsumerDisconnectedByMaskedPartitionSteal
+        {
+            get
+            {
+                return ResourceManager.GetString("ConsumerDisconnectedByMaskedPartitionSteal", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -360,4 +360,7 @@
   <data name="LongLastEnqueuedOffsetOffsetUnsupported" xml:space="preserve">
     <value>The Event Hubs services does not return a numeric offset for GeoDR-enabled namespaces.  Please use 'LastEnqueuedOffsetString' instead.</value>
   </data>
+  <data name="ConsumerDisconnectedByMaskedPartitionSteal" xml:space="preserve">
+    <value>The consumer was disconnected by a connection-level fault, which may mask a partition steal; the consumer will be invalidated so that ownership can be re-arbitrated.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -546,9 +546,15 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 closeHandler = (snd, args) =>
                 {
+                    // Propagate the connection's terminal exception to each child link so that the
+                    // cause of a connection-level fault is preserved as the link's terminal exception;
+                    // without it, the link would close with a null terminal exception and a masked
+                    // partition steal could not be distinguished from a benign close.  When the
+                    // connection has no terminal exception, this behaves identically to a bare close.
+
                     foreach (var link in ActiveLinks.Keys)
                     {
-                        link.SafeClose();
+                        link.SafeClose(connection.TerminalException);
                     }
 
                     connection.Closed -= closeHandler;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -565,7 +565,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                     // as a disconnect so that the next operation faults and the load balancer
                     // re-arbitrates ownership rather than silently re-opening a competing link.
 
-                    var maskedException = new EventHubsException(EventHubName, "The consumer was disconnected by a connection-level fault, which may mask a partition steal; the consumer will be invalidated so that ownership can be re-arbitrated.", EventHubsException.FailureReason.ConsumerDisconnected, linkException);
+                    var maskedException = new EventHubsException(EventHubName, Resources.ConsumerDisconnectedByMaskedPartitionSteal, EventHubsException.FailureReason.ConsumerDisconnected, linkException);
                     EventHubsEventSource.Log.AmqpConsumerLinkFaultCapture(EventHubName, ConsumerGroup, PartitionId, maskedException.Message);
                     _activePartitionStolenException = maskedException;
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -35,6 +35,20 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <summary>The interval that an attempt to receive events should wait for additional events when less than the requested count was available.</summary>
         private static readonly TimeSpan ReceiveBuildBatchInterval = TimeSpan.FromMilliseconds(20);
 
+        /// <summary>
+        ///   The set of connection-level AMQP error conditions that are treated as a masked partition steal
+        ///   for an exclusive consumer.  These represent abnormal connection-level faults that can hide an
+        ///   explicit link steal; any other AMQP fault is left to the normal self-healing flow to avoid
+        ///   needlessly relinquishing partition ownership.  Conditions observed in the field via
+        ///   <see cref="EventHubsEventSource.AmqpConsumerLinkFaultUnclassified" /> can be evaluated for
+        ///   inclusion here.
+        /// </summary>
+        private static readonly HashSet<string> ConnectionLevelFaultConditions = new(StringComparer.InvariantCultureIgnoreCase)
+        {
+            AmqpErrorCode.ConnectionForced.Value,
+            AmqpErrorCode.FramingError.Value
+        };
+
         /// <summary>A captured exception that indicates the partition was stolen by another consumer; this should be surfaced when an attempt is made to open a consumer link.</summary>
         private volatile Exception _activePartitionStolenException;
 
@@ -569,6 +583,15 @@ namespace Azure.Messaging.EventHubs.Amqp
                     EventHubsEventSource.Log.AmqpConsumerLinkFaultCapture(EventHubName, ConsumerGroup, PartitionId, maskedException.Message);
                     _activePartitionStolenException = maskedException;
                 }
+                else if (InvalidateConsumerWhenPartitionStolen && linkException is AmqpException unclassifiedFault)
+                {
+                    // For an exclusive consumer, the link closed asynchronously with an AMQP fault that is
+                    // not currently treated as a masked partition steal.  Leave it to the normal self-healing
+                    // flow, but log the condition so that faults which recur ahead of a re-steal can be
+                    // evaluated for inclusion in the connection-level fault allow-list.
+
+                    EventHubsEventSource.Log.AmqpConsumerLinkFaultUnclassified(EventHubName, ConsumerGroup, PartitionId, unclassifiedFault.Error?.Condition.Value, unclassifiedFault.Message);
+                }
             }
 
             // Close the link and it's associated session.
@@ -610,7 +633,7 @@ namespace Azure.Messaging.EventHubs.Amqp
             linkException switch
             {
                 null => true,
-                AmqpException => true,
+                AmqpException ex when ex.Error is not null && ConnectionLevelFaultConditions.Contains(ex.Error.Condition.Value) => true,
                 _ => false
             };
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -557,6 +557,18 @@ namespace Azure.Messaging.EventHubs.Amqp
                     EventHubsEventSource.Log.AmqpConsumerLinkFaultCapture(EventHubName, ConsumerGroup, PartitionId, linkException.Message);
                     _activePartitionStolenException = linkException;
                 }
+                else if (InvalidateConsumerWhenPartitionStolen && IsMaskedPartitionStolenException(linkException))
+                {
+                    // For an exclusive consumer (the processor), a partition steal can be masked by a
+                    // connection-level fault rather than an explicit link steal; in that case the link
+                    // closes with a connection-level fault or no terminal exception at all.  Capture it
+                    // as a disconnect so that the next operation faults and the load balancer
+                    // re-arbitrates ownership rather than silently re-opening a competing link.
+
+                    var maskedException = new EventHubsException(EventHubName, "The consumer was disconnected by a connection-level fault, which may mask a partition steal; the consumer will be invalidated so that ownership can be re-arbitrated.", EventHubsException.FailureReason.ConsumerDisconnected, linkException);
+                    EventHubsEventSource.Log.AmqpConsumerLinkFaultCapture(EventHubName, ConsumerGroup, PartitionId, maskedException.Message);
+                    _activePartitionStolenException = maskedException;
+                }
             }
 
             // Close the link and it's associated session.
@@ -580,6 +592,26 @@ namespace Azure.Messaging.EventHubs.Amqp
             {
                 null => null,
                 _ => link.TerminalException
+            };
+
+        /// <summary>
+        ///   Determines whether a terminal exception that closed the link asynchronously represents a
+        ///   partition steal that was masked by a connection-level fault rather than an explicit link
+        ///   steal.  Only a missing terminal exception or a connection-level AMQP fault qualifies; an
+        ///   exception already classified as a specific transient condition is left to the normal
+        ///   self-healing flow.
+        /// </summary>
+        ///
+        /// <param name="linkException">The terminal exception that closed the link, if any.</param>
+        ///
+        /// <returns><c>true</c> if <paramref name="linkException" /> represents a masked partition steal; otherwise, <c>false</c>.</returns>
+        ///
+        private static bool IsMaskedPartitionStolenException(Exception linkException) =>
+            linkException switch
+            {
+                null => true,
+                AmqpException => true,
+                _ => false
             };
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -1423,6 +1423,32 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that the link for an exclusive consumer closed asynchronously with an AMQP fault that is
+        ///   not classified as a masked partition steal; the fault is left to the normal self-healing flow.  This
+        ///   is logged so that conditions which recur ahead of a re-steal can be evaluated for inclusion in the
+        ///   set of connection-level faults treated as a masked steal.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub that the consumer is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that is associated with the link.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition associated with the link.</param>
+        /// <param name="errorCondition">The AMQP error condition associated with the fault, if any.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(132, Level = EventLevel.Verbose, Message = "The link for an exclusive consumer closed with an AMQP fault that is not classified as a masked partition steal; it will be left to the normal self-healing flow for Event Hub: '{0}', Consumer Group: '{1}', Partition: '{2}'. AMQP Condition: '{3}'. Error Message: '{4}'")]
+        public virtual void AmqpConsumerLinkFaultUnclassified(string eventHubName,
+                                                              string consumerGroup,
+                                                              string partitionId,
+                                                              string errorCondition,
+                                                              string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(132, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, errorCondition ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
         ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -51,6 +51,18 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   The set of test cases for terminal exceptions that mask a partition steal for an
+        ///   exclusive consumer; namely, a missing terminal exception or a connection-level fault.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> MaskedPartitionStolenTestCases()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new AmqpException(new Error { Condition = AmqpErrorCode.ConnectionForced }) };
+            yield return new object[] { new AmqpException(AmqpErrorCode.FramingError, "The connection framing was invalid.") };
+        }
+
+        /// <summary>
         ///   Verifies functionality of the constructor.
         /// </summary>
         ///
@@ -617,6 +629,90 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 mockConsumer.InvokeCloseConsumerLink(link);
                 Assert.That(GetActivePartitionStolenException(mockConsumer), Is.Null);
+            }
+            finally
+            {
+                link?.SafeClose();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.CloseConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(MaskedPartitionStolenTestCases))]
+        public async Task CloseConsumerLinkCapturesAMaskedPartitionStealForExclusiveConsumers(Exception terminalException)
+        {
+            var eventHub = "fake-hub";
+            var link = new ReceivingAmqpLink(new AmqpLinkSettings());
+            var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
+            var capturedException = default(Exception);
+
+            try
+            {
+                mockConsumer.InvokeCloseConsumerLink(link);
+
+                // The masked steal should be captured as a disconnect so that it can be surfaced
+                // when the next link creation is requested.
+
+                var activeException = GetActivePartitionStolenException(mockConsumer);
+                Assert.That(activeException, Is.InstanceOf<EventHubsException>(), "The captured exception should be an EventHubsException.");
+                Assert.That(((EventHubsException)activeException).Reason, Is.EqualTo(EventHubsException.FailureReason.ConsumerDisconnected), "The captured exception should indicate that the consumer was disconnected.");
+
+                try
+                {
+                    await mockConsumer.InvokeCreateConsumerLinkAsync("cg", "0", "fake-id", EventPosition.Earliest, 300, null, 34, true, TimeSpan.FromSeconds(30), CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+
+                Assert.That(capturedException, Is.InstanceOf<EventHubsException>(), "The captured steal should be surfaced on the next link creation.");
+                Assert.That(((EventHubsException)capturedException).Reason, Is.EqualTo(EventHubsException.FailureReason.ConsumerDisconnected), "The surfaced exception should indicate that the consumer was disconnected.");
+
+                // Because the steal was surfaced, the consumer should not attempt to re-open a competing link.
+
+                mockConsumer.MockConnectionScope
+                   .Verify(scope => scope.OpenConsumerLinkAsync(
+                       It.IsAny<string>(),
+                       It.IsAny<string>(),
+                       It.IsAny<EventPosition>(),
+                       It.IsAny<TimeSpan>(),
+                       It.IsAny<TimeSpan>(),
+                       It.IsAny<uint>(),
+                       It.IsAny<long?>(),
+                       It.IsAny<long?>(),
+                       It.IsAny<bool>(),
+                       It.IsAny<string>(),
+                       It.IsAny<CancellationToken>()),
+                   Times.Never);
+            }
+            finally
+            {
+                link?.SafeClose();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.CloseConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(MaskedPartitionStolenTestCases))]
+        public void CloseConsumerLinkIgnoresMaskedStealsForNonExclusiveConsumers(Exception terminalException)
+        {
+            var eventHub = "fake-hub";
+            var link = new ReceivingAmqpLink(new AmqpLinkSettings());
+            var mockConsumer = new MockAmqpConsumer(eventHub, false, terminalException);
+
+            try
+            {
+                mockConsumer.InvokeCloseConsumerLink(link);
+                Assert.That(GetActivePartitionStolenException(mockConsumer), Is.Null, "A non-exclusive consumer should not capture a masked steal.");
             }
             finally
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -63,6 +63,19 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   The set of test cases for terminal AMQP faults that are not classified as a masked partition
+        ///   steal for an exclusive consumer and should be left to the normal self-healing flow rather than
+        ///   relinquishing partition ownership.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> UnclassifiedAmqpFaultTestCases()
+        {
+            yield return new object[] { new AmqpException(AmqpErrorCode.ResourceLimitExceeded, "The resource limit was exceeded.") };
+            yield return new object[] { new AmqpException(AmqpErrorCode.InternalError, "An internal error occurred.") };
+            yield return new object[] { new AmqpException(new Error { Condition = AmqpErrorCode.IllegalState }) };
+        }
+
+        /// <summary>
         ///   Verifies functionality of the constructor.
         /// </summary>
         ///
@@ -713,6 +726,35 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 mockConsumer.InvokeCloseConsumerLink(link);
                 Assert.That(GetActivePartitionStolenException(mockConsumer), Is.Null, "A non-exclusive consumer should not capture a masked steal.");
+            }
+            finally
+            {
+                link?.SafeClose();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.CloseConsumerLink "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(UnclassifiedAmqpFaultTestCases))]
+        public void CloseConsumerLinkDoesNotCaptureUnclassifiedAmqpFaultsForExclusiveConsumers(Exception terminalException)
+        {
+            var eventHub = "fake-hub";
+            var link = new ReceivingAmqpLink(new AmqpLinkSettings());
+            var mockConsumer = new MockAmqpConsumer(eventHub, true, terminalException);
+
+            try
+            {
+                mockConsumer.InvokeCloseConsumerLink(link);
+
+                // An AMQP fault that is not a connection-level fault should not be treated as a masked
+                // steal for an exclusive consumer; it is left to the normal self-healing flow rather than
+                // relinquishing partition ownership.
+
+                Assert.That(GetActivePartitionStolenException(mockConsumer), Is.Null, "An unclassified AMQP fault should not be captured as a masked steal.");
             }
             finally
             {


### PR DESCRIPTION
## Summary

An exclusive (owner-level) consumer in the Event Hubs `EventProcessor` could re-steal a partition when the steal was delivered as a connection-level fault rather than a link-level `amqp:link:stolen` detach. The displaced consumer silently re-opened a competing owner-level link and re-asserted ownership, producing an unbounded dueling-owners loop that the load balancer could not see. This change makes such a masked steal surface so the consumer is invalidated and ownership is re-arbitrated.

## Motivation

On a connection-level fault, the close cascade in `AmqpConnectionScope` closed each child link with a bare `link.SafeClose()` (no error argument), leaving the link's `TerminalException` null. The asynchronous link-fault handler `CloseConsumerLink` reads that terminal exception; a null or connection-level cause is not recognized as a steal by `IsConsumerPartitionStolenException`, so `_activePartitionStolenException` was never set. The fault was then reclassified transient and retried, so `CreateConsumerLinkAsync` skipped its steal-guard throw and re-opened the link via `OpenConsumerLinkAsync`. The owner level used by the exclusive consumer is `0`, so the re-opened link competed at the same level and the two consumers dueled indefinitely without notifying the load balancer.

## Changes

`AmqpConnectionScope` now propagates the connection's terminal exception into each child link's close (`link.SafeClose(connection.TerminalException)`) when the connection-fault cascade runs, so a connection-level cause is preserved as the link's terminal exception; when there is no terminal exception this is identical to the previous bare close.

`CloseConsumerLink` in `AmqpConsumer` now, for an exclusive consumer (`InvalidateConsumerWhenPartitionStolen` is true), treats a terminal exception that is either null or a connection-level AMQP fault as a masked partition steal and captures it as an `EventHubsException` with `FailureReason.ConsumerDisconnected`. The next `CreateConsumerLinkAsync` surfaces it; the pump faults and the load balancer re-arbitrates ownership instead of re-opening a competing link.

The synchronous in-line receive retry path is unchanged, so a genuine mid-receive transient blip still self-heals. Exceptions already classified as a specific transient reason (for example `ServiceBusy`, `ClientClosed`, `GeneralError`) are not treated as steals.

Fixes #60352

## Test plan

- Added `CloseConsumerLinkCapturesAMaskedPartitionStealForExclusiveConsumers`, covering a null terminal exception and connection-level `AmqpException` cases, asserting the masked steal is captured as `ConsumerDisconnected` and that the subsequent `CreateConsumerLinkAsync` throws without calling `OpenConsumerLinkAsync` (`Times.Never`).
- Added `CloseConsumerLinkIgnoresMaskedStealsForNonExclusiveConsumers`, asserting a non-exclusive consumer does not capture these faults.
- Confirmed the existing `CloseConsumerLinkIgnoresGeneralExceptions` theory stays green, so explicitly classified transient exceptions are still not treated as steals.
- `dotnet build sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj`: succeeded, 0 warnings, 0 errors.
- `dotnet test ... --framework net10.0 --filter "FullyQualifiedName~AmqpConsumerTests"`: 43 passed, 0 failed. `AmqpConnectionScope` suite: 51 passed, 0 failed. Run on osx-arm64 with `RunConfiguration.TargetPlatform=arm64` because only the .NET 10 runtime is available in this environment.