### PR TITLE
[CODEOWNERS] Provisioning support owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1189,7 +1189,6 @@
 # ServiceLabel: %Provisioning
 # AzureSdkOwners:                                                  @ArcturusZhang @ArthurMa1978
 
-
 # ######## Eng Sys ########
 /eng/                                                              @danieljurek @benbp @raych1
 /eng/common/                                                       @Azure/azure-sdk-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -423,12 +423,6 @@
 # ServiceLabel: %PostgreSQL Auth
 # ServiceOwners: @alxhghs @carlovi81 @mattboentoro @nasc17 @nehrao1 @rmendiza
 
-# PRLabel: %Provisioning
-/sdk/provisioning/    @ArcturusZhang @ArthurMa1978 @m-nash
-
-# AzureSdkOwners: @ArthurMa1978
-# ServiceLabel: %Provisioning
-
 # PRLabel: %Schema Registry
 /sdk/schemaregistry/    @axisc @hmlam @sjkwak
 
@@ -906,12 +900,6 @@
 # PRLabel: %Mgmt
 /**/Azure.ResourceManager*/                                        @ArcturusZhang @ArthurMa1978 @live1206
 
-# PRLabel: %Provisioning
-/**/Azure.Provisioning*/                                           @ArcturusZhang @ArthurMa1978 @m-nash
-
-# ServiceLabel: %Provisioning
-# AzureSdkOwners:                                                  @ArcturusZhang @ArthurMa1978
-
 # -----------------------------------------------------------------
 # IMPORTANT NOTE:
 #   This block acts as a catch-all, assigning Arthur triage for
@@ -1190,6 +1178,17 @@
 
 # PRLabel: %Workload Orchestration %Mgmt
 /sdk/workloadorchestration/Azure.ResourceManager.*/                @ArcturusZhang @ArthurMa1978
+
+##########################
+# Provisioning Libraries
+##########################
+
+# PRLabel: %Provisioning
+/**/Azure.Provisioning*/                                           @ArcturusZhang @ArthurMa1978 @m-nash
+
+# ServiceLabel: %Provisioning
+# AzureSdkOwners:                                                  @ArcturusZhang @ArthurMa1978
+
 
 # ######## Eng Sys ########
 /eng/                                                              @danieljurek @benbp @raych1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -909,6 +909,9 @@
 # PRLabel: %Provisioning
 /**/Azure.Provisioning*/                                           @ArcturusZhang @ArthurMa1978 @m-nash
 
+# ServiceLabel: %Provisioning
+# AzureSdkOwners:                                                  @ArcturusZhang @ArthurMa1978
+
 # -----------------------------------------------------------------
 # IMPORTANT NOTE:
 #   This block acts as a catch-all, assigning Arthur triage for


### PR DESCRIPTION
# Summary

The focus of these changes is to add an official ownership path for all Provisioning-related support issues.  After moving provisioning libraries for locality with the associated service, ownership was lost and in many cases is wrongly attributed to service partners.