### PR TITLE
[Mgmt-Generator] Disambiguate flattened leaf names that collide with the wrapper

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -611,6 +611,22 @@ namespace Azure.Generator.Management.Visitors
 
         private void PropertyFlatten(ModelProvider model, ModelProvider propertyModel, IReadOnlyList<PropertyProvider> innerProperties, Dictionary<PropertyProvider, List<FlattenPropertyInfo>> propertyMap, PropertyProvider internalProperty)
         {
+            // Build the set of names already in use on this model so we can disambiguate
+            // colliding flatten-leaf names. This includes the wrapper property itself
+            // (about to be made internal at the end of this method, but it still occupies
+            // that C# name and two members on the same type cannot share a name regardless
+            // of accessibility), all other model properties, and any flatten-leaf names
+            // chosen by earlier iterations / by sibling internal properties processed in
+            // the enclosing FlattenModel loop.
+            var usedNames = new HashSet<string>(model.Properties.Select(p => p.Name), StringComparer.Ordinal);
+            foreach (var entries in propertyMap.Values)
+            {
+                foreach (var entry in entries)
+                {
+                    usedNames.Add(entry.FlattenedProperty.Name);
+                }
+            }
+
             foreach (var innerProperty in innerProperties)
             {
                 if (!innerProperty.Modifiers.HasFlag(MethodSignatureModifiers.Public))
@@ -625,7 +641,18 @@ namespace Azure.Generator.Management.Visitors
                 UpdateFlattenTypeCollectionProperty(internalProperty, innerProperty, model);
                 // flatten the property to public and associate it with the internal property
                 var (_, includeGetterNullCheck, _) = PropertyHelpers.GetFlags(internalProperty, innerProperty);
-                var flattenPropertyName = innerProperty.Name; // TODO: handle name conflicts
+                var flattenPropertyName = innerProperty.Name;
+                if (usedNames.Contains(flattenPropertyName))
+                {
+                    // Name conflict with an existing model member (usually the wrapper
+                    // itself, e.g. an envelope `properties` whose inner type also has a
+                    // `properties` member) or with another flattened sibling. Fall back
+                    // to a combined name so we don't emit two members with the same C#
+                    // name on this model, which would otherwise silently produce broken
+                    // generated code (missing/duplicate properties, wrong WirePath).
+                    flattenPropertyName = PropertyHelpers.GetCombinedPropertyName(innerProperty, internalProperty);
+                }
+                usedNames.Add(flattenPropertyName);
 
                 // The flattened public property is nullable iff the wrapping parent may be
                 // absent at runtime (see ShouldLiftToNullable). This applies symmetrically

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -1686,5 +1686,90 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(flattened!.Type.IsNullable, Is.True,
                 "Required value-type property flattened from an optional parent should be exposed as Nullable<T>");
         }
+
+        /// <summary>
+        /// Regression test for the name-conflict bug where the flattened envelope contains an
+        /// inner property whose name is identical to the envelope property itself
+        /// (e.g. <c>properties</c> on an outer model that has a <c>properties: { ..., properties: Record&lt;string&gt; }</c> shape).
+        /// Before the fix, the inner colliding leaf was emitted with the same C# name as the
+        /// outer wrapper, producing two members named <c>Properties</c> on the same model and
+        /// silently dropping the sibling flattened properties from the public surface.
+        /// After the fix, the colliding leaf is emitted with a disambiguated combined name,
+        /// preserving all sibling flattened members.
+        /// </summary>
+        [Test]
+        public void TestFlattenDisambiguatesNameConflictWithWrapper()
+        {
+            // Inner model has multiple public sub-properties, one of which is literally
+            // named "properties" — the same name as the wrapper envelope below.
+            var unitProp = InputFactory.Property("unit", InputPrimitiveType.String, isRequired: false, serializedName: "unit");
+            var kindProp = InputFactory.Property("kind", InputPrimitiveType.String, isRequired: false, serializedName: "kind");
+            var collidingProp = InputFactory.Property("properties", new InputDictionaryType("dict", InputPrimitiveType.String, InputPrimitiveType.String), isRequired: false, serializedName: "properties");
+            var innerModel = InputFactory.Model(
+                "WidgetProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [unitProp, kindProp, collidingProp]);
+
+            var wrapperProp = InputFactory.Property("properties", innerModel, isRequired: false, serializedName: "properties");
+            ApplyFlattenDecorator(wrapperProp);
+
+            var parentModel = InputFactory.Model(
+                "Widget",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [wrapperProp]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentModel, innerModel]);
+
+            var model = plugin.Object.TypeFactory.CreateModel(parentModel);
+            Assert.That(model, Is.Not.Null);
+
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(visitTypeCore, Is.Not.Null);
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [model]);
+            }
+
+            // No two members on the same model may share a C# name (regardless of accessibility).
+            var nameGroups = model!.Properties
+                .GroupBy(p => p.Name, StringComparer.Ordinal)
+                .Where(g => g.Count() > 1)
+                .ToList();
+            Assert.That(nameGroups, Is.Empty,
+                $"Duplicate property names found on model: [{string.Join(", ", nameGroups.Select(g => g.Key))}]");
+
+            // The non-colliding flattened siblings must still be present as public members.
+            Assert.That(
+                model.Properties.Any(p => p.Name == "Unit" && p.Modifiers.HasFlag(MethodSignatureModifiers.Public)),
+                Is.True,
+                "Expected flattened 'Unit' property to remain on public surface");
+            Assert.That(
+                model.Properties.Any(p => p.Name == "Kind" && p.Modifiers.HasFlag(MethodSignatureModifiers.Public)),
+                Is.True,
+                "Expected flattened 'Kind' property to remain on public surface");
+
+            // The colliding leaf must be emitted under a disambiguated name (not "Properties",
+            // which is taken by the wrapper). The exact combined name is produced by
+            // PropertyHelpers.GetCombinedPropertyName; here we verify only that it differs from
+            // "Properties" and references a dictionary value type (the inner colliding type).
+            var disambiguated = model.Properties.SingleOrDefault(p =>
+                p.Modifiers.HasFlag(MethodSignatureModifiers.Public) &&
+                p.Type.IsDictionary &&
+                p.Name != "Properties");
+            Assert.That(disambiguated, Is.Not.Null,
+                "Expected the colliding inner 'properties' dictionary to be emitted under a disambiguated name");
+
+            // The wrapper itself must be retained as an internal property (used by serialization).
+            var wrapper = model.Properties.SingleOrDefault(p => p.Name == "Properties");
+            Assert.That(wrapper, Is.Not.Null, "Wrapper 'Properties' must be retained on the model");
+            Assert.That(
+                wrapper!.Modifiers.HasFlag(MethodSignatureModifiers.Internal),
+                Is.True,
+                "Wrapper 'Properties' should be demoted to internal after flatten");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/Azure/azure-sdk-for-net/issues/60376

Resolves the long-standing `// TODO: handle name conflicts` in `FlattenPropertyVisitor.PropertyFlatten` (line 628, pre-existing) for the case where an inner property inside a flattened envelope has the same C# name as the envelope wrapper or as another already-flattened sibling.

Before this fix, the visitor unconditionally used `innerProperty.Name` as the flatten-leaf name. When the inner property name collided with the wrapper (e.g. an envelope `properties` whose inner type also has a `properties` member), two same-named members were emitted on the same `ModelProvider`. Two C# members on the same type cannot share a name regardless of accessibility, and the downstream emit silently dropped sibling flattened properties — producing broken generated code with the wrong `[WirePath]` attribute and a missing public surface.

## Change

`FlattenPropertyVisitor.PropertyFlatten` now tracks the set of names already in use on the model (existing properties + previously-chosen flatten-leaf names) and, on collision, falls back to `PropertyHelpers.GetCombinedPropertyName(innerProperty, internalProperty)` to produce a disambiguated leaf name. The wrapper still becomes internal at the end of the method as before.

## Verification

- New regression test `TestFlattenDisambiguatesNameConflictWithWrapper` reproduces the collision (envelope `properties` whose inner type contains `unit`, `kind`, and `properties: Record<string>`). Without the fix the test fails with `Duplicate property names found on model: [Properties]`. With the fix all flattened siblings remain on the public surface and the colliding leaf is emitted under the combined name.
- Full generator test suite: **243 passed, 0 failed, 0 skipped**.
- Local mgmt test-project regeneration (`Generate.ps1`): no diff produced in any of the existing generated test projects, confirming this is a strict bug-fix with zero behaviour change for non-colliding flatten scenarios.

## Related

- Refs #60376 (root-cause investigation, AppService `ResourceMetricDefinition`).
- Note: the AppService `ResourceMetricDefinition` symptom in #60376 has a second, deeper upstream bug in addition to the one fixed here — the wrapper property's type arrives at the FlattenPropertyVisitor already collapsed to the inner colliding type before flatten can run. That bug is in `Microsoft.TypeSpec.Generator` / TCGC (outside this repo) and will be filed separately. This PR is still an independently-valuable fix: it resolves a real, separately-reproducible duplicate-name bug and clears the pre-existing TODO.
