### PR TITLE
Refresh provisioning inventory after Search migration

### DIFF
--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -1,6 +1,6 @@
 # Azure SDK for .NET Libraries Inventory
 
-> **Auto-generated** by `Library_Inventory` on 2026-06-30 10:42:28 UTC.
+> **Auto-generated** by `Library_Inventory` on 2026-07-01 09:50:54 UTC.
 > Run that script to refresh this file.
 
 ## Table of Contents
@@ -26,8 +26,8 @@
   - New Emitter (TypeSpec): 45
   - Old TypeSpec: 2
 - Provisioning: 44
-  - Reflection-based generator: 33
-  - TypeSpec-based generator: 9
+  - Reflection-based generator: 32
+  - TypeSpec-based generator: 10
   - No generator: 2
 - No generator: 47
 
@@ -396,7 +396,7 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 47
 
 Libraries that provide infrastructure-as-code capabilities for Azure services. These libraries allow you to declaratively specify Azure infrastructure natively in .NET and generate Bicep templates for deployment.
 
-**Migration Status**: 9 / 44 migrated to TypeSpec-based generator
+**Migration Status**: 10 / 44 migrated to TypeSpec-based generator
 
 | Service | Library | Mgmt Peer Library | Generator |
 | ------- | ------- | ----------------- | --------- |
@@ -435,7 +435,7 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 | redis | Azure.Provisioning.Redis | Azure.ResourceManager.Redis ✅ | Reflection |
 | redisenterprise | Azure.Provisioning.RedisEnterprise | Azure.ResourceManager.RedisEnterprise ✅ | Reflection |
 | resourcegraph | Azure.Provisioning.ResourceGraph | Azure.ResourceManager.ResourceGraph ✅ | Reflection |
-| search | Azure.Provisioning.Search | Azure.ResourceManager.Search ✅ | Reflection |
+| search | Azure.Provisioning.Search | Azure.ResourceManager.Search ✅ | TypeSpec ✅ |
 | securitycenter | Azure.Provisioning.SecurityCenter | Azure.ResourceManager.SecurityCenter ✅ | Reflection |
 | servicebus | Azure.Provisioning.ServiceBus | Azure.ResourceManager.ServiceBus ✅ | Reflection |
 | servicenetworking | Azure.Provisioning.ServiceNetworking | Azure.ResourceManager.ServiceNetworking ✅ | TypeSpec ✅ |


### PR DESCRIPTION
Refreshes `doc/GeneratorMigration/Library_Inventory.md` after the Search provisioning migration.

Highlights:
- TypeSpec-based provisioning libraries increased to 10.
- Reflection-based provisioning libraries decreased to 32.
- `Azure.Provisioning.Search` is now reflected as TypeSpec-based.

Also updated migration milestone issue #57387 to mark Search as migrated.