### PR TITLE
[EventGrid] Fix CloudNativeCloudEvents netstandard2.0 build (DiagnosticSource 9.0)

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -29,7 +29,7 @@
 
     <!--
       Required because the shared Azure.Core DiagnosticScope.cs uses ActivityContext.TryParse(isRemote:),
-      which needs System.Diagnostics.DiagnosticSource 9.0+; netstandard2.0 otherwise resolves an older version.
+      which is available since System.Diagnostics.DiagnosticSource 7.0; netstandard2.0 otherwise resolves an older version. The version is centrally managed.
     -->
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -26,5 +26,11 @@
       The latest release (2.8.0) references a vulnerable System.Text.Json (8.0.4).
     -->
     <PackageReference Include="System.Text.Json" />
+
+    <!--
+      Required because the shared Azure.Core DiagnosticScope.cs uses ActivityContext.TryParse(isRemote:),
+      which needs System.Diagnostics.DiagnosticSource 9.0+; netstandard2.0 otherwise resolves an older version.
+    -->
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
The `net - eventgrid` build has failed since 2026-05-21, blocking all EventGrid .NET releases (incl. `Azure.Messaging.EventGrid.SystemEvents`):

```
sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs(382,69): error CS1739:
The best overload for 'TryParse' does not have a parameter named 'isRemote'
[...CloudNativeCloudEvents.csproj :: TargetFramework=netstandard2.0]
```

### Root cause
PR #59389 changed shared `DiagnosticScope.cs` to call `ActivityContext.TryParse(..., isRemote: true, ...)`, an overload that requires **System.Diagnostics.DiagnosticSource 9.0+**. `CloudNativeCloudEvents` compiles that shared source on `netstandard2.0` but only resolved an older DiagnosticSource transitively, so it fails to compile. (The PR's CI only built Azure.Core, not EventGrid, so it merged green; the nightly eventgrid build broke the next day.)

### Fix
Add a direct `System.Diagnostics.DiagnosticSource` reference (central-version 9.0+) to `CloudNativeCloudEvents.csproj` — matching what Azure.Core already does — so the `isRemote` overload is available on netstandard2.0.

### Impact
Unblocks the EventGrid build/release pipeline so SystemEvents (and the rest of the service dir) can ship. No code/version changes to other packages.