### PR TITLE
Add diagnostic logging for silent Vote=None paths in ServiceBusScaleMonitor

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMetricsProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMetricsProvider.cs
@@ -184,7 +184,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
             }
 
             // Path for connection strings with no manage claim
-            return CreateTriggerMetrics(activeMessage, 0, 0, 0, _isListeningOnDeadLetterQueue);
+            var fallbackMetrics = CreateTriggerMetrics(activeMessage, 0, 0, 0, _isListeningOnDeadLetterQueue);
+            _logger.LogInformation($"Fallback metrics for '{_entityPath}': MessageCount={fallbackMetrics.MessageCount}, QueueTime={fallbackMetrics.QueueTime.TotalSeconds:F1}s, PartitionCount={fallbackMetrics.PartitionCount}");
+            return fallbackMetrics;
         }
 
         private async Task<ServiceBusTriggerMetrics> GetQueueMetricsAsync(ServiceBusReceivedMessage message)
@@ -204,7 +206,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
             queueProperties = await _administrationClient.Value.GetQueueAsync(_mainQueueName).ConfigureAwait(false);
             partitionCount = queueProperties.EnablePartitioning ? 16 : 0;
 
-            return CreateTriggerMetrics(message, activeMessageCount, deadLetterCount, partitionCount, _isListeningOnDeadLetterQueue);
+            var metrics = CreateTriggerMetrics(message, activeMessageCount, deadLetterCount, partitionCount, _isListeningOnDeadLetterQueue);
+            _logger.LogInformation($"Metrics for '{_entityPath}': MessageCount={metrics.MessageCount}, QueueTime={metrics.QueueTime.TotalSeconds:F1}s, PartitionCount={metrics.PartitionCount}");
+            return metrics;
         }
 
         private async Task<ServiceBusTriggerMetrics> GetTopicMetricsAsync(ServiceBusReceivedMessage message)
@@ -224,7 +228,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
             topicProperties = await _administrationClient.Value.GetTopicAsync(_topicName).ConfigureAwait(false);
             partitionCount = topicProperties.EnablePartitioning ? 16 : 0;
 
-            return CreateTriggerMetrics(message, activeMessageCount, deadLetterCount, partitionCount, _isListeningOnDeadLetterQueue);
+            var metrics = CreateTriggerMetrics(message, activeMessageCount, deadLetterCount, partitionCount, _isListeningOnDeadLetterQueue);
+            _logger.LogInformation($"Metrics for '{_entityPath}': MessageCount={metrics.MessageCount}, QueueTime={metrics.QueueTime.TotalSeconds:F1}s, PartitionCount={metrics.PartitionCount}");
+            return metrics;
         }
 
         private bool TimeToLogWarning()

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusScaleMonitor.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusScaleMonitor.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             // Unable to determine the correct vote with no metrics.
             if (metrics == null || metrics.Length == 0)
             {
+                _logger.LogWarning($"No metrics available for Service Bus entity '{_entityPath}'. Voting to not scale.");
                 return status;
             }
 
@@ -100,6 +101,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             // At least 5 samples are required to make a scale decision for the rest of the checks.
             if (metrics.Length < NumberOfSamplesToConsider)
             {
+                _logger.LogWarning($"Insufficient metrics samples for Service Bus entity '{_entityPath}' ({metrics.Length}/{NumberOfSamplesToConsider}). Voting to not scale.");
                 return status;
             }
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -557,9 +557,19 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             var status = _scaleMonitor.GetScaleStatus(context);
             Assert.AreEqual(ScaleVote.None, status.Vote);
 
+            var logs = _loggerProvider.GetAllLogMessages().ToArray();
+            var log = logs.Single(l => l.Level == LogLevel.Warning);
+            Assert.AreEqual($"No metrics available for Service Bus entity '{_entityPath}'. Voting to not scale.", log.FormattedMessage);
+
+            _loggerProvider.ClearAllLogMessages();
+
             // verify the non-generic implementation works properly
             status = ((IScaleMonitor)_scaleMonitor).GetScaleStatus(context);
             Assert.AreEqual(ScaleVote.None, status.Vote);
+
+            logs = _loggerProvider.GetAllLogMessages().ToArray();
+            log = logs.Single(l => l.Level == LogLevel.Warning);
+            Assert.AreEqual($"No metrics available for Service Bus entity '{_entityPath}'. Voting to not scale.", log.FormattedMessage);
         }
 
         [Test]
@@ -848,6 +858,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
 
             var status = _scaleMonitor.GetScaleStatus(context);
             Assert.AreEqual(ScaleVote.None, status.Vote);
+
+            var logs = _loggerProvider.GetAllLogMessages().ToArray();
+            var log = logs.Single(l => l.Level == LogLevel.Warning);
+            Assert.AreEqual($"Insufficient metrics samples for Service Bus entity '{_entityPath}' (2/5). Voting to not scale.", log.FormattedMessage);
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds diagnostic logging to previously-silent Vote=None code paths in ServiceBusScaleMonitor and adds metric value logging to ServiceBusMetricsProvider.

## Problem
When a ServiceBus connection string lacks the Manage claim, the reactive scale monitor's `GetMetricsAsync` falls back to a no-manage-claim path. However, the scale status evaluation has two early-return paths that silently return `Vote=None` with no logging:
1. When metrics are null/empty
2. When the sample count is below the 5-sample threshold

These silent paths made it impossible to diagnose why workers were being held indefinitely (ICM 726023336: 20 workers held ~6 days for idle ServiceBus app).

## Changes
- **ServiceBusScaleMonitor.cs**: Added `LogWarning` to both silent `Vote=None` early-return paths (null/empty metrics and insufficient samples)
- **ServiceBusMetricsProvider.cs**: Added `LogInformation` for collected metric values in `GetQueueMetricsAsync`, `GetTopicMetricsAsync`, and fallback path
- **ServiceBusScaleMonitorTests.cs**: Updated tests to assert on new warning log messages

## Design Decision
The `throw;` in `GetMessageCountAsync`'s `UnauthorizedAccessException` handler is intentionally preserved. `GetMessageCountAsync` is only called by `ServiceBusTargetScaler`, which catches `UnauthorizedAccessException` to signal that target-based scaling is not supported (falling back to reactive scaling). Removing the re-throw would silently return 0 to the target scaler, potentially scaling to zero instances.

## Testing
All 50 ServiceBusScaleMonitorTests pass.

Fixes: AB#37023212