### PR TITLE
[AgentServer.Responses] Add ConversationChainId to ResponseContext

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-beta.7 (Unreleased)
 
 ### Features Added
+- Added `ResponseContext.ConversationChainId`, a deterministic correlation key for the logical conversation a response belongs to. It is the SHA-256 hash digest of `{agentName}:{sessionId}:{discriminator}:{partition}`, where the partition is extracted from the conversation ID, previous response ID, or response ID, and the discriminator namespaces the partition by source type.
 
 ### Breaking Changes
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
@@ -201,6 +201,7 @@ namespace Azure.AI.AgentServer.Responses
     {
         public ResponseContext(string responseId) { }
         public virtual System.Collections.Generic.IReadOnlyDictionary<string, string> ClientHeaders { get { throw null; } }
+        public virtual string ConversationChainId { get { throw null; } }
         public bool IsShutdownRequested { get { throw null; } set { } }
         public virtual Azure.AI.AgentServer.Core.PlatformContext PlatformContext { get { throw null; } }
         public virtual System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> QueryParameters { get { throw null; } }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
@@ -201,6 +201,7 @@ namespace Azure.AI.AgentServer.Responses
     {
         public ResponseContext(string responseId) { }
         public virtual System.Collections.Generic.IReadOnlyDictionary<string, string> ClientHeaders { get { throw null; } }
+        public virtual string ConversationChainId { get { throw null; } }
         public bool IsShutdownRequested { get { throw null; } set { } }
         public virtual Azure.AI.AgentServer.Core.PlatformContext PlatformContext { get { throw null; } }
         public virtual System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> QueryParameters { get { throw null; } }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ChainIdDerivation.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ChainIdDerivation.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text;
+using Azure.AI.AgentServer.Responses.Models;
+
+namespace Azure.AI.AgentServer.Responses.Internal;
+
+/// <summary>
+/// Conversation chain identity.
+/// <para>
+/// A conversation's stable identity is the <em>partition key</em> embedded in its
+/// response IDs. IDs have the shape <c>{prefix}_{partitionKey}{entropy}</c>; when a
+/// response ID is generated it inherits the partition key of its
+/// <c>previousResponseId</c> / <c>conversationId</c> hint (see <see cref="IdGenerator"/>).
+/// So every response in a chain carries the <em>same</em> embedded partition key, and
+/// extracting it yields a value that is stable across every turn of the chain.
+/// </para>
+/// <para>
+/// <see cref="Derive"/> is the foundational concept here — the agent/session-scoped hash
+/// of that partition, exposed to handlers as <see cref="ResponseContext.ConversationChainId"/>.
+/// </para>
+/// <para>
+/// Known limitation: the chain identity is derived from framework-generated IDs. A client
+/// that supplies its own response ID carrying a mismatched embedded partition can shift the
+/// chain identity for subsequent turns.
+/// </para>
+/// </summary>
+internal static class ChainIdDerivation
+{
+    /// <summary>
+    /// Length of the hex digest used for the chain id (and therefore the task id).
+    /// </summary>
+    private const int ChainIdHexLength = 32;
+
+    private const string DefaultAgentName = "server-default-agent";
+
+    /// <summary>
+    /// Derives the stable, agent/session-scoped conversation chain id.
+    /// <para>
+    /// The id is the same for every turn of a conversation chain. It is a hex digest, so it
+    /// is opaque and fixed-length — suitable as a handler-side correlation key.
+    /// </para>
+    /// </summary>
+    /// <param name="conversationId">Explicit conversation scope (highest priority).</param>
+    /// <param name="previousResponseId">Chain parent (used when no conversation ID).</param>
+    /// <param name="responseId">This response's unique ID (fallback / fork key).</param>
+    /// <param name="agentReference">Agent reference containing the name, for cross-agent scoping.</param>
+    /// <param name="sessionId">The resolved session scope identifier.</param>
+    /// <param name="steerable">Whether steerable conversations are enabled.</param>
+    /// <returns>A stable hex chain id.</returns>
+    public static string Derive(
+        string? conversationId,
+        string? previousResponseId,
+        string responseId,
+        AgentReference? agentReference,
+        string? sessionId,
+        bool steerable = true)
+    {
+        var (discriminator, partition) = ChainPartition(conversationId, previousResponseId, responseId, steerable);
+
+        var agentName = string.IsNullOrEmpty(agentReference?.Name) ? DefaultAgentName : agentReference!.Name;
+        var composite = $"{agentName}:{sessionId ?? string.Empty}:{discriminator}:{partition}";
+
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(composite));
+        return Convert.ToHexString(hashBytes).ToLowerInvariant()[..ChainIdHexLength];
+    }
+
+    /// <summary>
+    /// Resolves the <c>(discriminator, partition)</c> that identifies the chain.
+    /// <para>
+    /// Priority:
+    /// <list type="number">
+    /// <item><c>conversationId</c> — explicit conversation scope (extract its partition key, or use it raw when not in ID format).</item>
+    /// <item><c>steerable</c> — the sequential chain shares one identity: extract the partition key from <c>previousResponseId</c> (or <c>responseId</c> on the first turn).</item>
+    /// <item>otherwise (non-steerable) — each request is its own fork; the FULL <c>responseId</c> (entropy included) keeps concurrent forks distinct.</item>
+    /// </list>
+    /// The discriminator namespaces the partition by source type so that, e.g., a client-supplied
+    /// <c>conversationId</c> cannot collide with an extracted partition key or a response id.
+    /// </para>
+    /// </summary>
+    private static (string Discriminator, string Partition) ChainPartition(
+        string? conversationId,
+        string? previousResponseId,
+        string responseId,
+        bool steerable)
+    {
+        if (!string.IsNullOrEmpty(conversationId))
+        {
+            return ("conv", ExtractPartitionOrRaw(conversationId!));
+        }
+
+        if (steerable)
+        {
+            var source = !string.IsNullOrEmpty(previousResponseId) ? previousResponseId! : responseId;
+            return ("chain", ExtractPartitionOrRaw(source));
+        }
+
+        // Non-steerable: keep parallel forks distinct via the full response_id.
+        var discriminator = !string.IsNullOrEmpty(previousResponseId) ? "fork" : "resp";
+        return (discriminator, responseId);
+    }
+
+    /// <summary>
+    /// Extracts the embedded partition key from <paramref name="idValue"/>, or returns it
+    /// unchanged. Framework-generated IDs carry an embedded partition key that is shared across
+    /// a chain; values not in the ID format (e.g. a raw conversation ID) have no embedded key —
+    /// they are themselves the stable identity, so they are returned as-is.
+    /// </summary>
+    private static string ExtractPartitionOrRaw(string idValue)
+    {
+        try
+        {
+            return IdGenerator.ExtractPartitionKey(idValue);
+        }
+        catch (ArgumentException)
+        {
+            return idValue;
+        }
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseContextImpl.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseContextImpl.cs
@@ -28,6 +28,8 @@ internal sealed class ResponseContextImpl : ResponseContext
     private readonly IReadOnlyDictionary<string, string> _clientHeaders;
     private readonly IReadOnlyDictionary<string, StringValues> _queryParameters;
     private readonly PlatformContext _platformContext;
+    private readonly string? _conversationId;
+    private string? _conversationChainId;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ResponseContextImpl"/>.
@@ -57,6 +59,7 @@ internal sealed class ResponseContextImpl : ResponseContext
         _platformContext = platformContext ?? PlatformContext.Empty;
         _provider = provider;
         _request = request;
+        _conversationId = request.GetConversationId();
         _historyLimit = options?.Value.DefaultFetchHistoryCount ?? ResponsesServerOptions.DefaultFetchHistoryCountValue;
         _inputItemsResolved = new Lazy<Task<IReadOnlyList<Item>>>(() => ResolveInputItemsAsync(resolveReferences: true));
         _inputItemsUnresolved = new Lazy<Task<IReadOnlyList<Item>>>(() => ResolveInputItemsAsync(resolveReferences: false));
@@ -66,6 +69,15 @@ internal sealed class ResponseContextImpl : ResponseContext
 
     /// <inheritdoc/>
     public override BinaryData? RawBody => _rawBody;
+
+    /// <inheritdoc/>
+    public override string ConversationChainId
+        => _conversationChainId ??= ChainIdDerivation.Derive(
+            _conversationId,
+            _request.PreviousResponseId,
+            ResponseId,
+            _request.AgentReference,
+            _request.AgentSessionId);
 
     /// <inheritdoc/>
     public override PlatformContext PlatformContext => _platformContext;
@@ -170,7 +182,7 @@ internal sealed class ResponseContextImpl : ResponseContext
     private async Task<IReadOnlyList<string>> ResolveHistoryItemIdsAsync()
     {
         var previousResponseId = _request.PreviousResponseId;
-        var conversationId = _request.GetConversationId();
+        var conversationId = _conversationId;
 
         if (string.IsNullOrEmpty(previousResponseId) && string.IsNullOrEmpty(conversationId))
         {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/ResponseContext.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/ResponseContext.cs
@@ -31,6 +31,24 @@ public class ResponseContext
     public string ResponseId { get; }
 
     /// <summary>
+    /// Gets the stable identifier for the multi-turn conversation chain this response belongs to.
+    /// <para>
+    /// Every response in the same logical conversation shares this value, so handlers can use it
+    /// as a key into their own application-side conversation state (e.g., upstream SDK session IDs,
+    /// per-conversation rate limits, conversation indexes). It is the SHA-256 hash digest of
+    /// <c>{agentName}:{sessionId}:{discriminator}:{partition}</c>, where the partition is extracted
+    /// from the request's conversation ID, the <c>previous_response_id</c> chain, or this response's
+    /// own ID, and the discriminator namespaces the partition by source type. Including the agent
+    /// name and session ID scopes the value so it does not collide across agents or sessions.
+    /// </para>
+    /// <para>
+    /// The base implementation returns <see cref="ResponseId"/>; enhanced contexts override this to
+    /// derive the value from the request's conversation context.
+    /// </para>
+    /// </summary>
+    public virtual string ConversationChainId => ResponseId;
+
+    /// <summary>
     /// Gets or sets whether the server is shutting down.
     /// Handlers can use this to distinguish shutdown from explicit cancel or client disconnect.
     /// </summary>

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Unit/ChainIdDerivationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Unit/ChainIdDerivationTests.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text;
+using Azure.AI.AgentServer.Responses.Internal;
+using Azure.AI.AgentServer.Responses.Models;
+
+namespace Azure.AI.AgentServer.Responses.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="ChainIdDerivation"/> — deterministic conversation
+/// chain ID derivation: first 32 lowercase hex characters of
+/// <c>SHA-256("{agentName}:{sessionId}:{discriminator}:{partition}")</c>, where the partition is
+/// extracted from the conversation ID, previous response ID, or response ID, and the discriminator
+/// namespaces the partition by source type.
+/// </summary>
+public class ChainIdDerivationTests
+{
+    private const int ExpectedLength = 32;
+
+    // A canonical response ID (caresp_ + 18-char partition key + 32-char entropy).
+    private const string PartitionKey = "abcdef012345678900";
+    private const string ParentId = "caresp_abcdef012345678900abcdefghijklmnopqrstuvwxyz012345";
+    // A different response ID that shares the same partition key as ParentId.
+    private const string SamePartitionId = "caresp_abcdef0123456789000123456789abcdefghijklmnopqrstuv";
+    // A response ID with a different partition key.
+    private const string OtherPartitionId = "caresp_fedcba987654321000abcdefghijklmnopqrstuvwxyz012345";
+
+    // ── Format ──
+
+    [Test]
+    public void Derive_Returns32CharLowercaseHex()
+    {
+        var result = ChainIdDerivation.Derive(null, null, ParentId, new AgentReference("my-agent"), "sess-1");
+
+        Assert.That(result, Has.Length.EqualTo(ExpectedLength));
+        Assert.That(result, Does.Match("^[0-9a-f]+$"), "Should be lowercase hex");
+    }
+
+    // ── Determinism ──
+
+    [Test]
+    public void Derive_SameInputs_ReturnsSameChainId()
+    {
+        var agent = new AgentReference("my-agent") { Version = "1.0" };
+
+        var result1 = ChainIdDerivation.Derive(null, ParentId, SamePartitionId, agent, "sess-1");
+        var result2 = ChainIdDerivation.Derive(null, ParentId, SamePartitionId, agent, "sess-1");
+
+        Assert.That(result1, Is.EqualTo(result2));
+    }
+
+    // ── Partition-key stability across a chain ──
+
+    [Test]
+    public void Derive_ResponsesSharingPartitionKey_ProduceSameChainId()
+    {
+        var agent = new AgentReference("my-agent");
+
+        // previous_response_id is the source in one call; the same id appears as the
+        // response_id (partition source of last resort) in the other. Both share the
+        // same partition key, so the chain ID must match across the whole conversation.
+        var fromPrevious = ChainIdDerivation.Derive(null, ParentId, SamePartitionId, agent, "sess-1");
+        var fromResponse = ChainIdDerivation.Derive(null, null, ParentId, agent, "sess-1");
+
+        Assert.That(fromPrevious, Is.EqualTo(fromResponse),
+            "Every response in the same partition should share one chain ID");
+    }
+
+    [Test]
+    public void Derive_DifferentPartitionKey_ProducesDifferentChainId()
+    {
+        var agent = new AgentReference("my-agent");
+
+        var result1 = ChainIdDerivation.Derive(null, null, ParentId, agent, "sess-1");
+        var result2 = ChainIdDerivation.Derive(null, null, OtherPartitionId, agent, "sess-1");
+
+        Assert.That(result1, Is.Not.EqualTo(result2));
+    }
+
+    // ── Partition source priority: conversation_id → previous_response_id → response_id ──
+
+    [Test]
+    public void Derive_ConversationId_TakesPriorityOverPreviousAndResponse()
+    {
+        var agent = new AgentReference("my-agent");
+
+        var withConvOnly = ChainIdDerivation.Derive("conv-abc", null, ParentId, agent, "sess-1");
+        var withAll = ChainIdDerivation.Derive("conv-abc", OtherPartitionId, ParentId, agent, "sess-1");
+
+        Assert.That(withConvOnly, Is.EqualTo(withAll),
+            "conversation_id is the partition source when present; the others are ignored");
+    }
+
+    [Test]
+    public void Derive_PreviousResponseId_UsedWhenNoConversationId()
+    {
+        var agent = new AgentReference("my-agent");
+
+        var fromPrevious = ChainIdDerivation.Derive(null, ParentId, OtherPartitionId, agent, "sess-1");
+        var fromResponseDirect = ChainIdDerivation.Derive(null, null, ParentId, agent, "sess-1");
+
+        Assert.That(fromPrevious, Is.EqualTo(fromResponseDirect),
+            "previous_response_id is the partition source when conversation_id is absent");
+    }
+
+    // ── Empty strings treated as absent ──
+
+    [Test]
+    public void Derive_EmptyConversationId_FallsBackToPreviousResponseId()
+    {
+        var agent = new AgentReference("my-agent");
+
+        var withEmpty = ChainIdDerivation.Derive("", ParentId, OtherPartitionId, agent, "sess-1");
+        var withNull = ChainIdDerivation.Derive(null, ParentId, OtherPartitionId, agent, "sess-1");
+
+        Assert.That(withEmpty, Is.EqualTo(withNull));
+    }
+
+    // ── Agent and session scoping ──
+
+    [Test]
+    public void Derive_DifferentAgentName_ProducesDifferentChainId()
+    {
+        var result1 = ChainIdDerivation.Derive("conv-abc", null, ParentId, new AgentReference("agent-a"), "sess-1");
+        var result2 = ChainIdDerivation.Derive("conv-abc", null, ParentId, new AgentReference("agent-b"), "sess-1");
+
+        Assert.That(result1, Is.Not.EqualTo(result2), "Different agents must not collide");
+    }
+
+    [Test]
+    public void Derive_DifferentSessionId_ProducesDifferentChainId()
+    {
+        var agent = new AgentReference("my-agent");
+
+        var result1 = ChainIdDerivation.Derive("conv-abc", null, ParentId, agent, "sess-1");
+        var result2 = ChainIdDerivation.Derive("conv-abc", null, ParentId, agent, "sess-2");
+
+        Assert.That(result1, Is.Not.EqualTo(result2), "Different sessions must not collide");
+    }
+
+    [Test]
+    public void Derive_NullAgentReference_UsesDefaultName()
+    {
+        var withNull = ChainIdDerivation.Derive("conv-abc", null, ParentId, null, "sess-1");
+        var withEmptyName = ChainIdDerivation.Derive("conv-abc", null, ParentId, new AgentReference(""), "sess-1");
+
+        Assert.That(withNull, Is.EqualTo(withEmptyName),
+            "A null or empty agent name both fall back to the default agent name");
+    }
+
+    // ── Cross-language seed contract ──
+
+    [Test]
+    public void Derive_MatchesSeedContract()
+    {
+        // No conversation ID + steerable => discriminator "chain", partition = extracted partition key.
+        // The composite is "{agentName}:{sessionId}:{discriminator}:{partition}" hashed with SHA-256.
+        var result = ChainIdDerivation.Derive(null, null, ParentId, new AgentReference("my-agent"), "sess-1");
+
+        var composite = $"my-agent:sess-1:chain:{PartitionKey}";
+        var expectedBytes = SHA256.HashData(Encoding.UTF8.GetBytes(composite));
+        var expected = Convert.ToHexString(expectedBytes).ToLowerInvariant()[..ExpectedLength];
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Derive_NullSessionId_TreatedAsEmpty()
+    {
+        var withNull = ChainIdDerivation.Derive(null, null, ParentId, new AgentReference("my-agent"), null);
+
+        var composite = $"my-agent::chain:{PartitionKey}";
+        var expectedBytes = SHA256.HashData(Encoding.UTF8.GetBytes(composite));
+        var expected = Convert.ToHexString(expectedBytes).ToLowerInvariant()[..ExpectedLength];
+
+        Assert.That(withNull, Is.EqualTo(expected));
+    }
+
+    // ── Discriminator namespacing ──
+
+    [Test]
+    public void Derive_ConversationId_UsesConvDiscriminator()
+    {
+        // A raw conversation ID (not in canonical ID format) is used as-is for the partition,
+        // namespaced by the "conv" discriminator.
+        var result = ChainIdDerivation.Derive("my-partition", null, ParentId, new AgentReference("my-agent"), "sess-1");
+
+        var composite = "my-agent:sess-1:conv:my-partition";
+        var expectedBytes = SHA256.HashData(Encoding.UTF8.GetBytes(composite));
+        var expected = Convert.ToHexString(expectedBytes).ToLowerInvariant()[..ExpectedLength];
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Derive_DiscriminatorNamespacesIdenticalPartitionValues()
+    {
+        // Same raw partition value ("shared"), but one arrives as a conversation ID ("conv")
+        // and the other as a non-steerable response fork ("resp"). Neither value is in canonical
+        // ID format, so the partition is the raw value in both cases; only the discriminator differs.
+        var asConversation = ChainIdDerivation.Derive("shared", null, "ignored", new AgentReference("my-agent"), "sess-1");
+        var asResponse = ChainIdDerivation.Derive(null, null, "shared", new AgentReference("my-agent"), "sess-1", steerable: false);
+
+        Assert.That(asConversation, Is.Not.EqualTo(asResponse),
+            "Identical partition values from different sources must not collide");
+    }
+
+    // ── Non-steerable forking ──
+
+    [Test]
+    public void Derive_NonSteerable_UsesFullResponseIdAndForkDiscriminator()
+    {
+        // Non-steerable with a previous response => "fork" discriminator and the FULL response id.
+        var result = ChainIdDerivation.Derive(null, ParentId, OtherPartitionId, new AgentReference("my-agent"), "sess-1", steerable: false);
+
+        var composite = $"my-agent:sess-1:fork:{OtherPartitionId}";
+        var expectedBytes = SHA256.HashData(Encoding.UTF8.GetBytes(composite));
+        var expected = Convert.ToHexString(expectedBytes).ToLowerInvariant()[..ExpectedLength];
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Derive_NonSteerable_NoPreviousResponse_UsesRespDiscriminator()
+    {
+        // Non-steerable without a previous response => "resp" discriminator and the FULL response id.
+        var result = ChainIdDerivation.Derive(null, null, ParentId, new AgentReference("my-agent"), "sess-1", steerable: false);
+
+        var composite = $"my-agent:sess-1:resp:{ParentId}";
+        var expectedBytes = SHA256.HashData(Encoding.UTF8.GetBytes(composite));
+        var expected = Convert.ToHexString(expectedBytes).ToLowerInvariant()[..ExpectedLength];
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Derive_NonSteerable_DistinctResponseIds_DoNotShareChainId()
+    {
+        // Two concurrent forks sharing a partition key but with different entropy must stay distinct.
+        var fork1 = ChainIdDerivation.Derive(null, ParentId, ParentId, new AgentReference("my-agent"), "sess-1", steerable: false);
+        var fork2 = ChainIdDerivation.Derive(null, ParentId, SamePartitionId, new AgentReference("my-agent"), "sess-1", steerable: false);
+
+        Assert.That(fork1, Is.Not.EqualTo(fork2),
+            "Non-steerable forks keyed on the full response id must not collide");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ResponseContext.ConversationChainId`, a deterministic correlation key identifying the logical conversation a response belongs to. This ports the `conversation_chain_id` concept from the Python `azure-ai-agentserver-responses` SDK, matching `hosting/_chain_id.py` exactly (the chain-id derivation only — **not** the durable task-id wrapper in `_task_id.py`).

## Behavior

`ConversationChainId` is the first 32 characters of the lowercase hex SHA-256 digest of:

```
{agentName}:{sessionId}:{discriminator}:{partition}
```

The `(discriminator, partition)` pair is resolved with the following priority:

1. **`conversation_id`** present → discriminator `conv`; partition is its extracted embedded partition key, or the raw value when it is not in canonical ID format.
2. Otherwise, **steerable** (the default) → discriminator `chain`; partition is the embedded partition key extracted from `previous_response_id` (or `response_id` on the first turn). Because chained response IDs all inherit one partition key, every turn of a conversation resolves to the same chain id.
3. Otherwise (**non-steerable**) → each request is its own fork; discriminator is `fork` (when there is a `previous_response_id`) or `resp`, and the partition is the FULL `response_id` (entropy included) so concurrent forks stay distinct.

The agent name and session id scope the value so it does not collide across agents or sessions, and the discriminator namespaces the partition by source type (e.g. a client-supplied `conversation_id` cannot collide with an extracted partition key or a response id).

This mirrors Python's `derive_conversation_chain_id` byte-for-byte, including the `steerable` flag (defaults to `true`).

## Changes

- **New** `Internal/ChainIdDerivation.cs` — stateless derivation helper (`Derive` + private `ChainPartition` / `ExtractPartitionOrRaw`).
- `ResponseContext.cs` — adds the public virtual `ConversationChainId` property (base returns `ResponseId`, the chain-root fallback, since the base type has no request/conversation context).
- `Internal/ResponseContextImpl.cs` — overrides `ConversationChainId`, deriving from the request's conversation id / previous response id / response id, scoped by agent reference and resolved session id (cached, since conversation-id parsing reads JSON).
- **New** `tests/Unit/ChainIdDerivationTests.cs` — 17 unit tests covering digest format/length, partition-key stability across a chain, source priority, empty-string-as-absent handling, agent/session scoping, default agent name, the discriminator namespacing, non-steerable forking, and the cross-language composite contract.
- `CHANGELOG.md` — Features Added entry under the existing unreleased `1.0.0-beta.7`.
- Regenerated `api/*.cs` public API listings (via the `ExportApi` target).

## Notes

- Self-contained within the Responses package — no changes to Core or Invocations, so no version coupling.
- No version bump needed: rides along in the already-open unreleased `1.0.0-beta.7`.
- Build clean (0 warnings/0 errors); 17 unit tests pass on net10.0. `dotnet format` produced no changes.
