### PR TITLE
fix(eventhubs): force-abort stalled connection close on recovery

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -106,6 +106,20 @@ namespace Azure.Messaging.EventHubs.Amqp
         private static TimeSpan AuthorizationRefreshTimeout { get; } = TimeSpan.FromMinutes(3);
 
         /// <summary>
+        ///   The amount of time to allow a connection to gracefully finish closing before it is
+        ///   forcibly aborted.  A graceful close can stall indefinitely against a half-open or
+        ///   blackholed connection; this bounds how long the old connection may linger after a
+        ///   replacement has been opened during recovery.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   This is exposed as a virtual member so that tests may shorten the grace period; it is
+        ///   not intended to be a configuration surface for callers.
+        /// </remarks>
+        ///
+        protected virtual TimeSpan ConnectionCloseGracePeriod { get; } = TimeSpan.FromSeconds(60);
+
+        /// <summary>
         ///   The amount of buffer to apply when considering an authorization token
         ///   to be expired.  The token's actual expiration will be decreased by this
         ///   amount, ensuring that it is renewed before it has expired.
@@ -970,6 +984,61 @@ namespace Azure.Messaging.EventHubs.Amqp
         {
             connection.SafeClose();
             EventHubsEventSource.Log.FaultTolerantAmqpObjectClose(nameof(AmqpConnection), "", EventHubName, "", "", connection.TerminalException?.Message);
+
+            // SafeClose initiates a graceful close but, should it time out, completes without tearing
+            // down the underlying socket and without aborting; a half-open or blackholed connection can
+            // therefore remain live indefinitely while a replacement is already in use after recovery.
+            // Schedule a bounded background fallback that forcibly aborts the connection if it has not
+            // finished closing within the grace period.  Abort is idempotent and guarded by a state
+            // check, so a late fire after a successful graceful close is a no-op.
+
+            ScheduleCloseFallbackAbort(connection);
+        }
+
+        /// <summary>
+        ///   Schedules a background fallback that forcibly aborts an AMQP object if it has not finished
+        ///   closing within the <see cref="ConnectionCloseGracePeriod" />.  This guards against a graceful
+        ///   close that stalls (for example, against a half-open connection) leaving the transport live.
+        /// </summary>
+        ///
+        /// <param name="amqpObject">The AMQP object being closed to monitor and, if needed, abort.</param>
+        ///
+        /// <remarks>
+        ///   The fallback runs detached so that it does not block the caller initiating the close, which
+        ///   would otherwise serialize teardown into the recovery hot path.  It is cancelled when the scope
+        ///   is disposed so that it does not outlive the scope or leak a timer.
+        /// </remarks>
+        ///
+        private void ScheduleCloseFallbackAbort(AmqpObject amqpObject)
+        {
+            CancellationToken cancellationToken;
+
+            try
+            {
+                cancellationToken = OperationCancellationSource.Token;
+            }
+            catch (ObjectDisposedException)
+            {
+                // The scope has already been disposed; its teardown owns the connection and no
+                // fallback is needed.
+
+                return;
+            }
+
+            _ = Task.Delay(ConnectionCloseGracePeriod, cancellationToken).ContinueWith(
+                (_, state) =>
+                {
+                    var trackedObject = (AmqpObject)state;
+
+                    if (trackedObject.State != AmqpObjectState.End)
+                    {
+                        trackedObject.Abort();
+                    }
+                },
+                amqpObject,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -135,6 +135,20 @@ namespace Azure.Messaging.EventHubs.Amqp
         private FaultTolerantAmqpObject<ReceivingAmqpLink> ReceiveLink { get; }
 
         /// <summary>
+        ///   The amount of time to allow a receive link to gracefully finish closing before it is
+        ///   forcibly aborted.  A graceful close can stall indefinitely against a half-open connection;
+        ///   this bounds how long a stalled link may linger after a replacement has been opened during
+        ///   recovery.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   This is exposed as a virtual member so that tests may shorten the grace period; it is not
+        ///   intended to be a configuration surface for callers.
+        /// </remarks>
+        ///
+        protected virtual TimeSpan LinkCloseGracePeriod { get; } = TimeSpan.FromSeconds(60);
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="AmqpConsumer"/> class.
         /// </summary>
         ///
@@ -565,6 +579,48 @@ namespace Azure.Messaging.EventHubs.Amqp
             link.SafeClose();
 
             EventHubsEventSource.Log.FaultTolerantAmqpObjectClose(nameof(ReceivingAmqpLink), "", EventHubName, ConsumerGroup, PartitionId, link.TerminalException?.Message);
+
+            // SafeClose initiates a graceful close but, should it stall, completes without tearing down
+            // the underlying link and session; a half-open link can therefore linger after a replacement
+            // has been opened during recovery.  Schedule a bounded background fallback that forcibly
+            // aborts the link and its session if they have not finished closing within the grace period.
+            // Abort is idempotent and guarded by a state check, so a late fire after a successful graceful
+            // close is a no-op.
+
+            ScheduleCloseFallbackAbort(link);
+        }
+
+        /// <summary>
+        ///   Schedules a background fallback that forcibly aborts a receive link and its session if the
+        ///   link has not finished closing within the <see cref="LinkCloseGracePeriod" />.  This guards
+        ///   against a graceful close that stalls (for example, against a half-open connection) leaving
+        ///   the link live.
+        /// </summary>
+        ///
+        /// <param name="link">The link being closed to monitor and, if needed, abort.</param>
+        ///
+        /// <remarks>
+        ///   The fallback runs detached so that it does not block the caller initiating the close, which
+        ///   would otherwise serialize teardown into the recovery hot path.
+        /// </remarks>
+        ///
+        private void ScheduleCloseFallbackAbort(ReceivingAmqpLink link)
+        {
+            _ = Task.Delay(LinkCloseGracePeriod).ContinueWith(
+                (_, state) =>
+                {
+                    var trackedLink = (ReceivingAmqpLink)state;
+
+                    if (trackedLink.State != AmqpObjectState.End)
+                    {
+                        trackedLink.Session?.Abort();
+                        trackedLink.Abort();
+                    }
+                },
+                link,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -2286,6 +2286,82 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.CloseConnection" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseConnectionForciblyAbortsAConnectionThatStallsClosing()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var transport = EventHubsTransportType.AmqpTcp;
+            var idleTimeout = TimeSpan.FromSeconds(30);
+            var grace = TimeSpan.FromMilliseconds(250);
+            var mockCredential = new Mock<TokenCredential>();
+            var mockEventHubsCredential = new Mock<EventHubTokenCredential>(mockCredential.Object);
+            using var scope = new AbortFallbackMockScope(endpoint, endpoint, eventHub, mockEventHubsCredential.Object, transport, idleTimeout, grace);
+
+            var connectionTransport = new ObservableTransport();
+            var connection = new ObservableAmqpConnection(connectionTransport, closeCompletesSynchronously: false);
+
+            // Simulate a connection that has completed negotiation and whose graceful close stalls; the
+            // SafeClose performed by CloseConnection leaves it in the CloseSent state, never reaching End.
+
+            connection.ForceState(AmqpObjectState.Opened);
+
+            var abortCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            connection.Closed += (_, _) => abortCompletionSource.TrySetResult(true);
+
+            scope.InvokeCloseConnection(connection);
+
+            Assert.That(connection.State, Is.EqualTo(AmqpObjectState.CloseSent), "The graceful close should have left the connection stalled in the CloseSent state.");
+
+            var completed = await Task.WhenAny(abortCompletionSource.Task, Task.Delay(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit));
+            Assert.That(completed, Is.SameAs(abortCompletionSource.Task), "The fallback should have aborted the stalled connection within the time limit.");
+
+            Assert.That(connection.State, Is.EqualTo(AmqpObjectState.End), "The fallback abort should have transitioned the connection to the End state.");
+            Assert.That(connectionTransport.AbortCount, Is.EqualTo(1), "The fallback should have forcibly aborted the underlying transport exactly once.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.CloseConnection" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseConnectionDoesNotAbortAConnectionThatClosesGracefully()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var transport = EventHubsTransportType.AmqpTcp;
+            var idleTimeout = TimeSpan.FromSeconds(30);
+            var grace = TimeSpan.FromMilliseconds(250);
+            var mockCredential = new Mock<TokenCredential>();
+            var mockEventHubsCredential = new Mock<EventHubTokenCredential>(mockCredential.Object);
+            using var scope = new AbortFallbackMockScope(endpoint, endpoint, eventHub, mockEventHubsCredential.Object, transport, idleTimeout, grace);
+
+            var connectionTransport = new ObservableTransport();
+            var connection = new ObservableAmqpConnection(connectionTransport, closeCompletesSynchronously: true);
+
+            // Simulate a connection whose graceful close completes synchronously; the SafeClose performed
+            // by CloseConnection should transition it to End before the grace period elapses.
+
+            connection.ForceState(AmqpObjectState.Opened);
+
+            scope.InvokeCloseConnection(connection);
+            Assert.That(connection.State, Is.EqualTo(AmqpObjectState.End), "The graceful close should have transitioned the connection to the End state.");
+
+            // Allow more than the grace period to elapse to confirm that the fallback observes the End
+            // state and does not abort.
+
+            await Task.Delay(grace + grace + TimeSpan.FromMilliseconds(250));
+
+            Assert.That(connection.State, Is.EqualTo(AmqpObjectState.End), "The connection should remain in the End state.");
+            Assert.That(connectionTransport.AbortCount, Is.EqualTo(0), "The fallback should not have aborted a connection that closed gracefully.");
+        }
+
+        /// <summary>
         ///   Gets the active connection for the given scope, using the
         ///   private property accessor.
         /// </summary>
@@ -2391,6 +2467,71 @@ namespace Azure.Messaging.EventHubs.Tests
             public override bool WriteAsync(TransportAsyncCallbackArgs args) => throw new NotImplementedException();
             protected override void AbortInternal() => throw new NotImplementedException();
             protected override bool CloseInternal() => throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///   Provides a cooperative transport for testing connection teardown that records the number of
+        ///   times it is forcibly aborted.
+        /// </summary>
+        ///
+        private class ObservableTransport : TransportBase
+        {
+            private int _abortCount;
+
+            public ObservableTransport() : base("Observable") { }
+            public int AbortCount => Volatile.Read(ref _abortCount);
+            public override string LocalEndPoint { get; }
+            public override string RemoteEndPoint { get; }
+            public override bool ReadAsync(TransportAsyncCallbackArgs args) => false;
+            public override void SetMonitor(ITransportMonitor usageMeter) { }
+            public override bool WriteAsync(TransportAsyncCallbackArgs args) => false;
+            protected override void AbortInternal() => Interlocked.Increment(ref _abortCount);
+            protected override bool CloseInternal() => true;
+        }
+
+        /// <summary>
+        ///   Provides a connection whose graceful close behavior can be controlled and whose state can be
+        ///   forced for testing teardown.
+        /// </summary>
+        ///
+        private class ObservableAmqpConnection : AmqpConnection
+        {
+            private readonly bool _closeCompletesSynchronously;
+
+            public ObservableAmqpConnection(TransportBase transport,
+                                            bool closeCompletesSynchronously) : base(transport, CreateMockAmqpSettings(), new AmqpConnectionSettings())
+            {
+                _closeCompletesSynchronously = closeCompletesSynchronously;
+            }
+
+            public void ForceState(AmqpObjectState state) => State = state;
+
+            protected override bool CloseInternal() => _closeCompletesSynchronously || base.CloseInternal();
+        }
+
+        /// <summary>
+        ///   Provides a scope that exposes <see cref="AmqpConnectionScope.CloseConnection" /> and shortens
+        ///   the grace period before a stalled connection is forcibly aborted.
+        /// </summary>
+        ///
+        private class AbortFallbackMockScope : AmqpConnectionScope
+        {
+            private readonly TimeSpan _gracePeriod;
+
+            public AbortFallbackMockScope(Uri serviceEndpoint,
+                                          Uri connectionEndpoint,
+                                          string eventHubName,
+                                          EventHubTokenCredential credential,
+                                          EventHubsTransportType transport,
+                                          TimeSpan idleTimeout,
+                                          TimeSpan gracePeriod) : base(serviceEndpoint, connectionEndpoint, eventHubName, credential, transport, null, idleTimeout)
+            {
+                _gracePeriod = gracePeriod;
+            }
+
+            protected override TimeSpan ConnectionCloseGracePeriod => _gracePeriod;
+
+            public void InvokeCloseConnection(AmqpConnection connection) => base.CloseConnection(connection);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

On AMQP connection recovery the old connection is closed with a fire-and-forget graceful close and the replacement is opened eagerly without awaiting teardown. `AmqpConnectionScope.CloseConnection` is a bare `connection.SafeClose()`. `SafeClose` initiates a graceful close with a timeout, but on timeout it completes the close future with a `TimeoutException` without tearing down the socket and without calling `Abort` (Abort is only invoked when `BeginClose` throws synchronously). Because the heartbeat is stopped first and the transport does not set `SO_KEEPALIVE`, a half-open or blackholed old connection can remain live indefinitely with no client-side terminator while a new connection is already active, producing two live connections that (for a consumer) carry the same consumer identifier.

This change forcibly tears down the old connection if the graceful close stalls, without slowing recovery.

## Motivation

`SafeClose` is best-effort and, on timeout, leaves the underlying transport open. Awaiting the close before recovery is not acceptable because it would serialize teardown into the recovery hot path. The result is a connection (and, for a consumer, a duplicate consumer identifier) that can linger past the point where a replacement has taken over, with no bounded guarantee that the stale socket is ever released.

## Changes

`AmqpConnectionScope.CloseConnection` still calls `SafeClose`, then schedules a bounded background fallback that forcibly calls `connection.Abort()` if the connection has not reached `AmqpObjectState.End` within a grace period. `Abort()` forcibly closes the socket, transitions the object to `End`, fires `Closed`, and releases auth-refresh timers and references; it is idempotent and the fallback guards it with a state check, so a late fire after a successful graceful close is a no-op. The fallback runs detached (a `Task.Delay(...).ContinueWith(...)` that does not block the caller) and is tied to the scope's `OperationCancellationSource`, so it is cancelled when the scope is disposed and does not leak a timer. The grace period is a virtual member (`ConnectionCloseGracePeriod`, default 60 seconds) so tests can shorten it; it is not a new caller-facing configuration surface.

The same bounded-abort fallback is applied to `AmqpConsumer.CloseConsumerLink` after the existing `SafeClose` calls, aborting the receive link and its session if the link has not reached `End` within `LinkCloseGracePeriod`. The existing terminal-exception capture logic in `CloseConsumerLink` is left untouched.

## Test plan

Added two unit tests in `AmqpConnectionScopeTests` driving a real `AmqpConnection` over a cooperative test transport that records abort calls:

- A connection whose graceful close stalls in `CloseSent` is forcibly aborted after the grace window, transitioning to `End` with exactly one transport abort.
- A connection whose graceful close completes synchronously to `End` is never aborted after the window elapses.

Validation run:

- `dotnet build sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj` (build succeeded, 0 warnings, 0 errors).
- `dotnet test sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj -f net10.0 --arch arm64 --filter "FullyQualifiedName~AmqpConnectionScope"` (53 passed, including the 2 new tests).
- `dotnet test ... --filter "FullyQualifiedName~AmqpConsumer"` (37 passed).

Fixes #60353