### PR TITLE
Preserve flattened collection setters for compatibility

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/PropertyHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/PropertyHelpers.cs
@@ -139,9 +139,9 @@ namespace Azure.Generator.Management.Utilities
             }
         }
 
-        public static MethodBodyStatement? BuildSetterForPropertyFlatten(ModelProvider innerModel, PropertyProvider internalProperty, PropertyProvider innerProperty, bool isPropertyLiftedToNullable)
+        public static MethodBodyStatement? BuildSetterForPropertyFlatten(ModelProvider innerModel, PropertyProvider internalProperty, PropertyProvider innerProperty, bool isPropertyLiftedToNullable, bool allowCollectionSetter = false)
         {
-            if (innerProperty.Type.IsCollection)
+            if (innerProperty.Type.IsCollection && !allowCollectionSetter)
             {
                 return null;
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -714,7 +714,6 @@ namespace Azure.Generator.Management.Visitors
 
             var shouldPreserveSetter = ShouldPreserveLastContractSetter(model, flattenPropertyName);
             var shouldEmitCollectionSetter = shouldPreserveSetter
-                || !model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public)
                 || IsFlattenedIntoParentWithLastContractSetter(model, flattenPropertyName);
             var flattenPropertyBody = new MethodPropertyBody(
                 PropertyHelpers.BuildGetter(includeGetterNullCheck, internalProperty, modelProvider, innerProperty),
@@ -766,7 +765,7 @@ namespace Azure.Generator.Management.Visitors
 
             foreach (var parent in ManagementClientGenerator.Instance.OutputLibrary.TypeProviders.OfType<ModelProvider>())
             {
-                if (parent == model || !ShouldPreserveLastContractSetter(parent, propertyName))
+                if (parent == model || !ShouldPreserveLastContractSetter(parent, propertyName) || HasCustomSetter(parent, propertyName))
                 {
                     continue;
                 }
@@ -784,6 +783,9 @@ namespace Azure.Generator.Management.Visitors
         }
 
         private sealed record FlattenedSetterCacheKey(string? Namespace, string Name, string PropertyName);
+
+        private static bool HasCustomSetter(ModelProvider model, string propertyName)
+            => model.CustomCodeView?.Properties.Any(p => p.Name == propertyName && p.Body.HasSetter) == true;
 
         private void UpdateFlattenTypeCollectionProperty(PropertyProvider internalProperty, PropertyProvider innerProperty, ModelProvider modelProvider)
         {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -508,7 +508,7 @@ namespace Azure.Generator.Management.Visitors
         // This dictionary holds the flattened model types, where the key is the CSharpType of the model and the value is a dictionary of property names to flattened PropertyProvider.
         // So that, we can use this to update the model factory methods later.
         private readonly Dictionary<CSharpType, Dictionary<string, List<FlattenPropertyInfo>>> _flattenedModelTypes = new(new CSharpTypeNameComparer());
-        private readonly Dictionary<(string? Namespace, string Name, string PropertyName), bool> _flattenedIntoParentWithLastContractSetterCache = [];
+        private readonly Dictionary<FlattenedSetterCacheKey, bool> _flattenedIntoParentWithLastContractSetterCache = [];
         private readonly HashSet<CSharpType> _visitedModelTypes = new();
         private void FlattenModel(ModelProvider model)
         {
@@ -758,7 +758,7 @@ namespace Azure.Generator.Management.Visitors
 
         private bool IsFlattenedIntoParentWithLastContractSetter(ModelProvider model, string propertyName)
         {
-            var cacheKey = (model.Type.Namespace, model.Type.Name, propertyName);
+            var cacheKey = new FlattenedSetterCacheKey(model.Type.Namespace, model.Type.Name, propertyName);
             if (_flattenedIntoParentWithLastContractSetterCache.TryGetValue(cacheKey, out var result))
             {
                 return result;
@@ -782,6 +782,8 @@ namespace Azure.Generator.Management.Visitors
             _flattenedIntoParentWithLastContractSetterCache[cacheKey] = false;
             return false;
         }
+
+        private sealed record FlattenedSetterCacheKey(string? Namespace, string Name, string PropertyName);
 
         private void UpdateFlattenTypeCollectionProperty(PropertyProvider internalProperty, PropertyProvider innerProperty, ModelProvider modelProvider)
         {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -508,7 +508,7 @@ namespace Azure.Generator.Management.Visitors
         // This dictionary holds the flattened model types, where the key is the CSharpType of the model and the value is a dictionary of property names to flattened PropertyProvider.
         // So that, we can use this to update the model factory methods later.
         private readonly Dictionary<CSharpType, Dictionary<string, List<FlattenPropertyInfo>>> _flattenedModelTypes = new(new CSharpTypeNameComparer());
-        private readonly Dictionary<(CSharpType ModelType, string PropertyName), bool> _flattenedIntoParentWithLastContractSetterCache = [];
+        private readonly Dictionary<(string? Namespace, string Name, string PropertyName), bool> _flattenedIntoParentWithLastContractSetterCache = [];
         private readonly HashSet<CSharpType> _visitedModelTypes = new();
         private void FlattenModel(ModelProvider model)
         {
@@ -718,7 +718,7 @@ namespace Azure.Generator.Management.Visitors
                 || IsFlattenedIntoParentWithLastContractSetter(model, flattenPropertyName);
             var flattenPropertyBody = new MethodPropertyBody(
                 PropertyHelpers.BuildGetter(includeGetterNullCheck, internalProperty, modelProvider, innerProperty),
-                // Preserve public collection setters only when the previous API contract had one.
+                // Emit collection setters only when compatibility or parent delegation requires them.
                 isFlattenedPropertyReadOnly || (innerProperty.Type.IsCollection && !shouldEmitCollectionSetter) ? null : PropertyHelpers.BuildSetterForSafeFlatten(includeSetterNullCheck, modelProvider, internalProperty, innerProperty, shouldLiftToNullable)
             );
 
@@ -758,7 +758,7 @@ namespace Azure.Generator.Management.Visitors
 
         private bool IsFlattenedIntoParentWithLastContractSetter(ModelProvider model, string propertyName)
         {
-            var cacheKey = (model.Type, propertyName);
+            var cacheKey = (model.Type.Namespace, model.Type.Name, propertyName);
             if (_flattenedIntoParentWithLastContractSetterCache.TryGetValue(cacheKey, out var result))
             {
                 return result;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -634,9 +634,10 @@ namespace Azure.Generator.Management.Visitors
                 // leaves must be provided. When the parent is required, the property stays
                 // as the inner property's original type.
                 var shouldLiftToNullable = ShouldLiftToNullable(internalProperty);
+                var shouldPreserveSetter = ShouldPreserveLastContractSetter(model, flattenPropertyName);
                 var flattenPropertyBody = new MethodPropertyBody(
                     PropertyHelpers.BuildGetter(includeGetterNullCheck, internalProperty, propertyModel, innerProperty),
-                    !internalProperty.Body.HasSetter || !innerProperty.Body.HasSetter ? null : PropertyHelpers.BuildSetterForPropertyFlatten(propertyModel, internalProperty, innerProperty, shouldLiftToNullable)
+                    !internalProperty.Body.HasSetter || !innerProperty.Body.HasSetter ? null : PropertyHelpers.BuildSetterForPropertyFlatten(propertyModel, internalProperty, innerProperty, shouldLiftToNullable, shouldPreserveSetter)
                 );
 
                 var flattenedProperty =
@@ -710,10 +711,14 @@ namespace Azure.Generator.Management.Visitors
             // at runtime. Symmetric with PropertyFlatten — see ShouldLiftToNullable.
             var shouldLiftToNullable = ShouldLiftToNullable(internalProperty);
 
+            var shouldPreserveSetter = ShouldPreserveLastContractSetter(model, flattenPropertyName);
+            var shouldEmitCollectionSetter = shouldPreserveSetter
+                || !model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public)
+                || IsFlattenedIntoParentWithLastContractSetter(model, flattenPropertyName);
             var flattenPropertyBody = new MethodPropertyBody(
                 PropertyHelpers.BuildGetter(includeGetterNullCheck, internalProperty, modelProvider, innerProperty),
-                // if the flattened property is read-only or a collection, we don't generate a setter
-                isFlattenedPropertyReadOnly || innerProperty.Type.IsCollection ? null : PropertyHelpers.BuildSetterForSafeFlatten(includeSetterNullCheck, modelProvider, internalProperty, innerProperty, shouldLiftToNullable)
+                // Preserve public collection setters only when the previous API contract had one.
+                isFlattenedPropertyReadOnly || (innerProperty.Type.IsCollection && !shouldEmitCollectionSetter) ? null : PropertyHelpers.BuildSetterForSafeFlatten(includeSetterNullCheck, modelProvider, internalProperty, innerProperty, shouldLiftToNullable)
             );
 
             var flattenedProperty =
@@ -743,6 +748,30 @@ namespace Azure.Generator.Management.Visitors
                 propertyMap.Add(internalProperty, new List<FlattenPropertyInfo> { new(flattenedProperty, internalProperty) });
             }
             return isFlattened;
+        }
+
+        private static bool ShouldPreserveLastContractSetter(ModelProvider model, string propertyName)
+        {
+            return model.LastContractView?.Properties.Any(p => p.Name == propertyName && p.Body.HasSetter) == true;
+        }
+
+        private static bool IsFlattenedIntoParentWithLastContractSetter(ModelProvider model, string propertyName)
+        {
+            foreach (var parent in ManagementClientGenerator.Instance.OutputLibrary.TypeProviders.OfType<ModelProvider>())
+            {
+                if (parent == model || !ShouldPreserveLastContractSetter(parent, propertyName))
+                {
+                    continue;
+                }
+
+                if (ManagementClientGenerator.Instance.OutputLibrary.OutputFlattenPropertyMap.TryGetValue(parent, out var propertiesToFlatten)
+                    && propertiesToFlatten.Any(p => p.Type.AreNamesEqual(model.Type)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void UpdateFlattenTypeCollectionProperty(PropertyProvider internalProperty, PropertyProvider innerProperty, ModelProvider modelProvider)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -508,6 +508,7 @@ namespace Azure.Generator.Management.Visitors
         // This dictionary holds the flattened model types, where the key is the CSharpType of the model and the value is a dictionary of property names to flattened PropertyProvider.
         // So that, we can use this to update the model factory methods later.
         private readonly Dictionary<CSharpType, Dictionary<string, List<FlattenPropertyInfo>>> _flattenedModelTypes = new(new CSharpTypeNameComparer());
+        private readonly Dictionary<(CSharpType ModelType, string PropertyName), bool> _flattenedIntoParentWithLastContractSetterCache = [];
         private readonly HashSet<CSharpType> _visitedModelTypes = new();
         private void FlattenModel(ModelProvider model)
         {
@@ -755,8 +756,14 @@ namespace Azure.Generator.Management.Visitors
             return model.LastContractView?.Properties.Any(p => p.Name == propertyName && p.Body.HasSetter) == true;
         }
 
-        private static bool IsFlattenedIntoParentWithLastContractSetter(ModelProvider model, string propertyName)
+        private bool IsFlattenedIntoParentWithLastContractSetter(ModelProvider model, string propertyName)
         {
+            var cacheKey = (model.Type, propertyName);
+            if (_flattenedIntoParentWithLastContractSetterCache.TryGetValue(cacheKey, out var result))
+            {
+                return result;
+            }
+
             foreach (var parent in ManagementClientGenerator.Instance.OutputLibrary.TypeProviders.OfType<ModelProvider>())
             {
                 if (parent == model || !ShouldPreserveLastContractSetter(parent, propertyName))
@@ -767,10 +774,12 @@ namespace Azure.Generator.Management.Visitors
                 if (ManagementClientGenerator.Instance.OutputLibrary.OutputFlattenPropertyMap.TryGetValue(parent, out var propertiesToFlatten)
                     && propertiesToFlatten.Any(p => p.Type.AreNamesEqual(model.Type)))
                 {
+                    _flattenedIntoParentWithLastContractSetterCache[cacheKey] = true;
                     return true;
                 }
             }
 
+            _flattenedIntoParentWithLastContractSetterCache[cacheKey] = false;
             return false;
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -229,6 +229,57 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(renderedProperties, Does.Contain("Strategy = new global::Samples.Models.TestUpdateRunStrategy(value)"));
         }
 
+        [Test]
+        public void TestFlattenedCollectionSkipsDelegationSetterWhenParentCustomCodePreservesSetter()
+        {
+            var stagesProperty = InputFactory.Property("stages", InputFactory.Array(InputPrimitiveType.String), isRequired: true, serializedName: "stages");
+            var strategyModel = InputFactory.Model(
+                "TestUpdateRunStrategy",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [stagesProperty]);
+
+            var strategyProperty = InputFactory.Property("strategy", strategyModel, isRequired: false, serializedName: "strategy");
+            var propertiesModel = InputFactory.Model(
+                "TestUpdateRunProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [strategyProperty]);
+
+            var propertiesProperty = InputFactory.Property("properties", propertiesModel, isRequired: false, serializedName: "properties");
+            ApplyFlattenDecorator(propertiesProperty);
+            var parentModel = InputFactory.Model(
+                "TestUpdateRunData",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [propertiesProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentModel, propertiesModel, strategyModel]);
+
+            var parentProvider = plugin.Object.TypeFactory.CreateModel(parentModel);
+            var propertiesProvider = plugin.Object.TypeFactory.CreateModel(propertiesModel);
+            Assert.That(parentProvider, Is.Not.Null);
+            Assert.That(propertiesProvider, Is.Not.Null);
+
+            var lastContractView = CreateStrategyStagesView(parentProvider!.Name);
+            SetLastContractView(parentProvider, lastContractView);
+
+            var customCodeView = CreateStrategyStagesView(parentProvider.Name);
+            ManagementMockHelpers.SetCustomCodeView(parentProvider, customCodeView);
+
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(visitTypeCore, Is.Not.Null, "Could not find LibraryVisitor.VisitTypeCore method");
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [parentProvider]);
+            }
+
+            var renderedProperties = new TypeProviderWriter(propertiesProvider!).Write().Content;
+            Assert.That(renderedProperties, Does.Not.Match(@"set\s*\{"));
+            Assert.That(renderedProperties, Does.Not.Contain("Strategy = new global::Samples.Models.TestUpdateRunStrategy(value)"));
+        }
+
         /// <summary>
         /// Verifies that FixModelFactoryBackwardCompatOverloads correctly reorders arguments in
         /// backward-compat overloads when the primary method's parameter order has changed
@@ -852,6 +903,22 @@ namespace Azure.Generator.Mgmt.Tests
                     "ProcessTypeForBackCompatibility",
                     BindingFlags.NonPublic | BindingFlags.Instance)!
                 .Invoke(typeProvider, null);
+        }
+
+        private static TestTypeView CreateStrategyStagesView(string name)
+        {
+            var view = new TestTypeView(name);
+            view.PropertiesToBuild =
+            [
+                new PropertyProvider(
+                    null,
+                    MethodSignatureModifiers.Public,
+                    typeof(IList<string>),
+                    "StrategyStages",
+                    new AutoPropertyBody(true),
+                    view)
+            ];
+            return view;
         }
 
         private class TestTypeView : TypeProvider

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -166,6 +166,69 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(rendered, Does.Not.Match(@"\breturn\s+(?:this\.)?Data\.Errors;"));
         }
 
+        [Test]
+        public void TestFlattenedCollectionPreservesLastContractSetter()
+        {
+            var stagesProperty = InputFactory.Property("stages", InputFactory.Array(InputPrimitiveType.String), isRequired: true, serializedName: "stages");
+            var strategyModel = InputFactory.Model(
+                "TestUpdateRunStrategy",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [stagesProperty]);
+
+            var strategyProperty = InputFactory.Property("strategy", strategyModel, isRequired: false, serializedName: "strategy");
+            var propertiesModel = InputFactory.Model(
+                "TestUpdateRunProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [strategyProperty]);
+
+            var propertiesProperty = InputFactory.Property("properties", propertiesModel, isRequired: false, serializedName: "properties");
+            ApplyFlattenDecorator(propertiesProperty);
+            var parentModel = InputFactory.Model(
+                "TestUpdateRunData",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [propertiesProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentModel, propertiesModel, strategyModel]);
+
+            var parentProvider = plugin.Object.TypeFactory.CreateModel(parentModel);
+            var propertiesProvider = plugin.Object.TypeFactory.CreateModel(propertiesModel);
+            Assert.That(parentProvider, Is.Not.Null);
+            Assert.That(propertiesProvider, Is.Not.Null);
+
+            var lastContractView = new TestTypeView(parentProvider!.Name);
+            lastContractView.PropertiesToBuild =
+            [
+                new PropertyProvider(
+                    null,
+                    MethodSignatureModifiers.Public,
+                    typeof(IList<string>),
+                    "StrategyStages",
+                    new AutoPropertyBody(true),
+                    lastContractView)
+            ];
+            SetLastContractView(parentProvider, lastContractView);
+
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(visitTypeCore, Is.Not.Null, "Could not find LibraryVisitor.VisitTypeCore method");
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [parentProvider]);
+            }
+
+            var renderedParent = new TypeProviderWriter(parentProvider).Write().Content;
+            Assert.That(renderedParent, Does.Match(@"set\s*\{"));
+            Assert.That(renderedParent, Does.Contain("Properties = new global::Samples.Models.TestUpdateRunProperties()"));
+            Assert.That(renderedParent, Does.Contain("Properties.StrategyStages = value"));
+
+            var renderedProperties = new TypeProviderWriter(propertiesProvider!).Write().Content;
+            Assert.That(renderedProperties, Does.Match(@"set\s*\{"));
+            Assert.That(renderedProperties, Does.Contain("Strategy = new global::Samples.Models.TestUpdateRunStrategy(value)"));
+        }
+
         /// <summary>
         /// Verifies that FixModelFactoryBackwardCompatOverloads correctly reorders arguments in
         /// backward-compat overloads when the primary method's parameter order has changed
@@ -582,7 +645,7 @@ namespace Azure.Generator.Mgmt.Tests
                 null,
                 [new ParameterProvider("testProvisioningState", $"", typeof(string))]);
 
-            var lastContractView = new TestModelFactoryView(modelFactory.Name);
+            var lastContractView = new TestTypeView(modelFactory.Name);
             lastContractView.MethodsToBuild = [new MethodProvider(previousSignature, MethodBodyStatement.Empty, lastContractView)];
             SetLastContractView(modelFactory, lastContractView);
 
@@ -791,22 +854,25 @@ namespace Azure.Generator.Mgmt.Tests
                 .Invoke(typeProvider, null);
         }
 
-        private class TestModelFactoryView : TypeProvider
+        private class TestTypeView : TypeProvider
         {
             private readonly string _name;
 
-            public TestModelFactoryView(string name)
+            public TestTypeView(string name)
             {
                 _name = name;
             }
 
             public MethodProvider[] MethodsToBuild { get; set; } = [];
+            public PropertyProvider[] PropertiesToBuild { get; set; } = [];
 
             protected override string BuildName() => _name;
 
             protected override string BuildRelativeFilePath() => $"{Name}.cs";
 
             protected override MethodProvider[] BuildMethods() => MethodsToBuild;
+
+            protected override PropertyProvider[] BuildProperties() => PropertiesToBuild;
         }
 
         private static void ApplyFlattenDecorator(InputModelProperty property)


### PR DESCRIPTION
## Description

Fixes #56421 by preserving generated flattened collection setters when the previous API contract requires them.

The current Fleet workaround cleanup reproduced that generated flattened getters now lazy-create wrapper objects, but ApiCompat still fails if custom compatibility properties are removed because the shipped `StrategyStages` setters are missing. This updates the management generator to preserve collection setters for last-contract compatibility and to emit the internal safe-flatten wrapper setter needed for delegated top-level setters.

SDK regeneration diffs are intentionally excluded from this PR.

## Validation

- `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --filter TestFlattenedCollectionPreservesLastContractSetter`
- Verified separately that removing the ContainerServiceFleet workaround and regenerating with `eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1 -Services Azure.ResourceManager.ContainerServiceFleet -Parallel 1` produces generated `StrategyStages` setters and passes Fleet ApiCompat.
