### PR TITLE
Bump mgmt http-client-csharp base version

### DIFF
--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,13 +1,13 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-07-02 01:06:29 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-07-02 03:33:54 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Latest Published Version Chain
 
 ```
 @typespec/http-client-csharp (alpha.20260701.8)
-  └─ @azure-typespec/http-client-csharp (alpha.20260701.4)
+  └─ @azure-typespec/http-client-csharp (alpha.20260701.5)
        └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260701.2)
             └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260701.2)
 ```
@@ -17,7 +17,7 @@
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
 | `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260701.8](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260701.8) | [1.0.0-alpha.20260701.8](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260701.8) | [3e10b83](https://github.com/microsoft/typespec/commit/3e10b8376f3a20dfcd46050c712d6bc64d537b2c) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260629.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260629.2) | [1.0.0-alpha.20260701.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260701.4) | [3abfb23](https://github.com/Azure/azure-sdk-for-net/commit/3abfb237026bbc18469089f996829bf3f3911cc9) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260701.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260701.4) | [1.0.0-alpha.20260701.5](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260701.5) | [cf309ca](https://github.com/Azure/azure-sdk-for-net/commit/cf309ca16aeba3ba7a448c158ed6d4935ebb32cc) |
 | `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260630.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260630.2) | [1.0.0-alpha.20260701.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260701.2) | [26b0919](https://github.com/Azure/azure-sdk-for-net/commit/26b0919efd79467de030de5d0513fbf0f130e4fc) |
 
 ## Source Files

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260701.8</UnbrandedGeneratorVersion>
-    <AzureGeneratorVersion>1.0.0-alpha.20260629.2</AzureGeneratorVersion>
+    <AzureGeneratorVersion>1.0.0-alpha.20260701.4</AzureGeneratorVersion>
     <AzureManagementGeneratorVersion>1.0.0-alpha.20260630.2</AzureManagementGeneratorVersion>
   </PropertyGroup>
 

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260701.8</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20260701.4</AzureGeneratorVersion>
-    <AzureManagementGeneratorVersion>1.0.0-alpha.20260630.2</AzureManagementGeneratorVersion>
+    <AzureManagementGeneratorVersion>1.0.0-alpha.20260701.2</AzureManagementGeneratorVersion>
   </PropertyGroup>
 
   <!-- Packages used by the TypeSpec generators -->

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260629.2",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260629.10"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260701.4",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260701.6"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
@@ -223,12 +223,12 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260629.2",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260629.2.tgz",
-      "integrity": "sha1-Bopz0M8xS8B047DU7EWx0+KHHzY=",
+      "version": "1.0.0-alpha.20260701.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260701.4.tgz",
+      "integrity": "sha1-NxF8VHoodjlIKFJFDMuKCYl1Oes=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260629.10"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260701.6"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2222,9 +2222,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260629.10",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260629.10.tgz",
-      "integrity": "sha512-qhSAy7IhUiNGNFQxiVZoxgpH5u9KBFyqZvhVvjU69JzZMLgzSrXapzP64bCwoHBfJc3XzeqWnGrIn7BJxFt+lQ==",
+      "version": "1.0.0-alpha.20260701.6",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260701.6.tgz",
+      "integrity": "sha512-qQdm8G2VztdeP5y2tEbq26jCzwQFml25B9lUHMA0yzJekIx7Aj2Io8dhOpWw/mQr+mCnXpZxxQWw2QC5/rGdcA==",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -38,8 +38,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260629.2",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260629.10"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260701.4",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260701.6"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.42",


### PR DESCRIPTION
# Summary
- Bump mgmt `@azure-typespec/http-client-csharp` dependency to `1.0.0-alpha.20260701.4`
- Align `AzureGeneratorVersion` and the direct `@typespec/http-client-csharp` dependency
- Refresh the mgmt package lockfile and emitter version dashboard

# Validation
- `npm install`
- `npm run build:emitter`
- `npm run lint`
- `npm run prettier`
- `npm run build:generator`
- `pwsh eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1`
- `pwsh doc/GeneratorVersions/Emitter_Version_Dashboard.ps1`
