### PR TITLE
Fix management review trigger for fork PRs

### DIFF
--- a/.github/workflows/mgmt-review-trigger.yml
+++ b/.github/workflows/mgmt-review-trigger.yml
@@ -3,18 +3,25 @@ name: Azure .NET Management SDK PR Review Trigger
 on:
   check_run:
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Open pull request number to backfill"
+        required: true
+        type: string
 
 permissions:
   actions: write
+  checks: read
   contents: read
   pull-requests: read
 
 jobs:
   dispatch-mgmt-review:
     if: >
-      github.event.check_run.name == 'net - pullrequest' &&
-      (github.event.check_run.conclusion == 'success' || github.event.check_run.conclusion == 'failure') &&
-      github.event.check_run.pull_requests[0]
+      github.event_name != 'check_run' ||
+      (github.event.check_run.name == 'net - pullrequest' &&
+      (github.event.check_run.conclusion == 'success' || github.event.check_run.conclusion == 'failure'))
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch management review when in scope
@@ -26,34 +33,100 @@ jobs:
           CHECK_RUN_CONCLUSION: ${{ github.event.check_run.conclusion }}
           CHECK_RUN_HEAD_SHA: ${{ github.event.check_run.head_sha }}
           CHECK_RUN_URL: ${{ github.event.check_run.html_url }}
+          MANUAL_PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
 
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No pull request associated with this check run."
+          find_open_pr_for_head_sha() {
+            local head_sha="$1"
+            if [ -z "$head_sha" ]; then
+              return 0
+            fi
+
+            local pr_numbers
+            pr_numbers="$(gh api --paginate "repos/$REPOSITORY/pulls?state=open&per_page=100" \
+              --jq ".[] | select(.head.sha == \"$head_sha\") | .number")"
+            printf '%s\n' "$pr_numbers" | sed -n '1p'
+          }
+
+          has_completed_management_review_check() {
+            local head_sha="$1"
+            local review_check_ids
+            review_check_ids="$(gh api --paginate "repos/$REPOSITORY/commits/$head_sha/check-runs?per_page=100" \
+              --jq '.check_runs[] | select(.name == "Azure .NET Management SDK PR Review" and .status == "completed") | .id')"
+            [ -n "$review_check_ids" ]
+          }
+
+          get_terminal_net_pullrequest_check() {
+            local head_sha="$1"
+            gh api --paginate "repos/$REPOSITORY/commits/$head_sha/check-runs?per_page=100" \
+              --jq '.check_runs[] | select(.name == "net - pullrequest" and (.conclusion == "success" or .conclusion == "failure")) | [.completed_at, .conclusion, .head_sha, .html_url] | @tsv' |
+              sort |
+              tail -n 1 |
+              cut -f 2-
+          }
+
+          dispatch_management_review() {
+            local pr_number="$1"
+            local check_run_conclusion="$2"
+            local check_run_head_sha="$3"
+            local check_run_url="$4"
+
+            if [ -z "$pr_number" ]; then
+              echo "No pull request associated with this check run."
+              return 0
+            fi
+
+            if [ "$(gh pr view "$pr_number" --repo "$REPOSITORY" --json isDraft --jq '.isDraft')" = "true" ]; then
+              echo "Skipping draft PR #$pr_number."
+              return 0
+            fi
+
+            if ! gh api --paginate "repos/$REPOSITORY/pulls/$pr_number/files" --jq '.[].filename' |
+              grep -Eq '^sdk/[^/]+/Azure\.ResourceManager\.[^/]+/'; then
+              echo "Skipping PR #$pr_number; no Azure.ResourceManager.* package files changed."
+              return 0
+            fi
+
+            if has_completed_management_review_check "$check_run_head_sha"; then
+              echo "Skipping PR #$pr_number; management review check already exists for $check_run_head_sha."
+              return 0
+            fi
+
+            AW_CONTEXT=$(printf '{"item_type":"pull_request","item_number":%s}' "$pr_number")
+
+            gh workflow run mgmt-review.lock.yml \
+              --repo "$REPOSITORY" \
+              --ref "$DEFAULT_BRANCH" \
+              -f aw_context="$AW_CONTEXT" \
+              -f pr_number="$pr_number" \
+              -f check_run_conclusion="$check_run_conclusion" \
+              -f check_run_head_sha="$check_run_head_sha" \
+              -f check_run_url="$check_run_url"
+
+            echo "Dispatched management review for PR #$pr_number."
+          }
+
+          if [ "$GITHUB_EVENT_NAME" = "check_run" ]; then
+            if [ -z "$PR_NUMBER" ]; then
+              PR_NUMBER="$(find_open_pr_for_head_sha "$CHECK_RUN_HEAD_SHA")"
+            fi
+
+            dispatch_management_review "$PR_NUMBER" "$CHECK_RUN_CONCLUSION" "$CHECK_RUN_HEAD_SHA" "$CHECK_RUN_URL"
             exit 0
           fi
 
-          if [ "$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json isDraft --jq '.isDraft')" = "true" ]; then
-            echo "Skipping draft PR #$PR_NUMBER."
+          head_sha="$(gh api "repos/$REPOSITORY/pulls/$MANUAL_PR_NUMBER" --jq 'select(.state == "open") | .head.sha')"
+          if [ -z "$head_sha" ]; then
+            echo "Skipping PR #$MANUAL_PR_NUMBER; PR is not open."
             exit 0
           fi
 
-          if ! gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename' |
-            grep -Eq '^sdk/[^/]+/Azure\.ResourceManager\.[^/]+/'; then
-            echo "Skipping PR #$PR_NUMBER; no Azure.ResourceManager.* package files changed."
+          check_run="$(get_terminal_net_pullrequest_check "$head_sha")"
+          if [ -z "$check_run" ]; then
+            echo "Skipping PR #$MANUAL_PR_NUMBER; net - pullrequest is not complete."
             exit 0
           fi
 
-          AW_CONTEXT=$(printf '{"item_type":"pull_request","item_number":%s}' "$PR_NUMBER")
-
-          gh workflow run mgmt-review.lock.yml \
-            --repo "$REPOSITORY" \
-            --ref "$DEFAULT_BRANCH" \
-            -f aw_context="$AW_CONTEXT" \
-            -f pr_number="$PR_NUMBER" \
-            -f check_run_conclusion="$CHECK_RUN_CONCLUSION" \
-            -f check_run_head_sha="$CHECK_RUN_HEAD_SHA" \
-            -f check_run_url="$CHECK_RUN_URL"
-
-          echo "Dispatched management review for PR #$PR_NUMBER."
+          IFS=$'\t' read -r check_run_conclusion check_run_head_sha check_run_url <<< "$check_run"
+          dispatch_management_review "$MANUAL_PR_NUMBER" "$check_run_conclusion" "$check_run_head_sha" "$check_run_url"

--- a/.github/workflows/mgmt-review-trigger.yml
+++ b/.github/workflows/mgmt-review-trigger.yml
@@ -43,17 +43,17 @@ jobs:
               return 0
             fi
 
-            local pr_numbers
-            pr_numbers="$(gh api --paginate "repos/$REPOSITORY/pulls?state=open&per_page=100" \
-              --jq ".[] | select(.head.sha == \"$head_sha\") | .number")"
-            printf '%s\n' "$pr_numbers" | sed -n '1p'
+            gh api --paginate "repos/$REPOSITORY/pulls?state=open&per_page=100" \
+              --jq ".[] | select(.head.sha == \"$head_sha\") | [.updated_at, .number] | @tsv" |
+              sort -r |
+              sed -n '1s/^[^\t]*\t//p'
           }
 
-          has_completed_management_review_check() {
+          has_management_review_check() {
             local head_sha="$1"
             local review_check_ids
             review_check_ids="$(gh api --paginate "repos/$REPOSITORY/commits/$head_sha/check-runs?per_page=100" \
-              --jq '.check_runs[] | select(.name == "Azure .NET Management SDK PR Review" and .status == "completed") | .id')"
+              --jq '.check_runs[] | select(.name == "Azure .NET Management SDK PR Review") | .id')"
             [ -n "$review_check_ids" ]
           }
 
@@ -88,7 +88,7 @@ jobs:
               return 0
             fi
 
-            if has_completed_management_review_check "$check_run_head_sha"; then
+            if has_management_review_check "$check_run_head_sha"; then
               echo "Skipping PR #$pr_number; management review check already exists for $check_run_head_sha."
               return 0
             fi
@@ -116,7 +116,11 @@ jobs:
             exit 0
           fi
 
-          head_sha="$(gh api "repos/$REPOSITORY/pulls/$MANUAL_PR_NUMBER" --jq 'select(.state == "open") | .head.sha')"
+          if ! head_sha="$(gh api "repos/$REPOSITORY/pulls/$MANUAL_PR_NUMBER" --jq 'select(.state == "open") | .head.sha' 2>/dev/null)"; then
+            echo "Skipping PR #$MANUAL_PR_NUMBER; PR was not found or is inaccessible."
+            exit 0
+          fi
+
           if [ -z "$head_sha" ]; then
             echo "Skipping PR #$MANUAL_PR_NUMBER; PR is not open."
             exit 0


### PR DESCRIPTION
## Summary
- resolve open PRs by head SHA when the `net - pullrequest` check-run payload has no pull request association, which happens for fork PRs like #60625
- keep the success/failure routing based on the terminal `net - pullrequest` conclusion
- add a targeted manual backfill input so an open PR can be dispatched after the check already completed
- skip dispatch when the management review check already exists for the PR head SHA

## Validation
- dry-ran #60625 head SHA `f311a3aabd48135ae41142811b0f30c36395d431`: fallback resolves PR #60625
- detected terminal `net - pullrequest` conclusion `success` from https://github.com/Azure/azure-sdk-for-net/runs/84942873407
- confirmed no existing completed `Azure .NET Management SDK PR Review` check on that head SHA
- confirmed #60625 changes match the Azure.ResourceManager package path guard