### PR TITLE
Add CPM-007 check for inline PackageVersion items

### DIFF
--- a/eng/scripts/Validate-CpmCompliance.ps1
+++ b/eng/scripts/Validate-CpmCompliance.ps1
@@ -206,7 +206,7 @@ if (Test-Path $overrideDir) {
 LogInfo "Checking for PackageVersion items outside central package management"
 
 $packageVersionFiles = $allFiles |
-    Select-String -Pattern '<PackageVersion\s+Include' |
+    Select-String -Pattern '<PackageVersion\s+[^>]*\bInclude\b' |
     Select-Object -ExpandProperty Path -Unique
 
 foreach ($file in $packageVersionFiles) {

--- a/eng/scripts/Validate-CpmCompliance.ps1
+++ b/eng/scripts/Validate-CpmCompliance.ps1
@@ -10,6 +10,7 @@
       4. Rogue Directory.Packages.props files outside approved locations
       5. DirectoryPackagesPropsPath redirects outside the root Directory.Build.props
       6. Override files with incorrect casing (must be *.Packages.props)
+      7. PackageVersion items defined outside central package management
 
     Requires either -ServiceDirectory or -PackagePath to scope the scan.
 #>
@@ -197,6 +198,23 @@ if (Test-Path $overrideDir) {
             LogError "CPM-006: Override file has incorrect casing (expected *.Packages.props): $($file.Name)"
         }
     }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Check 7: PackageVersion items defined outside central package management
+# ─────────────────────────────────────────────────────────────────────────────
+LogInfo "Checking for PackageVersion items outside central package management"
+
+$packageVersionFiles = $allFiles |
+    Select-String -Pattern '<PackageVersion\s+Include' |
+    Select-Object -ExpandProperty Path -Unique
+
+foreach ($file in $packageVersionFiles) {
+    $rel = Get-RelativePath $file
+    if ($rel -like 'eng/centralpackagemanagement/*' -or (Test-IsAllowlisted $rel)) {
+        continue
+    }
+    LogError "CPM-007: PackageVersion item defined outside central package management in: $rel"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/eng/scripts/tests/Validate-CpmCompliance.tests.ps1
+++ b/eng/scripts/tests/Validate-CpmCompliance.tests.ps1
@@ -17,7 +17,7 @@ Then invoke tests with:
 . (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "Helpers" PSModule-Helpers.ps1)
 Install-ModuleIfNotInstalled "Pester" "5.3.3" | Import-Module
 
-Describe "Validate-CpmCompliance CPM-007" {
+Describe "Validate-CpmCompliance CPM-007" -Tag "UnitTest" {
     BeforeAll {
         $scriptPath = Join-Path $PSScriptRoot ".." "Validate-CpmCompliance.ps1"
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot ".." ".." "..")).Path.TrimEnd('\', '/')

--- a/eng/scripts/tests/Validate-CpmCompliance.tests.ps1
+++ b/eng/scripts/tests/Validate-CpmCompliance.tests.ps1
@@ -1,0 +1,106 @@
+#Requires -Version 7.0
+<#
+.How-To-Run
+This test file uses Pester, a testing framework for PowerShell.
+For more information about Pester, see: https://pester.dev/docs/quick-start
+
+First, ensure you have `pester` installed:
+
+`Install-Module Pester -Force`
+
+Then invoke tests with:
+
+`Invoke-Pester ./Validate-CpmCompliance.tests.ps1`
+
+#>
+
+. (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "Helpers" PSModule-Helpers.ps1)
+Install-ModuleIfNotInstalled "Pester" "5.3.3" | Import-Module
+
+Describe "Validate-CpmCompliance CPM-007" {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot ".." "Validate-CpmCompliance.ps1"
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot ".." ".." "..")).Path.TrimEnd('\', '/')
+
+        # Fixtures must live under the repo root so the script's Get-RelativePath works,
+        # and outside the artifacts/bin/obj folders that the scan excludes.
+        $fixtureName = ".cpm-compliance-tests-$([Guid]::NewGuid().ToString('N'))"
+        $fixtureRoot = Join-Path $repoRoot $fixtureName
+
+        function New-Fixture([string]$RelativeSubPath, [string]$FileName, [string]$Content) {
+            $dir = Join-Path $fixtureRoot $RelativeSubPath
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $dir $FileName) -Value $Content -NoNewline
+        }
+
+        New-Fixture "flag/src" "Test.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+  </ItemGroup>
+</Project>
+'@
+
+        New-Fixture "noflag/src" "Test.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" />
+  </ItemGroup>
+</Project>
+'@
+
+        New-Fixture "property/src" "Test.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageVersion>1.0.0-beta.1</PackageVersion>
+  </PropertyGroup>
+</Project>
+'@
+
+        New-Fixture "samplesopt/samples" "Sample.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>
+'@
+
+        function Invoke-Validator([string]$PackageRelativePath) {
+            $output = & $scriptPath -PackagePath (Join-Path $fixtureName $PackageRelativePath) *>&1
+            return [pscustomobject]@{
+                ExitCode = $LASTEXITCODE
+                Output   = ($output | Out-String)
+            }
+        }
+    }
+
+    AfterAll {
+        if (Test-Path $fixtureRoot) {
+            Remove-Item $fixtureRoot -Recurse -Force
+        }
+    }
+
+    It "flags an inline PackageVersion item in a csproj" {
+        $result = Invoke-Validator "flag"
+        $result.ExitCode | Should -Be 1
+        $result.Output | Should -Match 'CPM-007'
+    }
+
+    It "does not flag a PackageReference without a version" {
+        $result = Invoke-Validator "noflag"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Not -Match 'CPM-007'
+    }
+
+    It "does not flag the PackageVersion property form" {
+        $result = Invoke-Validator "property"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Not -Match 'CPM-007'
+    }
+
+    It "does not flag PackageVersion items under samples" {
+        $result = Invoke-Validator "samplesopt"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Not -Match 'CPM-007'
+    }
+}

--- a/eng/scripts/tests/Validate-CpmCompliance.tests.ps1
+++ b/eng/scripts/tests/Validate-CpmCompliance.tests.ps1
@@ -65,6 +65,14 @@ Describe "Validate-CpmCompliance CPM-007" {
 </Project>
 '@
 
+        New-Fixture "reordered/src" "Test.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageVersion Condition="'$(Foo)' == 'true'" Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+  </ItemGroup>
+</Project>
+'@
+
         function Invoke-Validator([string]$PackageRelativePath) {
             $output = & $scriptPath -PackagePath (Join-Path $fixtureName $PackageRelativePath) *>&1
             return [pscustomobject]@{
@@ -102,5 +110,11 @@ Describe "Validate-CpmCompliance CPM-007" {
         $result = Invoke-Validator "samplesopt"
         $result.ExitCode | Should -Be 0
         $result.Output | Should -Not -Match 'CPM-007'
+    }
+
+    It "flags a PackageVersion item where Include is not the first attribute" {
+        $result = Invoke-Validator "reordered"
+        $result.ExitCode | Should -Be 1
+        $result.Output | Should -Match 'CPM-007'
     }
 }


### PR DESCRIPTION
## Summary

Extends `eng/scripts/Validate-CpmCompliance.ps1` with a new **Check 7 (CPM-007)** that flags inline `<PackageVersion Include="..." Version="..." />` items defined outside Central Package Management.

### Background
The CPM compliance validator already runs in `eng/pipelines/templates/steps/analyze.yml`, but its existing six checks never inspected inline `PackageVersion` *items* in a `.csproj`/`.props` file. As a result, a package that declares its own `<PackageVersion>` inline (instead of using the central `eng/centralpackagemanagement` files/overrides) passes the Analyze stage cleanly. This gap surfaced in review of PR #59730, where the Analyze check stayed green despite an inline `PackageVersion` in a src `.csproj`.

### What CPM-007 does
- Flags `<PackageVersion Include=...>` items found in any scanned file.
- Skips `eng/centralpackagemanagement/*` (the legitimate home for package versions) and the existing opt-out allowlist (`samples/`, `doc/ApiDocGeneration/`).
- Matches the CPM **item** form only (`<PackageVersion\s+Include`), so the MSBuild `<PackageVersion>1.0.0</PackageVersion>` *property* form and versionless `<PackageReference>` are not affected.

### Tests
Adds `eng/scripts/tests/Validate-CpmCompliance.tests.ps1` (Pester), covering:
- flags an inline `PackageVersion` item (exit 1, CPM-007)
- ignores a versionless `PackageReference`
- ignores the `PackageVersion` property form
- respects the `samples/` allowlist

All 4 tests pass. Ran the validator against `core`, `storage`, `identity`, and `template` service directories with no false positives.