### PR TITLE
Scope Azure.SdkAnalyzers CI to its own packages

### DIFF
--- a/sdk/tools/ci.analyzers.yml
+++ b/sdk/tools/ci.analyzers.yml
@@ -21,6 +21,13 @@ pr:
     include:
     - sdk/tools/Azure.SdkAnalyzers/
 
+# The tools ServiceDirectory also contains Azure.GeneratorAgent, which targets only the LTS
+# framework and therefore cannot build on this pipeline's net462/net8.0/net9.0 test legs. Scope
+# service.proj globbing to just the analyzer packages so those legs don't sweep in the generator.
+variables:
+  - name: Project
+    value: Azure.SdkAnalyzers*
+
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:

--- a/sdk/tools/ci.analyzers.yml
+++ b/sdk/tools/ci.analyzers.yml
@@ -9,6 +9,7 @@ trigger:
   paths:
     include:
     - sdk/tools/Azure.SdkAnalyzers/
+    - sdk/tools/Azure.SdkAnalyzers.CodeFixes/
 
 pr:
   branches:
@@ -20,6 +21,7 @@ pr:
   paths:
     include:
     - sdk/tools/Azure.SdkAnalyzers/
+    - sdk/tools/Azure.SdkAnalyzers.CodeFixes/
 
 # The tools ServiceDirectory also contains Azure.GeneratorAgent, which targets only the LTS
 # framework and therefore cannot build on this pipeline's net462/net8.0/net9.0 test legs. Scope


### PR DESCRIPTION
## Summary

Scopes the `Azure.SdkAnalyzers` CI (`sdk/tools/ci.analyzers.yml`) to only the analyzer packages so its multi-target-framework test legs stop sweeping in the LTS-only `Azure.GeneratorAgent`.

## Background

The `tools` ServiceDirectory contains both the analyzer packages (`Azure.SdkAnalyzers`, `Azure.SdkAnalyzers.CodeFixes` — multi-targeting net462/net8.0/net9.0/net10.0) and `Azure.GeneratorAgent` (LTS-only, i.e. net10.0). `Azure.GeneratorAgent` was added in #55597, which also renamed this pipeline's YAML entrypoint; the pipeline definition was left pointing at the old path, so it has not run successfully since Feb 13, and this regression went unnoticed.

Because `eng/service.proj` globs every project under `sdk/$(ServiceDirectory)`, the analyzers pipeline's net462/net8.0/net9.0 test legs try to build `Azure.GeneratorAgent.Tests` on frameworks it does not target, failing with:

```
error NETSDK1005: Assets file '.../Azure.GeneratorAgent.Tests/project.assets.json' doesn't have a target for 'net9.0'.
```

That fails the Build stage and skips the `Release: Azure.SdkAnalyzers` publish stage. `Azure.GeneratorAgent` has its own pipeline (`ci.generator.yml`), which avoids the issue by using an LTS-only matrix.

## Fix

Set the `service.proj` `Project` glob (via a pipeline variable) to `Azure.SdkAnalyzers*`, so the pack and test steps only cover `sdk/tools/Azure.SdkAnalyzers*` — the two analyzer packages — and no longer include the LTS-only generator. Full net462/net8.0/net9.0/net10.0 coverage for the analyzers is preserved.

## Validation

Verified locally with `dotnet msbuild eng/service.proj -getItem:ProjectReference`:

- Default (`Project=**`) resolves `Azure.GeneratorAgent.Tests`, `Azure.SdkAnalyzers.Tests`, and `Azure.SdkAnalyzers.CodeFixes.Tests`.
- With `Project=Azure.SdkAnalyzers*` it resolves only `Azure.SdkAnalyzers.Tests` and `Azure.SdkAnalyzers.CodeFixes.Tests` (generator excluded).
- Confirmed the scoping also applies when `Project` is supplied as an environment variable (how an Azure Pipelines variable is exposed to MSBuild), not just via `/p:`.

The `Azure.SdkAnalyzers*` wildcard is intentional so both analyzer packages are covered; a bare `Azure.SdkAnalyzers` would drop the `Azure.SdkAnalyzers.CodeFixes` tests.