### PR TITLE
Fix nested collection resource ID validation

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -12,6 +12,7 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.ManagementGroups;
 using Humanizer;
+using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
@@ -311,8 +312,7 @@ namespace Azure.Generator.Management.Providers
                 bodyStatements.Add(clientInfo.RestClientField.Assign(New.Instance(clientInfo.RestClientProvider.Type, clientInfo.DiagnosticsField, thisCollection.Pipeline(), thisCollection.Endpoint(), effectiveApiVersion)).Terminate());
             }
 
-            // skip resource Id validation for extension resource without parent resource type, since we don't have enough information to validate the resource Id. For example, for an extension resource with resource scope of extension and no parent resource type specified, the resource Id pattern could be something like /{scope}/providers/Microsoft.ABC/def/{defName}, in this case we don't know what the {scope} is, it could be subscription, resource group, or even a management group, so we can't validate the resource Id.
-            if (_resourceMetadata.ParentResourceId is not null || _resourceMetadata.Scope.Kind != ResourceScope.Extension || _resourceMetadata.Scope.ScopeResourceType is not null)
+            if (TryGetResourceIdValidationType(out _))
             {
                 bodyStatements.Add(Static(Type).As<ArmCollection>().ValidateResourceId(idParameter).Terminate());
             }
@@ -349,18 +349,33 @@ namespace Azure.Generator.Management.Providers
             }
         }
 
-        protected override MethodProvider[] BuildMethods()
+        private bool TryGetResourceIdValidationType(out ValueExpression resourceType)
         {
-            var methods = new List<MethodProvider>();
             var parentResourceCsharpType = GetParentResourceType(_resourceMetadata, _resource);
             if (_resourceMetadata.ParentResourceId is not null || _resourceMetadata.Scope.Kind != ResourceScope.Extension)
             {
-                methods.Add(ResourceMethodSnippets.BuildValidateResourceIdMethod(this, Static(parentResourceCsharpType!).As<ArmResource>().ResourceType()));
+                resourceType = Static(parentResourceCsharpType!).As<ArmResource>().ResourceType();
+                return true;
             }
-            // For extension resource with known parent resource type, we can also generate a ValidateResourceId method
-            else if (_resourceMetadata.Scope.ScopeResourceType is { } parentResourceType)
+
+            // For extension resources with a known parent scope type, validate against that scope.
+            // Generic-scope extension resources do not have enough information to validate.
+            if (_resourceMetadata.Scope.ScopeResourceType is { } parentResourceType)
             {
-                methods.Add(ResourceMethodSnippets.BuildValidateResourceIdMethod(this, Literal(parentResourceType)));
+                resourceType = Literal(parentResourceType);
+                return true;
+            }
+
+            resourceType = null!;
+            return false;
+        }
+
+        protected override MethodProvider[] BuildMethods()
+        {
+            var methods = new List<MethodProvider>();
+            if (TryGetResourceIdValidationType(out var resourceType))
+            {
+                methods.Add(ResourceMethodSnippets.BuildValidateResourceIdMethod(this, resourceType));
             }
 
             methods.AddRange(BuildCreateOrUpdateMethods());

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -353,7 +353,7 @@ namespace Azure.Generator.Management.Providers
         {
             var methods = new List<MethodProvider>();
             var parentResourceCsharpType = GetParentResourceType(_resourceMetadata, _resource);
-            if (_resourceMetadata.Scope.Kind != ResourceScope.Extension)
+            if (_resourceMetadata.ParentResourceId is not null || _resourceMetadata.Scope.Kind != ResourceScope.Extension)
             {
                 methods.Add(ResourceMethodSnippets.BuildValidateResourceIdMethod(this, Static(parentResourceCsharpType!).As<ArmResource>().ResourceType()));
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -312,7 +312,7 @@ namespace Azure.Generator.Management.Providers
             }
 
             // skip resource Id validation for extension resource without parent resource type, since we don't have enough information to validate the resource Id. For example, for an extension resource with resource scope of extension and no parent resource type specified, the resource Id pattern could be something like /{scope}/providers/Microsoft.ABC/def/{defName}, in this case we don't know what the {scope} is, it could be subscription, resource group, or even a management group, so we can't validate the resource Id.
-            if (_resourceMetadata.Scope.Kind != ResourceScope.Extension || _resourceMetadata.Scope.ScopeResourceType is not null)
+            if (_resourceMetadata.ParentResourceId is not null || _resourceMetadata.Scope.Kind != ResourceScope.Extension || _resourceMetadata.Scope.ScopeResourceType is not null)
             {
                 bodyStatements.Add(Static(Type).As<ArmCollection>().ValidateResourceId(idParameter).Terminate());
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
@@ -793,6 +793,92 @@ namespace Azure.Generator.Management.Tests.Common
             return (parentClient, childClient, [parentModel, childModel, childPageModel]);
         }
 
+        public static (InputClient ParentClient, InputClient ChildClient, IReadOnlyList<InputModelType> InputModels) ClientWithNestedExtensionChildResource()
+        {
+            const string ParentClientName = "WatchlistsClient";
+            const string ChildClientName = "WatchlistItemsClient";
+
+            var parentModel = InputFactory.Model("Watchlist",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                ],
+                decorators: []);
+
+            var childModel = InputFactory.Model("WatchlistItem",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                ],
+                decorators: []);
+
+            var parentResponseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: parentModel);
+            var childResponseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: childModel);
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+
+            var subscriptionIdOpParam = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var resourceGroupNameOpParam = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var workspaceNameOpParam = InputFactory.PathParameter("workspaceName", InputPrimitiveType.String, isRequired: true);
+            var watchlistAliasOpParam = InputFactory.PathParameter("watchlistAlias", InputPrimitiveType.String, isRequired: true);
+            var watchlistItemIdOpParam = InputFactory.PathParameter("watchlistItemId", InputPrimitiveType.String, isRequired: true);
+
+            var scopeIdPattern = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}";
+            var parentIdPattern = scopeIdPattern + "/providers/Microsoft.SecurityInsights/watchlists/{watchlistAlias}";
+            var childIdPattern = parentIdPattern + "/watchlistItems/{watchlistItemId}";
+            var childListPath = parentIdPattern + "/watchlistItems";
+
+            var parentGetOp = InputFactory.Operation(name: "getWatchlist", responses: [parentResponseType], parameters: [subscriptionIdOpParam, resourceGroupNameOpParam, workspaceNameOpParam, watchlistAliasOpParam], path: parentIdPattern);
+            var childGetOp = InputFactory.Operation(name: "getWatchlistItem", responses: [childResponseType], parameters: [subscriptionIdOpParam, resourceGroupNameOpParam, workspaceNameOpParam, watchlistAliasOpParam, watchlistItemIdOpParam], path: childIdPattern);
+            var childPageModel = InputFactory.Model("WatchlistItemListResult",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("value", InputFactory.Array(childModel)),
+                    InputFactory.Property("nextLink", InputPrimitiveType.Url),
+                ]);
+            var childListOp = InputFactory.Operation(name: "listByWatchlist", responses: [InputFactory.OperationResponse(statusCodes: [200], bodytype: childPageModel)], parameters: [subscriptionIdOpParam, resourceGroupNameOpParam, workspaceNameOpParam, watchlistAliasOpParam], path: childListPath);
+
+            var subscriptionIdParam = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var resourceGroupNameParam = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var workspaceNameParam = InputFactory.MethodParameter("workspaceName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var watchlistAliasParam = InputFactory.MethodParameter("watchlistAlias", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var watchlistItemIdParam = InputFactory.MethodParameter("watchlistItemId", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+
+            var parentGetMethod = InputFactory.BasicServiceMethod("getWatchlist", parentGetOp, parameters: [watchlistAliasParam, workspaceNameParam, subscriptionIdParam, resourceGroupNameParam], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var childGetMethod = InputFactory.BasicServiceMethod("getWatchlistItem", childGetOp, parameters: [watchlistItemIdParam, watchlistAliasParam, workspaceNameParam, subscriptionIdParam, resourceGroupNameParam], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var childListMethod = InputFactory.PagingServiceMethod("listByWatchlist", childListOp, parameters: [watchlistAliasParam, workspaceNameParam, subscriptionIdParam, resourceGroupNameParam], pagingMetadata: InputFactory.NextLinkPagingMetadata("value", "nextLink", InputResponseLocation.Body));
+
+            var armProviderDecorator = BuildArmProviderSchemaMultiResource([
+                new ResourceSchemaInput(parentModel, [
+                    new ResourceMethod(ResourceOperationKind.Read, parentGetMethod, new RequestPathPattern(parentGetOp.Path), new ArmScopeInfo(ResourceScope.Extension, new RequestPathPattern(parentIdPattern), "Microsoft.OperationalInsights/workspaces"), null!)
+                ], parentIdPattern, "Microsoft.SecurityInsights/watchlists", null, ResourceScope.Extension, "Watchlist", null, scopeIdPattern, "Microsoft.OperationalInsights/workspaces"),
+                new ResourceSchemaInput(childModel, [
+                    new ResourceMethod(ResourceOperationKind.Read, childGetMethod, new RequestPathPattern(childGetOp.Path), new ArmScopeInfo(ResourceScope.Extension, new RequestPathPattern(childIdPattern), "Microsoft.OperationalInsights/workspaces"), null!),
+                    new ResourceMethod(ResourceOperationKind.List, childListMethod, new RequestPathPattern(childListPath), new ArmScopeInfo(ResourceScope.Extension, new RequestPathPattern(parentIdPattern), "Microsoft.OperationalInsights/workspaces"), null!)
+                ], childIdPattern, "Microsoft.SecurityInsights/watchlists/watchlistItems", null, ResourceScope.Extension, "WatchlistItem", parentIdPattern, scopeIdPattern, "Microsoft.OperationalInsights/workspaces")
+            ]);
+
+            var parentClient = InputFactory.Client(
+                ParentClientName,
+                methods: [parentGetMethod],
+                decorators: [armProviderDecorator],
+                crossLanguageDefinitionId: $"Test.{ParentClientName}");
+
+            var childClient = InputFactory.Client(
+                ChildClientName,
+                methods: [childGetMethod, childListMethod],
+                decorators: [],
+                crossLanguageDefinitionId: $"Test.{ChildClientName}");
+
+            return (parentClient, childClient, [parentModel, childModel, childPageModel]);
+        }
+
         public static (InputClient InputClient, IReadOnlyList<InputModelType> InputModels) ClientWithExtensionScopedResourceList()
         {
             const string TestClientName = "TestClient";
@@ -1021,7 +1107,8 @@ namespace Azure.Generator.Management.Tests.Common
                     ["scope"] = new Dictionary<string, string?>
                     {
                         ["kind"] = r.ResourceScope.ToString(),
-                        ["scopeIdPattern"] = r.ScopeIdPattern
+                        ["scopeIdPattern"] = r.ScopeIdPattern,
+                        ["scopeResourceType"] = r.ScopeResourceType
                     },
                     ["methods"] = r.Methods.Select(SerializeResourceMethod).ToList(),
                     ["singletonResourceName"] = r.SingletonResourceName,
@@ -1079,6 +1166,7 @@ namespace Azure.Generator.Management.Tests.Common
             ResourceScope ResourceScope,
             string? ResourceName,
             string? ParentResourceId,
-            string ScopeIdPattern);
+            string ScopeIdPattern,
+            string? ScopeResourceType = null);
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
@@ -49,6 +49,10 @@ namespace Azure.Generator.Management.Tests.Providers
             var bodyStatements = validateResourceId!.BodyStatements?.ToDisplayString();
             Assert.That(bodyStatements, Does.Contain("global::Samples.WatchlistResource.ResourceType"));
             Assert.That(bodyStatements, Does.Not.Contain("\"Microsoft.OperationalInsights/workspaces\""));
+
+            var constructor = collection.Constructors.SingleOrDefault(c => c.Signature.Parameters.Any(p => p.Name == "id"));
+            Assert.That(constructor, Is.Not.Null);
+            Assert.That(constructor!.BodyStatements?.ToDisplayString(), Does.Contain("global::Samples.WatchlistItemCollection.ValidateResourceId(id);"));
         }
 
         [TestCase]

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
@@ -31,6 +31,27 @@ namespace Azure.Generator.Management.Tests.Providers
         }
 
         [TestCase]
+        public void Verify_ExtensionChildCollectionValidateResourceIdUsesParentResource()
+        {
+            var (parentClient, childClient, models) = InputResourceData.ClientWithNestedExtensionChildResource();
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => models,
+                clients: () => [parentClient, childClient]);
+
+            var collection = plugin.Object.OutputLibrary.TypeProviders
+                .OfType<ResourceCollectionClientProvider>()
+                .SingleOrDefault(p => p.Name == "WatchlistItemCollection");
+            Assert.That(collection, Is.Not.Null);
+
+            var validateResourceId = collection!.Methods.SingleOrDefault(m => m.Signature.Name == "ValidateResourceId");
+            Assert.That(validateResourceId, Is.Not.Null);
+
+            var bodyStatements = validateResourceId!.BodyStatements?.ToDisplayString();
+            Assert.That(bodyStatements, Does.Contain("global::Samples.WatchlistResource.ResourceType"));
+            Assert.That(bodyStatements, Does.Not.Contain("\"Microsoft.OperationalInsights/workspaces\""));
+        }
+
+        [TestCase]
         public void Verify_GetOperationMethod()
         {
             MethodProvider getMethod = GetResourceCollectionClientProviderMethodByName("Get");


### PR DESCRIPTION
Fixes #60372.

## Root cause

Extension-scoped child resource collections that have a parent resource id generated `ValidateResourceId` against the extension scope resource type instead of the actual parent resource type.

For SecurityInsights watchlist items, this meant validating against `Microsoft.OperationalInsights/workspaces` instead of `SecurityInsightsWatchlistResource.ResourceType`.

## Fix

Update `ResourceCollectionClientProvider` to prefer `parentResourceId` when present, and add a regression test for nested extension child collections.

## Validation

- `npm install` in `eng/packages/http-client-csharp-mgmt`
- `pwsh eng/scripts/Generate.ps1` in `eng/packages/http-client-csharp-mgmt`
- `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --filter FullyQualifiedName~ResourceCollectionClientProviderTests.Verify_ExtensionChildCollectionValidateResourceIdUsesParentResource --no-restore`