### PR TITLE
Fix flatten targets for projected provisioning resources

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -83,9 +83,30 @@ namespace Azure.Generator.Management
         private IReadOnlyDictionary<ModelProvider, HashSet<PropertyProvider>>? _outputFlattenPropertyMap;
         internal IReadOnlyDictionary<ModelProvider, HashSet<PropertyProvider>> OutputFlattenPropertyMap => _outputFlattenPropertyMap ??= BuildOutputFlattenPropertyMap();
         private IReadOnlyDictionary<ModelProvider, HashSet<PropertyProvider>> BuildOutputFlattenPropertyMap()
-            => ManagementClientGenerator.Instance.InputLibrary.FlattenPropertyMap.ToDictionary(
-                kv => ManagementClientGenerator.Instance.TypeFactory.CreateModel(kv.Key)!,
-                kv => kv.Value.Select(p => ManagementClientGenerator.Instance.TypeFactory.CreateProperty(p, ManagementClientGenerator.Instance.TypeFactory.CreateModel(kv.Key)!)!).ToHashSet());
+        {
+            Dictionary<ModelProvider, HashSet<PropertyProvider>> result = [];
+            foreach (var (inputModel, flattenedProperties) in ManagementClientGenerator.Instance.InputLibrary.FlattenPropertyMap)
+            {
+                foreach (var model in ResolveFlattenTargetModels(inputModel))
+                {
+                    result[model] = flattenedProperties
+                        .Select(p => ManagementClientGenerator.Instance.TypeFactory.CreateProperty(p, model)!)
+                        .ToHashSet();
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Resolves output model providers that should receive flattenProperty customizations for an input model.
+        /// </summary>
+        /// <param name="inputModel">The input model that owns the decorated flattened properties.</param>
+        /// <returns>The output model providers that represent the input model.</returns>
+        protected virtual IReadOnlyList<ModelProvider> ResolveFlattenTargetModels(InputModelType inputModel)
+        {
+            var model = ManagementClientGenerator.Instance.TypeFactory.CreateModel(inputModel);
+            return model is null ? [] : [model];
+        }
 
         private HashSet<ModelProvider>? _safeFlattenDisabledModels;
         /// <summary>

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Azure.Generator.Provisioning.csproj
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Azure.Generator.Provisioning.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Generator" />
-    <PackageReference Include="Azure.Generator.Management" />
+    <ProjectReference Include="..\..\..\..\http-client-csharp-mgmt\generator\Azure.Generator.Management\src\Azure.Generator.Management.csproj" />
     <!-- Reference Azure.Provisioning for runtime types (ProvisionableConstruct, BicepValue<T>, etc.) -->
     <PackageReference Include="Azure.Provisioning" />
   </ItemGroup>

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
@@ -115,6 +115,14 @@ namespace Azure.Generator.Provisioning
         }
 
         /// <inheritdoc/>
+        protected override IReadOnlyList<ModelProvider> ResolveFlattenTargetModels(InputModelType inputModel)
+        {
+            return TryGetResourcesByModel(inputModel, out var resources)
+                ? resources
+                : base.ResolveFlattenTargetModels(inputModel);
+        }
+
+        /// <inheritdoc/>
         protected override TypeProvider[] BuildTypeProviders()
         {
             // TODO: Ideally we should call base.BuildTypeProviders() and filter the results


### PR DESCRIPTION
Fixes the provisioning generator flatten-property target mapping for cases where one input model is projected into multiple provisioning resource providers.

`ManagementOutputLibrary` now lets derived generators resolve all output model providers that should receive a `flattenProperty` customization for a given input model. The provisioning generator overrides that hook to return every projected resource provider for the shared model, so synthesized resource variants preserve flattened properties consistently.

Related to #60441.