### PR TITLE
Fix management review trigger file guard

### DIFF
--- a/.github/workflows/mgmt-review-trigger.yml
+++ b/.github/workflows/mgmt-review-trigger.yml
@@ -82,6 +82,7 @@ jobs:
               return 0
             fi
 
+            local changed_files
             changed_files="$(gh api --paginate "repos/$REPOSITORY/pulls/$pr_number/files?per_page=100" --jq '.[].filename')"
             if ! grep -Eq '^sdk/[^/]+/Azure\.ResourceManager\.[^/]+/' <<< "$changed_files"; then
               echo "Skipping PR #$pr_number; no Azure.ResourceManager.* package files changed."

--- a/.github/workflows/mgmt-review-trigger.yml
+++ b/.github/workflows/mgmt-review-trigger.yml
@@ -82,8 +82,8 @@ jobs:
               return 0
             fi
 
-            if ! gh api --paginate "repos/$REPOSITORY/pulls/$pr_number/files" --jq '.[].filename' |
-              grep -Eq '^sdk/[^/]+/Azure\.ResourceManager\.[^/]+/'; then
+            changed_files="$(gh api --paginate "repos/$REPOSITORY/pulls/$pr_number/files?per_page=100" --jq '.[].filename')"
+            if ! grep -Eq '^sdk/[^/]+/Azure\.ResourceManager\.[^/]+/' <<< "$changed_files"; then
               echo "Skipping PR #$pr_number; no Azure.ResourceManager.* package files changed."
               return 0
             fi


### PR DESCRIPTION
## Summary
- avoid piping the paginated PR file list directly into `grep -q` under `set -o pipefail`
- capture changed files first, then run the Azure.ResourceManager path guard
- add `per_page=100` to the PR files API call

## Root cause
#60438 is in scope, but the trigger logged `Skipping PR #60438; no Azure.ResourceManager.* package files changed.` The guard actually matched early, then `grep -q` closed the pipe and `gh api` exited with SIGPIPE/status 141, making the negated pipefail condition take the skip path.

## Validation
- reproduced the old guard returning status 141 on #60438
- verified the new guard matches #60438
- `git diff --check`