### PR TITLE
Prepare release for Azure.AI.AgentServer.Responses 1.0.0-beta.7

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Release History
 
-## 1.0.0-beta.7 (Unreleased)
+## 1.0.0-beta.7 (2026-07-07)
 
 ### Features Added
 - Added `ResponseContext.ConversationChainId`, a deterministic, agent- and session-scoped correlation key that identifies the logical conversation a response belongs to. Handlers can use it as a stable key into their own per-conversation state.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.0.0-beta.6 (2026-06-28)
 


### PR DESCRIPTION
Prepares the release of `Azure.AI.AgentServer.Responses` version `1.0.0-beta.7`.

## Changes
- Ran `eng/common/scripts/Prepare-Release.ps1` for `Azure.AI.AgentServer.Responses` (service directory `agentserver`) with release date `2026-07-07`.
- Updated the CHANGELOG to set the `1.0.0-beta.7` release date to `2026-07-07` (previously `Unreleased`) and removed the empty changelog sections.