### PR TITLE
Migrate docindex to GitHub App auth (AuthToken: '')

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -121,6 +121,7 @@ jobs:
             TargetRepoName: $(DocRepoName)
             TargetRepoOwner: $(DocRepoOwner)
             WorkingDirectory: $(DocRepoLocation)
+            AuthToken: ''
 
         - task: AzureCLI@2
           displayName: Queue Docs CI build for main branch
@@ -216,6 +217,7 @@ jobs:
             WorkingDirectory: $(DocRepoLocation)
             ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts
             PushArgs: -f
+            AuthToken: ''
 
         - task: AzureCLI@2
           displayName: Queue Docs CI build


### PR DESCRIPTION
## Summary

Migrates the docindex pipeline away from PAT (`azuresdk-github-pat`) usage by setting `AuthToken: ''` on both `git-push-changes.yml` usages in `eng/pipelines/docindex.yml`.

With `AuthToken: ''`, `git-push-changes.yml` invokes `login-to-github.yml` to obtain a GitHub App token (scoped to `$(DocRepoOwner)`) for pushing docs-repo updates, instead of using the shared PAT. This matches the pattern already adopted in the Java, JS, and Python repos.

## Changes
- `eng/pipelines/docindex.yml`: add `AuthToken: ''` to the main-branch docs push and the daily-docs push.

## Notes
- No behavioral change beyond the auth mechanism; the docs-repo checkout is public and unchanged.