### PR TITLE
Remove CFSClean policy from 1ES redirect settings

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,7 +40,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
+      networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,6 +40,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      # Do not add CFSClean until packages are published through ESRP instead of directly to NuGet.
       networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:


### PR DESCRIPTION
## Description
Remove `CFSClean` from the 1ES redirect pipeline `networkIsolationPolicy` settings while keeping `CFSClean2` and `CFSClean3` enabled.

This is needed because Azure SDK for .NET still publishes packages directly to NuGet rather than through ESRP.

## Validation
[Template release run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6536434&view=results)