### PR TITLE
Fix TrafficManagerEndpoint Delete: correct arg order and use GetLastType()

### DIFF
--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/assets.json
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/trafficmanager/Azure.ResourceManager.TrafficManager",
-  "Tag": "net/trafficmanager/Azure.ResourceManager.TrafficManager_f952b8a5f2"
+  "Tag": "net/trafficmanager/Azure.ResourceManager.TrafficManager_26a06c5758"
 }

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/src/Customization/TrafficManagerEndpointResource.cs
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/src/Customization/TrafficManagerEndpointResource.cs
@@ -225,7 +225,7 @@ namespace Azure.ResourceManager.TrafficManager
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _endpointsRestClient.CreateDeleteRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.Name, Id.ResourceType.Type, context);
+                HttpMessage message = _endpointsRestClient.CreateDeleteRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.ResourceType.GetLastType(), Id.Name, context);
                 Response result = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
                 Response<TrafficManagerDeleteOperationResult> response = Response.FromValue(TrafficManagerDeleteOperationResult.FromResponse(result), result);
                 RequestUriBuilder uri = message.Request.Uri;
@@ -257,7 +257,7 @@ namespace Azure.ResourceManager.TrafficManager
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _endpointsRestClient.CreateDeleteRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.Name, Id.ResourceType.Type, context);
+                HttpMessage message = _endpointsRestClient.CreateDeleteRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.Name, Id.ResourceType.GetLastType(), Id.Name, context);
                 Response result = Pipeline.ProcessMessage(message, context);
                 Response<TrafficManagerDeleteOperationResult> response = Response.FromValue(TrafficManagerDeleteOperationResult.FromResponse(result), result);
                 RequestUriBuilder uri = message.Request.Uri;

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/TrafficManagerManagementTestEnvironment.cs
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/TrafficManagerManagementTestEnvironment.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
 using Azure.Core.TestFramework;
-using Azure.Identity;
 
 namespace Azure.ResourceManager.TrafficManager.Tests
 {
     public class TrafficManagerManagementTestEnvironment : TestEnvironment
     {
-        protected override TokenCredential CreateDeveloperCredential() => new AzureCliCredential();
     }
 }

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/TrafficManagerManagementTestEnvironment.cs
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/TrafficManagerManagementTestEnvironment.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Core;
 using Azure.Core.TestFramework;
+using Azure.Identity;
 
 namespace Azure.ResourceManager.TrafficManager.Tests
 {
     public class TrafficManagerManagementTestEnvironment : TestEnvironment
     {
+        protected override TokenCredential CreateDeveloperCredential() => new AzureCliCredential();
     }
 }


### PR DESCRIPTION
Fix TrafficManagerEndpoint Delete: correct arg order and use GetLastType()

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
