### PR TITLE
Preserve provisioning property metadata

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningModelProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningModelProvider.cs
@@ -89,7 +89,7 @@ namespace Azure.Generator.Provisioning.Providers
                     if (prop.IsDiscriminator) continue;
                     if (!seen.Add(prop.Name)) continue;
 
-                    var property = CodeModelGenerator.Instance.TypeFactory.CreateProperty(prop, this);
+                    var property = ProvisioningGenerator.Instance.TypeFactory.CreateProvisioningProperty(prop, this);
                     if (property != null)
                         properties.Add(property);
                 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -100,6 +100,7 @@ namespace Azure.Generator.Provisioning.Providers
         {
             if (!_propertyLookup.TryGetValue(inputProp, out var propInfo))
                 return null;
+
             return new ProvisioningPropertyInfo(
                 propInfo.PropertyName,
                 propInfo.IsOutput,
@@ -200,7 +201,7 @@ namespace Azure.Generator.Provisioning.Providers
             var properties = new List<PropertyProvider>();
             foreach (var propInfo in _allProperties)
             {
-                var property = CodeModelGenerator.Instance.TypeFactory.CreateProperty(propInfo.Property, this);
+                var property = ProvisioningGenerator.Instance.TypeFactory.CreateProvisioningProperty(propInfo.Property, this);
                 if (property != null)
                     properties.Add(property);
             }
@@ -501,10 +502,10 @@ namespace Azure.Generator.Provisioning.Providers
                 var propertyName = prop.Name.ToIdentifierName();
                 // For singleton resources, the "name" property is output-only with a default value
                 string? defaultValue = null;
-                if (serializedName == "name"
-                    && _resourceProjection?.SingletonResourceName is not null)
+                if (string.Equals(serializedName, "name", StringComparison.OrdinalIgnoreCase)
+                    && _resourceProjection?.SingletonResourceName is string singletonResourceName)
                 {
-                    defaultValue = _resourceProjection.SingletonResourceName;
+                    defaultValue = singletonResourceName;
                     isOutput = true;
                     isSettable = false;
                 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -502,7 +502,7 @@ namespace Azure.Generator.Provisioning.Providers
                 var propertyName = prop.Name.ToIdentifierName();
                 // For singleton resources, the "name" property is output-only with a default value
                 string? defaultValue = null;
-                if (string.Equals(serializedName, "name", StringComparison.OrdinalIgnoreCase)
+                if (serializedName == "name"
                     && _resourceProjection?.SingletonResourceName is string singletonResourceName)
                 {
                     defaultValue = singletonResourceName;

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
@@ -171,6 +171,12 @@ namespace Azure.Generator.Provisioning
 
         /// <inheritdoc/>
         protected override PropertyProvider? CreatePropertyCore(InputProperty inputProperty, TypeProvider enclosingType)
+            => CreateProvisioningProperty(inputProperty, enclosingType);
+
+        // Provisioning property metadata can depend on the enclosing provider (for example,
+        // singleton resource names). Call this directly from provisioning providers instead of
+        // the cached CreateProperty wrapper so each provider can supply its own metadata.
+        internal PropertyProvider? CreateProvisioningProperty(InputProperty inputProperty, TypeProvider enclosingType)
         {
             // Run base chain which creates property and applies visitor renames (e.g., etag → ETag).
             var baseProperty = base.CreatePropertyCore(inputProperty, enclosingType);

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/ProfileRevision.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/ProfileRevision.cs
@@ -39,18 +39,13 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             }
         }
 
-        /// <summary> Gets or sets the Name. </summary>
+        /// <summary> Gets the Name. </summary>
         public BicepValue<string> Name
         {
             get
             {
                 Initialize();
                 return _name;
-            }
-            set
-            {
-                Initialize();
-                _name.Assign(value);
             }
         }
 
@@ -64,18 +59,13 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             }
         }
 
-        /// <summary> Gets or sets the Properties. </summary>
+        /// <summary> Gets the Properties. </summary>
         internal ProfileProperties Properties
         {
             get
             {
                 Initialize();
                 return _properties;
-            }
-            set
-            {
-                Initialize();
-                AssignOrReplace(ref _properties, value);
             }
         }
 
@@ -99,15 +89,7 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         {
             get
             {
-                return Properties is null ? default : Properties.Description;
-            }
-            set
-            {
-                if (Properties is null)
-                {
-                    Properties = new ProfileProperties();
-                }
-                Properties.Description = value;
+                return Properties.Description;
             }
         }
 
@@ -116,15 +98,7 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         {
             get
             {
-                return Properties is null ? default : Properties.SkuName;
-            }
-            set
-            {
-                if (Properties is null)
-                {
-                    Properties = new ProfileProperties();
-                }
-                Properties.SkuName = value;
+                return Properties.SkuName;
             }
         }
 


### PR DESCRIPTION
Fixes #60662.

This extracts the provisioning generator fix from #60549 into a standalone PR. Provisioning property generation now uses a provider-aware property creation path so metadata that depends on the enclosing provider, such as singleton resource names, is preserved instead of being lost through the cached generic property creation path.

Validation:
- `dotnet build eng\packages\http-client-csharp-provisioning\generator\Azure.Generator.Provisioning\src\Azure.Generator.Provisioning.csproj --no-restore -v:quiet`
- `dotnet test eng\packages\http-client-csharp-provisioning\generator\Azure.Generator.Provisioning\test\Azure.Generator.Provisioning.Tests.csproj --filter FullyQualifiedName~ProvisioningResourceProjectionTests --no-restore`

Note: DurableTask provisioning regeneration could not be run on this standalone branch because `Azure.Provisioning.DurableTask` is not present on current `origin/main`.