### PR TITLE
[SecurityCenter] Finalize CHANGELOG for 1.2.0-beta.8 release

### DIFF
--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/CHANGELOG.md
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.2.0-beta.8 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.0-beta.8 (2026-06-30)
 
 ### Other Changes
 


### PR DESCRIPTION
Finalizes the CHANGELOG entry for `Azure.ResourceManager.SecurityCenter` `1.2.0-beta.8` so the release pipeline's **Verify ChangeLogEntry** gate passes.

### What changed
- Set the release date: `## 1.2.0-beta.8 (Unreleased)` -> `## 1.2.0-beta.8 (2026-06-30)`
- Removed the empty `Features Added`, `Breaking Changes`, and `Bugs Fixed` sections (kept `Other Changes`).

### Why
Releasing 1.2.0-beta.8 (release plan 2226) failed at the changelog validation gate in pipeline `net - securitycenter - mgmt` (build [6499141](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6499141)):
> Entry has no release date set... / sections with no content (Breaking Changes, Features Added, Bugs Fixed)

The NuGet publish step was skipped, so nothing was published. Once this merges, the release pipeline will be re-run and the publish approved.

Follow-up to #59180.