### PR TITLE
Peel 5 high-activity packages off the NoWarn skip-list

### DIFF
--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -28,7 +28,6 @@ Azure.AI.VoiceLive.Snippets
 Azure.Analytics.Purview.DataMap
 Azure.Analytics.Synapse.Artifacts
 Azure.Core.Experimental
-Azure.Developer.DevCenter
 Azure.Health.Insights.CancerProfiling
 Azure.Health.Insights.ClinicalMatching
 Azure.Identity
@@ -72,7 +71,6 @@ Azure.Provisioning.EventGrid
 Azure.Provisioning.EventHubs
 Azure.Provisioning.FrontDoor
 Azure.Provisioning.KeyVault
-Azure.Provisioning.Kubernetes
 Azure.Provisioning.KubernetesConfiguration
 Azure.Provisioning.Kusto
 Azure.Provisioning.Logic
@@ -120,8 +118,5 @@ Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
 Microsoft.Azure.WebJobs.Extensions.Storage.Common
 Microsoft.Azure.WebJobs.Extensions.Storage.Queues
 Microsoft.Azure.WebJobs.Extensions.Tables
-Microsoft.Azure.WebJobs.Extensions.WebPubSub
 Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO
-Microsoft.Azure.WebPubSub.AspNetCore
-Microsoft.Azure.WebPubSub.Common
 Microsoft.ClientModel.TestFramework

--- a/eng/analyzerallowlist/Azure.Developer.DevCenter.txt
+++ b/eng/analyzerallowlist/Azure.Developer.DevCenter.txt
@@ -1,0 +1,7 @@
+# Azure.Developer.DevCenter approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# 'SkuName' is part of the GA'd public API (shipped in 1.0.0); renaming the
+# generated enum to avoid the collision with Azure.Storage.Blobs.Models.SkuName
+# would be a breaking change.
+nowarn:AZC0034 T:Azure.Developer.DevCenter.Models.SkuName

--- a/eng/analyzerallowlist/Microsoft.Azure.WebPubSub.Common.txt
+++ b/eng/analyzerallowlist/Microsoft.Azure.WebPubSub.Common.txt
@@ -1,0 +1,7 @@
+# Microsoft.Azure.WebPubSub.Common approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# WebPubSubCommonJsonSerializerContext is a System.Text.Json source-generated
+# JsonSerializerContext, which by design exposes System.Text.Json types on its
+# public surface.
+nowarn:AZC0014 T:Microsoft.Azure.WebPubSub.Common.WebPubSubCommonJsonSerializerContext

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Azure.Developer.DevCenter.csproj
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Azure.Developer.DevCenter.csproj
@@ -8,7 +8,6 @@
     <PackageTags>Azure DevCenter</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <NoWarn>$(NoWarn);AZC003;AZC0034</NoWarn>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/hybridkubernetes/Azure.Provisioning.Kubernetes/src/Azure.Provisioning.Kubernetes.csproj
+++ b/sdk/hybridkubernetes/Azure.Provisioning.Kubernetes/src/Azure.Provisioning.Kubernetes.csproj
@@ -7,7 +7,6 @@
     <LangVersion>12</LangVersion>
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/tools/Azure.SdkAnalyzers/src/AllowListDiagnosticSuppressor.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/AllowListDiagnosticSuppressor.cs
@@ -29,6 +29,7 @@ namespace Azure.SdkAnalyzers
         private static readonly string[] SupportedDiagnosticIds = new[]
         {
             "AZC0007",
+            "AZC0014",
             "AZC0030",
             "AZC0034",
             "AZC0035",

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AllowListDiagnosticSuppressorTests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AllowListDiagnosticSuppressorTests.cs
@@ -24,6 +24,14 @@ namespace Azure.SdkAnalyzers.Tests
     public class AllowListDiagnosticSuppressorTests
     {
         [Test]
+        public void SupportedSuppressions_IncludeAzc0014()
+        {
+            var suppressor = new AllowListDiagnosticSuppressor();
+            IEnumerable<string> ids = suppressor.SupportedSuppressions.Select(s => s.SuppressedDiagnosticId);
+            Assert.That(ids, Does.Contain("AZC0014"), "AZC0014 should be opted into scoped suppression.");
+        }
+
+        [Test]
         public async Task TypeTarget_SuppressesOnlyMatchingType()
         {
             const string source = @"

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <Nullable>annotations</Nullable>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.WebPubSub</PackageId>
     <PackageTags>Azure, WebPubSub</PackageTags>
     <Description>Azure Functions extension for the WebPubSub service</Description>
     <Version>1.10.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.10.0</ApiCompatVersion>
-    <NoWarn>$(NoWarn);CS8632;CA1056;CA2227</NoWarn>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Microsoft.Azure.WebPubSub.AspNetCore.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Microsoft.Azure.WebPubSub.AspNetCore.csproj
@@ -9,7 +9,6 @@
     <RequiredTargetFrameworks>$(RequiredRunnableTargetFrameworks)</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <SupportsNetStandard20>false</SupportsNetStandard20>
-    <NoWarn>$(NoWarn);419</NoWarn>
     <GenerateAPIListing>true</GenerateAPIListing>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/api/Microsoft.Azure.WebPubSub.Common.netstandard2.0.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/api/Microsoft.Azure.WebPubSub.Common.netstandard2.0.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.WebPubSub.Common
         [System.Text.Json.Serialization.JsonPropertyNameAttribute("thumbprint")]
         public string Thumbprint { get { throw null; } }
     }
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.Json.SourceGeneration", "10.0.14.7603")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.Json.SourceGeneration", "10.0.14.27113")]
     [System.Text.Json.Serialization.JsonSerializableAttribute(typeof(Microsoft.Azure.WebPubSub.Common.ConnectEventRequest))]
     [System.Text.Json.Serialization.JsonSerializableAttribute(typeof(Microsoft.Azure.WebPubSub.Common.ConnectEventResponse))]
     [System.Text.Json.Serialization.JsonSerializableAttribute(typeof(Microsoft.Azure.WebPubSub.Common.DisconnectedEventRequest))]

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Microsoft.Azure.WebPubSub.Common.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Microsoft.Azure.WebPubSub.Common.csproj
@@ -9,7 +9,6 @@
     <PackageTags>Azure, WebPubSub</PackageTags>
     <RequiredTargetFrameworks>netstandard2.0</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);CA1822;AZC0014</NoWarn>
     <GenerateAPIListing>true</GenerateAPIListing>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Continues draining `eng/NoWarnSkipValidation.txt`, targeting high-activity packages. Removes **5 packages** — preferring stale-removal and source fixes, and using point-suppression only where a live diagnostic genuinely can't be fixed.

## What changed

| Package | Disposition |
|---|---|
| `Microsoft.Azure.WebPubSub.AspNetCore` | dead `CS0419` removed (clean) |
| `Azure.Provisioning.Kubernetes` | dead `CS1591` removed (clean) |
| `Azure.Developer.DevCenter` | dead `AZC003` dropped; `AZC0034` on `SkuName` point-suppressed per-type |
| `Microsoft.Azure.WebPubSub.Common` | dead `CA1822` dropped; `AZC0014` point-suppressed per-type |
| `Microsoft.Azure.WebJobs.Extensions.WebPubSub` | **fixed** `CS8632` via `<Nullable>annotations</Nullable>`; dead `CA1056`/`CA2227` dropped |

### Point-suppression justifications
- **DevCenter `SkuName` (AZC0034):** `SkuName` is part of the GA'd public API (shipped in 1.0.0) and collides with `Azure.Storage.Blobs.Models.SkuName`. Renaming GA'd public API would be a breaking change.
- **WebPubSub.Common `WebPubSubCommonJsonSerializerContext` (AZC0014):** a System.Text.Json source-generated `JsonSerializerContext` that by design exposes `System.Text.Json` types on its public surface.

### Analyzer change
`AZC0014` is added to `AllowListDiagnosticSuppressor.SupportedDiagnosticIds` so the WebPubSub.Common suppression can be scoped to the specific type (`nowarn:AZC0014 T:...`) instead of applied project-wide. A test covers the opt-in. The analyzer is consumed as a project reference, so this is included in the PR that needs it.

## Validation
All 5 packages build clean; the analyzer suite passes (12 suppressor tests across 4 TFMs). The `CS8632` change enables only the nullable *annotations* context, so there is no public API change.
