### PR TITLE
[WebPubSub] Enforce signature validation for AzureKeyCredential endpoint

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.6.1 (Unreleased)
+## 1.6.1 (2026-07-01)
 
 ### Bugs Fixed
 

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.6.1 (Unreleased)
+
+### Bugs Fixed
+
+- Fixed inbound request signature validation being skipped when the service endpoint was configured with the `WebPubSubServiceEndpoint(Uri, AzureKeyCredential, ...)` constructor. The supplied key is now used to validate `ce-signature`, and credential rotation via `AzureKeyCredential.Update` is honored.
+
 ## 1.6.0 (2026-02-13)
 
 ### Features Added

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Internal/RequestValidator.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Internal/RequestValidator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore
     /// </summary>
     internal class RequestValidator
     {
-        private readonly Dictionary<string, string> _hostKeyMappings = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, WebPubSubServiceEndpoint> _hostEndpointMappings = new(StringComparer.OrdinalIgnoreCase);
 
         public RequestValidator(IOptions<WebPubSubOptions> options)
         {
@@ -28,21 +28,23 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore
             var endpoint = options.Value.ServiceEndpoint;
             if (endpoint != null)
             {
-                _hostKeyMappings.Add(endpoint.Endpoint.Host, endpoint.AccessKey);
+                _hostEndpointMappings.Add(endpoint.Endpoint.Host, endpoint);
             }
         }
 
         public bool IsValidSignature(WebPubSubConnectionContext context)
         {
             // no options skip validation.
-            if (_hostKeyMappings.Count == 0)
+            if (_hostEndpointMappings.Count == 0)
             {
                 return true;
             }
             foreach (var origin in ToHeaderList(context.Origin))
             {
-                if (_hostKeyMappings.TryGetValue(origin, out var accessKey))
+                if (_hostEndpointMappings.TryGetValue(origin, out var endpoint))
                 {
+                    // Read the key live so AzureKeyCredential rotation is honored.
+                    var accessKey = endpoint.AccessKey;
                     // server side disable signature checks.
                     if (string.IsNullOrEmpty(accessKey))
                     {
@@ -68,7 +70,7 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore
 
         public bool IsValidOrigin(IEnumerable<string> requestOrigins)
         {
-            if (_hostKeyMappings.Count == 0)
+            if (_hostEndpointMappings.Count == 0)
             {
                 return true;
             }
@@ -76,7 +78,7 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore
             {
                 foreach (var item in requestOrigins)
                 {
-                    if (_hostKeyMappings.ContainsKey(item))
+                    if (_hostEndpointMappings.ContainsKey(item))
                     {
                         return true;
                     }

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Microsoft.Azure.WebPubSub.AspNetCore.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Microsoft.Azure.WebPubSub.AspNetCore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Azure SDK client library for the WebPubSub service</Description>
     <AssemblyTitle>Azure SDK for WebPubSub</AssemblyTitle>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.0</ApiCompatVersion>
     <PackageTags>Azure, WebPubSub</PackageTags>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/WebPubSubServiceEndpoint.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/WebPubSubServiceEndpoint.cs
@@ -24,7 +24,12 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore
 
         internal string ConnectionString { get; }
 
-        internal string AccessKey { get; }
+        private readonly string _connectionStringAccessKey;
+
+        // Returns the access key for signature validation. For AzureKeyCredential the key is read
+        // live so credential rotation via AzureKeyCredential.Update is honored. Null means key-less
+        // (AAD/keys-disabled) where signature validation is intentionally skipped.
+        internal string AccessKey => AzureKeyCredential?.Key ?? _connectionStringAccessKey;
 
         internal TokenCredential TokenCredential { get; }
 
@@ -51,7 +56,7 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore
             CredentialKind = CredentialKind.ConnectionString;
             ConnectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
             ClientOptions = clientOptions ?? new WebPubSubServiceClientOptions();
-            (Endpoint, AccessKey) = ParseConnectionString(connectionString);
+            (Endpoint, _connectionStringAccessKey) = ParseConnectionString(connectionString);
         }
 
         /// <summary>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/WebPubSubEventRequestTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/WebPubSubEventRequestTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Azure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Azure.WebPubSub.Common;
@@ -368,6 +369,47 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore.Tests
             var validator = new RequestValidator(Options.Create(new WebPubSubOptions { ServiceEndpoint = new WebPubSubServiceEndpoint($"Endpoint={TestUri};AccessKey=7aab239577fd4f24bc919802fb629f5f;Version=1.0;") }));
             var result = validator.IsValidSignature(connectionContext);
             Assert.False(result);
+        }
+
+        [TestCase("7aab239577fd4f24bc919802fb629f5f", true)]
+        [TestCase("ccc", false)]
+        public void TestSignatureCheck_AzureKeyCredential(string accessKey, bool valid)
+        {
+            var connectionContext = new WebPubSubConnectionContext(
+                WebPubSubEventType.System,
+                null, null, "0f9c97a2f0bf4706afe87a14e0797b11",
+                signature: "sha256=7767effcb3946f3e1de039df4b986ef02c110b1469d02c0a06f41b3b727ab561",
+                origin: TestUri.Host);
+            var validator = new RequestValidator(Options.Create(new WebPubSubOptions { ServiceEndpoint = new WebPubSubServiceEndpoint(TestUri, new AzureKeyCredential(accessKey)) }));
+            var result = validator.IsValidSignature(connectionContext);
+            Assert.AreEqual(valid, result);
+        }
+
+        [Test]
+        public void TestSignatureCheck_AzureKeyCredentialNoSignatureFail()
+        {
+            var connectionContext = new WebPubSubConnectionContext(
+                WebPubSubEventType.System,
+                null, null, "0f9c97a2f0bf4706afe87a14e0797b11",
+                origin: TestUri.Host);
+            var validator = new RequestValidator(Options.Create(new WebPubSubOptions { ServiceEndpoint = new WebPubSubServiceEndpoint(TestUri, new AzureKeyCredential("7aab239577fd4f24bc919802fb629f5f")) }));
+            var result = validator.IsValidSignature(connectionContext);
+            Assert.False(result);
+        }
+
+        [Test]
+        public void TestSignatureCheck_AzureKeyCredentialRotation()
+        {
+            var connectionContext = new WebPubSubConnectionContext(
+                WebPubSubEventType.System,
+                null, null, "0f9c97a2f0bf4706afe87a14e0797b11",
+                signature: "sha256=7767effcb3946f3e1de039df4b986ef02c110b1469d02c0a06f41b3b727ab561",
+                origin: TestUri.Host);
+            var credential = new AzureKeyCredential("stale-key");
+            var validator = new RequestValidator(Options.Create(new WebPubSubOptions { ServiceEndpoint = new WebPubSubServiceEndpoint(TestUri, credential) }));
+            Assert.False(validator.IsValidSignature(connectionContext));
+            credential.Update("7aab239577fd4f24bc919802fb629f5f");
+            Assert.True(validator.IsValidSignature(connectionContext));
         }
 
         [TestCase("sha256=something,sha256=7767effcb3946f3e1de039df4b986ef02c110b1469d02c0a06f41b3b727ab561")]


### PR DESCRIPTION
## Summary

Fixes a security issue where inbound Web PubSub request signature validation is silently skipped for apps configured with the public `WebPubSubServiceEndpoint(Uri, AzureKeyCredential, ...)` constructor.

The constructor stored the `AzureKeyCredential` but never populated the internal `AccessKey`. `RequestValidator` only read `endpoint.AccessKey`, so the host mapped to a null key and `IsValidSignature` returned `true` without checking `ce-signature`. An attacker who knew the public webhook path, hub, and host could send unsigned requests and have them processed as if from Azure Web PubSub (spoofed user messages / connection events). The same credential is used for outbound calls, so keys are clearly enabled — the key was just dropped on the inbound side.

## Affected versions
`1.0.0-beta.3` (2022) through `1.6.0`. The omission existed since the ctor was introduced; not a regression. The connection-string-no-key and `TokenCredential` (AAD) paths legitimately have a null key and intentionally skip HMAC.

## Fix (rotation-safe)
- `WebPubSubServiceEndpoint.AccessKey` now reads the live key: `AzureKeyCredential?.Key ?? _connectionStringAccessKey`.
- `RequestValidator` stores host→endpoint and reads `AccessKey` per request, so `AzureKeyCredential.Update(...)` rotations take effect without restart.
- Result: key ctor now enforces `ce-signature`; key-less AAD paths still skip as intended.

## Tests
- Key-ctor valid/invalid signature, missing-signature → reject, and credential rotation.
- All 63 tests pass (net8.0, net10.0). No public API change (`AccessKey` is internal).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>