### PR TITLE
Add provisioning model customization hook

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningModelProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningModelProvider.cs
@@ -190,7 +190,7 @@ namespace Azure.Generator.Provisioning.Providers
 
             var method = new MethodProvider(
                 new MethodSignature(
-                        "DefineProvisionableProperties",
+                    "DefineProvisionableProperties",
                     $"Define all the provisionable properties for {Name}.",
                     MethodSignatureModifiers.Protected | MethodSignatureModifiers.Override,
                     null,

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningModelProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningModelProvider.cs
@@ -186,9 +186,11 @@ namespace Azure.Generator.Provisioning.Providers
                 ).Terminate());
             }
 
+            statements.Add(This.Invoke("DefineAdditionalProperties").Terminate());
+
             var method = new MethodProvider(
                 new MethodSignature(
-                    "DefineProvisionableProperties",
+                        "DefineProvisionableProperties",
                     $"Define all the provisionable properties for {Name}.",
                     MethodSignatureModifiers.Protected | MethodSignatureModifiers.Override,
                     null,
@@ -197,7 +199,20 @@ namespace Azure.Generator.Provisioning.Providers
                 statements,
                 this);
 
-            return [method];
+            return [method, BuildDefineAdditionalPropertiesMethod()];
+        }
+
+        private MethodProvider BuildDefineAdditionalPropertiesMethod()
+        {
+            var sig = new MethodSignature(
+                "DefineAdditionalProperties",
+                $"Define additional provisionable properties for {Name} that are not part of the generated code.",
+                MethodSignatureModifiers.Partial,
+                null,
+                null,
+                []);
+
+            return new MethodProvider(sig, this);
         }
 
         protected override TypeProvider[] BuildSerializationProviders()

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/BackupPolicy.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/BackupPolicy.cs
@@ -60,6 +60,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             base.DefineProvisionableProperties();
             _retentionDays = DefineProperty<int>(nameof(RetentionDays), new string[] { "retentionDays" });
             _isEnabled = DefineProperty<bool>(nameof(IsEnabled), new string[] { "isEnabled" });
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for BackupPolicy that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ConfigurationStoreProperties.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ConfigurationStoreProperties.cs
@@ -214,6 +214,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             _skuTier = DefineProperty<ConfigurationStoreSkuTier>(nameof(SkuTier), new string[] { "skuTier" });
             _createMode = DefineProperty<ConfigurationStoreCreateMode>(nameof(CreateMode), new string[] { "createMode" });
             _linkedResources = DefineListProperty<SubResource>(nameof(LinkedResources), new string[] { "linkedResources" });
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for ConfigurationStoreProperties that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ConfigurationStoreSku.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ConfigurationStoreSku.cs
@@ -40,6 +40,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         {
             base.DefineProvisionableProperties();
             _name = DefineProperty<string>(nameof(Name), new string[] { "name" }, isRequired: true);
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for ConfigurationStoreSku that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ContinuousBackupPolicy.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ContinuousBackupPolicy.cs
@@ -40,6 +40,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             base.DefineProvisionableProperties();
             DefineProperty<string>("kind", new string[] { "kind" }, defaultValue: "Continuous");
             _tier = DefineProperty<string>(nameof(Tier), new string[] { "tier" });
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for ContinuousBackupPolicy that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ExtensionAssignmentProperties.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ExtensionAssignmentProperties.cs
@@ -40,6 +40,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         {
             base.DefineProvisionableProperties();
             _displayName = DefineProperty<string>(nameof(DisplayName), new string[] { "displayName" });
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for ExtensionAssignmentProperties that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ItemAttributes.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ItemAttributes.cs
@@ -82,6 +82,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             _enabled = DefineProperty<bool>(nameof(Enabled), new string[] { "enabled" });
             _created = DefineProperty<DateTimeOffset>(nameof(Created), new string[] { "created" }, isOutput: true);
             _updated = DefineProperty<DateTimeOffset>(nameof(Updated), new string[] { "updated" }, isOutput: true);
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for ItemAttributes that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ItemProperties.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ItemProperties.cs
@@ -91,6 +91,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             _contentType = DefineProperty<string>(nameof(ContentType), new string[] { "contentType" });
             _nullableValue = DefineProperty<string>(nameof(NullableValue), new string[] { "nullableValue" });
             _attributes = DefineModelProperty<ItemAttributes>(nameof(Attributes), new string[] { "attributes" });
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for ItemProperties that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/KeyValueProperties.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/KeyValueProperties.cs
@@ -57,6 +57,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             base.DefineProvisionableProperties();
             _value = DefineProperty<string>(nameof(Value), new string[] { "value" });
             _contentType = DefineProperty<string>(nameof(ContentType), new string[] { "contentType" });
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for KeyValueProperties that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/PeriodicBackupPolicy.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/PeriodicBackupPolicy.cs
@@ -40,6 +40,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             base.DefineProvisionableProperties();
             DefineProperty<string>("kind", new string[] { "kind" }, defaultValue: "Periodic");
             _intervalInHours = DefineProperty<int>(nameof(IntervalInHours), new string[] { "intervalInHours" }, isRequired: true);
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for PeriodicBackupPolicy that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ProfileProperties.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ProfileProperties.cs
@@ -74,6 +74,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             base.DefineProvisionableProperties();
             _description = DefineProperty<string>(nameof(Description), new string[] { "description" });
             _sku = DefineModelProperty<ProfileSku>(nameof(Sku), new string[] { "sku" });
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for ProfileProperties that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ProfileSku.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ProfileSku.cs
@@ -40,6 +40,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         {
             base.DefineProvisionableProperties();
             _name = DefineProperty<string>(nameof(Name), new string[] { "name" }, isRequired: true);
+            DefineAdditionalProperties();
         }
+
+        /// <summary> Define additional provisionable properties for ProfileSku that are not part of the generated code. </summary>
+        partial void DefineAdditionalProperties();
     }
 }


### PR DESCRIPTION
Adds a DefineAdditionalProperties partial hook for generated provisioning model types, matching the existing resource customization hook. This allows flattened compatibility shims to register inside model/envelope types instead of at the parent resource level.