### PR TITLE
Require ApiCompatVersion for GA libraries to prevent silent ApiCompat bypass

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -18,6 +18,30 @@
            Text="Api Compat cannot be disabled."/>
   </Target>
 
+  <!--
+    ApiCompat is entirely gated on a non-empty ApiCompatVersion (see the '$(ApiCompatVersion)' != '' conditions below),
+    so simply deleting the auto-managed <ApiCompatVersion> element from a project's .csproj would silently disable all
+    ApiCompat enforcement without touching the CODEOWNERS-protected eng/apicompatbaselines files. This target requires
+    the version to be present for GA (non-preview) shipping client libraries so that removal fails the build.
+
+    A first GA (1.0.0) has no prior stable release to compare against, so ApiCompatVersion is legitimately absent there.
+    In the rare case the core team approves running without ApiCompat for an already-GA'd package, add the project name
+    to eng/apicompatbaselines/ApiCompatVersionOptOut.txt, which is CODEOWNERS-protected and therefore requires core team review.
+  -->
+  <Target Name="ValidateApiCompatVersionPresent" BeforeTargets="Build"
+          Condition="'$(ValidateRunApiCompat)' == 'true' and '$(ApiCompatVersion)' == '' and '$(IsShippingClientLibrary)' == 'true' and '$(HasReleaseVersion)' != 'false' and '$(IncludeBuildOutput)' != 'false' and '$(_VersionInProject)' != '1.0.0'">
+    <ReadLinesFromFile File="$(MSBuildThisFileDirectory)apicompatbaselines\ApiCompatVersionOptOut.txt"
+                       Condition="Exists('$(MSBuildThisFileDirectory)apicompatbaselines\ApiCompatVersionOptOut.txt')">
+      <Output TaskParameter="Lines" ItemName="_ApiCompatVersionOptOutLine" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_ApiCompatVersionOptOutMatch Include="@(_ApiCompatVersionOptOutLine)"
+                                    Condition="'%(Identity)' == '$(MSBuildProjectName)'" />
+    </ItemGroup>
+    <Error Condition="'@(_ApiCompatVersionOptOutMatch)' == ''"
+           Text="ApiCompatVersion is missing from $(MSBuildProjectName). It is required for GA (non-preview) libraries and is managed automatically by eng/scripts/Update-PkgVersion.ps1 - do not delete it. If the core team has approved shipping this package without ApiCompat, add '$(MSBuildProjectName)' to eng/apicompatbaselines/ApiCompatVersionOptOut.txt (CODEOWNERS-protected)." />
+  </Target>
+
   <PropertyGroup>
     <PackageRootDirectory>$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory)/../).TrimEnd("/").TrimEnd("\\"))</PackageRootDirectory>
 

--- a/eng/apicompatbaselines/ApiCompatVersionOptOut.txt
+++ b/eng/apicompatbaselines/ApiCompatVersionOptOut.txt
@@ -1,0 +1,13 @@
+# ApiCompat version presence opt-out list
+#
+# ApiCompat enforcement is gated on a non-empty <ApiCompatVersion> in each shipping library's .csproj.
+# To prevent a partner from silently disabling ApiCompat by deleting that auto-managed element, the
+# ValidateApiCompatVersionPresent target in eng/Directory.Build.Common.targets fails the build when a
+# GA (non-preview) shipping client library is missing ApiCompatVersion.
+#
+# In the rare case the core team approves shipping an already-GA'd package without ApiCompat, add the
+# project name (MSBuildProjectName, e.g. Azure.Storage.Blobs) on its own line below. Because this file
+# lives under the CODEOWNERS-protected eng/apicompatbaselines/ directory, every such exception requires
+# core team review.
+#
+# One project name per line. Lines starting with '#' are comments.


### PR DESCRIPTION
## Problem

API compatibility (ApiCompat) enforcement in this repo is entirely gated on a non-empty per-project `<ApiCompatVersion>` element in each shipping library's `src/*.csproj`. Every ApiCompat target in `eng/Directory.Build.Common.targets` carries `Condition="'$(ApiCompatVersion)' != ''"` (baseline download, `ValidateApiCompatForSrc`, the central-baseline redirect, `ValidateNoLocalApiCompatBaseline`, etc.).

We recently moved ApiCompat baseline suppressions into `eng/apicompatbaselines/` so the core team is always pulled into review (via CODEOWNERS) when a suppression is added. However, a partner team could **bypass all of that** by simply deleting the auto-managed `<ApiCompatVersion>` line from their own `.csproj` — this silently disables every ApiCompat check for the package without ever touching a CODEOWNERS-protected file. The existing `ValidateRunApiCompat` guard only catches `RunApiCompat == false`, not a missing `ApiCompatVersion`, and nothing in CI verifies its presence.

## Fix

Add a `ValidateApiCompatVersionPresent` target (next to the existing `ValidateRunApiCompat` guard) that fails the build when a GA (non-preview) shipping client library is missing `ApiCompatVersion`. It fires only when all of the following hold:

- `ValidateRunApiCompat == true` (the CI `dotnet pack` step; local dev builds are unaffected, matching the existing guard)
- `ApiCompatVersion` is empty
- `IsShippingClientLibrary == true` and `HasReleaseVersion != false` (GA / non-preview)
- `IncludeBuildOutput != false`
- `_VersionInProject != 1.0.0` — a first GA has no prior stable release to compare against, so the version is legitimately absent there

### Opt-out

For the rare case where the core team explicitly approves shipping an already-GA'd package without ApiCompat, add the project name to the new `eng/apicompatbaselines/ApiCompatVersionOptOut.txt`. This file lives in the already-CODEOWNERS-protected `eng/apicompatbaselines/` directory, so every exception requires core team review — closing the loop the same way the baselines themselves are protected.

A first GA at a version other than `1.0.0` (against convention) will trip the guard and require an opt-out entry, which intentionally routes it through core team review.

## Validation

- Isolated MSBuild harness across 10 scenarios (fire / first-GA skip / opt-out match incl. CRLF files / `ApiCompatVersion` present / preview / non-shipping / local dev / missing opt-out file / `IncludeBuildOutput=false`).
- End-to-end on real `Azure.Storage.Blobs`: at a forced GA version with `ApiCompatVersion` removed the build fails with the guidance message; with it present the guard is inert; and its current `12.30.0-beta.1` preview correctly stays inert.
