### PR TITLE
[Identity] Keep DefaultAzureCredential chain going when all MI sources unavailable

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs Fixed
 
 - Fixed a regression (introduced with managed identity host capability detection) where `DefaultAzureCredential` could throw an `AuthenticationFailedException` and stop evaluating the credential chain on hosts without a managed identity — for example, a developer machine running in Visual Studio where the IMDS endpoint (169.254.169.254) is unreachable. When `ManagedIdentityCredential` is part of a chain, a failure to detect the managed identity source/capabilities is now surfaced as a `CredentialUnavailableException`, allowing the chain to continue to the next credential.
+- Fixed a related case where `DefaultAzureCredential` could still abort the credential chain with an `AuthenticationFailedException` when managed identity source detection succeeded but the subsequent token acquisition reported that all managed identity sources were unavailable (MSAL `managed_identity_all_sources_unavailable`). When `ManagedIdentityCredential` is part of a chain, this is now surfaced as a `CredentialUnavailableException` so the chain continues to the next credential.
 
 ### Other Changes
 

--- a/sdk/core/Azure.Core/src/Identity/AzureIdentityEventSource.cs
+++ b/sdk/core/Azure.Core/src/Identity/AzureIdentityEventSource.cs
@@ -49,6 +49,7 @@ namespace Azure.Identity
         private const int KubernetesProxyCaCertificateReloadFailedEvent = 28;
         private const int KubernetesProxyCaCertificateReloadedEvent = 29;
         private const int TokenBindingEvent = 30;
+        private const int ManagedIdentitySourcesUnavailableEvent = 31;
 
         internal const string TenantIdDiscoveredAndNotUsedEventMessage = "A token was request for a different tenant than was configured on the credential, but the configured value was used since multi tenant authentication has been disabled. Configured TenantId: {0}, Requested TenantId {1}";
         internal const string TenantIdDiscoveredAndUsedEventMessage = "A token was requested for a different tenant than was configured on the credential, and the requested tenant id was used to authenticate. Configured TenantId: {0}, Requested TenantId {1}";
@@ -205,6 +206,21 @@ namespace Azure.Identity
         public void ImdsEndpointUnavailable(string uri, string error)
         {
             WriteEvent(ImdsEndpointUnavailableEvent, uri, error);
+        }
+
+        [NonEvent]
+        public void ManagedIdentitySourcesUnavailable(Exception e)
+        {
+            if (IsEnabled(EventLevel.Informational, EventKeywords.All))
+            {
+                ManagedIdentitySourcesUnavailable(FormatException(e));
+            }
+        }
+
+        [Event(ManagedIdentitySourcesUnavailableEvent, Level = EventLevel.Informational, Message = "No managed identity source is available. Error: {0}")]
+        public void ManagedIdentitySourcesUnavailable(string error)
+        {
+            WriteEvent(ManagedIdentitySourcesUnavailableEvent, error);
         }
 
         [NonEvent]

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -129,6 +129,14 @@ namespace Azure.Identity
                 // If the managed identity is not found, throw a more specific exception.
                 throw new CredentialUnavailableException(MsiUnavailableError, ex);
             }
+            // MSAL reports that every managed identity source was probed and none is available (for example, the IMDS
+            // endpoint is unreachable on a developer machine). When chained, surface a CredentialUnavailableException so
+            // DefaultAzureCredential continues to the next credential instead of aborting the chain.
+            catch (MsalException ex) when (_isChainedCredential && ex.ErrorCode == MsalError.ManagedIdentityAllSourcesUnavailable)
+            {
+                AzureIdentityEventSource.Singleton.ImdsEndpointUnavailable(ImdsManagedIdentityProbeSource.GetImdsUri(), ex);
+                throw new CredentialUnavailableException(MsiUnavailableError, ex);
+            }
 
             return result.ToAccessToken();
         }

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -129,12 +129,12 @@ namespace Azure.Identity
                 // If the managed identity is not found, throw a more specific exception.
                 throw new CredentialUnavailableException(MsiUnavailableError, ex);
             }
-            // MSAL reports that every managed identity source was probed and none is available (for example, the IMDS
-            // endpoint is unreachable on a developer machine). When chained, surface a CredentialUnavailableException so
-            // DefaultAzureCredential continues to the next credential instead of aborting the chain.
+            // MSAL reports that every managed identity source was probed and none is available (for example, on a
+            // developer machine with no managed identity configured). When chained, surface a CredentialUnavailableException
+            // so DefaultAzureCredential continues to the next credential instead of aborting the chain.
             catch (MsalException ex) when (_isChainedCredential && ex.ErrorCode == MsalError.ManagedIdentityAllSourcesUnavailable)
             {
-                AzureIdentityEventSource.Singleton.ImdsEndpointUnavailable(ImdsManagedIdentityProbeSource.GetImdsUri(), ex);
+                AzureIdentityEventSource.Singleton.ManagedIdentitySourcesUnavailable(ex);
                 throw new CredentialUnavailableException(MsiUnavailableError, ex);
             }
 

--- a/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
@@ -291,6 +291,63 @@ namespace Azure.Core.Tests.Identity
             Assert.IsNotInstanceOf<CredentialUnavailableException>(ex);
         }
 
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/issues/60650
+        // Managed identity source detection can succeed (Source == None) yet the subsequent MSAL token
+        // acquisition still throws MsalClientException with ManagedIdentityAllSourcesUnavailable (for example,
+        // the IMDS endpoint is unreachable on a developer machine). A chained ManagedIdentityCredential must
+        // surface a CredentialUnavailableException so DefaultAzureCredential continues to the next credential
+        // instead of aborting with an AuthenticationFailedException.
+        [NonParallelizable]
+        [Test]
+        public void ChainedManagedIdentityAllSourcesUnavailableThrowsCredentialUnavailable()
+        {
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
+
+            var acquireFailure = new MsalClientException(
+                MsalError.ManagedIdentityAllSourcesUnavailable,
+                "All Managed Identity sources are unavailable. The Azure Instance Metadata Service (IMDS) that runs on VMs was not detected: IMDSv2: IMDSv2 probe failed. Exception: Retry failed after 6 tries.");
+
+            var credential = BuildManagedIdentityCredential(
+                new TokenCredentialOptions { Transport = new MockTransport(_ => CreateSuccessResponse(ExpectedToken)), IsChainedCredential = true },
+                ManagedIdentityId.SystemAssigned,
+                configureMockMsal: mock =>
+                {
+                    mock.GetManagedIdentityCapabilitiesFactory = (_, _) => MockMsalManagedIdentityClient.CreateCapabilities(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.None);
+                    mock.AcquireTokenForManagedIdentityAsyncFactory = (_, _) => throw acquireFailure;
+                });
+
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.AreSame(acquireFailure, ex.InnerException);
+        }
+
+        // Companion to the regression test above: a standalone (non-chained) ManagedIdentityCredential keeps
+        // surfacing AuthenticationFailedException when the token acquisition reports all sources unavailable,
+        // preserving the documented single-credential behavior.
+        [NonParallelizable]
+        [Test]
+        public void StandaloneManagedIdentityAllSourcesUnavailableThrowsAuthenticationFailed()
+        {
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
+
+            var acquireFailure = new MsalClientException(
+                MsalError.ManagedIdentityAllSourcesUnavailable,
+                "All Managed Identity sources are unavailable. The Azure Instance Metadata Service (IMDS) that runs on VMs was not detected: IMDSv2: IMDSv2 probe failed. Exception: Retry failed after 6 tries.");
+
+            var credential = BuildManagedIdentityCredential(
+                new TokenCredentialOptions { Transport = new MockTransport(_ => CreateSuccessResponse(ExpectedToken)), IsChainedCredential = false },
+                ManagedIdentityId.SystemAssigned,
+                configureMockMsal: mock =>
+                {
+                    mock.GetManagedIdentityCapabilitiesFactory = (_, _) => MockMsalManagedIdentityClient.CreateCapabilities(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.None);
+                    mock.AcquireTokenForManagedIdentityAsyncFactory = (_, _) => throw acquireFailure;
+                });
+
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.IsNotInstanceOf<CredentialUnavailableException>(ex);
+        }
+
         [NonParallelizable]
         [Test]
         public async Task VerifyImdsRequestWithClientIdMock()

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
@@ -93,6 +93,14 @@ namespace Azure.Core.Tests.Identity.Mock
             return new ValueTask<ManagedIdentityCapabilities>(CreateManagedIdentityCapabilities(_detectedSource));
         }
 
+        /// <summary>
+        /// Builds a <see cref="ManagedIdentityCapabilities"/> reporting the given <paramref name="source"/>.
+        /// Tests use this with <see cref="GetManagedIdentityCapabilitiesFactory"/> to drive the credential down a
+        /// specific code path (for example, <c>None</c> to reach the token-acquisition call).
+        /// </summary>
+        internal static ManagedIdentityCapabilities CreateCapabilities(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source)
+            => CreateManagedIdentityCapabilities(source);
+
         private static ManagedIdentityCapabilities CreateManagedIdentityCapabilities(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source)
         {
             ConstructorInfo ctor = typeof(ManagedIdentityCapabilities).GetConstructor(


### PR DESCRIPTION
## Why

On a host without a managed identity (for example a developer machine where the IMDS endpoint `169.254.169.254` is unreachable), `DefaultAzureCredential` threw `AuthenticationFailedException` from `ManagedIdentityCredential` and stopped evaluating the rest of the chain, so it never fell through to `VisualStudioCredential` and friends. A previous fix (#60202, shipped in Azure.Core 1.60.0) only covered part of the flow, and customers still hit this.

## Root cause

With MSAL 4.84.2, managed identity source detection now succeeds and returns `Source == None` instead of throwing, so the guard added in #60202 is bypassed. Execution then reaches the token acquisition call, where MSAL throws `MsalClientException` with `ErrorCode == managed_identity_all_sources_unavailable` and no inner exception. The only catch there matched `MsalServiceException` whose inner `RequestFailedException` contained "timed out", so it did not match, and the exception got wrapped as `AuthenticationFailedException`, which aborts the chain.

## Fix

Add a catch in `ManagedIdentityClient.AuthenticateAsync` for `MsalException` with `ErrorCode == MsalError.ManagedIdentityAllSourcesUnavailable`, gated on `_isChainedCredential`, that surfaces a `CredentialUnavailableException` so the chain continues to the next credential. Standalone `ManagedIdentityCredential` behavior is unchanged (still `AuthenticationFailedException`), consistent with the existing companion test and the #60202 pattern.

## Tests

Added chained (expects `CredentialUnavailableException`) and standalone (expects `AuthenticationFailedException`) regression tests that force `Source == None` and make token acquisition throw the all-sources-unavailable error, plus a small `MockMsalManagedIdentityClient.CreateCapabilities` helper. They run in both the base and ConfigurableCredentials fixtures. The full `ManagedIdentityCredential` suite passes (300 tests) and Azure.Core builds clean across all target frameworks.

## Notes for reviewers

Design choice: only chained usage downgrades to `CredentialUnavailableException`; standalone keeps `AuthenticationFailedException`. Flagging in case reviewers would prefer uniform behavior across both.

Fixes #60650
