### PR TITLE
[Azure.Storage.Blobs] Update StorageTransferOptions doc comment: downloaded -> transferred

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/StorageTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageTransferOptions.cs
@@ -37,7 +37,7 @@ namespace Azure.Storage
         /// The size of the first request in bytes. Blobs smaller than this limit will
         /// be transferred in a single request. Blobs larger than this limit will continue being
         /// transferred in chunks of size <see cref="MaximumTransferSize"/>. This property is a
-        /// backwards-compatible facade for <see cref="MaximumTransferSize"/>, which supports
+        /// backwards-compatible facade for <see cref="InitialTransferSize"/>, which supports
         /// long values. Use <see cref="InitialTransferSize"/> for full access of supported values.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.Storage.Common/src/StorageTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageTransferOptions.cs
@@ -35,8 +35,8 @@ namespace Azure.Storage
 
         /// <summary>
         /// The size of the first range request in bytes. Blobs smaller than this limit will
-        /// be downloaded in a single request. Blobs larger than this limit will continue being
-        /// downloaded in chunks of size <see cref="MaximumTransferSize"/>. This property is a
+        /// be transferred in a single request. Blobs larger than this limit will continue being
+        /// transferred in chunks of size <see cref="MaximumTransferSize"/>. This property is a
         /// backwards-compatible facade for <see cref="MaximumTransferSize"/>, which supports
         /// long values. Use <see cref="InitialTransferSize"/> for full access of supported values.
         /// </summary>
@@ -49,8 +49,8 @@ namespace Azure.Storage
 
         /// <summary>
         /// The size of the first range request in bytes. Blobs smaller than this limit will
-        /// be downloaded in a single request. Blobs larger than this limit will continue being
-        /// downloaded in chunks of size <see cref="MaximumTransferSize"/>.
+        /// be transferred in a single request. Blobs larger than this limit will continue being
+        /// transferred in chunks of size <see cref="MaximumTransferSize"/>.
         /// </summary>
         public long? InitialTransferSize { get; set; }
 

--- a/sdk/storage/Azure.Storage.Common/src/StorageTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageTransferOptions.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage
         public int? MaximumConcurrency { get; set; }
 
         /// <summary>
-        /// The size of the first range request in bytes. Blobs smaller than this limit will
+        /// The size of the first request in bytes. Blobs smaller than this limit will
         /// be transferred in a single request. Blobs larger than this limit will continue being
         /// transferred in chunks of size <see cref="MaximumTransferSize"/>. This property is a
         /// backwards-compatible facade for <see cref="MaximumTransferSize"/>, which supports
@@ -48,7 +48,7 @@ namespace Azure.Storage
         }
 
         /// <summary>
-        /// The size of the first range request in bytes. Blobs smaller than this limit will
+        /// The size of the first request in bytes. Blobs smaller than this limit will
         /// be transferred in a single request. Blobs larger than this limit will continue being
         /// transferred in chunks of size <see cref="MaximumTransferSize"/>.
         /// </summary>


### PR DESCRIPTION
`StorageTransferOptions` doc comments for a few properties mention downloading. However, the options are used both for download and upload.
- The word "downloaded" is replaced with "transferred" as in other parts of the class
- "Range request" is dropped; "request" is used instead