### PR TITLE
[CODEOWNERS] Setting management CI ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -897,6 +897,9 @@
 /**/*Management*/                                                  @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %Mgmt
+/sdk/**/ci.mgmt.yml                                                @ArcturusZhang @ArthurMa1978 @live1206
+
+# PRLabel: %Mgmt
 /**/Azure.ResourceManager*/                                        @ArcturusZhang @ArthurMa1978 @live1206
 
 # PRLabel: %Provisioning


### PR DESCRIPTION
# Summary

The focus of these changes is to set ownership of the `ci.mgmt.yml` file that lives under each `/sdk/<< service >>/` slug.   As these are currently unowned, they bubble up to the catch-all.
