### PR TITLE
Add sample self-containment check for /samples

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -128,6 +128,10 @@ steps:
       }
     displayName: Validate CPM Compliance
 
+  - pwsh: |
+      ./eng/scripts/Validate-SampleSelfContainment.ps1
+    displayName: Validate Sample Self-Containment
+
   - template: /eng/pipelines/templates/steps/dotnet-diagnostics.yml
     parameters:
       LogFilePath: $(Build.ArtifactStagingDirectory)/rebuild.binlog

--- a/eng/scripts/Validate-SampleSelfContainment.ps1
+++ b/eng/scripts/Validate-SampleSelfContainment.ps1
@@ -28,12 +28,14 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 1
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path.TrimEnd('\', '/')
-$SamplesRoot = if ($SamplesDirectory) { (Resolve-Path (Join-Path $RepoRoot $SamplesDirectory)).Path.TrimEnd('\', '/') } else { Join-Path $RepoRoot "samples" }
+$SamplesRoot = if ($SamplesDirectory) { Join-Path $RepoRoot $SamplesDirectory } else { Join-Path $RepoRoot "samples" }
 
 if (-not (Test-Path $SamplesRoot)) {
     Write-Host "Samples directory not found, nothing to scan: $SamplesRoot"
     exit 0
 }
+
+$SamplesRoot = (Resolve-Path $SamplesRoot).Path.TrimEnd('\', '/')
 
 [string[]] $errors = @()
 

--- a/eng/scripts/Validate-SampleSelfContainment.ps1
+++ b/eng/scripts/Validate-SampleSelfContainment.ps1
@@ -1,0 +1,124 @@
+<#
+.SYNOPSIS
+    Validates that samples under the top-level /samples directory are self-contained.
+
+.DESCRIPTION
+    Samples published to the Azure samples browser are downloaded scoped to their own
+    directory (samples/<service>/<sample>). A sample that references projects outside of
+    its own directory is broken for anyone who downloads it standalone.
+
+    This static analysis flags, for every project under /samples:
+      SAMPLE-001: A ProjectReference or Import whose path escapes the sample's own
+                  directory (e.g. reaches into sdk/ or another sample).
+      SAMPLE-002: A ProjectReference or Import that relies on an MSBuild property
+                  ($(...)) to locate a project, which cannot be resolved standalone.
+
+    References that stay within the sample's own directory (for example a tests project
+    referencing a sibling src project) are allowed.
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string] $SamplesDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 1
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path.TrimEnd('\', '/')
+$SamplesRoot = if ($SamplesDirectory) { (Resolve-Path (Join-Path $RepoRoot $SamplesDirectory)).Path.TrimEnd('\', '/') } else { Join-Path $RepoRoot "samples" }
+
+if (-not (Test-Path $SamplesRoot)) {
+    Write-Host "Samples directory not found, nothing to scan: $SamplesRoot"
+    exit 0
+}
+
+[string[]] $errors = @()
+
+function LogError([string]$message) {
+    if ($env:TF_BUILD) {
+        Write-Host ("##vso[task.logissue type=error]$message" -replace "`n", "%0D%0A")
+    }
+    Write-Host -ForegroundColor Red "error: $message"
+    $script:errors += $message
+}
+
+function LogInfo([string]$message) {
+    Write-Host -ForegroundColor Cyan $message
+}
+
+function Get-RelativePath([string]$fullPath) {
+    return $fullPath.Substring($RepoRoot.Length + 1).Replace('\', '/')
+}
+
+# The sample's own directory is samples/<service>/<sample>. A project file deeper than
+# that (e.g. samples/<service>/<sample>/src) still belongs to the same sample root.
+function Get-SampleRoot([string]$projectFullPath) {
+    $relativeToSamples = $projectFullPath.Substring($SamplesRoot.Length).TrimStart('\', '/').Replace('\', '/')
+    $segments = $relativeToSamples.Split('/')
+    if ($segments.Count -lt 3) {
+        # Not inside a samples/<service>/<sample>/ subtree; treat the file's own folder as the root.
+        return (Split-Path $projectFullPath -Parent)
+    }
+    return (Join-Path (Join-Path $SamplesRoot $segments[0]) $segments[1])
+}
+
+function Get-ReferencePaths([string]$projectFullPath) {
+    try {
+        [xml]$xml = Get-Content -Path $projectFullPath -Raw
+    }
+    catch {
+        LogError "SAMPLE-000: Unable to parse project file $(Get-RelativePath $projectFullPath): $($_.Exception.Message)"
+        return @()
+    }
+
+    $refs = @()
+    foreach ($node in $xml.SelectNodes("//*[local-name()='ProjectReference']")) {
+        if ($node.Include) { $refs += [pscustomobject]@{ Kind = 'ProjectReference'; Path = $node.Include } }
+    }
+    foreach ($node in $xml.SelectNodes("//*[local-name()='Import']")) {
+        if ($node.Project) { $refs += [pscustomobject]@{ Kind = 'Import'; Path = $node.Project } }
+    }
+    return $refs
+}
+
+$projectFiles = Get-ChildItem -Path $SamplesRoot -Recurse -Include '*.csproj' |
+    Where-Object { $_.FullName -notmatch '[\\/](artifacts|node_modules|\.git|bin|obj)[\\/]' }
+LogInfo "Found $($projectFiles.Count) sample project(s) to scan under $(Get-RelativePath $SamplesRoot)."
+
+foreach ($project in $projectFiles) {
+    $projectDir = Split-Path $project.FullName -Parent
+    $sampleRoot = (Get-SampleRoot $project.FullName).TrimEnd('\', '/')
+    $sampleRootPrefix = $sampleRoot + [System.IO.Path]::DirectorySeparatorChar
+
+    foreach ($ref in Get-ReferencePaths $project.FullName) {
+        $rel = Get-RelativePath $project.FullName
+
+        if ($ref.Path -match '\$\(') {
+            LogError "SAMPLE-002: $($ref.Kind) '$($ref.Path)' in $rel relies on an MSBuild property and cannot be resolved when the sample is downloaded standalone."
+            continue
+        }
+
+        $normalized = $ref.Path.Replace('\', [System.IO.Path]::DirectorySeparatorChar).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+        $resolved = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($projectDir, $normalized))
+
+        if (-not ($resolved.StartsWith($sampleRootPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or $resolved.Equals($sampleRoot, [System.StringComparison]::OrdinalIgnoreCase))) {
+            $sampleRootRel = Get-RelativePath $sampleRoot
+            LogError "SAMPLE-001: $($ref.Kind) '$($ref.Path)' in $rel escapes the sample directory '$sampleRootRel'. Samples must be self-contained for the Azure samples browser."
+        }
+    }
+}
+
+Write-Host ""
+if ($errors.Count -gt 0) {
+    Write-Host -ForegroundColor Red "Sample self-containment check failed with $($errors.Count) error(s):"
+    foreach ($err in $errors) {
+        Write-Host -ForegroundColor Red "  - $err"
+    }
+    exit 1
+}
+else {
+    Write-Host -ForegroundColor Green "Sample self-containment check passed. No violations found."
+    exit 0
+}

--- a/eng/scripts/Validate-SampleSelfContainment.ps1
+++ b/eng/scripts/Validate-SampleSelfContainment.ps1
@@ -10,8 +10,9 @@
     This static analysis flags, for every project under /samples:
       SAMPLE-001: A ProjectReference or Import whose path escapes the sample's own
                   directory (e.g. reaches into sdk/ or another sample).
-      SAMPLE-002: A ProjectReference or Import that relies on an MSBuild property
-                  ($(...)) to locate a project, which cannot be resolved standalone.
+      SAMPLE-002: A ProjectReference or Import path that uses an MSBuild property
+                  ($(...)). Property expansion in reference paths is disallowed so
+                  samples stay portable when downloaded standalone.
 
     References that stay within the sample's own directory (for example a tests project
     referencing a sibling src project) are allowed.
@@ -96,7 +97,7 @@ foreach ($project in $projectFiles) {
         $rel = Get-RelativePath $project.FullName
 
         if ($ref.Path -match '\$\(') {
-            LogError "SAMPLE-002: $($ref.Kind) '$($ref.Path)' in $rel relies on an MSBuild property and cannot be resolved when the sample is downloaded standalone."
+            LogError "SAMPLE-002: $($ref.Kind) '$($ref.Path)' in $rel uses an MSBuild property. Property expansion in reference paths is not allowed in samples so they stay portable when downloaded standalone."
             continue
         }
 

--- a/eng/scripts/Validate-SampleSelfContainment.ps1
+++ b/eng/scripts/Validate-SampleSelfContainment.ps1
@@ -5,7 +5,9 @@
 .DESCRIPTION
     Samples published to the Azure samples browser are downloaded scoped to their own
     directory (samples/<service>/<sample>). A sample that references projects outside of
-    its own directory is broken for anyone who downloads it standalone.
+    its own directory is broken for anyone who downloads it standalone. A sample may only
+    use PackageReferences to published packages, or ProjectReferences to projects inside
+    its own directory.
 
     This static analysis flags, for every project under /samples:
       SAMPLE-001: A ProjectReference or Import whose path escapes the sample's own
@@ -110,7 +112,7 @@ foreach ($project in $projectFiles) {
 
         if (-not ($resolved.StartsWith($sampleRootPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or $resolved.Equals($sampleRoot, [System.StringComparison]::OrdinalIgnoreCase))) {
             $sampleRootRel = Get-RelativePath $sampleRoot
-            LogError "SAMPLE-001: $($ref.Kind) '$($ref.Path)' in $rel escapes the sample directory '$sampleRootRel'. Samples must be self-contained for the Azure samples browser."
+            LogError "SAMPLE-001: $($ref.Kind) '$($ref.Path)' in $rel escapes the sample directory '$sampleRootRel'. Samples must be self-contained for the Azure samples browser: use PackageReferences to published packages, or ProjectReferences only to projects inside the sample's own directory."
         }
     }
 }

--- a/eng/scripts/Validate-SampleSelfContainment.ps1
+++ b/eng/scripts/Validate-SampleSelfContainment.ps1
@@ -50,7 +50,9 @@ function LogInfo([string]$message) {
 }
 
 function Get-RelativePath([string]$fullPath) {
-    return $fullPath.Substring($RepoRoot.Length + 1).Replace('\', '/')
+    # Use the framework helper so callers passing an absolute path outside the repo
+    # (or a path equal to $RepoRoot) don't trip a Substring out-of-range error.
+    return [System.IO.Path]::GetRelativePath($RepoRoot, $fullPath).Replace('\', '/')
 }
 
 # The sample's own directory is samples/<service>/<sample>. A project file deeper than

--- a/eng/scripts/tests/Validate-SampleSelfContainment.tests.ps1
+++ b/eng/scripts/tests/Validate-SampleSelfContainment.tests.ps1
@@ -124,4 +124,10 @@ Describe "Validate-SampleSelfContainment" -Tag "UnitTest" {
         $result.ExitCode | Should -Be 1
         $result.Output | Should -Match 'SAMPLE-001'
     }
+
+    It "exits 0 with a nothing-to-scan message when the samples directory does not exist" {
+        $result = Invoke-Validator "does-not-exist-$([Guid]::NewGuid().ToString('N'))"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Match 'nothing to scan'
+    }
 }

--- a/eng/scripts/tests/Validate-SampleSelfContainment.tests.ps1
+++ b/eng/scripts/tests/Validate-SampleSelfContainment.tests.ps1
@@ -1,0 +1,127 @@
+#Requires -Version 7.0
+<#
+.How-To-Run
+This test file uses Pester, a testing framework for PowerShell.
+For more information about Pester, see: https://pester.dev/docs/quick-start
+
+First, ensure you have `pester` installed:
+
+`Install-Module Pester -Force`
+
+Then invoke tests with:
+
+`Invoke-Pester ./Validate-SampleSelfContainment.tests.ps1`
+
+#>
+
+. (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "Helpers" PSModule-Helpers.ps1)
+Install-ModuleIfNotInstalled "Pester" "5.3.3" | Import-Module
+
+Describe "Validate-SampleSelfContainment" -Tag "UnitTest" {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot ".." "Validate-SampleSelfContainment.ps1"
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot ".." ".." "..")).Path.TrimEnd('\', '/')
+
+        # Fixtures live under the repo root so the script's Get-RelativePath works, and each
+        # case gets its own samples/<service>/<sample> subtree scanned via -SamplesDirectory.
+        $fixtureName = ".sample-selfcontainment-tests-$([Guid]::NewGuid().ToString('N'))"
+        $fixtureRoot = Join-Path $repoRoot $fixtureName
+
+        function New-Fixture([string]$RelativeSubPath, [string]$FileName, [string]$Content) {
+            $dir = Join-Path $fixtureRoot $RelativeSubPath
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $dir $FileName) -Value $Content -NoNewline
+        }
+
+        # Case: ProjectReference escaping into sdk/
+        New-Fixture "escapes/svc/sample" "Bad.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\sdk\agentserver\Foo\src\Foo.csproj" />
+  </ItemGroup>
+</Project>
+'@
+
+        # Case: tests project referencing a sibling src project within the same sample (allowed)
+        New-Fixture "intra/svc/sample/tests" "Tests.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\src\Sample.csproj" />
+  </ItemGroup>
+</Project>
+'@
+        New-Fixture "intra/svc/sample/src" "Sample.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>
+'@
+
+        # Case: ProjectReference relying on an MSBuild property
+        New-Fixture "property/svc/sample" "Prop.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\sdk\agentserver\Foo\src\Foo.csproj" />
+  </ItemGroup>
+</Project>
+'@
+
+        # Case: self-contained sample referencing only published packages (allowed)
+        New-Fixture "clean/svc/sample" "Clean.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.2" />
+  </ItemGroup>
+</Project>
+'@
+
+        # Case: Import escaping into eng/
+        New-Fixture "importescape/svc/sample" "Imp.csproj" @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\eng\Shared.props" />
+</Project>
+'@
+
+        function Invoke-Validator([string]$CaseRelativePath) {
+            $output = & $scriptPath -SamplesDirectory (Join-Path $fixtureName $CaseRelativePath) *>&1
+            return [pscustomobject]@{
+                ExitCode = $LASTEXITCODE
+                Output   = ($output | Out-String)
+            }
+        }
+    }
+
+    AfterAll {
+        if (Test-Path $fixtureRoot) {
+            Remove-Item $fixtureRoot -Recurse -Force
+        }
+    }
+
+    It "flags a ProjectReference that escapes the sample directory" {
+        $result = Invoke-Validator "escapes"
+        $result.ExitCode | Should -Be 1
+        $result.Output | Should -Match 'SAMPLE-001'
+    }
+
+    It "allows a tests project referencing a sibling src project in the same sample" {
+        $result = Invoke-Validator "intra"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Not -Match 'SAMPLE-00'
+    }
+
+    It "flags a ProjectReference that relies on an MSBuild property" {
+        $result = Invoke-Validator "property"
+        $result.ExitCode | Should -Be 1
+        $result.Output | Should -Match 'SAMPLE-002'
+    }
+
+    It "allows a self-contained sample that references only published packages" {
+        $result = Invoke-Validator "clean"
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Not -Match 'SAMPLE-00'
+    }
+
+    It "flags an Import that escapes the sample directory" {
+        $result = Invoke-Validator "importescape"
+        $result.ExitCode | Should -Be 1
+        $result.Output | Should -Match 'SAMPLE-001'
+    }
+}


### PR DESCRIPTION
## Summary

Adds a static analysis check that enforces **self-containment for samples under the top-level `/samples` directory**.

### Background
Samples published to the Azure samples browser are downloaded scoped to their own directory (`samples/<service>/<sample>`). A sample that references a project outside of its own directory (for example a `ProjectReference` reaching into `sdk/`) is broken for anyone who downloads it standalone. This was raised in review of PR #59730, where sample projects referenced the SDK's `src` project directly. Nothing in CI catches this today — in-repo builds resolve the reference fine, so the standalone-download scenario is never exercised.

### What the check does
New `eng/scripts/Validate-SampleSelfContainment.ps1` scans every project under `/samples` and reports:
- **SAMPLE-001** — a `ProjectReference` or `Import` whose resolved path escapes the sample's own `samples/<service>/<sample>` directory.
- **SAMPLE-002** — a `ProjectReference`/`Import` that relies on an MSBuild `$(...)` property, which cannot be resolved standalone.

References that stay within the sample's own directory (e.g. a `tests` project referencing a sibling `src` project) are allowed.

The check is wired into `eng/pipelines/templates/steps/analyze.yml` as a **Validate Sample Self-Containment** step.

### Tests
Adds `eng/scripts/tests/Validate-SampleSelfContainment.tests.ps1` (Pester, tagged `UnitTest`), covering: escaping `ProjectReference`, allowed intra-sample reference, MSBuild-property reference, clean package-only sample, and escaping `Import`. All 5 pass.

### Verification
- Runs clean against the 14 existing samples in the repo (intra-sample `tests` → `..\src` references correctly allowed).
- Reproduced the escaping `..\..\..\sdk\...` reference from #59730 and confirmed SAMPLE-001 fires with a non-zero exit.