### PR TITLE
Add CostManagement provisioning package to CI

### DIFF
--- a/sdk/costmanagement/ci.mgmt.yml
+++ b/sdk/costmanagement/ci.mgmt.yml
@@ -8,5 +8,7 @@ extends:
     ServiceDirectory: costmanagement
     LimitForPullRequest: true
     Artifacts:
+    - name: Azure.Provisioning.CostManagement
+      safeName: AzureProvisioningCostManagement
     - name: Azure.ResourceManager.CostManagement
       safeName: AzureResourceManagerCostManagement


### PR DESCRIPTION
Adds the missing Azure.Provisioning.CostManagement artifact to the CostManagement management CI configuration after #58345.