### PR TITLE
Allow SDK review after CI rerun success

### DIFF
--- a/.github/workflows/mgmt-review-trigger.yml
+++ b/.github/workflows/mgmt-review-trigger.yml
@@ -49,11 +49,11 @@ jobs:
               sed -n '1s/^[^\t]*\t//p'
           }
 
-          has_management_review_check() {
+          has_active_management_review_check() {
             local head_sha="$1"
             local review_check_ids
             review_check_ids="$(gh api --paginate "repos/$REPOSITORY/commits/$head_sha/check-runs?per_page=100" \
-              --jq '.check_runs[] | select(.name == "Azure .NET Management SDK PR Review") | .id')"
+              --jq '.check_runs[] | select(.name == "Azure .NET Management SDK PR Review" and (.status == "queued" or .status == "in_progress")) | .id')"
             [ -n "$review_check_ids" ]
           }
 
@@ -61,8 +61,8 @@ jobs:
             local head_sha="$1"
             local details_url="${GITHUB_SERVER_URL:-https://github.com}/$REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-            if has_management_review_check "$head_sha"; then
-              echo "Management review check already exists for $head_sha."
+            if has_active_management_review_check "$head_sha"; then
+              echo "Management review check is already active for $head_sha."
               return 0
             fi
 
@@ -114,8 +114,8 @@ jobs:
               return 0
             fi
 
-            if has_management_review_check "$check_run_head_sha"; then
-              echo "Skipping PR #$pr_number; management review check already exists for $check_run_head_sha."
+            if has_active_management_review_check "$check_run_head_sha"; then
+              echo "Skipping PR #$pr_number; management review check is already active for $check_run_head_sha."
               return 0
             fi
 

--- a/.github/workflows/provisioning-review-trigger.yml
+++ b/.github/workflows/provisioning-review-trigger.yml
@@ -49,11 +49,11 @@ jobs:
               sed -n '1s/^[^\t]*\t//p'
           }
 
-          has_provisioning_review_check() {
+          has_active_provisioning_review_check() {
             local head_sha="$1"
             local review_check_ids
             review_check_ids="$(gh api --paginate "repos/$REPOSITORY/commits/$head_sha/check-runs?per_page=100" \
-              --jq '.check_runs[] | select(.name == "Azure .NET Provisioning SDK PR Review") | .id')"
+              --jq '.check_runs[] | select(.name == "Azure .NET Provisioning SDK PR Review" and (.status == "queued" or .status == "in_progress")) | .id')"
             [ -n "$review_check_ids" ]
           }
 
@@ -61,8 +61,8 @@ jobs:
             local head_sha="$1"
             local details_url="${GITHUB_SERVER_URL:-https://github.com}/$REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-            if has_provisioning_review_check "$head_sha"; then
-              echo "Provisioning review check already exists for $head_sha."
+            if has_active_provisioning_review_check "$head_sha"; then
+              echo "Provisioning review check is already active for $head_sha."
               return 0
             fi
 
@@ -114,8 +114,8 @@ jobs:
               return 0
             fi
 
-            if has_provisioning_review_check "$check_run_head_sha"; then
-              echo "Skipping PR #$pr_number; provisioning review check already exists for $check_run_head_sha."
+            if has_active_provisioning_review_check "$check_run_head_sha"; then
+              echo "Skipping PR #$pr_number; provisioning review check is already active for $check_run_head_sha."
               return 0
             fi
 


### PR DESCRIPTION
## Description

Fixes the rerun case observed in #60598. A failed net - pullrequest can dispatch CI failure analysis and publish a completed SDK review check on the same commit. If the user reruns CI and it later succeeds on that same commit, the trigger should dispatch the normal review instead of treating the old completed review check as an active duplicate.

This changes both management and provisioning review triggers to dedupe only active review checks: queued or in_progress. Completed review checks no longer suppress later CI rerun events on the same head.

## Validation

- Ran bash -n on the embedded trigger scripts extracted from both workflow files.
- Ran git diff --check for the commit.