### PR TITLE
Create a log file on code generation

### DIFF
--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -4,7 +4,7 @@
     <TypeSpecInput Condition="Exists('$(MSBuildProjectDirectory)/../tsp-location.yaml') and $(MSBuildProjectDirectory.EndsWith('src'))">$(MSBuildProjectDirectory)/../tsp-location.yaml</TypeSpecInput>
     <_TspClientDir>$(MSBuildThisFileDirectory)common/tsp-client</_TspClientDir>
     <_TypeSpecProjectGenerateCommand>npm exec --prefix $(_TspClientDir) --no -- tsp-client generate --no-prompt --output-dir $(MSBuildProjectDirectory)/../</_TypeSpecProjectGenerateCommand>
-    <_TypeSpecProjectSyncAndGenerateCommand>npm exec --prefix $(_TspClientDir) --no -- tsp-client update --no-prompt --output-dir $(MSBuildProjectDirectory)/../</_TypeSpecProjectSyncAndGenerateCommand>
+    <_TypeSpecProjectSyncAndGenerateCommand>npm exec --prefix $(_TspClientDir) --no -- tsp-client update --no-prompt --output-dir $(MSBuildProjectDirectory)/../&gt; $(MSBuildProjectDirectory)/../codeGeneration.log 2&gt;&amp;1 </_TypeSpecProjectSyncAndGenerateCommand>
     <_SaveInputs Condition="'$(SaveInputs)' == 'true'">--save-inputs</_SaveInputs>
     <_Trace Condition="'$(Trace)' == 'true'">--trace @typespec/http-client-csharp @azure-typespec/http-client-csharp @azure-typespec/http-client-csharp-mgmt --debug</_Trace>
     <!-- Here we append the generate-test-project configuration to TypespecAdditionalOptions if it is specified -->


### PR DESCRIPTION
Currently, if code generation fails, we are getting the non informative message:
>Azure.AI.Projects.Agents failed with 4 error(s) (506.0s)
>    Error : error Failed to generate the library. Exit code: 1.
>    error : error Error: Failed to generate the library. Exit code: 1.
>    [cause] : error Failed to generate the library. Exit code: 1.
>    C:\Users\nirovins\eclipse-workspace\azure-sdk-for-net\eng\CodeGeneration.targets(31,5): error MSB3073: The command "npm exec --prefix C:\Users\nirovins\eclipse-workspace\azure-sdk-for-net\eng\common/tsp-client --no -- tsp-client update --no-prompt --output-dir C:\Users\nirovins\eclipse-workspace\azure-sdk-for-net\sdk\ai\Azure.AI.Projects.Agents\src/../" exited with code 1.

To avoid rebuilding, I have redirected tsp-client update output to the log.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
