### PR TITLE
Scope analyze Verify Generated Code regeneration to changed projects

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -87,6 +87,7 @@ steps:
             -ServiceDirectory $ServiceDirectory `
             -SDKType ${{ parameters.SDKType }} `
             -SpellCheckPublicApiSurface `
+            -ProjectListOverrideFile "$(ProjectListOverrideFile)"
 
           if ($LASTEXITCODE -ne 0) {
             $failed = $true

--- a/eng/scripts/CodeChecks.Helpers.ps1
+++ b/eng/scripts/CodeChecks.Helpers.ps1
@@ -133,3 +133,73 @@ To fix this locally, run 'eng\scripts\CodeChecks.ps1 -ServiceDirectory $ServiceD
         Summary = $summary
     }
 }
+
+# When a batch-level project list override file is supplied (PR analyze batches), produce a project
+# list scoped to only the changed projects within $ServiceDirectory so code regeneration touches just
+# those projects instead of every package in the service directory. Returns a repo-root-relative path
+# to the scoped override file, or "" to fall back to whole-service-directory regeneration.
+#
+# Coverage invariant (why no changed project is dropped): every package in a given service directory
+# shares the "sdk/<ServiceDirectory>/" path prefix, so the filter matches either all of that service's
+# changed packages or none. When none match (e.g. a service-level shared file changed, with no package
+# in the targeted set), it returns "" so the caller regenerates the whole service directory. Worst case
+# is over-regeneration; a changed project can never be silently skipped.
+function Get-ScopedProjectListOverrideFile {
+    param(
+        [string] $GlobalOverrideFile,
+        [string] $ServiceDirectory,
+        [string] $RepoRoot
+    )
+
+    # Treat unexpanded pipeline variable references (e.g. "$(ProjectListOverrideFile)") as unset.
+    if (-not $GlobalOverrideFile -or $GlobalOverrideFile -like '$(*') {
+        return ""
+    }
+
+    $globalPath = Join-Path $RepoRoot $GlobalOverrideFile
+    if (-not (Test-Path $globalPath)) {
+        Write-Host "Project list override file '$globalPath' not found; regenerating the full '$ServiceDirectory' service directory."
+        return ""
+    }
+
+    try {
+        [xml] $overrideXml = Get-Content -Raw -Path $globalPath
+    }
+    catch {
+        Write-Host "Unable to parse project list override file '$globalPath'; regenerating the full '$ServiceDirectory' service directory."
+        return ""
+    }
+
+    $servicePattern = "(?i)sdk[\\/]$([regex]::Escape($ServiceDirectory))[\\/]"
+    $scopedIncludes = @(
+        $overrideXml.Project.ItemGroup.ProjectReference `
+        | Where-Object { $_.Include -match $servicePattern } `
+        | ForEach-Object { $_.Include }
+    )
+
+    if ($scopedIncludes.Count -eq 0) {
+        # The service changed but none of its packages are in the targeted project set (for example a
+        # service-level shared file changed). Regenerate the whole service directory to stay correct.
+        Write-Host "No changed projects matched 'sdk/$ServiceDirectory' in the project list override file; regenerating the full service directory."
+        return ""
+    }
+
+    $scopedDir = Join-Path $RepoRoot "projlist"
+    $null = New-Item -Path $scopedDir -ItemType Directory -Force
+    $safeName = $ServiceDirectory -replace '[\\/]', '_'
+    $scopedPath = Join-Path $scopedDir "codechecks_$safeName.props"
+
+    $scopedXml = [xml] '<Project><ItemGroup></ItemGroup></Project>'
+    $itemGroup = $scopedXml.SelectSingleNode("/Project/ItemGroup")
+    foreach ($include in $scopedIncludes) {
+        $node = $scopedXml.CreateElement("ProjectReference")
+        $node.SetAttribute("Include", $include)
+        $null = $itemGroup.AppendChild($node)
+    }
+    $scopedXml.Save($scopedPath)
+
+    Write-Host "Scoped code regeneration for '$ServiceDirectory' to $($scopedIncludes.Count) changed project(s):"
+    $scopedIncludes | ForEach-Object { Write-Host "  $_" }
+
+    return [System.IO.Path]::GetRelativePath($RepoRoot, $scopedPath)
+}

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -15,7 +15,10 @@ param (
     [switch] $SpellCheckPublicApiSurface,
 
     [Parameter()]
-    [switch] $SkipDiffValidation
+    [switch] $SkipDiffValidation,
+
+    [Parameter()]
+    [string] $ProjectListOverrideFile
 )
 
 Write-Host "Service Directory $ServiceDirectory"
@@ -82,6 +85,10 @@ try {
             $ServiceDirectory = $Matches['projectdir']
         }
     }
+    # Scope code regeneration to only the changed projects in this service directory when a project
+    # list override file is supplied; otherwise this is "" and the whole service directory regenerates.
+    $scopedOverrideFile = Get-ScopedProjectListOverrideFile -GlobalOverrideFile $ProjectListOverrideFile -ServiceDirectory $ServiceDirectory -RepoRoot $RepoRoot
+
     if (-not $ProjectDirectory)
     {
         # In PR builds, check if only CI config files changed for this service directory.
@@ -142,7 +149,7 @@ try {
 
             Write-Host "Re-generating clients"
             Invoke-Block {
-                & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory $diagnosticArguments /p:ProjectListOverrideFile=""
+                & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory $diagnosticArguments /p:ProjectListOverrideFile="$scopedOverrideFile"
             }
         }
     }
@@ -155,7 +162,7 @@ try {
 
         Write-Host "Re-generating listings"
         Invoke-Block {
-            & $PSScriptRoot\Export-API.ps1 -ServiceDirectory $ServiceDirectory -SDKType $SDKType -SpellCheckPublicApiSurface:$SpellCheckPublicApiSurface
+            & $PSScriptRoot\Export-API.ps1 -ServiceDirectory $ServiceDirectory -SDKType $SDKType -SpellCheckPublicApiSurface:$SpellCheckPublicApiSurface -ProjectListOverrideFile $scopedOverrideFile
         }
     }
     elseif ($ServiceDirectory -eq "tools") {

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -9,7 +9,9 @@ param (
     [Parameter(Mandatory=$true, ParameterSetName='PackagePath')]
     [string] $PackagePath,
     [Parameter(Mandatory=$true, ParameterSetName='PackagePath')]
-    [string] $SdkRepoPath
+    [string] $SdkRepoPath,
+
+    [string] $ProjectListOverrideFile = ""
 )
 
 if ($SpellCheckPublicApiSurface -and -not (Get-Command 'npx')) {
@@ -33,7 +35,14 @@ $debugLogging = $env:SYSTEM_DEBUG -eq "true"
 $logsFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 $diagnosticArguments = ($debugLogging -and $logsFolder) ? "/binarylogger:$logsFolder/exportapi.binlog" : ""
 
-Invoke-LoggedMsbuildCommand "dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope=`"$relativePackagePath`" /p:SDKType=$SDKType /restore $servicesProj $diagnosticArguments"
+# When a project list override file is supplied, scope the API export build to only those projects
+# instead of every package in the service directory ($(Scope) is then ignored for project selection).
+$projectListOverrideArgument = ""
+if ($ProjectListOverrideFile) {
+    $projectListOverrideArgument = "/p:ProjectListOverrideFile=`"$ProjectListOverrideFile`""
+}
+
+Invoke-LoggedMsbuildCommand "dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope=`"$relativePackagePath`" /p:SDKType=$SDKType $projectListOverrideArgument /restore $servicesProj $diagnosticArguments"
 
 # Normalize line endings to LF in generated API listing files
 Write-Host "Normalizing line endings in API listing files"

--- a/eng/scripts/tests/CodeChecks.Tests.ps1
+++ b/eng/scripts/tests/CodeChecks.Tests.ps1
@@ -677,3 +677,117 @@ Describe "Test-OnlyCiConfigChanged" -Tag "UnitTest" {
         }
     }
 }
+
+# ─────────────────────────────────────────────
+# Get-ScopedProjectListOverrideFile
+# ─────────────────────────────────────────────
+Describe "Get-ScopedProjectListOverrideFile" -Tag "UnitTest" {
+
+  BeforeAll {
+    # Writes a global override file shaped like the one set-artifact-packages.ps1 produces, and
+    # returns its repo-root-relative path (the form passed to the function in CI).
+    function New-GlobalOverride {
+        param([string] $RepoRoot, [string[]] $Includes)
+        $dir = Join-Path $RepoRoot "projlist"
+        New-Item -Path $dir -ItemType Directory -Force | Out-Null
+        $path = Join-Path $dir "packages_Project_0.props"
+        $lines = @('<Project>', '  <ItemGroup>')
+        foreach ($inc in $Includes) { $lines += "    <ProjectReference Include=`"$inc`" />" }
+        $lines += @('  </ItemGroup>', '</Project>')
+        Set-Content -Path $path -Value ($lines -join "`n") -Encoding utf8
+        return [System.IO.Path]::GetRelativePath($RepoRoot, $path)
+    }
+
+    function Get-ScopedIncludes {
+        param([string] $RepoRoot, [string] $RelativePath)
+        if (-not $RelativePath) { return @() }
+        [xml] $xml = Get-Content -Raw -Path (Join-Path $RepoRoot $RelativePath)
+        return @($xml.Project.ItemGroup.ProjectReference | ForEach-Object { $_.Include })
+    }
+  }
+
+    BeforeEach {
+        $script:repoRoot = Join-Path ([System.IO.Path]::GetTempPath()) "scoped-override-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -Path $script:repoRoot -ItemType Directory -Force | Out-Null
+    }
+
+    AfterEach {
+        if (Test-Path $script:repoRoot) { Remove-Item $script:repoRoot -Recurse -Force }
+    }
+
+    Context "fallback to whole-service regeneration (never drops a project)" {
+        It "returns empty when no override file is supplied" {
+            Get-ScopedProjectListOverrideFile -GlobalOverrideFile "" -ServiceDirectory "datafactory" -RepoRoot $script:repoRoot | Should -BeNullOrEmpty
+        }
+
+        It "returns empty for an unexpanded pipeline variable reference" {
+            Get-ScopedProjectListOverrideFile -GlobalOverrideFile '$(ProjectListOverrideFile)' -ServiceDirectory "datafactory" -RepoRoot $script:repoRoot | Should -BeNullOrEmpty
+        }
+
+        It "returns empty when the override file is missing" {
+            Get-ScopedProjectListOverrideFile -GlobalOverrideFile "projlist/does-not-exist.props" -ServiceDirectory "datafactory" -RepoRoot $script:repoRoot | Should -BeNullOrEmpty
+        }
+
+        It "returns empty when a changed service has no matching package (service-level shared file change)" {
+            $rel = New-GlobalOverride -RepoRoot $script:repoRoot -Includes @('$(RepoRoot)sdk/datafactory/Azure.Provisioning.DataFactory/**/*.csproj')
+            # 'storage' changed (e.g. a shared file) but no storage package is in the targeted set.
+            Get-ScopedProjectListOverrideFile -GlobalOverrideFile $rel -ServiceDirectory "storage" -RepoRoot $script:repoRoot | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "scoping to a single service" {
+        It "includes every changed package in the service and excludes other services" {
+            $rel = New-GlobalOverride -RepoRoot $script:repoRoot -Includes @(
+                '$(RepoRoot)sdk/datafactory/Azure.Provisioning.DataFactory/**/*.csproj',
+                '$(RepoRoot)sdk/datafactory/Azure.ResourceManager.DataFactory/**/*.csproj',
+                '$(RepoRoot)sdk/securitycenter/Azure.Provisioning.SecurityCenter/**/*.csproj'
+            )
+            $scoped = Get-ScopedIncludes -RepoRoot $script:repoRoot -RelativePath (Get-ScopedProjectListOverrideFile -GlobalOverrideFile $rel -ServiceDirectory "datafactory" -RepoRoot $script:repoRoot)
+            $scoped.Count | Should -Be 2
+            $scoped | Should -Contain '$(RepoRoot)sdk/datafactory/Azure.Provisioning.DataFactory/**/*.csproj'
+            $scoped | Should -Contain '$(RepoRoot)sdk/datafactory/Azure.ResourceManager.DataFactory/**/*.csproj'
+            $scoped | Should -Not -Contain '$(RepoRoot)sdk/securitycenter/Azure.Provisioning.SecurityCenter/**/*.csproj'
+        }
+
+        It "matches the service directory case-insensitively" {
+            $rel = New-GlobalOverride -RepoRoot $script:repoRoot -Includes @('$(RepoRoot)sdk/datafactory/Azure.Provisioning.DataFactory/**/*.csproj')
+            $scoped = Get-ScopedIncludes -RepoRoot $script:repoRoot -RelativePath (Get-ScopedProjectListOverrideFile -GlobalOverrideFile $rel -ServiceDirectory "DataFactory" -RepoRoot $script:repoRoot)
+            $scoped.Count | Should -Be 1
+        }
+
+        It "does not match a different service that shares a name prefix" {
+            $rel = New-GlobalOverride -RepoRoot $script:repoRoot -Includes @('$(RepoRoot)sdk/storagecache/Azure.ResourceManager.StorageCache/**/*.csproj')
+            # ServiceDirectory 'storage' must NOT match 'storagecache' (the trailing separator guards this).
+            Get-ScopedProjectListOverrideFile -GlobalOverrideFile $rel -ServiceDirectory "storage" -RepoRoot $script:repoRoot | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "no-drop coverage invariant across the whole batch" {
+        It "covers every changed project exactly once across all changed services" {
+            $allIncludes = @(
+                '$(RepoRoot)sdk/datafactory/Azure.Provisioning.DataFactory/**/*.csproj',
+                '$(RepoRoot)sdk/datafactory/Azure.ResourceManager.DataFactory/**/*.csproj',
+                '$(RepoRoot)sdk/securitycenter/Azure.Provisioning.SecurityCenter/**/*.csproj',
+                '$(RepoRoot)sdk/apimanagement/Azure.Provisioning.ApiManagement/**/*.csproj',
+                '$(RepoRoot)sdk/apimanagement/Azure.ResourceManager.ApiManagement/**/*.csproj'
+            )
+            $rel = New-GlobalOverride -RepoRoot $script:repoRoot -Includes $allIncludes
+            # ChangedServices is derived from the same package set, so it is exactly these services.
+            $changedServices = @('datafactory', 'securitycenter', 'apimanagement')
+
+            $covered = @()
+            foreach ($svc in $changedServices) {
+                $scopedFile = Get-ScopedProjectListOverrideFile -GlobalOverrideFile $rel -ServiceDirectory $svc -RepoRoot $script:repoRoot
+                # A service must always resolve to a concrete scoped file here (it has matching packages);
+                # an empty result would mean its packages fall back to whole-service regen (still covered),
+                # but for this batch every service has targeted packages, so assert it scoped.
+                $scopedFile | Should -Not -BeNullOrEmpty
+                $covered += Get-ScopedIncludes -RepoRoot $script:repoRoot -RelativePath $scopedFile
+            }
+
+            # Every changed project is regenerated, and none is regenerated twice.
+            ($covered | Sort-Object -Unique) | Should -Be ($allIncludes | Sort-Object -Unique)
+            $covered.Count | Should -Be $allIncludes.Count
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The analyze `Verify Generated Code` step (`eng/scripts/CodeChecks.ps1`) regenerates code per **service directory**, not per changed project. It invokes `service.proj /t:GenerateCode` with `/p:ProjectListOverrideFile=""`, which globs every package in the service directory.

Because of this, a change to a single package (e.g. `Azure.Provisioning.DataFactory`) also regenerates every co-located package in `sdk/datafactory/` — including the management-plane `Azure.ResourceManager.DataFactory`. After the recent AutoRest -> TypeSpec migration wave, those mgmt regenerations became multi-minute `tsp compile` operations.

This is invisible to the LOC-weighted analyze batching, which only counts the changed packages' source. Observed on PR #60388: a batch weighted at ~177k LOC ran **52 minutes**, dominated by `Verify Generated Code` (44 min) regenerating untouched co-located mgmt packages (DataFactory ~14.5 min, ApiManagement ~5 min, SecurityCenter ~3.3 min).

## Fix

Scope `GenerateCode` and `Export-API` to the **changed projects** using the `ProjectListOverrideFile` the analyze job already computes from `$(ProjectNames)` (via `set-artifact-packages`).

- `CodeChecks.Helpers.ps1`: new `Get-ScopedProjectListOverrideFile` that narrows the batch override file to the projects in the current service directory.
- `CodeChecks.ps1`: threads the scoped override into `GenerateCode` and `Export-API`.
- `Export-API.ps1`: accepts `-ProjectListOverrideFile` and passes it to the `ExportApi` build.
- `analyze.yml`: passes `$(ProjectListOverrideFile)` to `CodeChecks.ps1`.

## No-drop guarantee

A changed project is **never** silently skipped:
- The override file and `$(ChangedServices)` are both derived from the same `$(ProjectNames)`-filtered package set, so they are consistent.
- The per-service filter keys on the shared `sdk/<service>/` prefix, so it matches all of a service's changed packages or none.
- When none match (e.g. a service-level shared file changed with no targeted package), it falls back to whole-service regeneration. Worst case is over-regeneration, never under.

## Validation

- 8 new Pester tests in `eng/scripts/tests/CodeChecks.Tests.ps1`, including a no-drop coverage invariant and a prefix-collision guard (`storage` vs `storagecache`). Full suite: 70/70 pass.
- MSBuild `-getItem:ProjectReference` proof: a change in `storage` selects 17 packages today vs only `Azure.Storage.Queues` with the scoped override.

## Behavior change

The verify step no longer regenerates **unchanged** siblings, so it will not catch pre-existing drift in a package the PR did not touch. That is by design; full-repo CI on merge still validates everything.

A companion `test/*` PR replicating PR #60388's changes targets this branch to validate the analyze wall-clock improvement end to end.