### PR TITLE
renamed unreleased communication package alpha builds to beta for apicompatVersion gate check

### DIFF
--- a/sdk/communication/Azure.Communication.AlphaIds/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.AlphaIds/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-alpha.1 (Unreleased)
+## 1.0.0-beta.1 (Unreleased)
 
 ### Features Added
 

--- a/sdk/communication/Azure.Communication.AlphaIds/src/Azure.Communication.AlphaIds.csproj
+++ b/sdk/communication/Azure.Communication.AlphaIds/src/Azure.Communication.AlphaIds.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Microsoft Azure Communication Alpha ID Service;Microsoft;Azure;Azure Communication Service;Azure Communication Alpha ID Service;Alpha ID;Alpha Ids;Communication</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <IncludeAutorestDependency>true</IncludeAutorestDependency>
+    <IncludeAutorestDependency>false</IncludeAutorestDependency>
   </PropertyGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/communication/Azure.Communication.AlphaIds/src/Azure.Communication.AlphaIds.csproj
+++ b/sdk/communication/Azure.Communication.AlphaIds/src/Azure.Communication.AlphaIds.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This client library enables working with the Microsoft Azure Communication Alpha ID service.</Description>
     <AssemblyTitle>Azure Communication Alpha ID Service</AssemblyTitle>
-    <Version>1.0.0-alpha.1</Version>
+    <Version>1.0.0-beta.1</Version>
     <PackageTags>Microsoft Azure Communication Alpha ID Service;Microsoft;Azure;Azure Communication Service;Azure Communication Alpha ID Service;Alpha ID;Alpha Ids;Communication</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>

--- a/sdk/communication/Azure.Communication.ShortCodes/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.ShortCodes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-alpha.1 (Unreleased)
+## 1.0.0-beta.1 (Unreleased)
 
 ### Features Added
 

--- a/sdk/communication/Azure.Communication.ShortCodes/src/Azure.Communication.ShortCodes.csproj
+++ b/sdk/communication/Azure.Communication.ShortCodes/src/Azure.Communication.ShortCodes.csproj
@@ -5,7 +5,7 @@
       For this release, see notes - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.ShortCodes/README.md and https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.ShortCodes/CHANGELOG.md.
     </Description>
     <AssemblyTitle>Azure Communication Short Code Service</AssemblyTitle>
-    <Version>1.0.0-alpha.1</Version>
+    <Version>1.0.0-beta.1</Version>
     <PackageTags>Microsoft Azure Communication Short Codes Service;Microsoft;Azure;Azure Communication Service;Azure Communication Short Codes Service;Short Codes;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>

--- a/sdk/communication/Azure.Communication.ShortCodes/src/Azure.Communication.ShortCodes.csproj
+++ b/sdk/communication/Azure.Communication.ShortCodes/src/Azure.Communication.ShortCodes.csproj
@@ -9,7 +9,7 @@
     <PackageTags>Microsoft Azure Communication Short Codes Service;Microsoft;Azure;Azure Communication Service;Azure Communication Short Codes Service;Short Codes;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <IncludeAutorestDependency>true</IncludeAutorestDependency>
+    <IncludeAutorestDependency>false</IncludeAutorestDependency>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

The unreleased AlphaIds and ShortCodes package version are alpha, which should be internal dev build, and are not being considered by the ApiCompatVersion gate. 
- Updating them to beta to satisfy ApiCompatVersion gate 
- Excluding [autorest](https://github.com/Azure/autores) (deprecated and retired) dependencies as it's failing the PR checks
