### PR TITLE
[Azure.AI.AgentServer.Invocations] Serve AsyncAPI docs at /invocations/docs/asyncapi.{json,yaml}

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Features Added
 
+- AsyncAPI discovery endpoints — `InvocationHandler` now exposes two new
+  virtual methods, `GetAsyncApiJsonAsync` and `GetAsyncApiYamlAsync`, served
+  at `GET /invocations/docs/asyncapi.json` and `GET /invocations/docs/asyncapi.yaml`
+  respectively. Both default to `404`; override either or both to publish the
+  AsyncAPI companion to the existing `openapi.json` endpoint for
+  streaming/bidirectional surfaces (e.g. the `invocations_ws` WebSocket protocol)
+  that OpenAPI cannot express. The path extension is authoritative for the
+  returned content type — no `Accept` negotiation and no format conversion.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/README.md
@@ -57,7 +57,7 @@ For more control over the host (adding services, configuring middleware, composi
 
 ### InvocationHandler
 
-The abstract base class you subclass for HTTP-only handlers. Only `HandleAsync` is abstract — the remaining operations (`GetAsync`, `CancelAsync`, `GetOpenApiAsync`) return 404 by default and can be overridden as needed.
+The abstract base class you subclass for HTTP-only handlers. Only `HandleAsync` is abstract — the remaining operations (`GetAsync`, `CancelAsync`, `GetOpenApiAsync`, `GetAsyncApiJsonAsync`, `GetAsyncApiYamlAsync`) return 404 by default and can be overridden as needed.
 
 ### InvocationWebSocketHandler
 
@@ -87,6 +87,27 @@ When you need to add services, configure middleware, or compose multiple protoco
 ### Handler lifetime
 
 Handlers registered via `AddInvocations<THandler>()` or `InvocationsServer.Run<THandler>()` are resolved per request by default (scoped lifetime). Instance fields on your `InvocationHandler` subclass will not persist across requests. Store long-lived state in separate services or storage keyed by `InvocationContext.SessionId` or `InvocationContext.InvocationId`, or register a singleton handler explicitly if you require a single shared instance.
+
+### Serving discovery specs (OpenAPI / AsyncAPI)
+
+The Invocations host exposes three optional discovery endpoints for machine-readable agent contracts. Override the corresponding methods on your `InvocationHandler`; each returns `404` by default.
+
+| Method | Endpoint | Response media type |
+|---|---|---|
+| `GetOpenApiAsync` | `GET /invocations/docs/openapi.json` | `application/json` |
+| `GetAsyncApiJsonAsync` | `GET /invocations/docs/asyncapi.json` | `application/json` |
+| `GetAsyncApiYamlAsync` | `GET /invocations/docs/asyncapi.yaml` | `application/yaml` |
+
+AsyncAPI is the companion to OpenAPI for event-driven / streaming surfaces (e.g. the `invocations_ws` WebSocket protocol) that OpenAPI cannot express. The path extension is authoritative for the returned content type — there is no `Accept` negotiation and no format conversion between the JSON and YAML representations. Override `GetAsyncApiJsonAsync` and `GetAsyncApiYamlAsync` independently; publishing both is recommended for tooling compatibility.
+
+```C#
+public override async Task GetAsyncApiJsonAsync(
+    HttpRequest request, HttpResponse response, CancellationToken cancellationToken)
+{
+    response.ContentType = "application/json";
+    await response.WriteAsync(_asyncApiJson, cancellationToken);
+}
+```
 
 ### WebSocket protocol (`invocations_ws`)
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/README.md
@@ -104,6 +104,7 @@ AsyncAPI is the companion to OpenAPI for event-driven / streaming surfaces (e.g.
 public override async Task GetAsyncApiJsonAsync(
     HttpRequest request, HttpResponse response, CancellationToken cancellationToken)
 {
+    response.StatusCode = 200;
     response.ContentType = "application/json";
     await response.WriteAsync(_asyncApiJson, cancellationToken);
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/api/Azure.AI.AgentServer.Invocations.net10.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/api/Azure.AI.AgentServer.Invocations.net10.0.cs
@@ -14,6 +14,8 @@ namespace Azure.AI.AgentServer.Invocations
         protected InvocationHandler() { }
         public virtual System.Threading.Tasks.Task CancelAsync(string invocationId, Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, Azure.AI.AgentServer.Invocations.InvocationContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task GetAsync(string invocationId, Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, Azure.AI.AgentServer.Invocations.InvocationContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual System.Threading.Tasks.Task GetAsyncApiJsonAsync(Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual System.Threading.Tasks.Task GetAsyncApiYamlAsync(Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task GetOpenApiAsync(Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, System.Threading.CancellationToken cancellationToken) { throw null; }
         public abstract System.Threading.Tasks.Task HandleAsync(Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, Azure.AI.AgentServer.Invocations.InvocationContext context, System.Threading.CancellationToken cancellationToken);
     }

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/api/Azure.AI.AgentServer.Invocations.net8.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/api/Azure.AI.AgentServer.Invocations.net8.0.cs
@@ -14,6 +14,8 @@ namespace Azure.AI.AgentServer.Invocations
         protected InvocationHandler() { }
         public virtual System.Threading.Tasks.Task CancelAsync(string invocationId, Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, Azure.AI.AgentServer.Invocations.InvocationContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task GetAsync(string invocationId, Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, Azure.AI.AgentServer.Invocations.InvocationContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual System.Threading.Tasks.Task GetAsyncApiJsonAsync(Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual System.Threading.Tasks.Task GetAsyncApiYamlAsync(Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task GetOpenApiAsync(Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, System.Threading.CancellationToken cancellationToken) { throw null; }
         public abstract System.Threading.Tasks.Task HandleAsync(Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response, Azure.AI.AgentServer.Invocations.InvocationContext context, System.Threading.CancellationToken cancellationToken);
     }

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Hosting/InvocationsServerEndpointRouteBuilderExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Hosting/InvocationsServerEndpointRouteBuilderExtensions.cs
@@ -41,57 +41,57 @@ public static class InvocationsServerEndpointRouteBuilderExtensions
         // POST /invocations — invoke the agent
         group.MapPost("/invocations", async (
             HttpContext httpContext,
-            InvocationEndpointHandler handler,
-            InvocationHandler invocationHandler) =>
+            InvocationEndpointHandler endpointHandler,
+            InvocationHandler userHandler) =>
         {
-            await handler.HandleInvokeAsync(httpContext, invocationHandler);
+            await endpointHandler.HandleInvokeAsync(httpContext, userHandler);
         }).AddEndpointFilter<InvocationsErrorSourceFilter>();
 
         // GET /invocations/{invocationId} — get invocation result
         group.MapGet("/invocations/{invocationId}", async (
             HttpContext httpContext,
             string invocationId,
-            InvocationEndpointHandler handler,
-            InvocationHandler invocationHandler) =>
+            InvocationEndpointHandler endpointHandler,
+            InvocationHandler userHandler) =>
         {
-            await handler.HandleGetAsync(httpContext, invocationId, invocationHandler);
+            await endpointHandler.HandleGetAsync(httpContext, invocationId, userHandler);
         }).AddEndpointFilter<InvocationsErrorSourceFilter>();
 
         // POST /invocations/{invocationId}/cancel — cancel invocation
         group.MapPost("/invocations/{invocationId}/cancel", async (
             HttpContext httpContext,
             string invocationId,
-            InvocationEndpointHandler handler,
-            InvocationHandler invocationHandler) =>
+            InvocationEndpointHandler endpointHandler,
+            InvocationHandler userHandler) =>
         {
-            await handler.HandleCancelAsync(httpContext, invocationId, invocationHandler);
+            await endpointHandler.HandleCancelAsync(httpContext, invocationId, userHandler);
         }).AddEndpointFilter<InvocationsErrorSourceFilter>();
 
         // GET /invocations/docs/openapi.json — OpenAPI spec
         group.MapGet("/invocations/docs/openapi.json", async (
             HttpContext httpContext,
-            InvocationEndpointHandler handler,
-            InvocationHandler invocationHandler) =>
+            InvocationEndpointHandler endpointHandler,
+            InvocationHandler userHandler) =>
         {
-            await handler.HandleGetOpenApiAsync(httpContext, invocationHandler);
+            await endpointHandler.HandleGetOpenApiAsync(httpContext, userHandler);
         }).AddEndpointFilter<InvocationsErrorSourceFilter>();
 
         // GET /invocations/docs/asyncapi.json — AsyncAPI spec (JSON)
         group.MapGet("/invocations/docs/asyncapi.json", async (
             HttpContext httpContext,
-            InvocationEndpointHandler handler,
-            InvocationHandler invocationHandler) =>
+            InvocationEndpointHandler endpointHandler,
+            InvocationHandler userHandler) =>
         {
-            await handler.HandleGetAsyncApiJsonAsync(httpContext, invocationHandler);
+            await endpointHandler.HandleGetAsyncApiJsonAsync(httpContext, userHandler);
         }).AddEndpointFilter<InvocationsErrorSourceFilter>();
 
         // GET /invocations/docs/asyncapi.yaml — AsyncAPI spec (YAML)
         group.MapGet("/invocations/docs/asyncapi.yaml", async (
             HttpContext httpContext,
-            InvocationEndpointHandler handler,
-            InvocationHandler invocationHandler) =>
+            InvocationEndpointHandler endpointHandler,
+            InvocationHandler userHandler) =>
         {
-            await handler.HandleGetAsyncApiYamlAsync(httpContext, invocationHandler);
+            await endpointHandler.HandleGetAsyncApiYamlAsync(httpContext, userHandler);
         }).AddEndpointFilter<InvocationsErrorSourceFilter>();
 
         // /invocations_ws — WebSocket transport.
@@ -101,10 +101,10 @@ public static class InvocationsServerEndpointRouteBuilderExtensions
         // "endpoint not registered".
         group.Map(InvocationsWebSocketConstants.RoutePath, async (
             HttpContext httpContext,
-            WebSocketEndpointHandler handler,
-            InvocationHandler invocationHandler) =>
+            WebSocketEndpointHandler endpointHandler,
+            InvocationHandler userHandler) =>
         {
-            await handler.HandleAsync(httpContext, invocationHandler);
+            await endpointHandler.HandleAsync(httpContext, userHandler);
         });
 
         group.WithTags("Invocations");

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Hosting/InvocationsServerEndpointRouteBuilderExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Hosting/InvocationsServerEndpointRouteBuilderExtensions.cs
@@ -76,6 +76,24 @@ public static class InvocationsServerEndpointRouteBuilderExtensions
             await handler.HandleGetOpenApiAsync(httpContext, invocationHandler);
         }).AddEndpointFilter<InvocationsErrorSourceFilter>();
 
+        // GET /invocations/docs/asyncapi.json — AsyncAPI spec (JSON)
+        group.MapGet("/invocations/docs/asyncapi.json", async (
+            HttpContext httpContext,
+            InvocationEndpointHandler handler,
+            InvocationHandler invocationHandler) =>
+        {
+            await handler.HandleGetAsyncApiJsonAsync(httpContext, invocationHandler);
+        }).AddEndpointFilter<InvocationsErrorSourceFilter>();
+
+        // GET /invocations/docs/asyncapi.yaml — AsyncAPI spec (YAML)
+        group.MapGet("/invocations/docs/asyncapi.yaml", async (
+            HttpContext httpContext,
+            InvocationEndpointHandler handler,
+            InvocationHandler invocationHandler) =>
+        {
+            await handler.HandleGetAsyncApiYamlAsync(httpContext, invocationHandler);
+        }).AddEndpointFilter<InvocationsErrorSourceFilter>();
+
         // /invocations_ws — WebSocket transport.
         // Endpoint short-circuits to 404 when the handler does not override
         // `InvocationHandler.HandleWebSocketAsync`, so an upgrade attempt

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Internal/InvocationEndpointHandler.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Internal/InvocationEndpointHandler.cs
@@ -127,13 +127,7 @@ internal sealed class InvocationEndpointHandler
     /// </summary>
     internal async Task HandleGetOpenApiAsync(HttpContext httpContext, InvocationHandler handler)
     {
-        // OpenAPI docs endpoint — inject session ID from env var only (no invocation context).
-        var sessionId = FoundryEnvironment.SessionId;
-        if (!string.IsNullOrEmpty(sessionId))
-        {
-            httpContext.Response.Headers[SessionIdResponseHeader] = sessionId;
-        }
-
+        InjectSessionIdHeaderFromEnv(httpContext.Response);
         await handler.GetOpenApiAsync(httpContext.Request, httpContext.Response, httpContext.RequestAborted);
     }
 
@@ -143,12 +137,7 @@ internal sealed class InvocationEndpointHandler
     /// </summary>
     internal async Task HandleGetAsyncApiJsonAsync(HttpContext httpContext, InvocationHandler handler)
     {
-        var sessionId = FoundryEnvironment.SessionId;
-        if (!string.IsNullOrEmpty(sessionId))
-        {
-            httpContext.Response.Headers[SessionIdResponseHeader] = sessionId;
-        }
-
+        InjectSessionIdHeaderFromEnv(httpContext.Response);
         await handler.GetAsyncApiJsonAsync(httpContext.Request, httpContext.Response, httpContext.RequestAborted);
     }
 
@@ -157,12 +146,7 @@ internal sealed class InvocationEndpointHandler
     /// </summary>
     internal async Task HandleGetAsyncApiYamlAsync(HttpContext httpContext, InvocationHandler handler)
     {
-        var sessionId = FoundryEnvironment.SessionId;
-        if (!string.IsNullOrEmpty(sessionId))
-        {
-            httpContext.Response.Headers[SessionIdResponseHeader] = sessionId;
-        }
-
+        InjectSessionIdHeaderFromEnv(httpContext.Response);
         await handler.GetAsyncApiYamlAsync(httpContext.Request, httpContext.Response, httpContext.RequestAborted);
     }
 
@@ -196,13 +180,21 @@ internal sealed class InvocationEndpointHandler
     /// Injects the <c>x-agent-session-id</c> response header. Called before the
     /// handler writes the response body so the header is present on all responses.
     /// </summary>
-    private static void InjectSessionIdHeader(HttpResponse response, string sessionId)
+    private static void InjectSessionIdHeader(HttpResponse response, string? sessionId)
     {
         if (!string.IsNullOrEmpty(sessionId))
         {
             response.Headers[SessionIdResponseHeader] = sessionId;
         }
     }
+
+    /// <summary>
+    /// Injects the <c>x-agent-session-id</c> response header from the environment
+    /// variable. Used by discovery-docs endpoints (openapi.json, asyncapi.json,
+    /// asyncapi.yaml) that run without an invocation context.
+    /// </summary>
+    private static void InjectSessionIdHeaderFromEnv(HttpResponse response)
+        => InjectSessionIdHeader(response, FoundryEnvironment.SessionId);
 
     /// <summary>
     /// Wraps <paramref name="httpContext"/>.Response.Body with a <see cref="SseKeepAliveSession"/>

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Internal/InvocationEndpointHandler.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Internal/InvocationEndpointHandler.cs
@@ -138,6 +138,35 @@ internal sealed class InvocationEndpointHandler
     }
 
     /// <summary>
+    /// Handles <c>GET /invocations/docs/asyncapi.json</c>. Companion to the OpenAPI
+    /// endpoint for event-driven/streaming surfaces (e.g. <c>invocations_ws</c>).
+    /// </summary>
+    internal async Task HandleGetAsyncApiJsonAsync(HttpContext httpContext, InvocationHandler handler)
+    {
+        var sessionId = FoundryEnvironment.SessionId;
+        if (!string.IsNullOrEmpty(sessionId))
+        {
+            httpContext.Response.Headers[SessionIdResponseHeader] = sessionId;
+        }
+
+        await handler.GetAsyncApiJsonAsync(httpContext.Request, httpContext.Response, httpContext.RequestAborted);
+    }
+
+    /// <summary>
+    /// Handles <c>GET /invocations/docs/asyncapi.yaml</c>.
+    /// </summary>
+    internal async Task HandleGetAsyncApiYamlAsync(HttpContext httpContext, InvocationHandler handler)
+    {
+        var sessionId = FoundryEnvironment.SessionId;
+        if (!string.IsNullOrEmpty(sessionId))
+        {
+            httpContext.Response.Headers[SessionIdResponseHeader] = sessionId;
+        }
+
+        await handler.GetAsyncApiYamlAsync(httpContext.Request, httpContext.Response, httpContext.RequestAborted);
+    }
+
+    /// <summary>
     /// Builds an <see cref="InvocationContext"/> from the HTTP request.
     /// Used by GET and Cancel endpoints where the invocation ID comes from
     /// the route rather than a header.

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/InvocationHandler.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/InvocationHandler.cs
@@ -103,9 +103,10 @@ public abstract class InvocationHandler
     /// independently; publishing both is recommended for tooling compatibility.
     /// <para>
     /// When overriding, you MUST set <see cref="HttpResponse.StatusCode"/>
-    /// explicitly. The base implementation sets 404; if you override and forget
-    /// to set a status, the response defaults to 200 with whatever body you wrote
-    /// (or empty).
+    /// explicitly. This method returns 404 by default; once you override it the
+    /// default no longer runs (unless the override calls <c>base.GetAsyncApiJsonAsync(...)</c>
+    /// / <c>base.GetAsyncApiYamlAsync(...)</c>), so if you forget to set a status the
+    /// response defaults to 200 with whatever body you wrote (or empty).
     /// </para>
     /// </remarks>
     /// <param name="request">The incoming HTTP request.</param>
@@ -134,9 +135,10 @@ public abstract class InvocationHandler
     /// independently; publishing both is recommended for tooling compatibility.
     /// <para>
     /// When overriding, you MUST set <see cref="HttpResponse.StatusCode"/>
-    /// explicitly. The base implementation sets 404; if you override and forget
-    /// to set a status, the response defaults to 200 with whatever body you wrote
-    /// (or empty).
+    /// explicitly. This method returns 404 by default; once you override it the
+    /// default no longer runs (unless the override calls <c>base.GetAsyncApiJsonAsync(...)</c>
+    /// / <c>base.GetAsyncApiYamlAsync(...)</c>), so if you forget to set a status the
+    /// response defaults to 200 with whatever body you wrote (or empty).
     /// </para>
     /// </remarks>
     /// <param name="request">The incoming HTTP request.</param>

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/InvocationHandler.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/InvocationHandler.cs
@@ -7,8 +7,8 @@ namespace Azure.AI.AgentServer.Invocations;
 
 /// <summary>
 /// Base class for handling invocation requests. Only <see cref="HandleAsync"/>
-/// is required. Override the optional methods to opt in to GET, cancel, and
-/// OpenAPI endpoints (they return 404 by default).
+/// is required. Override the optional methods to opt in to GET, cancel, OpenAPI,
+/// and AsyncAPI endpoints (they return 404 by default).
 /// </summary>
 /// <remarks>
 /// To opt in to the <c>invocations_ws</c> (WebSocket) transport, derive from
@@ -81,6 +81,51 @@ public abstract class InvocationHandler
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task representing the async operation.</returns>
     public virtual Task GetOpenApiAsync(
+        HttpRequest request,
+        HttpResponse response,
+        CancellationToken cancellationToken)
+    {
+        response.StatusCode = 404;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Handles <c>GET /invocations/docs/asyncapi.json</c>. Returns 404 by default.
+    /// Override to return an AsyncAPI (JSON) spec for the agent's event-driven
+    /// contract (e.g. the <c>invocations_ws</c> WebSocket protocol) — the AsyncAPI
+    /// companion to <see cref="GetOpenApiAsync"/> for streaming/bidirectional
+    /// surfaces that OpenAPI cannot express.
+    /// </summary>
+    /// <remarks>
+    /// The path extension is authoritative for the returned content type — no
+    /// <c>Accept</c> negotiation and no format conversion between the JSON and
+    /// YAML representations. Override <see cref="GetAsyncApiYamlAsync"/>
+    /// independently; publishing both is recommended for tooling compatibility.
+    /// </remarks>
+    /// <param name="request">The incoming HTTP request.</param>
+    /// <param name="response">The outgoing HTTP response.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task representing the async operation.</returns>
+    public virtual Task GetAsyncApiJsonAsync(
+        HttpRequest request,
+        HttpResponse response,
+        CancellationToken cancellationToken)
+    {
+        response.StatusCode = 404;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Handles <c>GET /invocations/docs/asyncapi.yaml</c>. Returns 404 by default.
+    /// Override to return an AsyncAPI (YAML) spec for the agent's event-driven
+    /// contract. Companion to <see cref="GetAsyncApiJsonAsync"/>; each format is
+    /// served independently at its own path.
+    /// </summary>
+    /// <param name="request">The incoming HTTP request.</param>
+    /// <param name="response">The outgoing HTTP response.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task representing the async operation.</returns>
+    public virtual Task GetAsyncApiYamlAsync(
         HttpRequest request,
         HttpResponse response,
         CancellationToken cancellationToken)

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/InvocationHandler.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/InvocationHandler.cs
@@ -101,6 +101,12 @@ public abstract class InvocationHandler
     /// <c>Accept</c> negotiation and no format conversion between the JSON and
     /// YAML representations. Override <see cref="GetAsyncApiYamlAsync"/>
     /// independently; publishing both is recommended for tooling compatibility.
+    /// <para>
+    /// When overriding, you MUST set <see cref="HttpResponse.StatusCode"/>
+    /// explicitly. The base implementation sets 404; if you override and forget
+    /// to set a status, the response defaults to 200 with whatever body you wrote
+    /// (or empty).
+    /// </para>
     /// </remarks>
     /// <param name="request">The incoming HTTP request.</param>
     /// <param name="response">The outgoing HTTP response.</param>
@@ -121,6 +127,18 @@ public abstract class InvocationHandler
     /// contract. Companion to <see cref="GetAsyncApiJsonAsync"/>; each format is
     /// served independently at its own path.
     /// </summary>
+    /// <remarks>
+    /// The path extension is authoritative for the returned content type — no
+    /// <c>Accept</c> negotiation and no format conversion between the JSON and
+    /// YAML representations. Override <see cref="GetAsyncApiJsonAsync"/>
+    /// independently; publishing both is recommended for tooling compatibility.
+    /// <para>
+    /// When overriding, you MUST set <see cref="HttpResponse.StatusCode"/>
+    /// explicitly. The base implementation sets 404; if you override and forget
+    /// to set a status, the response defaults to 200 with whatever body you wrote
+    /// (or empty).
+    /// </para>
+    /// </remarks>
     /// <param name="request">The incoming HTTP request.</param>
     /// <param name="response">The outgoing HTTP response.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/tests/InvocationEndpointAdvancedTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/tests/InvocationEndpointAdvancedTests.cs
@@ -284,10 +284,9 @@ public class InvocationEndpointAdvancedTests
     }
 
     [Test]
-    public async Task GetAsyncApi_JsonAndYamlAreIndependent()
+    public async Task GetAsyncApiJson_Returns200_AndYamlStays404_WhenOnlyJsonOverridden()
     {
-        // Overriding only the JSON variant leaves YAML as 404 and vice versa —
-        // no format conversion, users may publish either or both.
+        // Overriding only the JSON variant leaves YAML as 404 — no format conversion.
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Services.AddInvocationsServer();
@@ -306,23 +305,27 @@ public class InvocationEndpointAdvancedTests
         Assert.That(yaml.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
 
         await app.StopAsync();
+    }
 
+    [Test]
+    public async Task GetAsyncApiYaml_Returns200_AndJsonStays404_WhenOnlyYamlOverridden()
+    {
         // Symmetric direction: only YAML override → JSON returns 404.
-        builder = WebApplication.CreateBuilder();
+        var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Services.AddInvocationsServer();
         builder.Services.AddScoped<InvocationHandler, YamlOnlyAsyncApiHandler>();
 
-        app = builder.Build();
+        var app = builder.Build();
         app.MapInvocationsServer();
         await app.StartAsync();
 
-        client = app.GetTestClient();
+        var client = app.GetTestClient();
 
-        yaml = await client.GetAsync("/invocations/docs/asyncapi.yaml");
+        var yaml = await client.GetAsync("/invocations/docs/asyncapi.yaml");
         Assert.That(yaml.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-        json = await client.GetAsync("/invocations/docs/asyncapi.json");
+        var json = await client.GetAsync("/invocations/docs/asyncapi.json");
         Assert.That(json.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
 
         await app.StopAsync();

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/tests/InvocationEndpointAdvancedTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/tests/InvocationEndpointAdvancedTests.cs
@@ -237,6 +237,97 @@ public class InvocationEndpointAdvancedTests
         await app.StopAsync();
     }
 
+    [Test]
+    public async Task GetAsyncApiJson_Returns200_WhenHandlerOverrides()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddInvocationsServer();
+        builder.Services.AddScoped<InvocationHandler, FullOverrideHandler>();
+
+        var app = builder.Build();
+        app.MapInvocationsServer();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/invocations/docs/asyncapi.json");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.That(body, Is.EqualTo("{\"asyncapi\":\"3.0\"}"));
+        Assert.That(response.Content.Headers.ContentType?.MediaType, Is.EqualTo("application/json"));
+
+        await app.StopAsync();
+    }
+
+    [Test]
+    public async Task GetAsyncApiYaml_Returns200_WhenHandlerOverrides()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddInvocationsServer();
+        builder.Services.AddScoped<InvocationHandler, FullOverrideHandler>();
+
+        var app = builder.Build();
+        app.MapInvocationsServer();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/invocations/docs/asyncapi.yaml");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.That(body, Is.EqualTo("asyncapi: 3.0\n"));
+        Assert.That(response.Content.Headers.ContentType?.MediaType, Is.EqualTo("application/yaml"));
+
+        await app.StopAsync();
+    }
+
+    [Test]
+    public async Task GetAsyncApi_JsonAndYamlAreIndependent()
+    {
+        // Overriding only the JSON variant leaves YAML as 404 and vice versa —
+        // no format conversion, users may publish either or both.
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddInvocationsServer();
+        builder.Services.AddScoped<InvocationHandler, JsonOnlyAsyncApiHandler>();
+
+        var app = builder.Build();
+        app.MapInvocationsServer();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+
+        var json = await client.GetAsync("/invocations/docs/asyncapi.json");
+        Assert.That(json.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var yaml = await client.GetAsync("/invocations/docs/asyncapi.yaml");
+        Assert.That(yaml.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+
+        await app.StopAsync();
+
+        // Symmetric direction: only YAML override → JSON returns 404.
+        builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddInvocationsServer();
+        builder.Services.AddScoped<InvocationHandler, YamlOnlyAsyncApiHandler>();
+
+        app = builder.Build();
+        app.MapInvocationsServer();
+        await app.StartAsync();
+
+        client = app.GetTestClient();
+
+        yaml = await client.GetAsync("/invocations/docs/asyncapi.yaml");
+        Assert.That(yaml.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        json = await client.GetAsync("/invocations/docs/asyncapi.json");
+        Assert.That(json.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+
+        await app.StopAsync();
+    }
+
     // ─── Test handler implementations ───
 
     private sealed class ThrowingHandler : InvocationHandler
@@ -298,6 +389,64 @@ public class InvocationEndpointAdvancedTests
             response.StatusCode = 200;
             response.ContentType = "application/json";
             await response.WriteAsync("{\"openapi\":\"3.0\"}", cancellationToken);
+        }
+
+        public override async Task GetAsyncApiJsonAsync(
+            HttpRequest request, HttpResponse response,
+            CancellationToken cancellationToken)
+        {
+            response.StatusCode = 200;
+            response.ContentType = "application/json";
+            await response.WriteAsync("{\"asyncapi\":\"3.0\"}", cancellationToken);
+        }
+
+        public override async Task GetAsyncApiYamlAsync(
+            HttpRequest request, HttpResponse response,
+            CancellationToken cancellationToken)
+        {
+            response.StatusCode = 200;
+            response.ContentType = "application/yaml";
+            await response.WriteAsync("asyncapi: 3.0\n", cancellationToken);
+        }
+    }
+
+    private sealed class JsonOnlyAsyncApiHandler : InvocationHandler
+    {
+        public override async Task HandleAsync(
+            HttpRequest request, HttpResponse response,
+            InvocationContext context, CancellationToken cancellationToken)
+        {
+            response.StatusCode = 200;
+            await response.WriteAsync("ok", cancellationToken);
+        }
+
+        public override async Task GetAsyncApiJsonAsync(
+            HttpRequest request, HttpResponse response,
+            CancellationToken cancellationToken)
+        {
+            response.StatusCode = 200;
+            response.ContentType = "application/json";
+            await response.WriteAsync("{\"asyncapi\":\"3.0\"}", cancellationToken);
+        }
+    }
+
+    private sealed class YamlOnlyAsyncApiHandler : InvocationHandler
+    {
+        public override async Task HandleAsync(
+            HttpRequest request, HttpResponse response,
+            InvocationContext context, CancellationToken cancellationToken)
+        {
+            response.StatusCode = 200;
+            await response.WriteAsync("ok", cancellationToken);
+        }
+
+        public override async Task GetAsyncApiYamlAsync(
+            HttpRequest request, HttpResponse response,
+            CancellationToken cancellationToken)
+        {
+            response.StatusCode = 200;
+            response.ContentType = "application/yaml";
+            await response.WriteAsync("asyncapi: 3.0\n", cancellationToken);
         }
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/tests/InvocationEndpointTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/tests/InvocationEndpointTests.cs
@@ -103,6 +103,46 @@ public class InvocationEndpointTests
     }
 
     [Test]
+    public async Task GetAsyncApiJson_Returns404_ByDefault()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddInvocationsServer();
+        builder.Services.AddScoped<InvocationHandler, TestInvocationHandler>();
+
+        var app = builder.Build();
+        app.MapInvocationsServer();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/invocations/docs/asyncapi.json");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+
+        await app.StopAsync();
+    }
+
+    [Test]
+    public async Task GetAsyncApiYaml_Returns404_ByDefault()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddInvocationsServer();
+        builder.Services.AddScoped<InvocationHandler, TestInvocationHandler>();
+
+        var app = builder.Build();
+        app.MapInvocationsServer();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/invocations/docs/asyncapi.yaml");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+
+        await app.StopAsync();
+    }
+
+    [Test]
     public async Task GetInvocation_SessionIdHeader_MatchesEnvVar()
     {
         var originalValue = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_SESSION_ID");


### PR DESCRIPTION
## Summary

`InvocationHandler` now exposes two new virtual methods, `GetAsyncApiJsonAsync` and `GetAsyncApiYamlAsync`, served at `GET /invocations/docs/asyncapi.json` and `GET /invocations/docs/asyncapi.yaml` respectively. Both default to `404`; override either or both to publish the AsyncAPI companion to the existing `openapi.json` endpoint for streaming/bidirectional surfaces (e.g. the `invocations_ws` WebSocket protocol) that OpenAPI cannot express.

Path extension is authoritative for the returned content type — no `Accept` negotiation, no format conversion between the two representations. JSON and YAML are served independently at their own paths; users may override one or both.

**Design**: two virtual methods (not a `format` enum) to mirror `GetOpenApiAsync`, avoid a YAML dependency in the SDK, and let handlers publishing only one format skip the other with no boilerplate.

## Rollout & compatibility

**This PR is independently mergeable and safe to ship ahead of the others.** Both new methods default to returning `404`, so an existing `InvocationHandler` subclass that does not override them behaves identically to today. No breaking API change; new members are additive `virtual` methods.

Part of a 5-repo change adding AsyncAPI discovery to Agent Server:
- Prose spec: coreai-microsoft/foundrysdk_specs#209
- TypeSpec: Azure/azure-rest-api-specs#44416
- Python SDK: Azure/azure-sdk-for-python#47829
- **This PR**: .NET SDK
- Backend service (Vienna): Microsoft internal PR #2182112 (msdata/Vienna) — internal link, no external dependency; provided for context only

## Test plan

- `dotnet build sdk/agentserver/Azure.AI.AgentServer.Invocations/src/Azure.AI.AgentServer.Invocations.csproj --framework net8.0` — passes locally.
- Unit tests in `InvocationEndpointTests` + `InvocationEndpointAdvancedTests` cover: default 404 (both new paths), override → 200 (JSON), override → 200 (YAML), and JSON/YAML representation independence in both directions (JSON-only handler → YAML returns 404; YAML-only handler → JSON returns 404).
- Full `dotnet test` deferred to CI (`net - pullrequest`) — local test host had environmental issues.
- API baseline (`net8.0.cs`, `net10.0.cs`) regenerated via `eng/scripts/Export-API.ps1 -ServiceDirectory agentserver`.

Fixes: AB#5407709