### PR TITLE
Migrate ClientConstructorAnalyzer (AZC0005-0007, AZC0021) in-repo and fix storage false positives

### DIFF
--- a/sdk/tools/Azure.SdkAnalyzers/src/ClientConstructorAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ClientConstructorAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Azure.SdkAnalyzers
         public override void Analyze(SymbolAnalysisContext context)
         {
             var type = (INamedTypeSymbol)context.Symbol;
-            if (type.TypeKind != TypeKind.Class || !type.Name.EndsWith(ClientSuffix, StringComparison.Ordinal) || type.DeclaredAccessibility != Accessibility.Public)
+            if (type.TypeKind != TypeKind.Class || !type.Name.EndsWith(ClientSuffix, StringComparison.Ordinal) || !IsPubliclyAccessible(type))
             {
                 return;
             }
@@ -96,6 +96,19 @@ namespace Azure.SdkAnalyzers
                     }
                 }
             }
+        }
+
+        private static bool IsPubliclyAccessible(INamedTypeSymbol type)
+        {
+            for (INamedTypeSymbol current = type; current != null; current = current.ContainingType)
+            {
+                if (current.DeclaredAccessibility != Accessibility.Public)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool IsClientOptionsParameter(IParameterSymbol symbol)

--- a/sdk/tools/Azure.SdkAnalyzers/src/ClientConstructorAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ClientConstructorAnalyzer.cs
@@ -205,7 +205,10 @@ namespace Azure.SdkAnalyzers
                             return false;
                         }
 
-                        if (!namedX.MetadataName.Equals(namedY.MetadataName) || namedX.TypeArguments.Length != namedY.TypeArguments.Length)
+                        // Compare the generic type definitions by full symbol identity (namespace,
+                        // containing type, assembly) rather than metadata name + arity, which would
+                        // conflate same-named generics from different namespaces/assemblies.
+                        if (!SymbolEqualityComparer.Default.Equals(namedX.OriginalDefinition, namedY.OriginalDefinition) || namedX.TypeArguments.Length != namedY.TypeArguments.Length)
                         {
                             return false;
                         }

--- a/sdk/tools/Azure.SdkAnalyzers/src/ClientConstructorAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ClientConstructorAnalyzer.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.SdkAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ClientConstructorAnalyzer : SymbolAnalyzerBase
+    {
+        private const string ClientSuffix = "Client";
+        private const string ClientOptionsSuffix = "ClientOptions";
+        private const string ClientsOptionsSuffix = "ClientsOptions";
+        private const string AzureCoreClientOptions = "Azure.Core.ClientOptions";
+        private const string SystemClientModelClientSettings = "System.ClientModel.Primitives.ClientSettings";
+
+        public override SymbolKind[] SymbolKinds { get; } = new[] { SymbolKind.NamedType };
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+            Descriptors.AZC0005,
+            Descriptors.AZC0006,
+            Descriptors.AZC0007,
+            Descriptors.AZC0021);
+
+        public override void Analyze(SymbolAnalysisContext context)
+        {
+            var type = (INamedTypeSymbol)context.Symbol;
+            if (type.TypeKind != TypeKind.Class || !type.Name.EndsWith(ClientSuffix, StringComparison.Ordinal) || type.DeclaredAccessibility != Accessibility.Public)
+            {
+                return;
+            }
+
+            if (!type.Constructors.Any(c => (c.DeclaredAccessibility == Accessibility.Protected || c.DeclaredAccessibility == Accessibility.Public) && c.Parameters.Length == 0))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0005, type.Locations.First()));
+            }
+
+            foreach (var constructor in type.Constructors)
+            {
+                if (constructor.DeclaredAccessibility != Accessibility.Public)
+                {
+                    continue;
+                }
+
+                var lastParameter = constructor.Parameters.LastOrDefault();
+
+                // Check if any parameter is ClientSettings - it should only be used alone
+                if (constructor.Parameters.Any(IsClientSettingsParameter) && constructor.Parameters.Length > 1)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0021, constructor.Locations.First()));
+                    continue;
+                }
+
+                // A client constructed from another client (a sub-client, e.g. a lease client) inherits its
+                // configuration from that client, so it legitimately has no service-connection or options overload.
+                if (constructor.Parameters.Any(IsClientParameter))
+                {
+                    continue;
+                }
+
+                if (IsClientOptionsParameter(lastParameter))
+                {
+                    // Allow optional options parameters
+                    if (lastParameter.IsOptional)
+                    {
+                        continue;
+                    }
+
+                    // When there are static properties in client, there would be static constructor implicitly added
+                    var nonOptionsMethod = FindMethod(
+                        type.Constructors, constructor.TypeParameters, constructor.Parameters.RemoveAt(constructor.Parameters.Length - 1), true);
+
+                    if (nonOptionsMethod == null || nonOptionsMethod.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0006, constructor.Locations.First()));
+                    }
+                }
+                else if (IsClientSettingsParameter(lastParameter))
+                {
+                    // Allow constructors ending with a ClientSettings parameter without requiring a ClientOptions overload.
+                    continue;
+                }
+                else
+                {
+                    var optionsMethod = FindMethod(
+                        type.Constructors, constructor.TypeParameters, constructor.Parameters, IsClientOptionsParameter);
+
+                    if (optionsMethod == null || optionsMethod.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0007, constructor.Locations.First()));
+                    }
+                }
+            }
+        }
+
+        private static bool IsClientOptionsParameter(IParameterSymbol symbol)
+            => symbol != null && IsClientOptionsType(symbol.Type);
+
+        private static bool IsClientSettingsParameter(IParameterSymbol symbol)
+            => symbol != null && IsClientSettingsType(symbol.Type);
+
+        private static bool IsClientParameter(IParameterSymbol symbol)
+        {
+            return symbol.Type is INamedTypeSymbol named
+                && named.TypeKind == TypeKind.Class
+                && named.Name.EndsWith(ClientSuffix, StringComparison.Ordinal)
+                && TopLevelNamespace(named) != "System";
+        }
+
+        private static string TopLevelNamespace(ITypeSymbol type)
+        {
+            string name = null;
+            for (INamespaceSymbol ns = type.ContainingNamespace; ns != null && !ns.IsGlobalNamespace; ns = ns.ContainingNamespace)
+            {
+                name = ns.Name;
+            }
+
+            return name;
+        }
+
+        private static bool IsClientOptionsType(ITypeSymbol typeSymbol)
+        {
+            if (typeSymbol.TypeKind != TypeKind.Class || typeSymbol.DeclaredAccessibility != Accessibility.Public)
+            {
+                return false;
+            }
+
+            for (ITypeSymbol baseType = typeSymbol.BaseType; baseType != null; baseType = baseType.BaseType)
+            {
+                if (baseType.ToDisplayString() == AzureCoreClientOptions)
+                {
+                    return typeSymbol.Name.EndsWith(ClientOptionsSuffix, StringComparison.Ordinal) || typeSymbol.Name.EndsWith(ClientsOptionsSuffix, StringComparison.Ordinal);
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsClientSettingsType(ITypeSymbol typeSymbol)
+        {
+            if (typeSymbol.TypeKind != TypeKind.Class || typeSymbol.DeclaredAccessibility != Accessibility.Public)
+            {
+                return false;
+            }
+
+            for (ITypeSymbol baseType = typeSymbol.BaseType; baseType != null; baseType = baseType.BaseType)
+            {
+                if (baseType.ToDisplayString() == SystemClientModelClientSettings)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IMethodSymbol FindMethod(IEnumerable<IMethodSymbol> methodSymbols, ImmutableArray<ITypeParameterSymbol> genericParameters, ImmutableArray<IParameterSymbol> parameters, bool ignoreStatic = false)
+        {
+            return methodSymbols.SingleOrDefault(symbol =>
+                (!ignoreStatic || !symbol.IsStatic) &&
+                genericParameters.SequenceEqual(symbol.TypeParameters, ParameterEquivalenceComparer.Default) &&
+                parameters.SequenceEqual(symbol.Parameters, ParameterEquivalenceComparer.Default));
+        }
+
+        private static IMethodSymbol FindMethod(IEnumerable<IMethodSymbol> methodSymbols, ImmutableArray<ITypeParameterSymbol> genericParameters, ImmutableArray<IParameterSymbol> parameters, Func<IParameterSymbol, bool> lastParameter)
+        {
+            return methodSymbols.SingleOrDefault(symbol =>
+            {
+                if (!symbol.Parameters.Any() || !genericParameters.SequenceEqual(symbol.TypeParameters, ParameterEquivalenceComparer.Default))
+                {
+                    return false;
+                }
+
+                var allButLast = symbol.Parameters.RemoveAt(symbol.Parameters.Length - 1);
+                return allButLast.SequenceEqual(parameters, ParameterEquivalenceComparer.Default) && lastParameter(symbol.Parameters.Last());
+            });
+        }
+
+        private class ParameterEquivalenceComparer : IEqualityComparer<IParameterSymbol>, IEqualityComparer<ITypeParameterSymbol>
+        {
+            public static ParameterEquivalenceComparer Default { get; } = new ParameterEquivalenceComparer();
+
+            public bool Equals(IParameterSymbol x, IParameterSymbol y)
+            {
+                // Constructor overload equivalence is determined by parameter type and position, not by
+                // parameter name (C# overload resolution ignores names). Comparing names would produce
+                // false AZC0006/AZC0007 when a with-options and without-options overload name the same
+                // positional parameter differently (e.g. "containerName" vs "blobContainerName").
+                return TypeSymbolEquals(x.Type, y.Type);
+            }
+
+            private bool TypeSymbolEquals(ITypeSymbol x, ITypeSymbol y)
+            {
+                switch (x)
+                {
+                    case INamedTypeSymbol namedX when namedX.IsGenericType:
+                        var namedY = y as INamedTypeSymbol;
+                        if (namedY == null || !namedY.IsGenericType)
+                        {
+                            return false;
+                        }
+
+                        if (!namedX.MetadataName.Equals(namedY.MetadataName) || namedX.TypeArguments.Length != namedY.TypeArguments.Length)
+                        {
+                            return false;
+                        }
+
+                        for (int i = 0; i < namedX.TypeArguments.Length; i++)
+                        {
+                            if (!TypeSymbolEquals(namedX.TypeArguments[i], namedY.TypeArguments[i]))
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
+
+                    case ITypeSymbol typeSym when typeSym.TypeKind == TypeKind.TypeParameter:
+                        return y.TypeKind == TypeKind.TypeParameter && x.Name.Equals(y.Name);
+
+                    default:
+                        return SymbolEqualityComparer.Default.Equals(x, y) && x.Name.Equals(y.Name);
+                }
+            }
+
+            public int GetHashCode(IParameterSymbol obj)
+            {
+                return SymbolEqualityComparer.Default.GetHashCode(obj.Type);
+            }
+
+            public bool Equals(ITypeParameterSymbol x, ITypeParameterSymbol y)
+            {
+                return x.Name.Equals(y.Name);
+            }
+
+            public int GetHashCode(ITypeParameterSymbol obj)
+            {
+                return obj.Name.GetHashCode();
+            }
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/ClientConstructorAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ClientConstructorAnalyzer.cs
@@ -200,11 +200,12 @@ namespace Azure.SdkAnalyzers
 
             public bool Equals(IParameterSymbol x, IParameterSymbol y)
             {
-                // Constructor overload equivalence is determined by parameter type and position, not by
-                // parameter name (C# overload resolution ignores names). Comparing names would produce
-                // false AZC0006/AZC0007 when a with-options and without-options overload name the same
-                // positional parameter differently (e.g. "containerName" vs "blobContainerName").
-                return TypeSymbolEquals(x.Type, y.Type);
+                // Constructor overload equivalence is determined by parameter type, ref-kind (ref/out/in)
+                // and params-ness, but NOT by parameter name (C# overload resolution ignores names).
+                // Comparing names would produce false AZC0006/AZC0007 when a with-options and
+                // without-options overload name the same positional parameter differently (e.g.
+                // "containerName" vs "blobContainerName").
+                return x.RefKind == y.RefKind && x.IsParams == y.IsParams && TypeSymbolEquals(x.Type, y.Type);
             }
 
             private bool TypeSymbolEquals(ITypeSymbol x, ITypeSymbol y)

--- a/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
@@ -76,7 +76,7 @@ namespace Azure.SdkAnalyzers
         public static readonly DiagnosticDescriptor AZC0007 = new(
             nameof(AZC0007),
             "DO provide a minimal constructor that takes only the parameters required to connect to the service.",
-            "A client type should have a public constructor with equivalent parameters that doesn't take an Azure.Core.ClientOptions-derived type as the last argument.",
+            "A client type should have a public constructor with equivalent parameters that does not take an Azure.Core.ClientOptions-derived type as the last argument.",
             DiagnosticCategory.Usage,
             DiagnosticSeverity.Warning,
             true,

--- a/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
@@ -53,6 +53,45 @@ namespace Azure.SdkAnalyzers
             true,
             "Output model types returned from client methods should have corresponding model factory methods for mocking support.");
 
+        public static readonly DiagnosticDescriptor AZC0005 = new(
+            nameof(AZC0005),
+            "DO provide protected parameterless constructor for mocking.",
+            "DO provide protected parameterless constructor for mocking.",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Warning,
+            true,
+            "Client types should provide a protected parameterless constructor to support mocking.",
+            "https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-client-constructor-for-mocking");
+
+        public static readonly DiagnosticDescriptor AZC0006 = new(
+            nameof(AZC0006),
+            "DO provide constructor overloads that allow specifying additional options.",
+            "A client type should have a public constructor with equivalent parameters that takes a Azure.Core.ClientOptions-derived type as the last argument",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Warning,
+            true,
+            "Client types should provide constructor overloads that allow specifying additional options via an Azure.Core.ClientOptions-derived type.",
+            "https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-client-constructor-overloads");
+
+        public static readonly DiagnosticDescriptor AZC0007 = new(
+            nameof(AZC0007),
+            "DO provide a minimal constructor that takes only the parameters required to connect to the service.",
+            "A client type should have a public constructor with equivalent parameters that doesn't take a Azure.Core.ClientOptions-derived type as the last argument",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Warning,
+            true,
+            "Client types should provide a minimal constructor that takes only the parameters required to connect to the service.",
+            "https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-client-constructor-minimal");
+
+        public static readonly DiagnosticDescriptor AZC0021 = new(
+            nameof(AZC0021),
+            "ClientSettings constructor parameters should not be combined with other parameters",
+            "A constructor with a ClientSettings-derived parameter should only take that single parameter",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Warning,
+            true,
+            "A constructor that takes a System.ClientModel.Primitives.ClientSettings-derived parameter should only take that single parameter.");
+
         public static readonly DiagnosticDescriptor AZC0040 = new(
             nameof(AZC0040),
             "Do not expose Apache.Arrow types on the public API surface",

--- a/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
@@ -66,7 +66,7 @@ namespace Azure.SdkAnalyzers
         public static readonly DiagnosticDescriptor AZC0006 = new(
             nameof(AZC0006),
             "DO provide constructor overloads that allow specifying additional options.",
-            "A client type should have a public constructor with equivalent parameters that takes a Azure.Core.ClientOptions-derived type as the last argument",
+            "A client type should have a public constructor with equivalent parameters that takes an Azure.Core.ClientOptions-derived type as the last argument.",
             DiagnosticCategory.Usage,
             DiagnosticSeverity.Warning,
             true,
@@ -76,7 +76,7 @@ namespace Azure.SdkAnalyzers
         public static readonly DiagnosticDescriptor AZC0007 = new(
             nameof(AZC0007),
             "DO provide a minimal constructor that takes only the parameters required to connect to the service.",
-            "A client type should have a public constructor with equivalent parameters that doesn't take a Azure.Core.ClientOptions-derived type as the last argument",
+            "A client type should have a public constructor with equivalent parameters that doesn't take an Azure.Core.ClientOptions-derived type as the last argument.",
             DiagnosticCategory.Usage,
             DiagnosticSeverity.Warning,
             true,

--- a/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
@@ -60,7 +60,7 @@ namespace Azure.SdkAnalyzers
             DiagnosticCategory.Usage,
             DiagnosticSeverity.Warning,
             true,
-            "Client types should provide a protected parameterless constructor to support mocking.",
+            "Client types should provide a protected (or public) parameterless constructor to support mocking.",
             "https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-client-constructor-for-mocking");
 
         public static readonly DiagnosticDescriptor AZC0006 = new(

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0005Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0005Tests.cs
@@ -9,6 +9,27 @@ namespace Azure.SdkAnalyzers.Tests
 {
     public class AZC0005Tests
     {
+        [Test]
+        public async Task AZC0005ProducedForClientWithOnlyClientSettingsAndNoParameterlessCtor()
+        {
+            const string code = @"
+namespace System.ClientModel.Primitives
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
+
+    public class {|AZC0005:SomeClient|}
+    {
+        public SomeClient(SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
 #if !NETFRAMEWORK // Deriving from Azure.Core.ClientOptions requires netstandard2.0+ support (net472+)
         [Test]
         public async Task AZC0005ProducedForClientTypesWithoutProtectedCtor()

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0005Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0005Tests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.ClientConstructorAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0005Tests
+    {
+#if !NETFRAMEWORK // Deriving from Azure.Core.ClientOptions requires netstandard2.0+ support (net472+)
+        [Test]
+        public async Task AZC0005ProducedForClientTypesWithoutProtectedCtor()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class {|AZC0005:SomeClient|}
+    {
+        public SomeClient(string connectionString) {}
+        public SomeClient(string connectionString, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+#endif
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0006Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0006Tests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.ClientConstructorAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0006Tests
+    {
+#if !NETFRAMEWORK // Deriving from Azure.Core.ClientOptions requires netstandard2.0+ support (net472+)
+        [Test]
+        public async Task AZC0006ProducedForClientsWithoutOptionsCtor()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0006:SomeClient|}(SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0006ProducedForClientsWithoutOptionsCtorWithArguments()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0006:SomeClient|}(string connectionString, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0006NotProducedForClientsWithoutOptionsCtorWithArguments()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string connectionString, SomeClientOptions options = null) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0006NotProducedForSharedClientOptions()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SharedClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string connectionString, SharedClientOptions options = null) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0006NotProducedForClientsOptions()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientsOptions : Azure.Core.ClientOptions { } // 'ClientsOptions' suffix instead of 'ClientOptions'
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string connectionString, SomeClientsOptions options = null) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0006NotProducedForClientsWithStaticProperties()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        public static int a = 1;
+        public SomeClient() {}
+        public SomeClient(SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        // Regression for azure-sdk-tools#127: a required-options constructor and its non-options
+        // overload differ only in a parameter name (Storage's BlockBlobClient uses "containerName"
+        // on one and "blobContainerName" on the other). Overload equivalence is by type, not name,
+        // so neither AZC0006 nor AZC0007 should fire.
+        [Test]
+        public async Task AZC0006NotProducedWhenOverloadDiffersOnlyByParameterName()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string connectionString, string containerName, string blobName) {}
+        public SomeClient(string connectionString, string blobContainerName, string blobName, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+#endif
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0006Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0006Tests.cs
@@ -134,6 +134,28 @@ namespace RandomNamespace
 }";
             await Verifier.VerifyAnalyzerAsync(code);
         }
+
+        // Parameter ref-kind (ref/out/in) is part of the constructor signature, so overloads that
+        // differ only by a ref modifier are NOT equivalent and must not be paired: the minimal ctor
+        // still lacks a matching options overload (AZC0007) and the options ctor still lacks a
+        // matching non-options overload (AZC0006).
+        [Test]
+        public async Task AZC0006AndAZC0007ProducedWhenOverloadsDifferOnlyByRefModifier()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0007:SomeClient|}(int x) {}
+        public {|AZC0006:SomeClient|}(ref int x, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
 #endif
     }
 }

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0006Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0006Tests.cs
@@ -45,7 +45,7 @@ namespace RandomNamespace
         }
 
         [Test]
-        public async Task AZC0006NotProducedForClientsWithoutOptionsCtorWithArguments()
+        public async Task AZC0006NotProducedWhenOptionsParameterIsOptional()
         {
             const string code = @"
 namespace RandomNamespace

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0007Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0007Tests.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.ClientConstructorAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0007Tests
+    {
+        [Test]
+        public async Task AZC0007ProducedForClientsWithoutOptionsCtor()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public {|AZC0007:SomeClient|}() {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0007ProducedForClientsWithoutOptionsCtorWithArguments()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0007:SomeClient|}(string connectionString) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0007ProducedForClientsWithOptionsNotDerivedFromClientOptions()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0007:SomeClient|}(string connectionString, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+#if !NETFRAMEWORK // Deriving from Azure.Core.ClientOptions requires netstandard2.0+ support (net472+)
+        [Test]
+        public async Task AZC0007NotProducedForClientsWithDefaultOptionsCtorWithArguments()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System;
+
+    public class SomeClientOptions : Azure.Core.ClientOptions {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string connectionString, SomeClientOptions clientOptions = default) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0007NotProducedForClientWithMultipleCtors()
+        {
+            const string code = @"
+using System;
+using Azure;
+using Azure.Core;
+
+namespace RandomNamespace.Foo
+{
+    public partial class RoomsClientOptions : ClientOptions {}
+
+    public partial class RoomsClient
+    {
+        protected RoomsClient() {}
+        public RoomsClient(string connectionString) {}
+        public RoomsClient(string connectionString, RoomsClientOptions options) {}
+        public RoomsClient(Uri endpoint, AzureKeyCredential credential, RoomsClientOptions options = null) {}
+        public RoomsClient(Uri endpoint, TokenCredential credential, RoomsClientOptions options = null) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+#endif
+
+        [Test]
+        public async Task AZC0007NotProducedForClientWithClientSettings()
+        {
+            const string code = @"
+namespace System.ClientModel.Primitives
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0005ProducedForClientWithOnlyClientSettingsAndNoParameterlessCtor()
+        {
+            const string code = @"
+namespace System.ClientModel.Primitives
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
+
+    public class {|AZC0005:SomeClient|}
+    {
+        public SomeClient(SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+#if !NETFRAMEWORK // Deriving from Azure.Core.ClientOptions requires netstandard2.0+ support (net472+)
+        [Test]
+        public async Task AZC0007NotProducedForClientWithClientSettingsAndOtherOverloads()
+        {
+            const string code = @"
+namespace System.ClientModel.Primitives
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    using Azure.Core;
+
+    public class SomeClientOptions : ClientOptions {}
+    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string connectionString) {}
+        public SomeClient(string connectionString, SomeClientOptions options) {}
+        public SomeClient(SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+#endif
+
+        [Test]
+        public async Task AZC0007ProducedForClientWithClientSettingsButMissingOptionsOverload()
+        {
+            const string code = @"
+namespace System.ClientModel.Primitives
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0007:SomeClient|}(string connectionString) {}
+        public SomeClient(SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0007NotProducedForClientWithMultipleClientSettingsOverloads()
+        {
+            const string code = @"
+namespace System.ClientModel.Primitives
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    using System;
+    using Azure;
+
+    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
+    public class AnotherClientSettings : System.ClientModel.Primitives.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(SomeClientSettings settings) {}
+        public SomeClient(AnotherClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0007ProducedForClientsWithSettingsNotDerivedFromClientSettings()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientSettings { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0007:SomeClient|}(SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+#if !NETFRAMEWORK // Deriving from Azure.Core.ClientOptions requires netstandard2.0+ support (net472+)
+        // Regression for azure-sdk-tools#127: a sub-client constructed from another client
+        // (Storage's BlobLeaseClient takes a BlobBaseClient/BlobContainerClient plus an optional
+        // lease id) inherits its configuration from that client and has no service-connection or
+        // options overload, so AZC0007 should not fire.
+        [Test]
+        public async Task AZC0007NotProducedForSubClientConstructedFromAnotherClient()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class ParentClient
+    {
+        protected ParentClient() {}
+        public ParentClient(string connectionString) {}
+        public ParentClient(string connectionString, SomeClientOptions options) {}
+    }
+
+    public class LeaseClient
+    {
+        protected LeaseClient() {}
+        public LeaseClient(ParentClient client, string leaseId = null) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+#endif
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0007Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0007Tests.cs
@@ -122,6 +122,25 @@ namespace RandomNamespace
             await Verifier.VerifyAnalyzerAsync(code);
         }
 
+        // A public client type nested in a non-public type is not publicly accessible, so the
+        // constructor rules should not analyze it (no AZC0005/AZC0006/AZC0007/AZC0021).
+        [Test]
+        public async Task NoDiagnosticsForPublicClientNestedInNonPublicType()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    internal class Outer
+    {
+        public class SomeClient
+        {
+            public SomeClient(string connectionString) {}
+        }
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
 #if !NETFRAMEWORK // Deriving from Azure.Core.ClientOptions requires netstandard2.0+ support (net472+)
         [Test]
         public async Task AZC0007NotProducedForClientWithClientSettingsAndOtherOverloads()

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0007Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0007Tests.cs
@@ -122,27 +122,6 @@ namespace RandomNamespace
             await Verifier.VerifyAnalyzerAsync(code);
         }
 
-        [Test]
-        public async Task AZC0005ProducedForClientWithOnlyClientSettingsAndNoParameterlessCtor()
-        {
-            const string code = @"
-namespace System.ClientModel.Primitives
-{
-    public class ClientSettings {}
-}
-
-namespace RandomNamespace
-{
-    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
-
-    public class {|AZC0005:SomeClient|}
-    {
-        public SomeClient(SomeClientSettings settings) {}
-    }
-}";
-            await Verifier.VerifyAnalyzerAsync(code);
-        }
-
 #if !NETFRAMEWORK // Deriving from Azure.Core.ClientOptions requires netstandard2.0+ support (net472+)
         [Test]
         public async Task AZC0007NotProducedForClientWithClientSettingsAndOtherOverloads()

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0007Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0007Tests.cs
@@ -267,6 +267,32 @@ namespace RandomNamespace
 }";
             await Verifier.VerifyAnalyzerAsync(code);
         }
+
+        // Regression: overload matching must distinguish generic parameter types by their full
+        // identity, not just metadata name + arity. Two generic types with the same name and arity
+        // in different namespaces (NsA.Wrapper<string> vs NsB.Wrapper<string>) must NOT be treated
+        // as equivalent, otherwise the analyzer wrongly pairs the constructors and suppresses the
+        // AZC0006/AZC0007 diagnostics that should fire.
+        [Test]
+        public async Task AZC0007AndAZC0006ProducedWhenGenericParametersDifferOnlyByNamespace()
+        {
+            const string code = @"
+namespace NsA { public class Wrapper<T> { } }
+namespace NsB { public class Wrapper<T> { } }
+
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0007:SomeClient|}(NsA.Wrapper<string> w) {}
+        public {|AZC0006:SomeClient|}(NsB.Wrapper<string> w, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
 #endif
     }
 }

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0021Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0021Tests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.ClientConstructorAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0021Tests
+    {
+        [Test]
+        public async Task AZC0021ProducedForClientSettingsCtorWithAdditionalParameter()
+        {
+            const string code = @"
+namespace System.ClientModel.Primitives
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(SomeClientSettings settings) {}
+        public {|AZC0021:SomeClient|}(string connectionString, SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0021NotProducedForClientSettingsCtorWithSingleParameter()
+        {
+            const string code = @"
+namespace System.ClientModel.Primitives
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.Primitives.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Migrates `ClientConstructorAnalyzer` (AZC0005, AZC0006, AZC0007, AZC0021) from `azure-sdk-tools` into the in-repo `Azure.SdkAnalyzers`, mirroring the AZC0034/AZC0035 migrations, and fixes the two Storage false positives tracked by [azure-sdk-tools#127](https://github.com/Azure/azure-sdk-tools/issues/127).

This is step 1 of the usual two-PR analyzer move. A follow-up PR in `azure-sdk-tools` will remove these rules there and bump the `Azure.ClientSdk.Analyzers` package version here. Until that lands, the external analyzer still emits the Storage false positives (still `NoWarn`'d in the Storage props), so this PR is safe to merge on its own but does not yet unblock the Storage suppression cleanup.

## What changed

- **New `src/ClientConstructorAnalyzer.cs`** - self-contained port extending the in-repo `SymbolAnalyzerBase`, inlining `IsClientOptionsType` / `IsClientSettingsType` / `FindMethod`.
- **`src/Descriptors.cs`** - added the AZC0005/AZC0006/AZC0007/AZC0021 descriptors (Warning severity).
- **New NUnit tests** - the existing tool tests ported to `AZC0005Tests` / `AZC0006Tests` / `AZC0007Tests`, plus two regression tests for the false positives below.

## Fixes for azure-sdk-tools#127

Both were reproduced by building `Azure.Storage.Blobs` with the Storage props `NoWarn`s removed, then fixed at the analyzer:

1. **Overload equivalence by parameter type, not name.** `BlockBlobClient` names the same positional parameter `containerName` on its minimal constructor but `blobContainerName` on the options constructor. The overload comparer required name+type equality, so it failed to pair the two and raised AZC0006 (on the options ctor) + AZC0007 (on the minimal ctor). C# overload resolution ignores parameter names, so the comparer now matches by type only. This only ever reduces diagnostics.

   Note: the inconsistent parameter naming in `BlockBlobClient` is still a real (minor) code smell worth a separate Storage cleanup - an overload analyzer correctly should not flag it, but equivalent parameters should be named consistently.

2. **Sub-client constructors.** `BlobLeaseClient(BlobBaseClient/BlobContainerClient client, string leaseId = null)` is constructed from an existing client, inherits its configuration, and has no service-connection or options overload by design. Constructors that take a client-instance parameter (a class ending in `Client`, outside a `System` namespace) are now exempt from AZC0006/AZC0007.

## Validation

Full `Azure.SdkAnalyzers.Tests` suite passes: net8.0/net9.0/net10.0 = 194, net462 = 180. The `ClientOptions`-deriving tests are guarded with `#if !NETFRAMEWORK` (net462 predates the netstandard2.0 facade needed to derive from `Azure.Core.ClientOptions`), matching the existing AZC0101 precedent.

Because the in-repo diagnostics are a strict subset of what the external analyzer already emits (and existing `NoWarn`s cover both), no new build breakage is expected.