### PR TITLE
Remove link verification from compliance job

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -190,15 +190,6 @@ jobs:
           parameters:
             ScriptToValidateUpgrade: eng/scripts/spell-check-public-api.ps1
 
-        - template: /eng/common/pipelines/templates/steps/verify-links.yml
-          parameters:
-            ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-              Directory: ''
-              Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-            ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-              Directory: sdk/${{ parameters.ServiceDirectory }}
-            CheckLinkGuidance: $true
-
         - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
           parameters:
             SourceDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
This pull request removes the step that verifies links in markdown files as part of the CI pipeline. The main change is the deletion of the `verify-links.yml` template invocation from the pipeline configuration.

Pipeline configuration changes:

* Removed the `verify-links.yml` step from `eng/pipelines/templates/jobs/ci.yml`, which previously checked for broken links in markdown files during CI runs.