### PR TITLE
Support both release-bot logins in sdk-build-repair eligibility gate

### DIFF
--- a/.github/workflows/sdk-build-repair.lock.yml
+++ b/.github/workflows/sdk-build-repair.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"1c422413ab24b91c9fca3849988a2920dad3f4760b2568f8844630a402000e28","body_hash":"5878ca9371588f7efc7991712889f1012863d53a9e83329e0bdb8946f9796b4e","compiler_version":"v0.79.4","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"9a946fdbd5fb07b82b2f5a4466058b876ab72bb2","version":"v5.3.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d059700c6a8ec3b5fd798b9ea60f5d048447b918","version":"v0.79.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.0"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.0"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"3cb50a7120da7c3859f4909869516cd0d375b49e1f131a06a14d5502fe36d19d","body_hash":"d866216553868a5c59ab5096698beba4fd7a616b90abe438cd8000918cd13e16","compiler_version":"v0.79.4","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"9a946fdbd5fb07b82b2f5a4466058b876ab72bb2","version":"v5.3.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d059700c6a8ec3b5fd798b9ea60f5d048447b918","version":"v0.79.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.0"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.0"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -33,8 +33,8 @@
 # Custom actions used:
 #   - actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+#   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -51,7 +51,7 @@
 name: "SDK Build Repair"
 on:
   # bots: # Bots processed as bot check in pre-activation job
-  # - azure-sdk # Bots processed as bot check in pre-activation job
+  # - azure-sdk-automation[bot] # Bots processed as bot check in pre-activation job
   issue_comment:
     types:
     - created
@@ -80,7 +80,7 @@ jobs:
       && (github.event_name != 'pull_request'
       || (github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.base.ref == 'main'
-      && github.event.pull_request.user.login == 'azure-sdk'
+      && github.event.pull_request.user.login == 'azure-sdk-automation[bot]'
       && startsWith(github.event.pull_request.head.ref, 'sdkauto/')))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'auto-sdk-build-fix'))
     runs-on: ubuntu-slim
     permissions:
@@ -229,7 +229,7 @@ jobs:
         id: sanitized
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_ALLOWED_BOTS: "azure-sdk"
+          GH_AW_ALLOWED_BOTS: "azure-sdk-automation[bot]"
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
         with:
           script: |
@@ -522,7 +522,7 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.27.0
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
         env:
           GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
@@ -1521,11 +1521,11 @@ jobs:
 
   pre_activation:
     if: >
-      (github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) || github.actor == 'azure-sdk') && (((vars.SDK_BUILD_REPAIR_ENABLED == 'true'
+      (github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) || github.actor == 'azure-sdk-automation[bot]') && (((vars.SDK_BUILD_REPAIR_ENABLED == 'true'
       && (github.event_name != 'pull_request'
       || (github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.base.ref == 'main'
-      && github.event.pull_request.user.login == 'azure-sdk'
+      && github.event.pull_request.user.login == 'azure-sdk-automation[bot]'
       && startsWith(github.event.pull_request.head.ref, 'sdkauto/')))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'auto-sdk-build-fix'))
     runs-on: ubuntu-slim
     outputs:
@@ -1552,7 +1552,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-          GH_AW_ALLOWED_BOTS: "azure-sdk"
+          GH_AW_ALLOWED_BOTS: "azure-sdk-automation[bot]"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/sdk-build-repair.lock.yml
+++ b/.github/workflows/sdk-build-repair.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"3cb50a7120da7c3859f4909869516cd0d375b49e1f131a06a14d5502fe36d19d","body_hash":"d866216553868a5c59ab5096698beba4fd7a616b90abe438cd8000918cd13e16","compiler_version":"v0.79.4","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"d9ef9ff398595610ba7d8b6814cb4d9fd8259169076a4b14819a12da6926dd31","body_hash":"059d4d6411e55c56af78efc608a70c0fdfa10d7856207f98b990b32978550e23","compiler_version":"v0.79.4","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"9a946fdbd5fb07b82b2f5a4466058b876ab72bb2","version":"v5.3.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d059700c6a8ec3b5fd798b9ea60f5d048447b918","version":"v0.79.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.0"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.0"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -51,6 +51,7 @@
 name: "SDK Build Repair"
 on:
   # bots: # Bots processed as bot check in pre-activation job
+  # - azure-sdk # Bots processed as bot check in pre-activation job
   # - azure-sdk-automation[bot] # Bots processed as bot check in pre-activation job
   issue_comment:
     types:
@@ -80,7 +81,8 @@ jobs:
       && (github.event_name != 'pull_request'
       || (github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.base.ref == 'main'
-      && github.event.pull_request.user.login == 'azure-sdk-automation[bot]'
+      && (github.event.pull_request.user.login == 'azure-sdk'
+      || github.event.pull_request.user.login == 'azure-sdk-automation[bot]')
       && startsWith(github.event.pull_request.head.ref, 'sdkauto/')))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'auto-sdk-build-fix'))
     runs-on: ubuntu-slim
     permissions:
@@ -229,7 +231,7 @@ jobs:
         id: sanitized
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_ALLOWED_BOTS: "azure-sdk-automation[bot]"
+          GH_AW_ALLOWED_BOTS: "azure-sdk,azure-sdk-automation[bot]"
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
         with:
           script: |
@@ -1521,11 +1523,12 @@ jobs:
 
   pre_activation:
     if: >
-      (github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) || github.actor == 'azure-sdk-automation[bot]') && (((vars.SDK_BUILD_REPAIR_ENABLED == 'true'
+      (github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) || github.actor == 'azure-sdk' || github.actor == 'azure-sdk-automation[bot]') && (((vars.SDK_BUILD_REPAIR_ENABLED == 'true'
       && (github.event_name != 'pull_request'
       || (github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.base.ref == 'main'
-      && github.event.pull_request.user.login == 'azure-sdk-automation[bot]'
+      && (github.event.pull_request.user.login == 'azure-sdk'
+      || github.event.pull_request.user.login == 'azure-sdk-automation[bot]')
       && startsWith(github.event.pull_request.head.ref, 'sdkauto/')))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'auto-sdk-build-fix'))
     runs-on: ubuntu-slim
     outputs:
@@ -1552,7 +1555,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-          GH_AW_ALLOWED_BOTS: "azure-sdk-automation[bot]"
+          GH_AW_ALLOWED_BOTS: "azure-sdk,azure-sdk-automation[bot]"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/sdk-build-repair.md
+++ b/.github/workflows/sdk-build-repair.md
@@ -49,12 +49,12 @@ on:
   # label is allow-listed so the automatic path works. This is the prompt-injection /
   # abuse guard (gh-aw default roles are [admin, maintainer, write]).
   roles: [admin, maintainer, write]
-  bots: ["azure-sdk"]
+  bots: ["azure-sdk-automation[bot]"]
 
 # Master kill-switch (fail-safe) + PR-eligibility gate. The workflow stays dormant unless
 # the repo Actions variable SDK_BUILD_REPAIR_ENABLED is exactly 'true'. In addition, on the
 # automatic (pull_request) path the PR must be a genuine release-planner Auto SDK PR:
-# same-repo (no forks), opened by the `azure-sdk` release bot, targeting `main`, on an
+# same-repo (no forks), opened by the `azure-sdk-automation[bot]` release bot, targeting `main`, on an
 # `sdkauto/` branch. This gates *which PRs are eligible* (not just *who* can trigger), so a
 # stray label on an unrelated/untrusted PR cannot run the repair agent against its code. The
 # label name itself is filtered by `names:` under `on:` above. The manual /repair-build path
@@ -65,7 +65,7 @@ if: >-
       && (github.event_name != 'pull_request'
           || (github.event.pull_request.head.repo.full_name == github.repository
               && github.event.pull_request.base.ref == 'main'
-              && github.event.pull_request.user.login == 'azure-sdk'
+              && github.event.pull_request.user.login == 'azure-sdk-automation[bot]'
               && startsWith(github.event.pull_request.head.ref, 'sdkauto/'))) }}
 
 engine: copilot
@@ -155,7 +155,7 @@ azsdk tsp client customized-update \
 This workflow only repairs genuine **release-planner Auto SDK PRs**. Before building anything, use the read-only GitHub tools to confirm **all** of the following about PR #${{ github.event.pull_request.number || github.event.issue.number }}:
 
 - it is in **this same repository** (the head branch is not from a fork),
-- it was **opened by the `azure-sdk` release bot**,
+- it was **opened by the `azure-sdk-automation[bot]` release bot**,
 - its **base branch is `main`**, and
 - its **head branch starts with `sdkauto/`**.
 

--- a/.github/workflows/sdk-build-repair.md
+++ b/.github/workflows/sdk-build-repair.md
@@ -49,12 +49,13 @@ on:
   # label is allow-listed so the automatic path works. This is the prompt-injection /
   # abuse guard (gh-aw default roles are [admin, maintainer, write]).
   roles: [admin, maintainer, write]
-  bots: ["azure-sdk-automation[bot]"]
+  bots: ["azure-sdk", "azure-sdk-automation[bot]"]
 
 # Master kill-switch (fail-safe) + PR-eligibility gate. The workflow stays dormant unless
 # the repo Actions variable SDK_BUILD_REPAIR_ENABLED is exactly 'true'. In addition, on the
 # automatic (pull_request) path the PR must be a genuine release-planner Auto SDK PR:
-# same-repo (no forks), opened by the `azure-sdk-automation[bot]` release bot, targeting `main`, on an
+# same-repo (no forks), opened by the `azure-sdk` or `azure-sdk-automation[bot]` release bot,
+# targeting `main`, on an
 # `sdkauto/` branch. This gates *which PRs are eligible* (not just *who* can trigger), so a
 # stray label on an unrelated/untrusted PR cannot run the repair agent against its code. The
 # label name itself is filtered by `names:` under `on:` above. The manual /repair-build path
@@ -65,7 +66,8 @@ if: >-
       && (github.event_name != 'pull_request'
           || (github.event.pull_request.head.repo.full_name == github.repository
               && github.event.pull_request.base.ref == 'main'
-              && github.event.pull_request.user.login == 'azure-sdk-automation[bot]'
+              && (github.event.pull_request.user.login == 'azure-sdk'
+                  || github.event.pull_request.user.login == 'azure-sdk-automation[bot]')
               && startsWith(github.event.pull_request.head.ref, 'sdkauto/'))) }}
 
 engine: copilot
@@ -155,7 +157,7 @@ azsdk tsp client customized-update \
 This workflow only repairs genuine **release-planner Auto SDK PRs**. Before building anything, use the read-only GitHub tools to confirm **all** of the following about PR #${{ github.event.pull_request.number || github.event.issue.number }}:
 
 - it is in **this same repository** (the head branch is not from a fork),
-- it was **opened by the `azure-sdk-automation[bot]` release bot**,
+- it was **opened by the `azure-sdk` or `azure-sdk-automation[bot]` release bot**,
 - its **base branch is `main`**, and
 - its **head branch starts with `sdkauto/`**.
 


### PR DESCRIPTION
## What

Corrects the release-bot login(s) recognized by the `sdk-build-repair` auto-build-repair workflow's eligibility gate.

The gate keyed the automatic path on the PR author being **`azure-sdk`** only. Auto SDK PRs may be opened by either release-bot identity:
- **`azure-sdk-automation[bot]`** — the release-planner bot that opens Auto SDK PRs and applies the `auto-sdk-build-fix` label, verified on the AppConfiguration Auto SDK PR #60612 (`pull_request.user.login == "azure-sdk-automation[bot]"`, `user.type == "Bot"`), and
- **`azure-sdk`** — the pre-existing release-bot login used elsewhere.

To be robust to both, the workflow now accepts **either** login.

With the old (single `azure-sdk`) value:
- the labeled-PR **automatic path** was filtered out by the job `if:` when the author was `azure-sdk-automation[bot]` (it never matched), and
- the manual **`/repair-build`** path would also bail, because the skill's eligibility re-check requires the PR to be opened by the release bot.

## Changes (`sdk-build-repair.md`)

- `if:` → `(github.event.pull_request.user.login == 'azure-sdk' || github.event.pull_request.user.login == 'azure-sdk-automation[bot]')`
- `bots: ["azure-sdk", "azure-sdk-automation[bot]"]` (gh-aw auto-normalizes the `[bot]` suffix per the [triggers docs](https://githubnext.github.io/gh-aw/reference/triggers/))
- Prose eligibility references updated to mention both logins (frontmatter comment + agent-prompt "Eligibility" bullet)
- `sdk-build-repair.lock.yml` recompiled with `gh aw compile` (pinned **v0.79.4**); `GH_AW_ALLOWED_BOTS`, the `github.actor` checks, and both `if:` conditions now list both logins

## Notes for reviewers

- The recompile also realigns one `actions/github-script` reference from an orphaned `@v9` (`373c709c`, not present in `.github/aw/actions-lock.json`) to the pinned `@v9.0.0` (`3a2844b7`) that the lock JSON actually records. This is a byproduct of recompiling against the committed pin set, not a functional change.
- Still gated behind `SDK_BUILD_REPAIR_ENABLED == 'true'` (currently `false`) — this PR does not enable the workflow.
- Independent of the (still-unmerged) label **emission** work; this only corrects the identity the workflow matches once a label is present.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
