### PR TITLE
[Service Bus] Prepare Azure.Messaging.ServiceBus 7.20.2 for release

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Release History
 
-## 7.21.0-beta.1 (Unreleased)
+## 7.20.2 (2026-07-08)
 
 ### Acknowledgments
 
 Thank you to our developer community members who helped to make the Service Bus client library better with their contributions to this release:
 
 - Daniel Marbach  _([GitHub](https://github.com/danielmarbach))_
-
-### Features Added
-
-### Breaking Changes
 
 ### Bugs Fixed
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Service Bus is a fully managed enterprise integration message broker. Service Bus can decouple applications and services. Service Bus offers a reliable and secure platform for asynchronous transfer of data and state. This client library allows for both sending and receiving messages using Azure Service Bus. For more information about Service Bus, see https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview</Description>
-    <Version>7.21.0-beta.1</Version>
+    <Version>7.20.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>7.20.1</ApiCompatVersion>
     <PackageTags>Azure;Service Bus;ServiceBus;.NET;AMQP;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
Prepares `Azure.Messaging.ServiceBus` **7.20.2** (stable patch) for release.

### Changes
- `CHANGELOG.md`: date-stamped `## 7.20.2 (2026-07-08)`; empty sections removed.
- `src/Azure.Messaging.ServiceBus.csproj`: `<Version>` `7.21.0-beta.1` → `7.20.2` (`<ApiCompatVersion>` stays `7.20.1`).

Generated via `eng/common/scripts/Prepare-Release.ps1`.

### Why a stable patch (not `7.21.0-beta.1`)
The accumulated changes since `7.20.1` are all bug fixes plus an internal AMQP transport refactor — **no new public API** (zero `api/*.cs` member delta; `ApiCompatVersion` remains `7.20.1` and enforces compatibility). A beta/minor is not warranted, so this ships as a stable patch.

### Contents
**Bugs Fixed**
- Masked SAS key tolerance in `ServiceBusAdministrationClient` ([#60469](https://github.com/Azure/azure-sdk-for-net/issues/60469))
- Processor tight-loop delay on terminal errors ([#54572](https://github.com/Azure/azure-sdk-for-net/issues/54572))
- `AmqpSender` batch-size TOCTOU race ([#56301](https://github.com/Azure/azure-sdk-for-net/issues/56301))
- `max-message-batch-size` vendor property; 4,500-count cap removed ([#44914](https://github.com/Azure/azure-sdk-for-net/issues/44914))

**Other Changes**
- AMQP transport cleanup (community contribution, [@danielmarbach](https://github.com/danielmarbach))
