### PR TITLE
[automation] Add tracking issue for Automation account keys pageable customization

### DIFF
--- a/sdk/automation/Azure.ResourceManager.Automation/src/Customized/AutomationAccountResource.cs
+++ b/sdk/automation/Azure.ResourceManager.Automation/src/Customized/AutomationAccountResource.cs
@@ -17,6 +17,10 @@ namespace Azure.ResourceManager.Automation
     /// <summary> A class representing an Automation account resource. </summary>
     public partial class AutomationAccountResource
     {
+        // Workaround for https://github.com/Azure/typespec-azure/issues/4729:
+        // Legacy.markAsPageable cannot currently specify the page item property. The
+        // listKeys response returns items under "keys" instead of "value", so these
+        // methods preserve the existing pageable API until TypeSpec can model this.
         /// <summary>
         /// Retrieve the automation keys for an account.
         /// <list type="bullet">


### PR DESCRIPTION
## Description

Adds the TypeSpec Azure tracking issue link to the Automation account keys pageable customization.

The custom code is needed because `Legacy.markAsPageable` cannot currently specify `keys` as the page item property for the `listKeys` response. This keeps the existing pageable API documented until the TypeSpec decorator supports that scenario.