### PR TITLE
Added support for Files Change Feed Reset Events

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -539,6 +539,18 @@ namespace Azure.Storage
             public const int TimeWindowMinutes = 15;
             public const string ChangeFeedContainerHeader = "x-ms-file-blob-container-for-xfiles-change-feed";
 
+            /// <summary>
+            /// Path (relative to the change-feed container) of the mutable pointer blob
+            /// that identifies the most recent reset marker for the share.
+            /// </summary>
+            public const string ResetLatestJsonPath = "meta/reset-latest.json";
+
+            /// <summary>
+            /// Prefix (relative to the change-feed container) under which per-event
+            /// immutable reset marker blobs are stored (<c>meta/resets/&lt;20-digit-FILETIME&gt;.json</c>).
+            /// </summary>
+            public const string ResetEventPrefix = "meta/resets/";
+
             internal static class Event
             {
                 public const string SchemaVersion = "SchemaVersion";
@@ -567,6 +579,36 @@ namespace Azure.Storage
             {
                 public const string EntraOID = "EntraOID";
                 public const string SID = "SID";
+            }
+
+            /// <summary>
+            /// JSON field names for the mutable pointer blob <c>meta/reset-latest.json</c>.
+            /// </summary>
+            internal static class ResetPointer
+            {
+                public const string SchemaVersion = "schemaVersion";
+                public const string LatestResetId = "latestResetId";
+                public const string LatestResetFileTime = "latestResetFileTime";
+                public const string LatestResetTimeUtc = "latestResetTimeUtc";
+                public const string LatestMarkerPath = "latestMarkerPath";
+                public const string AccountName = "accountName";
+                public const string ContainerName = "containerName";
+                public const string Reason = "reason";
+            }
+
+            /// <summary>
+            /// JSON field names for the per-event immutable reset marker blobs
+            /// <c>meta/resets/&lt;20-digit-FILETIME&gt;.json</c>.
+            /// </summary>
+            internal static class ResetMarker
+            {
+                public const string SchemaVersion = "schemaVersion";
+                public const string ResetId = "resetId";
+                public const string ResetFileTime = "resetFileTime";
+                public const string ResetTimeUtc = "resetTimeUtc";
+                public const string AccountName = "accountName";
+                public const string ContainerName = "containerName";
+                public const string Reason = "reason";
             }
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 ### Features Added
 - Initial release of Azure.Storage.Files.Shares.ChangeFeed.
-- Added `ShareChangeFeedResetPolicy` and `ShareChangeFeedClientOptions.ResetPolicy` to control how the SDK reacts when a change feed reset marker is discovered during enumeration. Batched APIs (`GetChanges(start, end)` and `GetChangesBetweenSnapshots(begin, end)`, including their continuation-token and async counterparts) default to `ThrowOnReset`; streaming APIs (`GetChanges()` and `GetChanges(continuationToken)` plus async counterparts) default to `ContinueOnReset`.
-- Added `ShareChangeFeedResetEvent` (a specialized `ShareChangeFeedEvent` with `ResetId`, `ResetFileTime`, `AccountName`, `ContainerName`, and `ResetReason` properties) and the `ShareChangeFeedReasonType.Reset` well-known value for surfacing reset markers in-band on `Pageable<ShareChangeFeedEvent>` enumerations.
-- Added `ShareChangeFeedResetException` with a `ResetEvent` property so callers configured with `ShareChangeFeedResetPolicy.ThrowOnReset` can inspect the reset metadata (id, time, account, share, reason) and drive recovery.
-- Added `ShareChangeFeedModelFactory.ShareChangeFeedResetEvent(...)` for mocking reset events in tests.
 
 ### Breaking Changes
 

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features Added
 - Initial release of Azure.Storage.Files.Shares.ChangeFeed.
+- Added `ShareChangeFeedResetPolicy` and `ShareChangeFeedClientOptions.ResetPolicy` to control how the SDK reacts when a change feed reset marker is discovered during enumeration. Batched APIs (`GetChanges(start, end)` and `GetChangesBetweenSnapshots(begin, end)`, including their continuation-token and async counterparts) default to `ThrowOnReset`; streaming APIs (`GetChanges()` and `GetChanges(continuationToken)` plus async counterparts) default to `ContinueOnReset`.
+- Added `ShareChangeFeedResetEvent` (a specialized `ShareChangeFeedEvent` with `ResetId`, `ResetFileTime`, `AccountName`, `ContainerName`, and `ResetReason` properties) and the `ShareChangeFeedReasonType.Reset` well-known value for surfacing reset markers in-band on `Pageable<ShareChangeFeedEvent>` enumerations.
+- Added `ShareChangeFeedResetException` with a `ResetEvent` property so callers configured with `ShareChangeFeedResetPolicy.ThrowOnReset` can inspect the reset metadata (id, time, account, share, reason) and drive recovery.
+- Added `ShareChangeFeedModelFactory.ShareChangeFeedResetEvent(...)` for mocking reset events in tests.
 
 ### Breaking Changes
 

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/api/Azure.Storage.Files.Shares.ChangeFeed.net10.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/api/Azure.Storage.Files.Shares.ChangeFeed.net10.0.cs
@@ -27,6 +27,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public ShareChangeFeedClientOptions() { }
         public bool IncludeNonFinalizedEvents { get { throw null; } set { } }
         public long? MaximumTransferSize { get { throw null; } set { } }
+        public Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetPolicy? ResetPolicy { get { throw null; } set { } }
     }
     public partial class ShareChangeFeedEvent
     {
@@ -69,6 +70,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEvent ShareChangeFeedEvent(long schemaVersion = (long)0, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType reason = default(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType), Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol protocol = default(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol), System.DateTimeOffset eventTime = default(System.DateTimeOffset), string id = null, long containerVersionNumber = (long)0, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventData eventData = null) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventData ShareChangeFeedEventData(string fileId = null, string parentFileId = null, Azure.ETag? eTag = default(Azure.ETag?), string fileName = null, string fullFilePath = null, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventIdentity identity = null, string description = null, string initiator = null, bool isDirectory = false) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventIdentity ShareChangeFeedEventIdentity(string entraObjectId = null, string securityIdentifier = null) { throw null; }
+        public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent ShareChangeFeedResetEvent(System.Guid resetId = default(System.Guid), long resetFileTime = (long)0, System.DateTimeOffset resetTimeUtc = default(System.DateTimeOffset), string accountName = null, string containerName = null, string resetReason = null, long schemaVersion = (long)1) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ShareChangeFeedProtocol : System.IEquatable<Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol>
@@ -94,6 +96,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public ShareChangeFeedReasonType(string value) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType AsyncCopyFile { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType ControlEvent { get { throw null; } }
+        public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType Reset { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestCreate { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestCreateTruncate { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestDelete { get { throw null; } }
@@ -117,6 +120,28 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public static implicit operator Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType (string value) { throw null; }
         public static bool operator !=(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType left, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType right) { throw null; }
         public override string ToString() { throw null; }
+    }
+    public partial class ShareChangeFeedResetEvent : Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEvent
+    {
+        internal ShareChangeFeedResetEvent() { }
+        public string AccountName { get { throw null; } }
+        public string ContainerName { get { throw null; } }
+        public long ResetFileTime { get { throw null; } }
+        public System.Guid ResetId { get { throw null; } }
+        public string ResetReason { get { throw null; } }
+        public override string ToString() { throw null; }
+    }
+    public partial class ShareChangeFeedResetException : System.Exception
+    {
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent) { }
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent, string message) { }
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent, string message, System.Exception innerException) { }
+        public Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent ResetEvent { get { throw null; } }
+    }
+    public enum ShareChangeFeedResetPolicy
+    {
+        ThrowOnReset = 0,
+        ContinueOnReset = 1,
     }
     public enum ShareChangeFeedSnapshotStatus
     {

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/api/Azure.Storage.Files.Shares.ChangeFeed.net8.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/api/Azure.Storage.Files.Shares.ChangeFeed.net8.0.cs
@@ -27,6 +27,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public ShareChangeFeedClientOptions() { }
         public bool IncludeNonFinalizedEvents { get { throw null; } set { } }
         public long? MaximumTransferSize { get { throw null; } set { } }
+        public Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetPolicy? ResetPolicy { get { throw null; } set { } }
     }
     public partial class ShareChangeFeedEvent
     {
@@ -69,6 +70,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEvent ShareChangeFeedEvent(long schemaVersion = (long)0, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType reason = default(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType), Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol protocol = default(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol), System.DateTimeOffset eventTime = default(System.DateTimeOffset), string id = null, long containerVersionNumber = (long)0, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventData eventData = null) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventData ShareChangeFeedEventData(string fileId = null, string parentFileId = null, Azure.ETag? eTag = default(Azure.ETag?), string fileName = null, string fullFilePath = null, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventIdentity identity = null, string description = null, string initiator = null, bool isDirectory = false) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventIdentity ShareChangeFeedEventIdentity(string entraObjectId = null, string securityIdentifier = null) { throw null; }
+        public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent ShareChangeFeedResetEvent(System.Guid resetId = default(System.Guid), long resetFileTime = (long)0, System.DateTimeOffset resetTimeUtc = default(System.DateTimeOffset), string accountName = null, string containerName = null, string resetReason = null, long schemaVersion = (long)1) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ShareChangeFeedProtocol : System.IEquatable<Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol>
@@ -94,6 +96,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public ShareChangeFeedReasonType(string value) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType AsyncCopyFile { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType ControlEvent { get { throw null; } }
+        public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType Reset { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestCreate { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestCreateTruncate { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestDelete { get { throw null; } }
@@ -117,6 +120,28 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public static implicit operator Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType (string value) { throw null; }
         public static bool operator !=(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType left, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType right) { throw null; }
         public override string ToString() { throw null; }
+    }
+    public partial class ShareChangeFeedResetEvent : Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEvent
+    {
+        internal ShareChangeFeedResetEvent() { }
+        public string AccountName { get { throw null; } }
+        public string ContainerName { get { throw null; } }
+        public long ResetFileTime { get { throw null; } }
+        public System.Guid ResetId { get { throw null; } }
+        public string ResetReason { get { throw null; } }
+        public override string ToString() { throw null; }
+    }
+    public partial class ShareChangeFeedResetException : System.Exception
+    {
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent) { }
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent, string message) { }
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent, string message, System.Exception innerException) { }
+        public Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent ResetEvent { get { throw null; } }
+    }
+    public enum ShareChangeFeedResetPolicy
+    {
+        ThrowOnReset = 0,
+        ContinueOnReset = 1,
     }
     public enum ShareChangeFeedSnapshotStatus
     {

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/api/Azure.Storage.Files.Shares.ChangeFeed.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/api/Azure.Storage.Files.Shares.ChangeFeed.netstandard2.0.cs
@@ -27,6 +27,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public ShareChangeFeedClientOptions() { }
         public bool IncludeNonFinalizedEvents { get { throw null; } set { } }
         public long? MaximumTransferSize { get { throw null; } set { } }
+        public Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetPolicy? ResetPolicy { get { throw null; } set { } }
     }
     public partial class ShareChangeFeedEvent
     {
@@ -69,6 +70,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEvent ShareChangeFeedEvent(long schemaVersion = (long)0, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType reason = default(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType), Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol protocol = default(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol), System.DateTimeOffset eventTime = default(System.DateTimeOffset), string id = null, long containerVersionNumber = (long)0, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventData eventData = null) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventData ShareChangeFeedEventData(string fileId = null, string parentFileId = null, Azure.ETag? eTag = default(Azure.ETag?), string fileName = null, string fullFilePath = null, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventIdentity identity = null, string description = null, string initiator = null, bool isDirectory = false) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEventIdentity ShareChangeFeedEventIdentity(string entraObjectId = null, string securityIdentifier = null) { throw null; }
+        public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent ShareChangeFeedResetEvent(System.Guid resetId = default(System.Guid), long resetFileTime = (long)0, System.DateTimeOffset resetTimeUtc = default(System.DateTimeOffset), string accountName = null, string containerName = null, string resetReason = null, long schemaVersion = (long)1) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ShareChangeFeedProtocol : System.IEquatable<Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedProtocol>
@@ -94,6 +96,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public ShareChangeFeedReasonType(string value) { throw null; }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType AsyncCopyFile { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType ControlEvent { get { throw null; } }
+        public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType Reset { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestCreate { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestCreateTruncate { get { throw null; } }
         public static Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType RestDelete { get { throw null; } }
@@ -117,6 +120,28 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public static implicit operator Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType (string value) { throw null; }
         public static bool operator !=(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType left, Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedReasonType right) { throw null; }
         public override string ToString() { throw null; }
+    }
+    public partial class ShareChangeFeedResetEvent : Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedEvent
+    {
+        internal ShareChangeFeedResetEvent() { }
+        public string AccountName { get { throw null; } }
+        public string ContainerName { get { throw null; } }
+        public long ResetFileTime { get { throw null; } }
+        public System.Guid ResetId { get { throw null; } }
+        public string ResetReason { get { throw null; } }
+        public override string ToString() { throw null; }
+    }
+    public partial class ShareChangeFeedResetException : System.Exception
+    {
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent) { }
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent, string message) { }
+        public ShareChangeFeedResetException(Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent resetEvent, string message, System.Exception innerException) { }
+        public Azure.Storage.Files.Shares.ChangeFeed.ShareChangeFeedResetEvent ResetEvent { get { throw null; } }
+    }
+    public enum ShareChangeFeedResetPolicy
+    {
+        ThrowOnReset = 0,
+        ContinueOnReset = 1,
     }
     public enum ShareChangeFeedSnapshotStatus
     {

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedClientOptions.cs
@@ -36,5 +36,25 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// the underlying segments may change between calls.
         /// </remarks>
         public bool IncludeNonFinalizedEvents { get; set; }
+
+        /// <summary>
+        /// Controls how the <see cref="ShareChangeFeedClient"/> reacts when it discovers a
+        /// change feed reset marker during enumeration.
+        /// </summary>
+        /// <remarks>
+        /// When <c>null</c> (the default), the client applies a per-API smart default:
+        /// batched APIs
+        /// (<see cref="ShareChangeFeedClient.GetChanges(System.DateTimeOffset?, System.DateTimeOffset?)"/>,
+        /// <see cref="ShareChangeFeedClient.GetChangesBetweenSnapshots(string, string)"/>, and
+        /// their continuation-token / async counterparts) default to
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>; streaming APIs
+        /// (<see cref="ShareChangeFeedClient.GetChanges()"/> and
+        /// <see cref="ShareChangeFeedClient.GetChanges(string)"/> plus their async counterparts)
+        /// default to <see cref="ShareChangeFeedResetPolicy.ContinueOnReset"/>.
+        ///
+        /// Explicitly setting this property applies the chosen policy to every method on the
+        /// client, overriding the per-API smart default.
+        /// </remarks>
+        public ShareChangeFeedResetPolicy? ResetPolicy { get; set; }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedCursor.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedCursor.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Storage.ChangeFeed.Common;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Outer continuation-token envelope produced by <see cref="ShareChangeFeedPageable"/> and
+    /// <see cref="ShareChangeFeedAsyncPageable"/>. Wraps the underlying Common
+    /// <see cref="ChangeFeedCursor"/> plus the last reset marker observed by this consumer so
+    /// the SDK can decide on resume whether a new reset (with a strictly-greater
+    /// <see cref="LastSeenResetFileTime"/>) has appeared since the token was issued.
+    /// </summary>
+    /// <remarks>
+    /// This envelope is Files-only and is not shared with
+    /// <c>Azure.Storage.Blobs.ChangeFeed</c>; the Common
+    /// <see cref="ChangeFeedCursor"/> is left unchanged so Blob Change Feed cursors remain
+    /// stable on the wire.
+    ///
+    /// Persisted as the JSON-serialized <see cref="Page{T}.ContinuationToken"/> string on
+    /// pages emitted by the streaming pageables. When
+    /// <see cref="ShareChangeFeedClientOptions.IncludeNonFinalizedEvents"/> is enabled,
+    /// pages do not carry a continuation token and this envelope is not emitted.
+    /// </remarks>
+    internal class ShareChangeFeedCursor
+    {
+        /// <summary>
+        /// Schema version of the envelope. Pinned at <c>1</c> today; bump and gate in
+        /// <see cref="ShareChangeFeedCursorSerializer.Validate"/> when the shape changes.
+        /// </summary>
+        public int CursorVersion { get; set; }
+
+        /// <summary>
+        /// Host portion of the change-feed container URL, used to validate that a cursor
+        /// matches the target account. Mirrors <see cref="ChangeFeedCursor.UrlHost"/> from Common.
+        /// </summary>
+        public string UrlHost { get; set; }
+
+        /// <summary>
+        /// Underlying Common change-feed cursor from the raw page. Forwarded back into
+        /// <see cref="ChangeFeedFactoryBase{TEvent}.BuildChangeFeed(ChangeFeedCursor, bool, System.Threading.CancellationToken, bool)"/>
+        /// on resume so the typed cursor crosses the layer boundary without a JSON round-trip.
+        /// </summary>
+        public ChangeFeedCursor InnerCursor { get; set; }
+
+        /// <summary>
+        /// GUID of the most recent reset marker observed by this consumer, or <c>null</c> when
+        /// no reset marker has been observed. Compared against the pointer's
+        /// <see cref="ShareChangeFeedResetPointer.LatestResetId"/> at resume time to detect
+        /// resets that occurred while the caller held the token.
+        /// </summary>
+        public Guid? LastSeenResetId { get; set; }
+
+        /// <summary>
+        /// FILETIME ticks of the most recent reset marker observed by this consumer, or
+        /// <c>null</c> when no reset marker has been observed. FILETIME is monotonic per stamp
+        /// and is used as the actual ordering key when comparing against
+        /// <see cref="ShareChangeFeedResetPointer.LatestResetFileTime"/>.
+        /// </summary>
+        public long? LastSeenResetFileTime { get; set; }
+
+        /// <summary>
+        /// Parameterless constructor for <c>JsonSerializer</c>.
+        /// </summary>
+        public ShareChangeFeedCursor() { }
+
+        /// <summary>
+        /// Initializes a new envelope wrapping <paramref name="innerCursor"/> and the supplied
+        /// reset-observation state.
+        /// </summary>
+        internal ShareChangeFeedCursor(
+            string urlHost,
+            ChangeFeedCursor innerCursor,
+            Guid? lastSeenResetId,
+            long? lastSeenResetFileTime)
+        {
+            CursorVersion = 1;
+            UrlHost = urlHost;
+            InnerCursor = innerCursor;
+            LastSeenResetId = lastSeenResetId;
+            LastSeenResetFileTime = lastSeenResetFileTime;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedCursor.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedCursor.cs
@@ -62,6 +62,31 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public long? LastSeenResetFileTime { get; set; }
 
         /// <summary>
+        /// Lower bound of the original query's time range, or <c>null</c> when the query was
+        /// unbounded (streaming). Persisted so a resumed batched <c>GetChanges(start, end)</c>
+        /// reconstructs its range and does not degrade to unbounded reset detection. Absent on
+        /// tokens issued before this field was added, in which case it deserializes to <c>null</c>.
+        /// </summary>
+        public DateTimeOffset? RangeStart { get; set; }
+
+        /// <summary>
+        /// Upper bound of the original query's time range, or <c>null</c> when the query was
+        /// unbounded (streaming). Persisted so a resumed batched <c>GetChanges(start, end)</c>
+        /// does not read events past the requested end. Absent on tokens issued before this
+        /// field was added, in which case it deserializes to <c>null</c>.
+        /// </summary>
+        public DateTimeOffset? RangeEnd { get; set; }
+
+        /// <summary>
+        /// <c>true</c> when the token was issued by a batched (time-range) query, <c>false</c>
+        /// for a streaming query. Persisted so resume via <c>GetChanges(continuationToken)</c>
+        /// reuses the original API's smart policy default instead of always resolving as
+        /// streaming. Absent on tokens issued before this field was added, in which case it
+        /// deserializes to <c>false</c>.
+        /// </summary>
+        public bool IsBatched { get; set; }
+
+        /// <summary>
         /// Parameterless constructor for <c>JsonSerializer</c>.
         /// </summary>
         public ShareChangeFeedCursor() { }
@@ -74,13 +99,19 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             string urlHost,
             ChangeFeedCursor innerCursor,
             Guid? lastSeenResetId,
-            long? lastSeenResetFileTime)
+            long? lastSeenResetFileTime,
+            DateTimeOffset? rangeStart = null,
+            DateTimeOffset? rangeEnd = null,
+            bool isBatched = false)
         {
             CursorVersion = 1;
             UrlHost = urlHost;
             InnerCursor = innerCursor;
             LastSeenResetId = lastSeenResetId;
             LastSeenResetFileTime = lastSeenResetFileTime;
+            RangeStart = rangeStart;
+            RangeEnd = rangeEnd;
+            IsBatched = isBatched;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedModelFactory.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedModelFactory.cs
@@ -69,5 +69,38 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 EntraObjectId = entraObjectId,
                 SecurityIdentifier = securityIdentifier,
             };
+
+        /// <summary>
+        /// Creates a new <see cref="ShareChangeFeedResetEvent"/> instance for mocking.
+        /// </summary>
+        /// <param name="resetId">Server-generated GUID identifying this reset event.</param>
+        /// <param name="resetFileTime">Windows FILETIME ticks (100 ns since 1601 UTC) at emit time.</param>
+        /// <param name="resetTimeUtc">Human-readable UTC timestamp corresponding to <paramref name="resetFileTime"/>.</param>
+        /// <param name="accountName">Unversioned account name.</param>
+        /// <param name="containerName">Unversioned share (container) name.</param>
+        /// <param name="resetReason">Free-form human-readable cause recorded on the reset marker.</param>
+        /// <param name="schemaVersion">Schema version of the reset marker (defaults to 1).</param>
+        public static ShareChangeFeedResetEvent ShareChangeFeedResetEvent(
+            Guid resetId = default,
+            long resetFileTime = default,
+            DateTimeOffset resetTimeUtc = default,
+            string accountName = default,
+            string containerName = default,
+            string resetReason = default,
+            long schemaVersion = 1)
+            => new ShareChangeFeedResetEvent
+            {
+                SchemaVersion = schemaVersion,
+                Reason = ShareChangeFeedReasonType.Reset,
+                EventTime = resetTimeUtc,
+                Id = resetId.ToString(),
+                ContainerVersionNumber = 0,
+                EventData = null,
+                ResetId = resetId,
+                ResetFileTime = resetFileTime,
+                AccountName = accountName,
+                ContainerName = containerName,
+                ResetReason = resetReason,
+            };
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedReasonType.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedReasonType.cs
@@ -57,6 +57,14 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public static ShareChangeFeedReasonType ControlEvent { get; } = new ShareChangeFeedReasonType("ControlEvent");
         /// <summary> A file was created with truncation via REST API. </summary>
         public static ShareChangeFeedReasonType RestCreateTruncate { get; } = new ShareChangeFeedReasonType("RestCreateTruncate");
+        /// <summary>
+        /// A change feed reset marker. Emitted synthetically by the SDK when the service records
+        /// a reset event (for example, HardFailover or classic account migration) in
+        /// <c>meta/reset-latest.json</c>. Log-sequence continuity is broken at this point and the
+        /// consumer must decide whether to re-baseline or continue reading past the marker.
+        /// See <see cref="ShareChangeFeedResetEvent"/>.
+        /// </summary>
+        public static ShareChangeFeedReasonType Reset { get; } = new ShareChangeFeedReasonType("Reset");
 
         public static implicit operator ShareChangeFeedReasonType(string value) => new ShareChangeFeedReasonType(value);
 

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedResetEvent.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedResetEvent.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// A specialized <see cref="ShareChangeFeedEvent"/> that represents an Azure Files
+    /// Change Feed reset marker. Reset markers are emitted by the service on events such as
+    /// HardFailover or classic account migration. When observed, log-sequence continuity has
+    /// been broken from this point onward and consumers must decide whether to stop,
+    /// re-baseline, or continue reading past the marker.
+    /// </summary>
+    /// <remarks>
+    /// A reset event is surfaced in-band on <see cref="ShareChangeFeedClient.GetChanges()"/>
+    /// enumerations (default <see cref="ShareChangeFeedResetPolicy.ContinueOnReset"/>) at its
+    /// ordered position in the stream, or via <see cref="ShareChangeFeedResetException.ResetEvent"/>
+    /// when the client is configured with <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>.
+    /// The base <see cref="ShareChangeFeedEvent.Reason"/> is always
+    /// <see cref="ShareChangeFeedReasonType.Reset"/>; the base <see cref="ShareChangeFeedEvent.Id"/>
+    /// holds the reset event GUID as its string form; the base
+    /// <see cref="ShareChangeFeedEvent.EventTime"/> holds the reset time.
+    /// </remarks>
+    public class ShareChangeFeedResetEvent : ShareChangeFeedEvent
+    {
+        /// <summary>
+        /// Server-generated GUID identifying this reset event. Matches the
+        /// <c>resetId</c> field in the per-event marker JSON.
+        /// </summary>
+        public Guid ResetId { get; internal set; }
+
+        /// <summary>
+        /// Windows FILETIME ticks (100 ns since 1601 UTC) at which the reset was emitted.
+        /// Monotonic per stamp and also encoded into the per-event blob key.
+        /// </summary>
+        public long ResetFileTime { get; internal set; }
+
+        /// <summary>
+        /// Unversioned account name recorded on the reset event.
+        /// </summary>
+        public string AccountName { get; internal set; }
+
+        /// <summary>
+        /// Unversioned share (container) name recorded on the reset event.
+        /// </summary>
+        public string ContainerName { get; internal set; }
+
+        /// <summary>
+        /// Verbatim, human-readable cause of the reset (for example,
+        /// "Customer-managed unplanned failover" or "Tracking State Reset"). This is the free-form
+        /// <c>reason</c> field from the reset marker JSON; it is exposed here under a distinct
+        /// name to avoid shadowing the inherited <see cref="ShareChangeFeedEvent.Reason"/> property
+        /// (which is the strongly-typed <see cref="ShareChangeFeedReasonType"/> and is always
+        /// <see cref="ShareChangeFeedReasonType.Reset"/> for a reset event).
+        /// </summary>
+        public string ResetReason { get; internal set; }
+
+        /// <summary>
+        /// Initializes a new <see cref="ShareChangeFeedResetEvent"/> from a pointer plus its
+        /// per-event marker.
+        /// </summary>
+        /// <param name="pointer">The parsed <c>meta/reset-latest.json</c> pointer.</param>
+        /// <param name="perEvent">The parsed <c>meta/resets/&lt;FILETIME&gt;.json</c> per-event blob.</param>
+        internal ShareChangeFeedResetEvent(
+            ShareChangeFeedResetPointer pointer,
+            ShareChangeFeedResetMarker perEvent)
+        {
+            if (pointer == null)
+                throw new ArgumentNullException(nameof(pointer));
+            if (perEvent == null)
+                throw new ArgumentNullException(nameof(perEvent));
+
+            // Populate base ShareChangeFeedEvent fields so the reset event flows through the
+            // ordered stream indistinguishably from a normal event, except for Reason and the
+            // reset-specific properties below.
+            SchemaVersion = perEvent.SchemaVersion;
+            Reason = ShareChangeFeedReasonType.Reset;
+            // Reset markers are not tied to a wire protocol (SMB/REST); leave Protocol at default.
+            EventTime = perEvent.ResetTimeUtc;
+            Id = perEvent.ResetId.ToString();
+            // Reset events are not associated with a container version number.
+            ContainerVersionNumber = 0;
+            EventData = null;
+
+            ResetId = perEvent.ResetId;
+            ResetFileTime = perEvent.ResetFileTime;
+            AccountName = perEvent.AccountName;
+            ContainerName = perEvent.ContainerName;
+            ResetReason = perEvent.Reason;
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="ShareChangeFeedResetEvent"/> for mocking purposes.
+        /// </summary>
+        internal ShareChangeFeedResetEvent()
+        {
+            Reason = ShareChangeFeedReasonType.Reset;
+        }
+
+        /// <summary>
+        /// Returns a human-readable string summarizing the reset event.
+        /// </summary>
+        public override string ToString()
+            => $"{EventTime}: Reset ({ResetReason ?? "Unknown"}) {AccountName}/{ContainerName} [{ResetId}]";
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedResetPolicy.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedResetPolicy.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Controls how <see cref="ShareChangeFeedClient"/> reacts when a change feed reset marker
+    /// is discovered during enumeration.
+    /// </summary>
+    /// <remarks>
+    /// Azure Files emits a reset marker on events such as HardFailover or classic account
+    /// migration. A reset breaks log-sequence continuity, so consumers must decide whether to
+    /// stop and re-baseline or observe the reset in the ordered stream and continue reading.
+    ///
+    /// If <see cref="ShareChangeFeedClientOptions.ResetPolicy"/> is <c>null</c>, the client
+    /// applies a per-API default:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///     Batched APIs (<see cref="ShareChangeFeedClient.GetChanges(System.DateTimeOffset?, System.DateTimeOffset?)"/>,
+    ///     <see cref="ShareChangeFeedClient.GetChangesBetweenSnapshots(string, string)"/>, and their
+    ///     continuation-token / async counterparts) default to <see cref="ThrowOnReset"/> so
+    ///     correctness-sensitive consumers fail fast when a reset falls inside the requested range.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Streaming APIs (<see cref="ShareChangeFeedClient.GetChanges()"/> and
+    ///     <see cref="ShareChangeFeedClient.GetChanges(string)"/> plus their async counterparts)
+    ///     default to <see cref="ContinueOnReset"/> so consumers receive the reset event in-band
+    ///     at its ordered position.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    /// Explicitly setting <see cref="ShareChangeFeedClientOptions.ResetPolicy"/> overrides the
+    /// per-API default for every method on the client.
+    /// </remarks>
+    public enum ShareChangeFeedResetPolicy
+    {
+        /// <summary>
+        /// When a reset marker is detected, throw <see cref="ShareChangeFeedResetException"/>.
+        /// Batched APIs fail before yielding any events when the requested range crosses a reset
+        /// boundary; streaming APIs stop at the reset boundary.
+        /// </summary>
+        ThrowOnReset = 0,
+
+        /// <summary>
+        /// When a reset marker is detected, surface it in-band as a
+        /// <see cref="ShareChangeFeedResetEvent"/> at its position in the ordered stream and
+        /// continue enumeration. Consumers must decide whether to stop, re-baseline, or keep
+        /// reading past the marker.
+        /// </summary>
+        ContinueOnReset = 1,
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedSnapshotCursor.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Models/ShareChangeFeedSnapshotCursor.cs
@@ -66,6 +66,22 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public ChangeFeedCursor InnerCursor { get; set; }
 
         /// <summary>
+        /// GUID of the most recent reset marker observed by this consumer, or <c>null</c> when
+        /// no reset marker has been observed. Compared against the pointer's
+        /// <see cref="ShareChangeFeedResetPointer.LatestResetId"/> at resume time to detect
+        /// resets that occurred while the caller held the token.
+        /// </summary>
+        public System.Guid? LastSeenResetId { get; set; }
+
+        /// <summary>
+        /// FILETIME ticks of the most recent reset marker observed by this consumer, or
+        /// <c>null</c> when no reset marker has been observed. FILETIME is monotonic per stamp
+        /// and is used as the actual ordering key when comparing against
+        /// <see cref="ShareChangeFeedResetPointer.LatestResetFileTime"/>.
+        /// </summary>
+        public long? LastSeenResetFileTime { get; set; }
+
+        /// <summary>
         /// Parameterless constructor for <c>JsonSerializer</c>.
         /// </summary>
         public ShareChangeFeedSnapshotCursor() { }
@@ -79,7 +95,9 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             string endSnapshot,
             long beginCvId,
             long endCvId,
-            ChangeFeedCursor innerCursor)
+            ChangeFeedCursor innerCursor,
+            System.Guid? lastSeenResetId = null,
+            long? lastSeenResetFileTime = null)
         {
             CursorVersion = 1;
             UrlHost = urlHost;
@@ -88,6 +106,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             BeginCvId = beginCvId;
             EndCvId = endCvId;
             InnerCursor = innerCursor;
+            LastSeenResetId = lastSeenResetId;
+            LastSeenResetFileTime = lastSeenResetFileTime;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ResetDetector.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ResetDetector.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Pure decision logic for whether a reset referenced by <c>meta/reset-latest.json</c>
+    /// should be surfaced to the caller. Shared by the streaming/batched and snapshot
+    /// pageables (sync and async) so the surface/dedup rules live in a single, unit-testable
+    /// place.
+    /// </summary>
+    internal static class ResetDetector
+    {
+        /// <summary>
+        /// Decides whether the latest reset described by the pointer should be surfaced.
+        /// </summary>
+        /// <param name="resetTime">
+        /// UTC time of the latest reset (<see cref="ShareChangeFeedResetPointer.LatestResetTimeUtc"/>).
+        /// </param>
+        /// <param name="resetFileTime">
+        /// FILETIME of the latest reset (<see cref="ShareChangeFeedResetPointer.LatestResetFileTime"/>),
+        /// used as the ordering anchor against the resumed last-seen value.
+        /// </param>
+        /// <param name="resetId">
+        /// Id of the latest reset (<see cref="ShareChangeFeedResetPointer.LatestResetId"/>),
+        /// used to de-duplicate a reset that was already surfaced on a prior page.
+        /// </param>
+        /// <param name="lastSeenResetFileTime">
+        /// Last-seen reset FILETIME carried on the resume token, or <c>null</c> on a fresh enumeration.
+        /// </param>
+        /// <param name="lastSeenResetId">
+        /// Last-seen reset id carried on the resume token, or <c>null</c> on a fresh enumeration.
+        /// </param>
+        /// <param name="rangeStart">
+        /// Lower bound of the requested range (start time or begin-snapshot timestamp), or
+        /// <c>null</c> when unbounded (streaming) or unavailable (resume).
+        /// </param>
+        /// <param name="rangeEnd">
+        /// Upper bound of the requested range (end time or end-snapshot timestamp), or
+        /// <c>null</c> when unbounded (streaming) or unavailable (resume). Only used to detect
+        /// the unbounded/resume case; the reset time is intentionally not compared against it,
+        /// since the pointer only ever references the latest reset and an in-range reset must be
+        /// surfaced even when a newer reset lands past the end of the range.
+        /// </param>
+        /// <returns><c>true</c> when the reset should be surfaced (yielded or thrown).</returns>
+        public static bool ShouldSurface(
+            DateTimeOffset resetTime,
+            long resetFileTime,
+            Guid resetId,
+            long? lastSeenResetFileTime,
+            Guid? lastSeenResetId,
+            DateTimeOffset? rangeStart,
+            DateTimeOffset? rangeEnd)
+        {
+            bool resetIsNewer = !lastSeenResetFileTime.HasValue
+                || resetFileTime > lastSeenResetFileTime.Value;
+
+            // Avoid re-emitting a reset we already surfaced: the resumed token carries the id of
+            // the last-seen reset, so skip when the pointer still references that same id.
+            bool sameReset = lastSeenResetId.HasValue && resetId == lastSeenResetId.Value;
+
+            // The pointer only ever references the latest reset. A reset in range must be surfaced
+            // even when a newer reset lands past the end of the range, so only the lower bound is
+            // checked.
+            bool resetInRange = rangeStart.HasValue && resetTime >= rangeStart.Value;
+
+            // Unbounded (streaming) or a resume where the range bounds were not re-derived: the
+            // pointer being strictly newer than the resume state is enough.
+            bool unbounded = !rangeStart.HasValue && !rangeEnd.HasValue;
+
+            return resetIsNewer && !sameReset && (unbounded || resetInRange);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ResetMarkerReader.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ResetMarkerReader.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Helper for reading Files Change Feed reset markers from the change feed container.
+    /// Reset markers are emitted on events such as HardFailover or classic account migration
+    /// and signal that the log-sequence continuity has been broken from that point onward.
+    /// </summary>
+    internal static class ResetMarkerReader
+    {
+        /// <summary>
+        /// Attempts to download and parse the mutable pointer blob
+        /// <c>meta/reset-latest.json</c>. Returns <c>null</c> when the pointer blob does not
+        /// exist (i.e. the share has never emitted a reset).
+        /// </summary>
+        /// <param name="containerClient">Blob container client for the change feed container.</param>
+        /// <param name="async">Whether to execute the download asynchronously.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>
+        /// A <see cref="ShareChangeFeedResetPointer"/> parsed from the JSON content, or
+        /// <c>null</c> when the pointer blob is not found.
+        /// </returns>
+        internal static async Task<ShareChangeFeedResetPointer> TryReadPointerAsync(
+            BlobContainerClient containerClient,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            BlobClient blobClient = containerClient.GetBlobClient(Constants.FilesChangeFeed.ResetLatestJsonPath);
+            BlobDownloadStreamingResult result;
+
+            try
+            {
+                if (async)
+                {
+                    result = await blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    result = blobClient.DownloadStreaming(cancellationToken: cancellationToken);
+                }
+            }
+            catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
+            {
+                return null;
+            }
+
+            return await ParsePointerAsync(result, async, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Downloads and parses a per-event reset marker blob referenced by
+        /// <see cref="ShareChangeFeedResetPointer.LatestMarkerPath"/>. Validates that the path
+        /// stays under the expected <c>meta/resets/</c> prefix to guard against a malformed
+        /// pointer redirecting the reader outside the reset marker area.
+        /// </summary>
+        /// <param name="containerClient">Blob container client for the change feed container.</param>
+        /// <param name="markerPath">Relative blob key for the per-event marker.</param>
+        /// <param name="async">Whether to execute the download asynchronously.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="ShareChangeFeedResetMarker"/> parsed from the JSON content.</returns>
+        internal static async Task<ShareChangeFeedResetMarker> ReadPerEventAsync(
+            BlobContainerClient containerClient,
+            string markerPath,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(markerPath))
+            {
+                throw new InvalidOperationException(
+                    "Reset marker pointer did not include a target marker path.");
+            }
+
+            if (!markerPath.StartsWith(Constants.FilesChangeFeed.ResetEventPrefix, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Reset marker path '{markerPath}' does not begin with the expected prefix " +
+                    $"'{Constants.FilesChangeFeed.ResetEventPrefix}'.");
+            }
+
+            BlobClient blobClient = containerClient.GetBlobClient(markerPath);
+            BlobDownloadStreamingResult result;
+
+            try
+            {
+                if (async)
+                {
+                    result = await blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    result = blobClient.DownloadStreaming(cancellationToken: cancellationToken);
+                }
+            }
+            catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
+            {
+                throw new InvalidOperationException(
+                    $"Reset marker pointer references '{markerPath}' but that per-event blob was not found. " +
+                    "The reset marker set may still be publishing.",
+                    ex);
+            }
+
+            return await ParsePerEventAsync(result, markerPath, async, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="ShareChangeFeedResetEvent"/> from a pointer + per-event pair.
+        /// The event surfaces on the change feed stream at the reset's event time.
+        /// </summary>
+        internal static ShareChangeFeedResetEvent BuildResetEvent(
+            ShareChangeFeedResetPointer pointer,
+            ShareChangeFeedResetMarker perEvent)
+        {
+            if (pointer == null)
+                throw new ArgumentNullException(nameof(pointer));
+            if (perEvent == null)
+                throw new ArgumentNullException(nameof(perEvent));
+
+            return new ShareChangeFeedResetEvent(pointer, perEvent);
+        }
+
+        private static async Task<ShareChangeFeedResetPointer> ParsePointerAsync(
+            BlobDownloadStreamingResult result,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            JsonDocument json = null;
+            try
+            {
+                if (async)
+                {
+                    json = await JsonDocument.ParseAsync(result.Content, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    json = JsonDocument.Parse(result.Content);
+                }
+
+                JsonElement root = json.RootElement;
+                string path = Constants.FilesChangeFeed.ResetLatestJsonPath;
+
+                return new ShareChangeFeedResetPointer
+                {
+                    SchemaVersion = RequireInt32(root, Constants.FilesChangeFeed.ResetPointer.SchemaVersion, path),
+                    LatestResetId = RequireGuid(root, Constants.FilesChangeFeed.ResetPointer.LatestResetId, path),
+                    LatestResetFileTime = RequireInt64(root, Constants.FilesChangeFeed.ResetPointer.LatestResetFileTime, path),
+                    LatestResetTimeUtc = RequireDateTimeOffset(root, Constants.FilesChangeFeed.ResetPointer.LatestResetTimeUtc, path),
+                    LatestMarkerPath = RequireString(root, Constants.FilesChangeFeed.ResetPointer.LatestMarkerPath, path),
+                    AccountName = RequireString(root, Constants.FilesChangeFeed.ResetPointer.AccountName, path),
+                    ContainerName = RequireString(root, Constants.FilesChangeFeed.ResetPointer.ContainerName, path),
+                    Reason = RequireString(root, Constants.FilesChangeFeed.ResetPointer.Reason, path),
+                };
+            }
+            finally
+            {
+                json?.Dispose();
+            }
+        }
+
+        private static async Task<ShareChangeFeedResetMarker> ParsePerEventAsync(
+            BlobDownloadStreamingResult result,
+            string path,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            JsonDocument json = null;
+            try
+            {
+                if (async)
+                {
+                    json = await JsonDocument.ParseAsync(result.Content, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    json = JsonDocument.Parse(result.Content);
+                }
+
+                JsonElement root = json.RootElement;
+
+                return new ShareChangeFeedResetMarker
+                {
+                    SchemaVersion = RequireInt32(root, Constants.FilesChangeFeed.ResetMarker.SchemaVersion, path),
+                    ResetId = RequireGuid(root, Constants.FilesChangeFeed.ResetMarker.ResetId, path),
+                    ResetFileTime = RequireInt64(root, Constants.FilesChangeFeed.ResetMarker.ResetFileTime, path),
+                    ResetTimeUtc = RequireDateTimeOffset(root, Constants.FilesChangeFeed.ResetMarker.ResetTimeUtc, path),
+                    AccountName = RequireString(root, Constants.FilesChangeFeed.ResetMarker.AccountName, path),
+                    ContainerName = RequireString(root, Constants.FilesChangeFeed.ResetMarker.ContainerName, path),
+                    Reason = RequireString(root, Constants.FilesChangeFeed.ResetMarker.Reason, path),
+                };
+            }
+            finally
+            {
+                json?.Dispose();
+            }
+        }
+
+        private static string RequireString(JsonElement root, string field, string path)
+        {
+            if (!root.TryGetProperty(field, out JsonElement value))
+                throw new FormatException($"Reset marker at '{path}' is missing required field '{field}'.");
+            string s = value.GetString();
+            if (s == null)
+                throw new FormatException($"Reset marker at '{path}' field '{field}' is null.");
+            return s;
+        }
+
+        private static int RequireInt32(JsonElement root, string field, string path)
+        {
+            if (!root.TryGetProperty(field, out JsonElement value))
+                throw new FormatException($"Reset marker at '{path}' is missing required field '{field}'.");
+            try
+            {
+                return value.GetInt32();
+            }
+            catch (Exception ex) when (ex is FormatException || ex is InvalidOperationException)
+            {
+                throw new FormatException(
+                    $"Reset marker at '{path}' field '{field}' is not a valid Int32.",
+                    ex);
+            }
+        }
+
+        private static long RequireInt64(JsonElement root, string field, string path)
+        {
+            if (!root.TryGetProperty(field, out JsonElement value))
+                throw new FormatException($"Reset marker at '{path}' is missing required field '{field}'.");
+            try
+            {
+                return value.GetInt64();
+            }
+            catch (Exception ex) when (ex is FormatException || ex is InvalidOperationException)
+            {
+                throw new FormatException(
+                    $"Reset marker at '{path}' field '{field}' is not a valid Int64.",
+                    ex);
+            }
+        }
+
+        private static Guid RequireGuid(JsonElement root, string field, string path)
+        {
+            if (!root.TryGetProperty(field, out JsonElement value))
+                throw new FormatException($"Reset marker at '{path}' is missing required field '{field}'.");
+            string s = value.GetString();
+            if (s == null)
+                throw new FormatException($"Reset marker at '{path}' field '{field}' is null.");
+            if (!Guid.TryParse(s, out Guid guid))
+                throw new FormatException($"Reset marker at '{path}' field '{field}' is not a valid GUID: '{s}'.");
+            return guid;
+        }
+
+        private static DateTimeOffset RequireDateTimeOffset(JsonElement root, string field, string path)
+        {
+            if (!root.TryGetProperty(field, out JsonElement value))
+                throw new FormatException($"Reset marker at '{path}' is missing required field '{field}'.");
+            string s = value.GetString();
+            if (s == null)
+                throw new FormatException($"Reset marker at '{path}' field '{field}' is null.");
+            if (!DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTimeOffset ts))
+                throw new FormatException($"Reset marker at '{path}' field '{field}' is not a valid DateTimeOffset: '{s}'.");
+            return ts;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedAsyncPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedAsyncPageable.cs
@@ -16,11 +16,13 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         private readonly DateTimeOffset? _startTime;
         private readonly DateTimeOffset? _endTime;
         private readonly string _continuation;
+        private readonly ShareChangeFeedResetPolicy _policy;
 
         internal ShareChangeFeedAsyncPageable(
             ShareChangeFeedClient client,
             long? maxTransferSize,
             bool includeNonFinalizedEvents,
+            ShareChangeFeedResetPolicy policy = ShareChangeFeedResetPolicy.ContinueOnReset,
             DateTimeOffset? startTime = default,
             DateTimeOffset? endTime = default,
             string continuation = default)
@@ -28,6 +30,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             _client = client;
             _maxTransferSize = maxTransferSize;
             _includeNonFinalizedEvents = includeNonFinalizedEvents;
+            _policy = policy;
             _startTime = startTime;
             _endTime = endTime;
             _continuation = continuation;
@@ -45,27 +48,160 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 cancellationToken: default)
                 .ConfigureAwait(false);
 
+            // Deserialize the outer Files-only envelope on resume so we can compare the
+            // last-seen reset marker against the current pointer.
+            ShareChangeFeedCursor outerCursor = null;
+            ChangeFeedCursor innerCursor = null;
+            Guid? lastSeenResetId = null;
+            long? lastSeenResetFileTime = null;
+            if (_continuation != null)
+            {
+                outerCursor = ShareChangeFeedCursorSerializer.Deserialize(_continuation);
+                ShareChangeFeedCursorSerializer.Validate(containerClient, outerCursor);
+                innerCursor = outerCursor.InnerCursor;
+                lastSeenResetId = outerCursor.LastSeenResetId;
+                lastSeenResetFileTime = outerCursor.LastSeenResetFileTime;
+            }
+
+            // Read the reset pointer once at the start of enumeration. Detection is decided
+            // against either the resume state (last-seen FILETIME) or the requested range.
+            ShareChangeFeedResetPointer pointer = await ResetMarkerReader.TryReadPointerAsync(
+                containerClient,
+                async: true,
+                cancellationToken: default)
+                .ConfigureAwait(false);
+
+            ShareChangeFeedResetEvent resetToEmit = null;
+            DateTimeOffset resetTime = default;
+
+            if (pointer != null)
+            {
+                resetTime = pointer.LatestResetTimeUtc;
+                bool resetIsNewer = !lastSeenResetFileTime.HasValue
+                    || pointer.LatestResetFileTime > lastSeenResetFileTime.Value;
+                bool resetInRange = _startTime.HasValue
+                    && _endTime.HasValue
+                    && resetTime >= _startTime.Value
+                    && resetTime <= _endTime.Value;
+
+                bool shouldSurface = resetIsNewer && (
+                    (!_startTime.HasValue && !_endTime.HasValue)
+                    || resetInRange);
+
+                if (shouldSurface)
+                {
+                    ShareChangeFeedResetMarker perEvent = await ResetMarkerReader.ReadPerEventAsync(
+                        containerClient,
+                        pointer.LatestMarkerPath,
+                        async: true,
+                        cancellationToken: default)
+                        .ConfigureAwait(false);
+
+                    resetToEmit = ResetMarkerReader.BuildResetEvent(pointer, perEvent);
+
+                    if (_policy == ShareChangeFeedResetPolicy.ThrowOnReset)
+                    {
+                        throw new ShareChangeFeedResetException(resetToEmit);
+                    }
+                }
+            }
+
             ChangeFeedFactoryBase<ShareChangeFeedEvent> factory = new ChangeFeedFactoryBase<ShareChangeFeedEvent>(
                 containerClient,
                 _maxTransferSize,
                 config,
                 _includeNonFinalizedEvents);
 
-            ChangeFeedBase<ShareChangeFeedEvent> changeFeed = await factory.BuildChangeFeed(
-                _startTime,
-                _endTime,
-                _continuation,
-                async: true,
-                cancellationToken: default)
-                .ConfigureAwait(false);
+            ChangeFeedBase<ShareChangeFeedEvent> changeFeed = innerCursor != null
+                ? await factory.BuildChangeFeed(
+                    innerCursor,
+                    async: true,
+                    cancellationToken: default)
+                    .ConfigureAwait(false)
+                : await factory.BuildChangeFeed(
+                    _startTime,
+                    _endTime,
+                    continuation: null,
+                    async: true,
+                    cancellationToken: default)
+                    .ConfigureAwait(false);
+
+            bool resetEmitted = false;
+            int pageSize = pageSizeHint ?? Constants.ChangeFeed.DefaultPageSize;
 
             while (changeFeed.HasNext())
             {
-                yield return await changeFeed.GetPage(
+                Page<ShareChangeFeedEvent> rawPage = await changeFeed.GetPage(
                     async: true,
-                    pageSize: pageSizeHint ?? Constants.ChangeFeed.DefaultPageSize)
+                    pageSize: pageSize)
                     .ConfigureAwait(false);
+
+                List<ShareChangeFeedEvent> events = new List<ShareChangeFeedEvent>();
+                foreach (ShareChangeFeedEvent evt in rawPage.Values)
+                {
+                    if (!resetEmitted && resetToEmit != null && evt.EventTime >= resetTime)
+                    {
+                        events.Add(resetToEmit);
+                        resetEmitted = true;
+                    }
+
+                    events.Add(evt);
+                }
+
+                long? nextFileTime = resetEmitted
+                    ? pointer?.LatestResetFileTime ?? lastSeenResetFileTime
+                    : lastSeenResetFileTime;
+                Guid? nextId = resetEmitted
+                    ? pointer?.LatestResetId ?? lastSeenResetId
+                    : lastSeenResetId;
+
+                ChangeFeedCursor typedInner = rawPage.ContinuationToken != null
+                    ? changeFeed.GetCursor()
+                    : null;
+
+                string outerToken = BuildOuterToken(
+                    containerClient,
+                    typedInner,
+                    nextId,
+                    nextFileTime);
+
+                yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(events, outerToken);
             }
+
+            if (!resetEmitted && resetToEmit != null)
+            {
+                List<ShareChangeFeedEvent> tail = new List<ShareChangeFeedEvent> { resetToEmit };
+                string outerToken = BuildOuterToken(
+                    containerClient,
+                    innerCursor: null,
+                    pointer.LatestResetId,
+                    pointer.LatestResetFileTime);
+                yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(tail, outerToken);
+            }
+        }
+
+        /// <summary>
+        /// Wraps the inner Common change-feed cursor in the Files-only outer envelope so that
+        /// the last-seen reset marker travels alongside the underlying position.
+        /// </summary>
+        private static string BuildOuterToken(
+            BlobContainerClient containerClient,
+            ChangeFeedCursor innerCursor,
+            Guid? lastSeenResetId,
+            long? lastSeenResetFileTime)
+        {
+            if (innerCursor == null && !lastSeenResetId.HasValue && !lastSeenResetFileTime.HasValue)
+            {
+                return null;
+            }
+
+            ShareChangeFeedCursor outer = new ShareChangeFeedCursor(
+                urlHost: containerClient.Uri.Host,
+                innerCursor: innerCursor,
+                lastSeenResetId: lastSeenResetId,
+                lastSeenResetFileTime: lastSeenResetFileTime);
+
+            return ShareChangeFeedCursorSerializer.Serialize(outer);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedAsyncPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedAsyncPageable.cs
@@ -77,16 +77,14 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             if (pointer != null)
             {
                 resetTime = pointer.LatestResetTimeUtc;
-                bool resetIsNewer = !lastSeenResetFileTime.HasValue
-                    || pointer.LatestResetFileTime > lastSeenResetFileTime.Value;
-                bool resetInRange = _startTime.HasValue
-                    && _endTime.HasValue
-                    && resetTime >= _startTime.Value
-                    && resetTime <= _endTime.Value;
-
-                bool shouldSurface = resetIsNewer && (
-                    (!_startTime.HasValue && !_endTime.HasValue)
-                    || resetInRange);
+                bool shouldSurface = ResetDetector.ShouldSurface(
+                    resetTime,
+                    pointer.LatestResetFileTime,
+                    pointer.LatestResetId,
+                    lastSeenResetFileTime,
+                    lastSeenResetId,
+                    rangeStart: _startTime,
+                    rangeEnd: _endTime);
 
                 if (shouldSurface)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedAsyncPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedAsyncPageable.cs
@@ -17,6 +17,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         private readonly DateTimeOffset? _endTime;
         private readonly string _continuation;
         private readonly ShareChangeFeedResetPolicy _policy;
+        private readonly bool _isBatched;
 
         internal ShareChangeFeedAsyncPageable(
             ShareChangeFeedClient client,
@@ -25,7 +26,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ShareChangeFeedResetPolicy policy = ShareChangeFeedResetPolicy.ContinueOnReset,
             DateTimeOffset? startTime = default,
             DateTimeOffset? endTime = default,
-            string continuation = default)
+            string continuation = default,
+            bool isBatched = false)
         {
             _client = client;
             _maxTransferSize = maxTransferSize;
@@ -34,6 +36,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             _startTime = startTime;
             _endTime = endTime;
             _continuation = continuation;
+            _isBatched = isBatched;
         }
 
         public override async IAsyncEnumerable<Page<ShareChangeFeedEvent>> AsPages(
@@ -54,6 +57,15 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ChangeFeedCursor innerCursor = null;
             Guid? lastSeenResetId = null;
             long? lastSeenResetFileTime = null;
+
+            // Range bounds and batched intent default to the values captured at construction.
+            // On resume they are recovered from the token so a batched query keeps its range
+            // (and its policy default) instead of degrading to unbounded streaming behavior.
+            DateTimeOffset? rangeStart = _startTime;
+            DateTimeOffset? rangeEnd = _endTime;
+            bool isBatched = _isBatched;
+            ShareChangeFeedResetPolicy effectivePolicy = _policy;
+
             if (_continuation != null)
             {
                 outerCursor = ShareChangeFeedCursorSerializer.Deserialize(_continuation);
@@ -61,6 +73,14 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 innerCursor = outerCursor.InnerCursor;
                 lastSeenResetId = outerCursor.LastSeenResetId;
                 lastSeenResetFileTime = outerCursor.LastSeenResetFileTime;
+                rangeStart = outerCursor.RangeStart;
+                rangeEnd = outerCursor.RangeEnd;
+                isBatched = outerCursor.IsBatched;
+
+                // Resume via the single GetChangesAsync(continuationToken) overload cannot know
+                // statically whether the original query was batched, so resolve the effective
+                // policy from the intent persisted on the token.
+                effectivePolicy = _client.ResolveEffectivePolicy(isBatched);
             }
 
             // Read the reset pointer once at the start of enumeration. Detection is decided
@@ -83,8 +103,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                     pointer.LatestResetId,
                     lastSeenResetFileTime,
                     lastSeenResetId,
-                    rangeStart: _startTime,
-                    rangeEnd: _endTime);
+                    rangeStart: rangeStart,
+                    rangeEnd: rangeEnd);
 
                 if (shouldSurface)
                 {
@@ -97,7 +117,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
 
                     resetToEmit = ResetMarkerReader.BuildResetEvent(pointer, perEvent);
 
-                    if (_policy == ShareChangeFeedResetPolicy.ThrowOnReset)
+                    if (effectivePolicy == ShareChangeFeedResetPolicy.ThrowOnReset)
                     {
                         throw new ShareChangeFeedResetException(resetToEmit);
                     }
@@ -161,7 +181,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                     containerClient,
                     typedInner,
                     nextId,
-                    nextFileTime);
+                    nextFileTime,
+                    rangeStart,
+                    rangeEnd,
+                    isBatched);
 
                 yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(events, outerToken);
             }
@@ -173,7 +196,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                     containerClient,
                     innerCursor: null,
                     pointer.LatestResetId,
-                    pointer.LatestResetFileTime);
+                    pointer.LatestResetFileTime,
+                    rangeStart,
+                    rangeEnd,
+                    isBatched);
                 yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(tail, outerToken);
             }
         }
@@ -186,7 +212,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             BlobContainerClient containerClient,
             ChangeFeedCursor innerCursor,
             Guid? lastSeenResetId,
-            long? lastSeenResetFileTime)
+            long? lastSeenResetFileTime,
+            DateTimeOffset? rangeStart,
+            DateTimeOffset? rangeEnd,
+            bool isBatched)
         {
             if (innerCursor == null && !lastSeenResetId.HasValue && !lastSeenResetFileTime.HasValue)
             {
@@ -197,7 +226,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 urlHost: containerClient.Uri.Host,
                 innerCursor: innerCursor,
                 lastSeenResetId: lastSeenResetId,
-                lastSeenResetFileTime: lastSeenResetFileTime);
+                lastSeenResetFileTime: lastSeenResetFileTime,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+                isBatched: isBatched);
 
             return ShareChangeFeedCursorSerializer.Serialize(outer);
         }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedClient.cs
@@ -25,6 +25,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         internal readonly BlobServiceClient _blobServiceClient;
         internal readonly long? _maxTransferSize;
         internal readonly bool _includeNonFinalizedEvents;
+        internal readonly ShareChangeFeedResetPolicy? _resetPolicy;
 
         // Lazily resolved after the first call to DiscoverContainerNameAsync.
         private string _containerName;
@@ -46,6 +47,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 throw new ArgumentNullException(nameof(shareName));
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
+            _resetPolicy = changeFeedOptions?.ResetPolicy;
 
             ShareServiceClient shareServiceClient = new ShareServiceClient(connectionString);
             _shareClient = shareServiceClient.GetShareClient(shareName);
@@ -68,6 +70,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 throw new ArgumentNullException(nameof(shareName));
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
+            _resetPolicy = changeFeedOptions?.ResetPolicy;
 
             ShareServiceClient shareServiceClient = new ShareServiceClient(fileServiceUri, credential);
             _shareClient = shareServiceClient.GetShareClient(shareName);
@@ -93,6 +96,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
 
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
+            _resetPolicy = changeFeedOptions?.ResetPolicy;
 
             ShareServiceClient shareServiceClient = new ShareServiceClient(fileServiceUri, credential);
             _shareClient = shareServiceClient.GetShareClient(shareName);
@@ -117,6 +121,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
 
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
+            _resetPolicy = changeFeedOptions?.ResetPolicy;
 
             ShareServiceClient shareServiceClient = new ShareServiceClient(fileServiceUri);
             _shareClient = shareServiceClient.GetShareClient(shareName);
@@ -144,8 +149,35 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             _shareClient = shareClient;
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
+            _resetPolicy = changeFeedOptions?.ResetPolicy;
         }
         #endregion ctors
+
+        /// <summary>
+        /// Resolves the effective <see cref="ShareChangeFeedResetPolicy"/> for a given API.
+        /// When <see cref="ShareChangeFeedClientOptions.ResetPolicy"/> was set explicitly, that
+        /// value is used for every method; otherwise a smart per-API default is applied:
+        /// batched APIs default to <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/> and
+        /// streaming APIs default to <see cref="ShareChangeFeedResetPolicy.ContinueOnReset"/>.
+        /// </summary>
+        /// <param name="isBatched">
+        /// <c>true</c> for the batched APIs (<c>GetChanges(start, end)</c>,
+        /// <c>GetChangesBetweenSnapshots(begin, end)</c>, and their continuation-token /
+        /// async counterparts), <c>false</c> for the streaming APIs
+        /// (<c>GetChanges()</c> and <c>GetChanges(continuationToken)</c>).
+        /// </param>
+        /// <returns>The effective policy to enforce for the call.</returns>
+        internal ShareChangeFeedResetPolicy ResolveEffectivePolicy(bool isBatched)
+        {
+            if (_resetPolicy.HasValue)
+            {
+                return _resetPolicy.Value;
+            }
+
+            return isBatched
+                ? ShareChangeFeedResetPolicy.ThrowOnReset
+                : ShareChangeFeedResetPolicy.ContinueOnReset;
+        }
 
         /// <summary>
         /// Discovers the change feed blob container (lazily, once) and returns the <see cref="BlobContainerClient"/>.
@@ -170,14 +202,40 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// <summary>
         /// Returns all change feed events for the file share.
         /// </summary>
+        /// <remarks>
+        /// When a reset marker is discovered on the change feed, this streaming API defaults to
+        /// <see cref="ShareChangeFeedResetPolicy.ContinueOnReset"/>: the reset is yielded in-band
+        /// as a <see cref="ShareChangeFeedResetEvent"/> at its position in the ordered stream.
+        /// Explicitly setting <see cref="ShareChangeFeedClientOptions.ResetPolicy"/> overrides
+        /// this default; when configured with <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>
+        /// the enumeration throws <see cref="ShareChangeFeedResetException"/> at the reset
+        /// boundary.
+        /// </remarks>
         public virtual Pageable<ShareChangeFeedEvent> GetChanges()
-            => new ShareChangeFeedPageable(this, _maxTransferSize, _includeNonFinalizedEvents);
+            => new ShareChangeFeedPageable(
+                this,
+                _maxTransferSize,
+                _includeNonFinalizedEvents,
+                ResolveEffectivePolicy(isBatched: false));
 
         /// <summary>
         /// Returns all change feed events for the file share.
         /// </summary>
+        /// <remarks>
+        /// When a reset marker is discovered on the change feed, this streaming API defaults to
+        /// <see cref="ShareChangeFeedResetPolicy.ContinueOnReset"/>: the reset is yielded in-band
+        /// as a <see cref="ShareChangeFeedResetEvent"/> at its position in the ordered stream.
+        /// Explicitly setting <see cref="ShareChangeFeedClientOptions.ResetPolicy"/> overrides
+        /// this default; when configured with <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>
+        /// the enumeration throws <see cref="ShareChangeFeedResetException"/> at the reset
+        /// boundary.
+        /// </remarks>
         public virtual AsyncPageable<ShareChangeFeedEvent> GetChangesAsync()
-            => new ShareChangeFeedAsyncPageable(this, _maxTransferSize, _includeNonFinalizedEvents);
+            => new ShareChangeFeedAsyncPageable(
+                this,
+                _maxTransferSize,
+                _includeNonFinalizedEvents,
+                ResolveEffectivePolicy(isBatched: false));
 
         /// <summary>
         /// Returns change feed events within the specified time range.
@@ -186,7 +244,16 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// Events near the <paramref name="start"/> and <paramref name="end"/> boundaries
         /// may be missing or unexpectedly included due to clock skew between the storage
         /// service and the client.
+        ///
+        /// This batched API defaults to <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>:
+        /// if a reset marker falls inside the requested range, the enumeration throws
+        /// <see cref="ShareChangeFeedResetException"/> before yielding any events.
         /// </remarks>
+        /// <exception cref="ShareChangeFeedResetException">
+        /// Thrown at the start of enumeration when a reset marker is discovered inside the
+        /// requested range and the effective policy is
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>.
+        /// </exception>
         public virtual Pageable<ShareChangeFeedEvent> GetChanges(
             DateTimeOffset? start,
             DateTimeOffset? end)
@@ -196,6 +263,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 this,
                 _maxTransferSize,
                 _includeNonFinalizedEvents,
+                ResolveEffectivePolicy(isBatched: true),
                 startTime: start,
                 endTime: end);
         }
@@ -207,7 +275,16 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// Events near the <paramref name="start"/> and <paramref name="end"/> boundaries
         /// may be missing or unexpectedly included due to clock skew between the storage
         /// service and the client.
+        ///
+        /// This batched API defaults to <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>:
+        /// if a reset marker falls inside the requested range, the enumeration throws
+        /// <see cref="ShareChangeFeedResetException"/> before yielding any events.
         /// </remarks>
+        /// <exception cref="ShareChangeFeedResetException">
+        /// Thrown at the start of enumeration when a reset marker is discovered inside the
+        /// requested range and the effective policy is
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>.
+        /// </exception>
         public virtual AsyncPageable<ShareChangeFeedEvent> GetChangesAsync(
             DateTimeOffset? start,
             DateTimeOffset? end)
@@ -217,6 +294,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 this,
                 _maxTransferSize,
                 _includeNonFinalizedEvents,
+                ResolveEffectivePolicy(isBatched: true),
                 startTime: start,
                 endTime: end);
         }
@@ -244,6 +322,12 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// is enabled. Resumption is not supported in non-finalized mode because pages
         /// produced in that mode never carry a continuation token.
         /// </exception>
+        /// <exception cref="ShareChangeFeedResetException">
+        /// Thrown at the start of enumeration when a reset marker that is newer than the one
+        /// captured on the token is discovered and the effective policy is
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>. Streaming APIs default to
+        /// <see cref="ShareChangeFeedResetPolicy.ContinueOnReset"/>.
+        /// </exception>
         /// <remarks>
         /// To resume from a saved position, the client must be configured with
         /// <see cref="ShareChangeFeedClientOptions.IncludeNonFinalizedEvents"/> set to <c>false</c>.
@@ -256,6 +340,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 this,
                 _maxTransferSize,
                 _includeNonFinalizedEvents,
+                ResolveEffectivePolicy(isBatched: false),
                 continuation: continuationToken);
         }
 
@@ -272,6 +357,12 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// is enabled. Resumption is not supported in non-finalized mode because pages
         /// produced in that mode never carry a continuation token.
         /// </exception>
+        /// <exception cref="ShareChangeFeedResetException">
+        /// Thrown at the start of enumeration when a reset marker that is newer than the one
+        /// captured on the token is discovered and the effective policy is
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>. Streaming APIs default to
+        /// <see cref="ShareChangeFeedResetPolicy.ContinueOnReset"/>.
+        /// </exception>
         /// <remarks>
         /// To resume from a saved position, the client must be configured with
         /// <see cref="ShareChangeFeedClientOptions.IncludeNonFinalizedEvents"/> set to <c>false</c>.
@@ -284,6 +375,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 this,
                 _maxTransferSize,
                 _includeNonFinalizedEvents,
+                ResolveEffectivePolicy(isBatched: false),
                 continuation: continuationToken);
         }
 
@@ -308,24 +400,48 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// <summary>
         /// Returns change feed events between two snapshots, filtered by container version ID.
         /// </summary>
+        /// <remarks>
+        /// This batched API defaults to <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>:
+        /// if a reset marker falls between the two snapshot timestamps, the enumeration throws
+        /// <see cref="ShareChangeFeedResetException"/> before yielding any events. Consumers
+        /// receiving this exception must treat the snapshot diff as unreliable and re-baseline.
+        /// </remarks>
+        /// <exception cref="ShareChangeFeedResetException">
+        /// Thrown at the start of enumeration when a reset marker falls between
+        /// <paramref name="beginSnapshot"/> and <paramref name="endSnapshot"/> and the effective
+        /// policy is <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>.
+        /// </exception>
         public virtual Pageable<ShareChangeFeedEvent> GetChangesBetweenSnapshots(
             string beginSnapshot,
             string endSnapshot)
             => new ShareChangeFeedSnapshotPageable(
                 this,
                 _maxTransferSize,
+                ResolveEffectivePolicy(isBatched: true),
                 beginSnapshot,
                 endSnapshot);
 
         /// <summary>
         /// Returns change feed events between two snapshots, filtered by container version ID.
         /// </summary>
+        /// <remarks>
+        /// This batched API defaults to <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>:
+        /// if a reset marker falls between the two snapshot timestamps, the enumeration throws
+        /// <see cref="ShareChangeFeedResetException"/> before yielding any events. Consumers
+        /// receiving this exception must treat the snapshot diff as unreliable and re-baseline.
+        /// </remarks>
+        /// <exception cref="ShareChangeFeedResetException">
+        /// Thrown at the start of enumeration when a reset marker falls between
+        /// <paramref name="beginSnapshot"/> and <paramref name="endSnapshot"/> and the effective
+        /// policy is <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>.
+        /// </exception>
         public virtual AsyncPageable<ShareChangeFeedEvent> GetChangesBetweenSnapshotsAsync(
             string beginSnapshot,
             string endSnapshot)
             => new ShareChangeFeedSnapshotAsyncPageable(
                 this,
                 _maxTransferSize,
+                ResolveEffectivePolicy(isBatched: true),
                 beginSnapshot,
                 endSnapshot);
 
@@ -344,11 +460,18 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// Thrown when the token is malformed, was issued against a different storage
         /// account, or uses an unsupported cursor version.
         /// </exception>
+        /// <exception cref="ShareChangeFeedResetException">
+        /// Thrown at the start of enumeration when a reset marker that is newer than the one
+        /// captured on the token is discovered and the effective policy is
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>. Batched APIs default to
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>.
+        /// </exception>
         public virtual Pageable<ShareChangeFeedEvent> GetChangesBetweenSnapshots(
             string continuationToken)
             => new ShareChangeFeedSnapshotPageable(
                 this,
                 _maxTransferSize,
+                ResolveEffectivePolicy(isBatched: true),
                 continuation: continuationToken);
 
         /// <summary>
@@ -366,11 +489,18 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// Thrown when the token is malformed, was issued against a different storage
         /// account, or uses an unsupported cursor version.
         /// </exception>
+        /// <exception cref="ShareChangeFeedResetException">
+        /// Thrown at the start of enumeration when a reset marker that is newer than the one
+        /// captured on the token is discovered and the effective policy is
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>. Batched APIs default to
+        /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>.
+        /// </exception>
         public virtual AsyncPageable<ShareChangeFeedEvent> GetChangesBetweenSnapshotsAsync(
             string continuationToken)
             => new ShareChangeFeedSnapshotAsyncPageable(
                 this,
                 _maxTransferSize,
+                ResolveEffectivePolicy(isBatched: true),
                 continuation: continuationToken);
         #endregion GetChangesBetweenSnapshots
 
@@ -510,7 +640,12 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// Resolves the change feed container and builds a <see cref="BlobContainerClient"/>
         /// and <see cref="ChangeFeedConfiguration{ShareChangeFeedEvent}"/>. Called by pageables.
         /// </summary>
-        internal async Task<(BlobContainerClient ContainerClient, ChangeFeedConfiguration<ShareChangeFeedEvent> Config)>
+        /// <remarks>
+        /// Declared <c>virtual</c> so mocked unit tests can inject a pre-built
+        /// <see cref="BlobContainerClient"/> without going through
+        /// <see cref="ShareClient.GetPropertiesAsync(System.Threading.CancellationToken)"/>.
+        /// </remarks>
+        internal virtual async Task<(BlobContainerClient ContainerClient, ChangeFeedConfiguration<ShareChangeFeedEvent> Config)>
             ResolveContainerAsync(bool async, CancellationToken cancellationToken)
         {
             BlobContainerClient containerClient = await GetContainerClientAsync(async, cancellationToken).ConfigureAwait(false);

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedClient.cs
@@ -265,7 +265,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 _includeNonFinalizedEvents,
                 ResolveEffectivePolicy(isBatched: true),
                 startTime: start,
-                endTime: end);
+                endTime: end,
+                isBatched: true);
         }
 
         /// <summary>
@@ -296,7 +297,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 _includeNonFinalizedEvents,
                 ResolveEffectivePolicy(isBatched: true),
                 startTime: start,
-                endTime: end);
+                endTime: end,
+                isBatched: true);
         }
 
         private static void ThrowIfStartAfterEnd(DateTimeOffset? start, DateTimeOffset? end)

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedCursorSerializer.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedCursorSerializer.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json;
+using Azure.Storage.Blobs;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Serialization / validation helpers for <see cref="ShareChangeFeedCursor"/>. Mirrors
+    /// <see cref="SnapshotCursorSerializer"/>.
+    /// </summary>
+    internal static class ShareChangeFeedCursorSerializer
+    {
+        /// <summary>
+        /// Serializes the streaming cursor envelope to its on-the-wire string form.
+        /// </summary>
+        public static string Serialize(ShareChangeFeedCursor cursor)
+            => JsonSerializer.Serialize(cursor);
+
+        /// <summary>
+        /// Deserializes a previously-emitted streaming cursor string. Throws
+        /// <see cref="ArgumentException"/> when the input is not a valid envelope.
+        /// </summary>
+        public static ShareChangeFeedCursor Deserialize(string continuationToken)
+        {
+            if (continuationToken == null)
+                throw new ArgumentNullException(nameof(continuationToken));
+
+            ShareChangeFeedCursor cursor;
+            try
+            {
+                cursor = JsonSerializer.Deserialize<ShareChangeFeedCursor>(continuationToken);
+            }
+            catch (JsonException ex)
+            {
+                throw new ArgumentException(
+                    "Continuation token is not a valid Files change feed cursor envelope.",
+                    nameof(continuationToken),
+                    ex);
+            }
+
+            if (cursor == null || string.IsNullOrEmpty(cursor.UrlHost) || cursor.InnerCursor == null)
+            {
+                throw new ArgumentException(
+                    "Continuation token is not a valid Files change feed cursor envelope.",
+                    nameof(continuationToken));
+            }
+
+            return cursor;
+        }
+
+        /// <summary>
+        /// Validates that <paramref name="cursor"/> targets the same change-feed container as
+        /// <paramref name="containerClient"/> and uses a supported cursor version.
+        /// </summary>
+        public static void Validate(BlobContainerClient containerClient, ShareChangeFeedCursor cursor)
+        {
+            if (!string.Equals(containerClient.Uri.Host, cursor.UrlHost, StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException("Cursor URL Host does not match container URL host.");
+
+            if (cursor.CursorVersion != 1)
+                throw new ArgumentException("Unsupported cursor version.");
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedPageable.cs
@@ -17,11 +17,13 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         private readonly DateTimeOffset? _startTime;
         private readonly DateTimeOffset? _endTime;
         private readonly string _continuation;
+        private readonly ShareChangeFeedResetPolicy _policy;
 
         internal ShareChangeFeedPageable(
             ShareChangeFeedClient client,
             long? maxTransferSize,
             bool includeNonFinalizedEvents,
+            ShareChangeFeedResetPolicy policy = ShareChangeFeedResetPolicy.ContinueOnReset,
             DateTimeOffset? startTime = default,
             DateTimeOffset? endTime = default,
             string continuation = default)
@@ -29,6 +31,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             _client = client;
             _maxTransferSize = maxTransferSize;
             _includeNonFinalizedEvents = includeNonFinalizedEvents;
+            _policy = policy;
             _startTime = startTime;
             _endTime = endTime;
             _continuation = continuation;
@@ -43,27 +46,172 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
 
             (BlobContainerClient containerClient, ChangeFeedConfiguration<ShareChangeFeedEvent> config) = _client.ResolveContainerAsync(async: false, cancellationToken: default).EnsureCompleted();
 
+            // Deserialize the outer Files-only envelope on resume so we can compare the
+            // last-seen reset marker against the current pointer.
+            ShareChangeFeedCursor outerCursor = null;
+            ChangeFeedCursor innerCursor = null;
+            Guid? lastSeenResetId = null;
+            long? lastSeenResetFileTime = null;
+            if (_continuation != null)
+            {
+                outerCursor = ShareChangeFeedCursorSerializer.Deserialize(_continuation);
+                ShareChangeFeedCursorSerializer.Validate(containerClient, outerCursor);
+                innerCursor = outerCursor.InnerCursor;
+                lastSeenResetId = outerCursor.LastSeenResetId;
+                lastSeenResetFileTime = outerCursor.LastSeenResetFileTime;
+            }
+
+            // Read the reset pointer once at the start of enumeration. Detection is decided
+            // against either the resume state (last-seen FILETIME) or the requested range.
+            ShareChangeFeedResetPointer pointer = ResetMarkerReader.TryReadPointerAsync(
+                containerClient,
+                async: false,
+                cancellationToken: default)
+                .EnsureCompleted();
+
+            ShareChangeFeedResetEvent resetToEmit = null;
+            DateTimeOffset resetTime = default;
+
+            if (pointer != null)
+            {
+                resetTime = pointer.LatestResetTimeUtc;
+                bool resetIsNewer = !lastSeenResetFileTime.HasValue
+                    || pointer.LatestResetFileTime > lastSeenResetFileTime.Value;
+                bool resetInRange = _startTime.HasValue
+                    && _endTime.HasValue
+                    && resetTime >= _startTime.Value
+                    && resetTime <= _endTime.Value;
+
+                bool shouldSurface = resetIsNewer && (
+                    // Streaming (no bounded range): surface when strictly newer than resume.
+                    (!_startTime.HasValue && !_endTime.HasValue)
+                    // Bounded range: surface only when reset falls inside the range.
+                    || resetInRange);
+
+                if (shouldSurface)
+                {
+                    ShareChangeFeedResetMarker perEvent = ResetMarkerReader.ReadPerEventAsync(
+                        containerClient,
+                        pointer.LatestMarkerPath,
+                        async: false,
+                        cancellationToken: default)
+                        .EnsureCompleted();
+
+                    resetToEmit = ResetMarkerReader.BuildResetEvent(pointer, perEvent);
+
+                    if (_policy == ShareChangeFeedResetPolicy.ThrowOnReset)
+                    {
+                        throw new ShareChangeFeedResetException(resetToEmit);
+                    }
+                }
+            }
+
             ChangeFeedFactoryBase<ShareChangeFeedEvent> factory = new ChangeFeedFactoryBase<ShareChangeFeedEvent>(
                 containerClient,
                 _maxTransferSize,
                 config,
                 _includeNonFinalizedEvents);
 
-            ChangeFeedBase<ShareChangeFeedEvent> changeFeed = factory.BuildChangeFeed(
-                _startTime,
-                _endTime,
-                _continuation,
-                async: false,
-                cancellationToken: default)
-                .EnsureCompleted();
+            ChangeFeedBase<ShareChangeFeedEvent> changeFeed = innerCursor != null
+                ? factory.BuildChangeFeed(
+                    innerCursor,
+                    async: false,
+                    cancellationToken: default)
+                    .EnsureCompleted()
+                : factory.BuildChangeFeed(
+                    _startTime,
+                    _endTime,
+                    continuation: null,
+                    async: false,
+                    cancellationToken: default)
+                    .EnsureCompleted();
+
+            bool resetEmitted = false;
+            int pageSize = pageSizeHint ?? Constants.ChangeFeed.DefaultPageSize;
 
             while (changeFeed.HasNext())
             {
-                yield return changeFeed.GetPage(
+                Page<ShareChangeFeedEvent> rawPage = changeFeed.GetPage(
                     async: false,
-                    pageSize: pageSizeHint ?? Constants.ChangeFeed.DefaultPageSize)
+                    pageSize: pageSize)
                     .EnsureCompleted();
+
+                List<ShareChangeFeedEvent> events = new List<ShareChangeFeedEvent>();
+                foreach (ShareChangeFeedEvent evt in rawPage.Values)
+                {
+                    if (!resetEmitted && resetToEmit != null && evt.EventTime >= resetTime)
+                    {
+                        events.Add(resetToEmit);
+                        resetEmitted = true;
+                    }
+
+                    events.Add(evt);
+                }
+
+                // If the reset falls after every event in this page (or the page was empty),
+                // emit it on the terminal page below.
+
+                long? nextFileTime = resetEmitted
+                    ? pointer?.LatestResetFileTime ?? lastSeenResetFileTime
+                    : lastSeenResetFileTime;
+                Guid? nextId = resetEmitted
+                    ? pointer?.LatestResetId ?? lastSeenResetId
+                    : lastSeenResetId;
+
+                // The underlying page contains a JSON-serialized ChangeFeedCursor. Use the
+                // typed accessor to avoid a JSON round-trip when the read is finalized; in
+                // non-finalized mode ChangeFeedBase suppresses the token and we surface null.
+                ChangeFeedCursor typedInner = rawPage.ContinuationToken != null
+                    ? changeFeed.GetCursor()
+                    : null;
+
+                string outerToken = BuildOuterToken(
+                    containerClient,
+                    typedInner,
+                    nextId,
+                    nextFileTime);
+
+                yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(events, outerToken);
             }
+
+            // Emit any pending reset event that hadn't yet been surfaced (e.g., reset time
+            // sits after every event returned above, or the underlying feed was empty).
+            if (!resetEmitted && resetToEmit != null)
+            {
+                List<ShareChangeFeedEvent> tail = new List<ShareChangeFeedEvent> { resetToEmit };
+                string outerToken = BuildOuterToken(
+                    containerClient,
+                    innerCursor: null,
+                    pointer.LatestResetId,
+                    pointer.LatestResetFileTime);
+                yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(tail, outerToken);
+            }
+        }
+
+        /// <summary>
+        /// Wraps the inner Common change-feed cursor in the Files-only outer envelope so that
+        /// the last-seen reset marker travels alongside the underlying position.
+        /// </summary>
+        private static string BuildOuterToken(
+            BlobContainerClient containerClient,
+            ChangeFeedCursor innerCursor,
+            Guid? lastSeenResetId,
+            long? lastSeenResetFileTime)
+        {
+            if (innerCursor == null && !lastSeenResetId.HasValue && !lastSeenResetFileTime.HasValue)
+            {
+                // Terminal / non-finalized read: the underlying feed suppresses its own token
+                // and no reset state to carry forward — mirror the Common contract.
+                return null;
+            }
+
+            ShareChangeFeedCursor outer = new ShareChangeFeedCursor(
+                urlHost: containerClient.Uri.Host,
+                innerCursor: innerCursor,
+                lastSeenResetId: lastSeenResetId,
+                lastSeenResetFileTime: lastSeenResetFileTime);
+
+            return ShareChangeFeedCursorSerializer.Serialize(outer);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedPageable.cs
@@ -18,6 +18,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         private readonly DateTimeOffset? _endTime;
         private readonly string _continuation;
         private readonly ShareChangeFeedResetPolicy _policy;
+        private readonly bool _isBatched;
 
         internal ShareChangeFeedPageable(
             ShareChangeFeedClient client,
@@ -26,7 +27,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ShareChangeFeedResetPolicy policy = ShareChangeFeedResetPolicy.ContinueOnReset,
             DateTimeOffset? startTime = default,
             DateTimeOffset? endTime = default,
-            string continuation = default)
+            string continuation = default,
+            bool isBatched = false)
         {
             _client = client;
             _maxTransferSize = maxTransferSize;
@@ -35,6 +37,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             _startTime = startTime;
             _endTime = endTime;
             _continuation = continuation;
+            _isBatched = isBatched;
         }
 
         public override IEnumerable<Page<ShareChangeFeedEvent>> AsPages(
@@ -52,6 +55,15 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ChangeFeedCursor innerCursor = null;
             Guid? lastSeenResetId = null;
             long? lastSeenResetFileTime = null;
+
+            // Range bounds and batched intent default to the values captured at construction.
+            // On resume they are recovered from the token so a batched query keeps its range
+            // (and its policy default) instead of degrading to unbounded streaming behavior.
+            DateTimeOffset? rangeStart = _startTime;
+            DateTimeOffset? rangeEnd = _endTime;
+            bool isBatched = _isBatched;
+            ShareChangeFeedResetPolicy effectivePolicy = _policy;
+
             if (_continuation != null)
             {
                 outerCursor = ShareChangeFeedCursorSerializer.Deserialize(_continuation);
@@ -59,6 +71,14 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 innerCursor = outerCursor.InnerCursor;
                 lastSeenResetId = outerCursor.LastSeenResetId;
                 lastSeenResetFileTime = outerCursor.LastSeenResetFileTime;
+                rangeStart = outerCursor.RangeStart;
+                rangeEnd = outerCursor.RangeEnd;
+                isBatched = outerCursor.IsBatched;
+
+                // Resume via the single GetChanges(continuationToken) overload cannot know
+                // statically whether the original query was batched, so resolve the effective
+                // policy from the intent persisted on the token.
+                effectivePolicy = _client.ResolveEffectivePolicy(isBatched);
             }
 
             // Read the reset pointer once at the start of enumeration. Detection is decided
@@ -81,8 +101,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                     pointer.LatestResetId,
                     lastSeenResetFileTime,
                     lastSeenResetId,
-                    rangeStart: _startTime,
-                    rangeEnd: _endTime);
+                    rangeStart: rangeStart,
+                    rangeEnd: rangeEnd);
 
                 if (shouldSurface)
                 {
@@ -95,7 +115,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
 
                     resetToEmit = ResetMarkerReader.BuildResetEvent(pointer, perEvent);
 
-                    if (_policy == ShareChangeFeedResetPolicy.ThrowOnReset)
+                    if (effectivePolicy == ShareChangeFeedResetPolicy.ThrowOnReset)
                     {
                         throw new ShareChangeFeedResetException(resetToEmit);
                     }
@@ -165,7 +185,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                     containerClient,
                     typedInner,
                     nextId,
-                    nextFileTime);
+                    nextFileTime,
+                    rangeStart,
+                    rangeEnd,
+                    isBatched);
 
                 yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(events, outerToken);
             }
@@ -179,7 +202,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                     containerClient,
                     innerCursor: null,
                     pointer.LatestResetId,
-                    pointer.LatestResetFileTime);
+                    pointer.LatestResetFileTime,
+                    rangeStart,
+                    rangeEnd,
+                    isBatched);
                 yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(tail, outerToken);
             }
         }
@@ -192,7 +218,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             BlobContainerClient containerClient,
             ChangeFeedCursor innerCursor,
             Guid? lastSeenResetId,
-            long? lastSeenResetFileTime)
+            long? lastSeenResetFileTime,
+            DateTimeOffset? rangeStart,
+            DateTimeOffset? rangeEnd,
+            bool isBatched)
         {
             if (innerCursor == null && !lastSeenResetId.HasValue && !lastSeenResetFileTime.HasValue)
             {
@@ -205,7 +234,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 urlHost: containerClient.Uri.Host,
                 innerCursor: innerCursor,
                 lastSeenResetId: lastSeenResetId,
-                lastSeenResetFileTime: lastSeenResetFileTime);
+                lastSeenResetFileTime: lastSeenResetFileTime,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+                isBatched: isBatched);
 
             return ShareChangeFeedCursorSerializer.Serialize(outer);
         }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedPageable.cs
@@ -75,18 +75,14 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             if (pointer != null)
             {
                 resetTime = pointer.LatestResetTimeUtc;
-                bool resetIsNewer = !lastSeenResetFileTime.HasValue
-                    || pointer.LatestResetFileTime > lastSeenResetFileTime.Value;
-                bool resetInRange = _startTime.HasValue
-                    && _endTime.HasValue
-                    && resetTime >= _startTime.Value
-                    && resetTime <= _endTime.Value;
-
-                bool shouldSurface = resetIsNewer && (
-                    // Streaming (no bounded range): surface when strictly newer than resume.
-                    (!_startTime.HasValue && !_endTime.HasValue)
-                    // Bounded range: surface only when reset falls inside the range.
-                    || resetInRange);
+                bool shouldSurface = ResetDetector.ShouldSurface(
+                    resetTime,
+                    pointer.LatestResetFileTime,
+                    pointer.LatestResetId,
+                    lastSeenResetFileTime,
+                    lastSeenResetId,
+                    rangeStart: _startTime,
+                    rangeEnd: _endTime);
 
                 if (shouldSurface)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedResetException.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedResetException.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Thrown by <see cref="ShareChangeFeedClient"/> when a reset marker is discovered on
+    /// the change feed and the effective reset policy is
+    /// <see cref="ShareChangeFeedResetPolicy.ThrowOnReset"/>.
+    /// </summary>
+    /// <remarks>
+    /// A reset marker signals that log-sequence continuity has been broken (for example, by a
+    /// HardFailover or classic account migration). Batched APIs
+    /// (<see cref="ShareChangeFeedClient.GetChanges(System.DateTimeOffset?, System.DateTimeOffset?)"/>
+    /// and <see cref="ShareChangeFeedClient.GetChangesBetweenSnapshots(string, string)"/>) fail
+    /// fast before yielding any events when the requested range crosses a reset boundary; the
+    /// streaming <see cref="ShareChangeFeedClient.GetChanges()"/> overloads stop at the reset
+    /// boundary. Inspect <see cref="ResetEvent"/> to recover reset context (id, time, account,
+    /// share, reason) and drive the appropriate recovery path (typically a full re-baseline).
+    /// </remarks>
+    public class ShareChangeFeedResetException : Exception
+    {
+        /// <summary>
+        /// The reset marker discovered on the change feed. Never <c>null</c> for exceptions
+        /// produced by the SDK; the property is nullable only to support serialization.
+        /// </summary>
+        public ShareChangeFeedResetEvent ResetEvent { get; }
+
+        /// <summary>
+        /// Initializes a new <see cref="ShareChangeFeedResetException"/> around the supplied
+        /// reset event, using a generated default message.
+        /// </summary>
+        /// <param name="resetEvent">The reset event that triggered the exception.</param>
+        public ShareChangeFeedResetException(ShareChangeFeedResetEvent resetEvent)
+            : base(BuildMessage(resetEvent))
+        {
+            ResetEvent = resetEvent;
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="ShareChangeFeedResetException"/> with a caller-supplied
+        /// message.
+        /// </summary>
+        /// <param name="resetEvent">The reset event that triggered the exception.</param>
+        /// <param name="message">A descriptive error message.</param>
+        public ShareChangeFeedResetException(ShareChangeFeedResetEvent resetEvent, string message)
+            : base(message)
+        {
+            ResetEvent = resetEvent;
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="ShareChangeFeedResetException"/> with a caller-supplied
+        /// message and inner exception.
+        /// </summary>
+        /// <param name="resetEvent">The reset event that triggered the exception.</param>
+        /// <param name="message">A descriptive error message.</param>
+        /// <param name="innerException">The exception that caused the current exception.</param>
+        public ShareChangeFeedResetException(ShareChangeFeedResetEvent resetEvent, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            ResetEvent = resetEvent;
+        }
+
+        private static string BuildMessage(ShareChangeFeedResetEvent resetEvent)
+        {
+            if (resetEvent == null)
+            {
+                return "A Files Change Feed reset marker was discovered.";
+            }
+
+            return $"A Files Change Feed reset marker was discovered at {resetEvent.EventTime:O} " +
+                $"(resetId: {resetEvent.ResetId}, reason: {resetEvent.ResetReason ?? "Unknown"}). " +
+                "Log-sequence continuity has been broken; the caller must re-baseline before " +
+                "resuming change feed consumption.";
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedResetMarker.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedResetMarker.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Parsed representation of an immutable per-event reset marker blob
+    /// (<c>meta/resets/&lt;20-digit-FILETIME&gt;.json</c>) in the change feed container.
+    /// Exactly one blob is written per reset event.
+    /// </summary>
+    internal class ShareChangeFeedResetMarker
+    {
+        /// <summary>
+        /// Add-only contract version of the per-event JSON. Today the service emits <c>1</c>.
+        /// </summary>
+        public int SchemaVersion { get; set; }
+
+        /// <summary>
+        /// Server-generated GUID (<c>controlEventId</c>) for this reset event.
+        /// </summary>
+        public Guid ResetId { get; set; }
+
+        /// <summary>
+        /// Windows FILETIME ticks (100 ns since 1601 UTC) at which the reset was emitted.
+        /// </summary>
+        public long ResetFileTime { get; set; }
+
+        /// <summary>
+        /// Human-readable ISO-8601 UTC representation of <see cref="ResetFileTime"/>.
+        /// </summary>
+        public DateTimeOffset ResetTimeUtc { get; set; }
+
+        /// <summary>
+        /// Unversioned account name recorded on the reset event.
+        /// </summary>
+        public string AccountName { get; set; }
+
+        /// <summary>
+        /// Unversioned share (container) name recorded on the reset event.
+        /// </summary>
+        public string ContainerName { get; set; }
+
+        /// <summary>
+        /// Verbatim, human-readable cause of the reset. The service emits the reason directly
+        /// (e.g. "Customer-managed unplanned failover" or "Tracking State Reset").
+        /// </summary>
+        public string Reason { get; set; }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedResetPointer.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedResetPointer.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Parsed representation of the mutable pointer blob <c>meta/reset-latest.json</c>
+    /// in the change feed container. Rewritten on every reset to point at the newest
+    /// per-event blob, so a single conditional GET lets a consumer detect a reset.
+    /// </summary>
+    internal class ShareChangeFeedResetPointer
+    {
+        /// <summary>
+        /// The schema version of the pointer JSON. Today the service emits <c>1</c>.
+        /// </summary>
+        public int SchemaVersion { get; set; }
+
+        /// <summary>
+        /// Server-generated GUID identifying the latest reset event.
+        /// Matches the <see cref="ShareChangeFeedResetMarker.ResetId"/> of the blob at
+        /// <see cref="LatestMarkerPath"/>.
+        /// </summary>
+        public Guid LatestResetId { get; set; }
+
+        /// <summary>
+        /// Windows FILETIME ticks (100 ns since 1601 UTC) at which the reset was emitted.
+        /// Monotonic per stamp and also encoded into the per-event blob key.
+        /// </summary>
+        public long LatestResetFileTime { get; set; }
+
+        /// <summary>
+        /// Human-readable ISO-8601 UTC representation of <see cref="LatestResetFileTime"/>.
+        /// </summary>
+        public DateTimeOffset LatestResetTimeUtc { get; set; }
+
+        /// <summary>
+        /// Relative blob key of the per-event reset marker
+        /// (<c>meta/resets/&lt;20-digit-FILETIME&gt;.json</c>) — usable directly as the GET path.
+        /// </summary>
+        public string LatestMarkerPath { get; set; }
+
+        /// <summary>
+        /// Unversioned account name recorded on the reset event.
+        /// </summary>
+        public string AccountName { get; set; }
+
+        /// <summary>
+        /// Unversioned share (container) name recorded on the reset event.
+        /// </summary>
+        public string ContainerName { get; set; }
+
+        /// <summary>
+        /// Verbatim, human-readable cause of the reset (e.g. "Customer-managed unplanned failover"
+        /// or "Tracking State Reset").
+        /// </summary>
+        public string Reason { get; set; }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotAsyncPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotAsyncPageable.cs
@@ -15,34 +15,59 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         private readonly string _beginSnapshot;
         private readonly string _endSnapshot;
         private readonly string _continuation;
+        private readonly ShareChangeFeedResetPolicy _policy;
 
         internal ShareChangeFeedSnapshotAsyncPageable(
             ShareChangeFeedClient client,
             long? maxTransferSize,
+            ShareChangeFeedResetPolicy policy,
             string beginSnapshot,
             string endSnapshot)
         {
             SnapshotInputValidator.ValidateInputStrings(beginSnapshot, endSnapshot);
             _client = client;
             _maxTransferSize = maxTransferSize;
+            _policy = policy;
             _beginSnapshot = beginSnapshot;
             _endSnapshot = endSnapshot;
             _continuation = null;
         }
 
+        // Backwards-compat overload for existing tests that build the pageable directly
+        // without specifying a reset policy. Defaults to the batched-API smart default.
         internal ShareChangeFeedSnapshotAsyncPageable(
             ShareChangeFeedClient client,
             long? maxTransferSize,
+            string beginSnapshot,
+            string endSnapshot)
+            : this(client, maxTransferSize, ShareChangeFeedResetPolicy.ThrowOnReset, beginSnapshot, endSnapshot)
+        {
+        }
+
+        internal ShareChangeFeedSnapshotAsyncPageable(
+            ShareChangeFeedClient client,
+            long? maxTransferSize,
+            ShareChangeFeedResetPolicy policy,
             string continuation)
         {
             if (string.IsNullOrEmpty(continuation))
                 throw new ArgumentNullException(nameof(continuation));
             _client = client;
             _maxTransferSize = maxTransferSize;
+            _policy = policy;
             _continuation = continuation;
             // beginSnapshot/endSnapshot are recovered from the cursor envelope at enumeration time.
             _beginSnapshot = null;
             _endSnapshot = null;
+        }
+
+        // Backwards-compat overload for existing tests. Defaults to the batched-API smart default.
+        internal ShareChangeFeedSnapshotAsyncPageable(
+            ShareChangeFeedClient client,
+            long? maxTransferSize,
+            string continuation)
+            : this(client, maxTransferSize, ShareChangeFeedResetPolicy.ThrowOnReset, continuation)
+        {
         }
 
         public override async IAsyncEnumerable<Page<ShareChangeFeedEvent>> AsPages(
@@ -69,7 +94,54 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 cancellationToken: default)
                 .ConfigureAwait(false);
 
+            // Reset detection: read the pointer once. Range for snapshot APIs is
+            // [BeginSnapshotTimestamp, EndSnapshotTimestamp] on fresh enumerations; on resume,
+            // use last-seen FILETIME as the comparison anchor.
+            ShareChangeFeedResetPointer pointer = await ResetMarkerReader.TryReadPointerAsync(
+                containerClient,
+                async: true,
+                cancellationToken: default)
+                .ConfigureAwait(false);
+
+            ShareChangeFeedResetEvent resetToEmit = null;
+            DateTimeOffset resetTime = default;
+
+            if (pointer != null)
+            {
+                resetTime = pointer.LatestResetTimeUtc;
+                bool resetIsNewer = !iter.LastSeenResetFileTime.HasValue
+                    || pointer.LatestResetFileTime > iter.LastSeenResetFileTime.Value;
+
+                bool resetInSnapshotRange = iter.BeginSnapshotTimestamp.HasValue
+                    && iter.EndSnapshotTimestamp.HasValue
+                    && resetTime >= iter.BeginSnapshotTimestamp.Value
+                    && resetTime <= iter.EndSnapshotTimestamp.Value;
+
+                bool shouldSurface = resetIsNewer && (
+                    resetInSnapshotRange
+                    || (!iter.BeginSnapshotTimestamp.HasValue && !iter.EndSnapshotTimestamp.HasValue));
+
+                if (shouldSurface)
+                {
+                    ShareChangeFeedResetMarker perEvent = await ResetMarkerReader.ReadPerEventAsync(
+                        containerClient,
+                        pointer.LatestMarkerPath,
+                        async: true,
+                        cancellationToken: default)
+                        .ConfigureAwait(false);
+
+                    resetToEmit = ResetMarkerReader.BuildResetEvent(pointer, perEvent);
+
+                    if (_policy == ShareChangeFeedResetPolicy.ThrowOnReset)
+                    {
+                        throw new ShareChangeFeedResetException(resetToEmit);
+                    }
+                }
+            }
+
+            bool resetEmitted = false;
             int pageSize = pageSizeHint ?? Constants.ChangeFeed.DefaultPageSize;
+
             while (iter.ChangeFeed.HasNext())
             {
                 Page<ShareChangeFeedEvent> rawPage = await iter.ChangeFeed
@@ -80,14 +152,44 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 foreach (ShareChangeFeedEvent evt in rawPage.Values)
                 {
                     if (SnapshotEventFilter.IsInRange(evt, iter.BeginCvId, iter.EndCvId))
+                    {
+                        if (!resetEmitted && resetToEmit != null && evt.EventTime >= resetTime)
+                        {
+                            filtered.Add(resetToEmit);
+                            resetEmitted = true;
+                        }
+
                         filtered.Add(evt);
+                    }
                 }
 
                 if (filtered.Count > 0)
                 {
-                    string outerToken = iter.WrapInnerCursor(containerClient, iter.ChangeFeed.GetCursor());
+                    Guid? nextId = resetEmitted
+                        ? pointer?.LatestResetId ?? iter.LastSeenResetId
+                        : iter.LastSeenResetId;
+                    long? nextFileTime = resetEmitted
+                        ? pointer?.LatestResetFileTime ?? iter.LastSeenResetFileTime
+                        : iter.LastSeenResetFileTime;
+
+                    string outerToken = iter.WrapInnerCursor(
+                        containerClient,
+                        iter.ChangeFeed.GetCursor(),
+                        nextId,
+                        nextFileTime);
                     yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(filtered, outerToken);
                 }
+            }
+
+            if (!resetEmitted && resetToEmit != null)
+            {
+                List<ShareChangeFeedEvent> tail = new List<ShareChangeFeedEvent> { resetToEmit };
+                string outerToken = iter.WrapInnerCursor(
+                    containerClient,
+                    innerCursor: null,
+                    pointer.LatestResetId,
+                    pointer.LatestResetFileTime);
+                yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(tail, outerToken);
             }
         }
     }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotAsyncPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotAsyncPageable.cs
@@ -109,17 +109,14 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             if (pointer != null)
             {
                 resetTime = pointer.LatestResetTimeUtc;
-                bool resetIsNewer = !iter.LastSeenResetFileTime.HasValue
-                    || pointer.LatestResetFileTime > iter.LastSeenResetFileTime.Value;
-
-                bool resetInSnapshotRange = iter.BeginSnapshotTimestamp.HasValue
-                    && iter.EndSnapshotTimestamp.HasValue
-                    && resetTime >= iter.BeginSnapshotTimestamp.Value
-                    && resetTime <= iter.EndSnapshotTimestamp.Value;
-
-                bool shouldSurface = resetIsNewer && (
-                    resetInSnapshotRange
-                    || (!iter.BeginSnapshotTimestamp.HasValue && !iter.EndSnapshotTimestamp.HasValue));
+                bool shouldSurface = ResetDetector.ShouldSurface(
+                    resetTime,
+                    pointer.LatestResetFileTime,
+                    pointer.LatestResetId,
+                    iter.LastSeenResetFileTime,
+                    iter.LastSeenResetId,
+                    rangeStart: iter.BeginSnapshotTimestamp,
+                    rangeEnd: iter.EndSnapshotTimestamp);
 
                 if (shouldSurface)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotIteration.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotIteration.cs
@@ -25,18 +25,50 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public long BeginCvId { get; }
         public long EndCvId { get; }
 
+        /// <summary>
+        /// UTC timestamp captured from the begin snapshot's meta.json (<c>snapshotTimestamp</c>).
+        /// Null on a resumed enumeration where the snapshot metas are not re-downloaded.
+        /// </summary>
+        public DateTimeOffset? BeginSnapshotTimestamp { get; }
+
+        /// <summary>
+        /// UTC timestamp captured from the end snapshot's meta.json (<c>snapshotTimestamp</c>).
+        /// Null on a resumed enumeration where the snapshot metas are not re-downloaded.
+        /// </summary>
+        public DateTimeOffset? EndSnapshotTimestamp { get; }
+
+        /// <summary>
+        /// Last-seen reset id carried on the resumed <see cref="ShareChangeFeedSnapshotCursor"/>,
+        /// or <c>null</c> on a fresh enumeration.
+        /// </summary>
+        public Guid? LastSeenResetId { get; }
+
+        /// <summary>
+        /// Last-seen reset FILETIME carried on the resumed <see cref="ShareChangeFeedSnapshotCursor"/>,
+        /// or <c>null</c> on a fresh enumeration.
+        /// </summary>
+        public long? LastSeenResetFileTime { get; }
+
         private ShareChangeFeedSnapshotIteration(
             ChangeFeedBase<ShareChangeFeedEvent> changeFeed,
             string beginSnapshot,
             string endSnapshot,
             long beginCvId,
-            long endCvId)
+            long endCvId,
+            DateTimeOffset? beginSnapshotTimestamp,
+            DateTimeOffset? endSnapshotTimestamp,
+            Guid? lastSeenResetId,
+            long? lastSeenResetFileTime)
         {
             ChangeFeed = changeFeed;
             BeginSnapshot = beginSnapshot;
             EndSnapshot = endSnapshot;
             BeginCvId = beginCvId;
             EndCvId = endCvId;
+            BeginSnapshotTimestamp = beginSnapshotTimestamp;
+            EndSnapshotTimestamp = endSnapshotTimestamp;
+            LastSeenResetId = lastSeenResetId;
+            LastSeenResetFileTime = lastSeenResetFileTime;
         }
 
         /// <summary>
@@ -62,6 +94,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ChangeFeedCursor innerCursor;
             DateTimeOffset? startTime = null;
             DateTimeOffset? endTime = null;
+            DateTimeOffset? beginSnapshotTs = null;
+            DateTimeOffset? endSnapshotTs = null;
+            Guid? lastSeenResetId = null;
+            long? lastSeenResetFileTime = null;
 
             if (continuation != null)
             {
@@ -95,6 +131,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 beginCvId = cursor.BeginCvId;
                 endCvId = cursor.EndCvId;
                 innerCursor = cursor.InnerCursor;
+                lastSeenResetId = cursor.LastSeenResetId;
+                lastSeenResetFileTime = cursor.LastSeenResetFileTime;
                 // startTime/endTime stay null: the inner cursor encodes its own position and the
                 // typed BuildChangeFeed overload derives both from it.
             }
@@ -121,6 +159,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 beginCvId = beginMeta.CvId;
                 endCvId = endMeta.CvId;
                 innerCursor = null;
+                beginSnapshotTs = beginMeta.SnapshotTimestamp;
+                endSnapshotTs = endMeta.SnapshotTimestamp;
 
                 // The log-window times bound only which Avro segments are read. Rows inside those
                 // segments are filtered solely by container version id (see SnapshotEventFilter):
@@ -161,7 +201,11 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 effectiveBegin,
                 effectiveEnd,
                 beginCvId,
-                endCvId);
+                endCvId,
+                beginSnapshotTs,
+                endSnapshotTs,
+                lastSeenResetId,
+                lastSeenResetFileTime);
         }
 
         /// <summary>
@@ -170,7 +214,11 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         /// then serializes it for use as the outer page's continuation token. Returns <c>null</c>
         /// when <paramref name="innerCursor"/> is null (terminal page).
         /// </summary>
-        public string WrapInnerCursor(BlobContainerClient containerClient, ChangeFeedCursor innerCursor)
+        public string WrapInnerCursor(
+            BlobContainerClient containerClient,
+            ChangeFeedCursor innerCursor,
+            Guid? lastSeenResetId,
+            long? lastSeenResetFileTime)
         {
             if (innerCursor == null)
                 return null;
@@ -181,7 +229,9 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 endSnapshot: EndSnapshot,
                 beginCvId: BeginCvId,
                 endCvId: EndCvId,
-                innerCursor: innerCursor);
+                innerCursor: innerCursor,
+                lastSeenResetId: lastSeenResetId,
+                lastSeenResetFileTime: lastSeenResetFileTime);
 
             return SnapshotCursorSerializer.Serialize(envelope);
         }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotPageable.cs
@@ -16,34 +16,59 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         private readonly string _beginSnapshot;
         private readonly string _endSnapshot;
         private readonly string _continuation;
+        private readonly ShareChangeFeedResetPolicy _policy;
 
         internal ShareChangeFeedSnapshotPageable(
             ShareChangeFeedClient client,
             long? maxTransferSize,
+            ShareChangeFeedResetPolicy policy,
             string beginSnapshot,
             string endSnapshot)
         {
             SnapshotInputValidator.ValidateInputStrings(beginSnapshot, endSnapshot);
             _client = client;
             _maxTransferSize = maxTransferSize;
+            _policy = policy;
             _beginSnapshot = beginSnapshot;
             _endSnapshot = endSnapshot;
             _continuation = null;
         }
 
+        // Backwards-compat overload for existing tests that build the pageable directly
+        // without specifying a reset policy. Defaults to the batched-API smart default.
         internal ShareChangeFeedSnapshotPageable(
             ShareChangeFeedClient client,
             long? maxTransferSize,
+            string beginSnapshot,
+            string endSnapshot)
+            : this(client, maxTransferSize, ShareChangeFeedResetPolicy.ThrowOnReset, beginSnapshot, endSnapshot)
+        {
+        }
+
+        internal ShareChangeFeedSnapshotPageable(
+            ShareChangeFeedClient client,
+            long? maxTransferSize,
+            ShareChangeFeedResetPolicy policy,
             string continuation)
         {
             if (string.IsNullOrEmpty(continuation))
                 throw new ArgumentNullException(nameof(continuation));
             _client = client;
             _maxTransferSize = maxTransferSize;
+            _policy = policy;
             _continuation = continuation;
             // beginSnapshot/endSnapshot are recovered from the cursor envelope at enumeration time.
             _beginSnapshot = null;
             _endSnapshot = null;
+        }
+
+        // Backwards-compat overload for existing tests. Defaults to the batched-API smart default.
+        internal ShareChangeFeedSnapshotPageable(
+            ShareChangeFeedClient client,
+            long? maxTransferSize,
+            string continuation)
+            : this(client, maxTransferSize, ShareChangeFeedResetPolicy.ThrowOnReset, continuation)
+        {
         }
 
         public override IEnumerable<Page<ShareChangeFeedEvent>> AsPages(
@@ -70,7 +95,57 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 cancellationToken: default)
                 .EnsureCompleted();
 
+            // Reset detection: read the pointer once. Range for snapshot APIs is
+            // [BeginSnapshotTimestamp, EndSnapshotTimestamp] on fresh enumerations; on resume,
+            // use last-seen FILETIME as the comparison anchor.
+            ShareChangeFeedResetPointer pointer = ResetMarkerReader.TryReadPointerAsync(
+                containerClient,
+                async: false,
+                cancellationToken: default)
+                .EnsureCompleted();
+
+            ShareChangeFeedResetEvent resetToEmit = null;
+            DateTimeOffset resetTime = default;
+
+            if (pointer != null)
+            {
+                resetTime = pointer.LatestResetTimeUtc;
+                bool resetIsNewer = !iter.LastSeenResetFileTime.HasValue
+                    || pointer.LatestResetFileTime > iter.LastSeenResetFileTime.Value;
+
+                bool resetInSnapshotRange = iter.BeginSnapshotTimestamp.HasValue
+                    && iter.EndSnapshotTimestamp.HasValue
+                    && resetTime >= iter.BeginSnapshotTimestamp.Value
+                    && resetTime <= iter.EndSnapshotTimestamp.Value;
+
+                bool shouldSurface = resetIsNewer && (
+                    resetInSnapshotRange
+                    // On resume without begin/end snapshot timestamps, the fact that the
+                    // pointer is strictly newer than the token's last-seen is enough — the
+                    // caller was mid-way through a snapshot enumeration when the reset landed.
+                    || (!iter.BeginSnapshotTimestamp.HasValue && !iter.EndSnapshotTimestamp.HasValue));
+
+                if (shouldSurface)
+                {
+                    ShareChangeFeedResetMarker perEvent = ResetMarkerReader.ReadPerEventAsync(
+                        containerClient,
+                        pointer.LatestMarkerPath,
+                        async: false,
+                        cancellationToken: default)
+                        .EnsureCompleted();
+
+                    resetToEmit = ResetMarkerReader.BuildResetEvent(pointer, perEvent);
+
+                    if (_policy == ShareChangeFeedResetPolicy.ThrowOnReset)
+                    {
+                        throw new ShareChangeFeedResetException(resetToEmit);
+                    }
+                }
+            }
+
+            bool resetEmitted = false;
             int pageSize = pageSizeHint ?? Constants.ChangeFeed.DefaultPageSize;
+
             while (iter.ChangeFeed.HasNext())
             {
                 Page<ShareChangeFeedEvent> rawPage = iter.ChangeFeed
@@ -81,14 +156,46 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
                 foreach (ShareChangeFeedEvent evt in rawPage.Values)
                 {
                     if (SnapshotEventFilter.IsInRange(evt, iter.BeginCvId, iter.EndCvId))
+                    {
+                        if (!resetEmitted && resetToEmit != null && evt.EventTime >= resetTime)
+                        {
+                            filtered.Add(resetToEmit);
+                            resetEmitted = true;
+                        }
+
                         filtered.Add(evt);
+                    }
                 }
 
                 if (filtered.Count > 0)
                 {
-                    string outerToken = iter.WrapInnerCursor(containerClient, iter.ChangeFeed.GetCursor());
+                    Guid? nextId = resetEmitted
+                        ? pointer?.LatestResetId ?? iter.LastSeenResetId
+                        : iter.LastSeenResetId;
+                    long? nextFileTime = resetEmitted
+                        ? pointer?.LatestResetFileTime ?? iter.LastSeenResetFileTime
+                        : iter.LastSeenResetFileTime;
+
+                    string outerToken = iter.WrapInnerCursor(
+                        containerClient,
+                        iter.ChangeFeed.GetCursor(),
+                        nextId,
+                        nextFileTime);
                     yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(filtered, outerToken);
                 }
+            }
+
+            // Emit any pending reset event that hadn't yet been surfaced (e.g. reset time
+            // sits after every filtered event, or no cvId-in-range events existed).
+            if (!resetEmitted && resetToEmit != null)
+            {
+                List<ShareChangeFeedEvent> tail = new List<ShareChangeFeedEvent> { resetToEmit };
+                string outerToken = iter.WrapInnerCursor(
+                    containerClient,
+                    innerCursor: null,
+                    pointer.LatestResetId,
+                    pointer.LatestResetFileTime);
+                yield return new ChangeFeedEventPageBase<ShareChangeFeedEvent>(tail, outerToken);
             }
         }
     }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotPageable.cs
@@ -110,20 +110,14 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             if (pointer != null)
             {
                 resetTime = pointer.LatestResetTimeUtc;
-                bool resetIsNewer = !iter.LastSeenResetFileTime.HasValue
-                    || pointer.LatestResetFileTime > iter.LastSeenResetFileTime.Value;
-
-                bool resetInSnapshotRange = iter.BeginSnapshotTimestamp.HasValue
-                    && iter.EndSnapshotTimestamp.HasValue
-                    && resetTime >= iter.BeginSnapshotTimestamp.Value
-                    && resetTime <= iter.EndSnapshotTimestamp.Value;
-
-                bool shouldSurface = resetIsNewer && (
-                    resetInSnapshotRange
-                    // On resume without begin/end snapshot timestamps, the fact that the
-                    // pointer is strictly newer than the token's last-seen is enough — the
-                    // caller was mid-way through a snapshot enumeration when the reset landed.
-                    || (!iter.BeginSnapshotTimestamp.HasValue && !iter.EndSnapshotTimestamp.HasValue));
+                bool shouldSurface = ResetDetector.ShouldSurface(
+                    resetTime,
+                    pointer.LatestResetFileTime,
+                    pointer.LatestResetId,
+                    iter.LastSeenResetFileTime,
+                    iter.LastSeenResetId,
+                    rangeStart: iter.BeginSnapshotTimestamp,
+                    rangeEnd: iter.EndSnapshotTimestamp);
 
                 if (shouldSurface)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedClientLiveTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedClientLiveTests.cs
@@ -192,7 +192,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
                         firstPageEventTimes.Add(e.EventTime);
                     }
                     continuationToken = page.ContinuationToken;
-                    if (firstPageEventTimes.Count >= 10) break;
+                    if (firstPageEventTimes.Count >= 10)
+                        break;
                 }
             }
             else
@@ -204,7 +205,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
                         firstPageEventTimes.Add(e.EventTime);
                     }
                     continuationToken = page.ContinuationToken;
-                    if (firstPageEventTimes.Count >= 10) break;
+                    if (firstPageEventTimes.Count >= 10)
+                        break;
                 }
             }
 
@@ -222,7 +224,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
                         {
                             secondPageEventTimes.Add(e.EventTime);
                         }
-                        if (secondPageEventTimes.Count >= 10) break;
+                        if (secondPageEventTimes.Count >= 10)
+                            break;
                     }
                 }
                 else
@@ -233,7 +236,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
                         {
                             secondPageEventTimes.Add(e.EventTime);
                         }
-                        if (secondPageEventTimes.Count >= 10) break;
+                        if (secondPageEventTimes.Count >= 10)
+                            break;
                     }
                 }
 

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedClientMockedTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedClientMockedTests.cs
@@ -159,14 +159,16 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
             {
                 Assert.ThrowsAsync<ArgumentException>(async () =>
                 {
-                    await foreach (ShareChangeFeedEvent _ in h.Client.GetChangesBetweenSnapshotsAsync(beginSnap, endSnap)) { }
+                    await foreach (ShareChangeFeedEvent _ in h.Client.GetChangesBetweenSnapshotsAsync(beginSnap, endSnap))
+                    { }
                 });
             }
             else
             {
                 Assert.Throws<ArgumentException>(() =>
                 {
-                    foreach (ShareChangeFeedEvent _ in h.Client.GetChangesBetweenSnapshots(beginSnap, endSnap)) { }
+                    foreach (ShareChangeFeedEvent _ in h.Client.GetChangesBetweenSnapshots(beginSnap, endSnap))
+                    { }
                 });
             }
         }
@@ -339,6 +341,21 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
 
                 Mock<BlobClient> metaBlob = new Mock<BlobClient>(MockBehavior.Loose);
                 h.Container.Setup(c => c.GetBlobClient("meta/segments.json")).Returns(metaBlob.Object);
+
+                // Default: no reset marker exists. Tests that exercise reset detection can
+                // override this by re-setting up c.GetBlobClient("meta/reset-latest.json")
+                // through the Container mock directly.
+                Mock<BlobClient> resetPointerBlob = new Mock<BlobClient>(MockBehavior.Loose);
+                h.Container.Setup(c => c.GetBlobClient("meta/reset-latest.json")).Returns(resetPointerBlob.Object);
+                RequestFailedException resetNotFound = new RequestFailedException(
+                    status: 404,
+                    message: "The specified blob does not exist.",
+                    errorCode: BlobErrorCode.BlobNotFound.ToString(),
+                    innerException: null);
+                resetPointerBlob.Setup(b => b.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(resetNotFound);
+                resetPointerBlob.Setup(b => b.DownloadStreaming(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                    .Throws(resetNotFound);
 
                 if (metaBlobExists)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedNonFinalizedTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedNonFinalizedTests.cs
@@ -152,7 +152,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
                     .Returns((GetBlobsByHierarchyOptions opts, CancellationToken _) =>
                     {
                         callCount++;
-                        if (callCount == 1) return new MockAsyncPageable((_, _) => Task.FromResult(YearListing()));
+                        if (callCount == 1)
+                            return new MockAsyncPageable((_, _) => Task.FromResult(YearListing()));
                         requestedSegmentPrefixes.Add(opts.Prefix);
                         return new MockAsyncPageable((_, _) => Task.FromResult(EmptyListing()));
                     });
@@ -163,7 +164,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
                     .Returns((GetBlobsByHierarchyOptions opts, CancellationToken _) =>
                     {
                         callCount++;
-                        if (callCount == 1) return new MockSyncPageable((_, _) => YearListing());
+                        if (callCount == 1)
+                            return new MockSyncPageable((_, _) => YearListing());
                         requestedSegmentPrefixes.Add(opts.Prefix);
                         return new MockSyncPageable((_, _) => EmptyListing());
                     });
@@ -178,7 +180,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
             DateTimeOffset startTime = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero);
             ChangeFeedBase<ShareChangeFeedEvent> changeFeed = await factory.BuildChangeFeed(
                 startTime: startTime, endTime: null, continuation: null, async: IsAsync, cancellationToken: CancellationToken.None);
-            while (changeFeed.HasNext()) await changeFeed.GetPage(IsAsync, pageSize: 5000, CancellationToken.None);
+            while (changeFeed.HasNext())
+                await changeFeed.GetPage(IsAsync, pageSize: 5000, CancellationToken.None);
 
             // 2023/ should NOT appear (year is rounded down to 2023, which is before startTime's year 2024).
             CollectionAssert.DoesNotContain(requestedSegmentPrefixes, "idx/segments/2023/");
@@ -205,7 +208,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
             DateTimeOffset endTime = new DateTimeOffset(2024, 1, 15, 8, 45, 0, TimeSpan.Zero);
             ChangeFeedBase<ShareChangeFeedEvent> changeFeed = await factory.BuildChangeFeed(
                 startTime: null, endTime: endTime, continuation: null, async: IsAsync, cancellationToken: CancellationToken.None);
-            while (changeFeed.HasNext()) await changeFeed.GetPage(IsAsync, pageSize: 5000, CancellationToken.None);
+            while (changeFeed.HasNext())
+                await changeFeed.GetPage(IsAsync, pageSize: 5000, CancellationToken.None);
 
             // With IncludeNonFinalizedEvents=true and user endTime=08:45, segments at 08:00, 08:15, 08:30,
             // 08:45 should be visited; segment at 09:00 should NOT be visited (past user's endTime).
@@ -231,7 +235,8 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
             DateTimeOffset endTime = new DateTimeOffset(2024, 1, 15, 8, 45, 0, TimeSpan.Zero);
             ChangeFeedBase<ShareChangeFeedEvent> changeFeed = await factory.BuildChangeFeed(
                 startTime: null, endTime: endTime, continuation: null, async: IsAsync, cancellationToken: CancellationToken.None);
-            while (changeFeed.HasNext()) await changeFeed.GetPage(IsAsync, pageSize: 5000, CancellationToken.None);
+            while (changeFeed.HasNext())
+                await changeFeed.GetPage(IsAsync, pageSize: 5000, CancellationToken.None);
 
             // With IncludeNonFinalizedEvents=false, MinDateTime(lastConsumable=08:30, endTime=08:45) = 08:30
             // caps the effective endTime.

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedResetTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedResetTests.cs
@@ -1,0 +1,470 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.ChangeFeed.Common;
+using Azure.Storage.Files.Shares;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
+{
+    /// <summary>
+    /// Mocked unit tests for the Files Change Feed reset-marker support
+    /// (<see cref="ResetMarkerReader"/>, <see cref="ShareChangeFeedResetEvent"/>,
+    /// <see cref="ShareChangeFeedResetException"/>, <see cref="ShareChangeFeedCursor"/>,
+    /// <see cref="ShareChangeFeedSnapshotCursor"/> reset fields, and
+    /// <see cref="ShareChangeFeedClient.ResolveEffectivePolicy(bool)"/>).
+    /// The container client is mocked so no service traffic is generated.
+    /// </summary>
+    public class ShareChangeFeedResetTests : ShareChangeFeedTestBase
+    {
+        private static readonly Guid ResetIdFixture = Guid.Parse("A1B2C3D4-E5F6-7890-ABCD-EF0123456789");
+        private const long ResetFileTimeFixture = 133871234567890123L;
+        private static readonly DateTimeOffset ResetTimeUtcFixture =
+            new DateTimeOffset(2025, 11, 19, 14, 32, 11, 456, TimeSpan.Zero);
+        private const string ResetMarkerPathFixture = "meta/resets/00133871234567890123.json";
+        private const string ResetReasonFixture = "Customer-managed unplanned failover";
+        private const string AccountNameFixture = "contosostorage";
+        private const string ContainerNameFixture = "mysharename";
+
+        private static readonly Uri ChangeFeedContainerUri =
+            new Uri("https://contosostorage.blob.core.windows.net/fileschangefeed-mysharename");
+
+        public ShareChangeFeedResetTests(bool async, ShareClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null)
+        {
+        }
+
+        #region ResetMarkerReader parsing
+
+        [Test]
+        public async Task TryReadPointerAsync_BlobNotFound_ReturnsNull()
+        {
+            Mock<BlobContainerClient> container = MockContainer();
+            SetupBlob(container, Constants.FilesChangeFeed.ResetLatestJsonPath, exists: false, json: null);
+
+            ShareChangeFeedResetPointer result = await ResetMarkerReader.TryReadPointerAsync(
+                container.Object,
+                async: IsAsync,
+                cancellationToken: default);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public async Task TryReadPointerAsync_HappyPath_ParsesAllFields()
+        {
+            Mock<BlobContainerClient> container = MockContainer();
+            SetupBlob(
+                container,
+                Constants.FilesChangeFeed.ResetLatestJsonPath,
+                exists: true,
+                json: BuildPointerJson());
+
+            ShareChangeFeedResetPointer result = await ResetMarkerReader.TryReadPointerAsync(
+                container.Object,
+                async: IsAsync,
+                cancellationToken: default);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.SchemaVersion);
+            Assert.AreEqual(ResetIdFixture, result.LatestResetId);
+            Assert.AreEqual(ResetFileTimeFixture, result.LatestResetFileTime);
+            Assert.AreEqual(ResetTimeUtcFixture, result.LatestResetTimeUtc);
+            Assert.AreEqual(ResetMarkerPathFixture, result.LatestMarkerPath);
+            Assert.AreEqual(AccountNameFixture, result.AccountName);
+            Assert.AreEqual(ContainerNameFixture, result.ContainerName);
+            Assert.AreEqual(ResetReasonFixture, result.Reason);
+        }
+
+        [Test]
+        public void TryReadPointer_MissingRequiredField_ThrowsFormatException()
+        {
+            // Drop "resetId" (LatestResetId key).
+            string malformed = @"{""schemaVersion"":1,""latestResetFileTime"":133871234567890123,""latestResetTimeUtc"":""2025-11-19T14:32:11.456Z"",""latestMarkerPath"":""meta/resets/00133871234567890123.json"",""accountName"":""a"",""containerName"":""c"",""reason"":""r""}";
+
+            Mock<BlobContainerClient> container = MockContainer();
+            SetupBlob(container, Constants.FilesChangeFeed.ResetLatestJsonPath, exists: true, json: malformed);
+
+            Assert.ThrowsAsync<FormatException>(async () =>
+                await ResetMarkerReader.TryReadPointerAsync(container.Object, async: true, cancellationToken: default));
+        }
+
+        [Test]
+        public void TryReadPointer_InvalidGuid_ThrowsFormatException()
+        {
+            string malformed = @"{""schemaVersion"":1,""latestResetId"":""not-a-guid"",""latestResetFileTime"":1,""latestResetTimeUtc"":""2025-11-19T14:32:11.456Z"",""latestMarkerPath"":""meta/resets/0.json"",""accountName"":""a"",""containerName"":""c"",""reason"":""r""}";
+
+            Mock<BlobContainerClient> container = MockContainer();
+            SetupBlob(container, Constants.FilesChangeFeed.ResetLatestJsonPath, exists: true, json: malformed);
+
+            Assert.ThrowsAsync<FormatException>(async () =>
+                await ResetMarkerReader.TryReadPointerAsync(container.Object, async: true, cancellationToken: default));
+        }
+
+        [Test]
+        public async Task ReadPerEventAsync_HappyPath_ParsesAllFields()
+        {
+            Mock<BlobContainerClient> container = MockContainer();
+            SetupBlob(container, ResetMarkerPathFixture, exists: true, json: BuildPerEventJson());
+
+            ShareChangeFeedResetMarker result = await ResetMarkerReader.ReadPerEventAsync(
+                container.Object,
+                ResetMarkerPathFixture,
+                async: IsAsync,
+                cancellationToken: default);
+
+            Assert.AreEqual(1, result.SchemaVersion);
+            Assert.AreEqual(ResetIdFixture, result.ResetId);
+            Assert.AreEqual(ResetFileTimeFixture, result.ResetFileTime);
+            Assert.AreEqual(ResetTimeUtcFixture, result.ResetTimeUtc);
+            Assert.AreEqual(AccountNameFixture, result.AccountName);
+            Assert.AreEqual(ContainerNameFixture, result.ContainerName);
+            Assert.AreEqual(ResetReasonFixture, result.Reason);
+        }
+
+        [Test]
+        public void ReadPerEventAsync_PathOutsideResetPrefix_Throws()
+        {
+            Mock<BlobContainerClient> container = MockContainer();
+            // The mock does not need to actually serve this blob; the reader must reject
+            // the malformed path before it issues the download.
+
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await ResetMarkerReader.ReadPerEventAsync(
+                    container.Object,
+                    markerPath: "meta/segments/2025/attack.json",
+                    async: true,
+                    cancellationToken: default));
+
+            StringAssert.Contains(Constants.FilesChangeFeed.ResetEventPrefix, ex.Message);
+        }
+
+        [Test]
+        public void ReadPerEventAsync_EmptyPath_Throws()
+        {
+            Mock<BlobContainerClient> container = MockContainer();
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await ResetMarkerReader.ReadPerEventAsync(
+                    container.Object,
+                    markerPath: null,
+                    async: true,
+                    cancellationToken: default));
+        }
+
+        [Test]
+        public void ReadPerEventAsync_BlobNotFound_ThrowsInvalidOperation()
+        {
+            Mock<BlobContainerClient> container = MockContainer();
+            SetupBlob(container, ResetMarkerPathFixture, exists: false, json: null);
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await ResetMarkerReader.ReadPerEventAsync(
+                    container.Object,
+                    ResetMarkerPathFixture,
+                    async: true,
+                    cancellationToken: default));
+        }
+
+        #endregion ResetMarkerReader parsing
+
+        #region ShareChangeFeedResetEvent
+
+        [Test]
+        public void BuildResetEvent_PopulatesAllFieldsFromPointerAndMarker()
+        {
+            ShareChangeFeedResetPointer pointer = BuildPointer();
+            ShareChangeFeedResetMarker perEvent = BuildPerEvent();
+
+            ShareChangeFeedResetEvent evt = ResetMarkerReader.BuildResetEvent(pointer, perEvent);
+
+            Assert.AreEqual(ResetIdFixture, evt.ResetId);
+            Assert.AreEqual(ResetFileTimeFixture, evt.ResetFileTime);
+            Assert.AreEqual(AccountNameFixture, evt.AccountName);
+            Assert.AreEqual(ContainerNameFixture, evt.ContainerName);
+            Assert.AreEqual(ResetReasonFixture, evt.ResetReason);
+            // Base fields populated from the per-event marker.
+            Assert.AreEqual(ShareChangeFeedReasonType.Reset, evt.Reason);
+            Assert.AreEqual(ResetTimeUtcFixture, evt.EventTime);
+            Assert.AreEqual(ResetIdFixture.ToString(), evt.Id);
+            Assert.AreEqual(1, evt.SchemaVersion);
+        }
+
+        [Test]
+        public void BuildResetEvent_NullPointer_Throws()
+            => Assert.Throws<ArgumentNullException>(() => ResetMarkerReader.BuildResetEvent(null, BuildPerEvent()));
+
+        [Test]
+        public void BuildResetEvent_NullPerEvent_Throws()
+            => Assert.Throws<ArgumentNullException>(() => ResetMarkerReader.BuildResetEvent(BuildPointer(), null));
+
+        [Test]
+        public void ShareChangeFeedResetException_PopulatesResetEvent()
+        {
+            ShareChangeFeedResetEvent evt = ResetMarkerReader.BuildResetEvent(BuildPointer(), BuildPerEvent());
+            ShareChangeFeedResetException ex = new ShareChangeFeedResetException(evt);
+
+            Assert.AreSame(evt, ex.ResetEvent);
+            StringAssert.Contains(ResetIdFixture.ToString(), ex.Message);
+            StringAssert.Contains(ResetReasonFixture, ex.Message);
+        }
+
+        #endregion ShareChangeFeedResetEvent
+
+        #region ShareChangeFeedCursor round-trip
+
+        [Test]
+        public void ShareChangeFeedCursor_SerializeThenDeserialize_PreservesAllFields()
+        {
+            ChangeFeedCursor inner = new ChangeFeedCursor(
+                urlHost: ChangeFeedContainerUri.Host,
+                endDateTime: new DateTimeOffset(2025, 11, 20, 0, 0, 0, TimeSpan.Zero),
+                currentSegmentCursor: new SegmentCursor("idx/segments/2025/11/19/1500/meta.json", null, null));
+
+            ShareChangeFeedCursor original = new ShareChangeFeedCursor(
+                urlHost: ChangeFeedContainerUri.Host,
+                innerCursor: inner,
+                lastSeenResetId: ResetIdFixture,
+                lastSeenResetFileTime: ResetFileTimeFixture);
+
+            string serialized = ShareChangeFeedCursorSerializer.Serialize(original);
+            ShareChangeFeedCursor round = ShareChangeFeedCursorSerializer.Deserialize(serialized);
+
+            Assert.AreEqual(1, round.CursorVersion);
+            Assert.AreEqual(ChangeFeedContainerUri.Host, round.UrlHost);
+            Assert.IsNotNull(round.InnerCursor);
+            Assert.AreEqual(inner.UrlHost, round.InnerCursor.UrlHost);
+            Assert.AreEqual(inner.EndTime, round.InnerCursor.EndTime);
+            Assert.AreEqual(ResetIdFixture, round.LastSeenResetId);
+            Assert.AreEqual(ResetFileTimeFixture, round.LastSeenResetFileTime);
+        }
+
+        [Test]
+        public void ShareChangeFeedCursor_Deserialize_NullOrGarbage_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => ShareChangeFeedCursorSerializer.Deserialize(null));
+            Assert.Throws<ArgumentException>(() => ShareChangeFeedCursorSerializer.Deserialize("not-a-json-doc"));
+            // Valid JSON but missing required InnerCursor / UrlHost.
+            Assert.Throws<ArgumentException>(() => ShareChangeFeedCursorSerializer.Deserialize("{}"));
+        }
+
+        [Test]
+        public void ShareChangeFeedCursor_Validate_MismatchedHost_Throws()
+        {
+            ShareChangeFeedCursor cursor = new ShareChangeFeedCursor(
+                urlHost: "otheraccount.blob.core.windows.net",
+                innerCursor: new ChangeFeedCursor(ChangeFeedContainerUri.Host, null, null),
+                lastSeenResetId: null,
+                lastSeenResetFileTime: null);
+
+            Mock<BlobContainerClient> container = MockContainer();
+
+            Assert.Throws<ArgumentException>(() =>
+                ShareChangeFeedCursorSerializer.Validate(container.Object, cursor));
+        }
+
+        [Test]
+        public void ShareChangeFeedCursor_Validate_UnsupportedVersion_Throws()
+        {
+            ShareChangeFeedCursor cursor = new ShareChangeFeedCursor(
+                urlHost: ChangeFeedContainerUri.Host,
+                innerCursor: new ChangeFeedCursor(ChangeFeedContainerUri.Host, null, null),
+                lastSeenResetId: null,
+                lastSeenResetFileTime: null)
+            {
+                CursorVersion = 999,
+            };
+
+            Mock<BlobContainerClient> container = MockContainer();
+
+            Assert.Throws<ArgumentException>(() =>
+                ShareChangeFeedCursorSerializer.Validate(container.Object, cursor));
+        }
+
+        #endregion ShareChangeFeedCursor round-trip
+
+        #region ShareChangeFeedSnapshotCursor reset fields
+
+        [Test]
+        public void ShareChangeFeedSnapshotCursor_SerializeThenDeserialize_PreservesResetFields()
+        {
+            ChangeFeedCursor inner = new ChangeFeedCursor(
+                urlHost: ChangeFeedContainerUri.Host,
+                endDateTime: null,
+                currentSegmentCursor: new SegmentCursor("idx/segments/2025/11/19/1500/meta.json", null, null));
+
+            ShareChangeFeedSnapshotCursor original = new ShareChangeFeedSnapshotCursor(
+                urlHost: ChangeFeedContainerUri.Host,
+                beginSnapshot: "2025-11-19T13:00:00.000Z",
+                endSnapshot: "2025-11-19T15:00:00.000Z",
+                beginCvId: 100,
+                endCvId: 200,
+                innerCursor: inner,
+                lastSeenResetId: ResetIdFixture,
+                lastSeenResetFileTime: ResetFileTimeFixture);
+
+            string serialized = SnapshotCursorSerializer.Serialize(original);
+            ShareChangeFeedSnapshotCursor round = SnapshotCursorSerializer.Deserialize(serialized);
+
+            Assert.AreEqual(ResetIdFixture, round.LastSeenResetId);
+            Assert.AreEqual(ResetFileTimeFixture, round.LastSeenResetFileTime);
+            Assert.AreEqual("2025-11-19T13:00:00.000Z", round.BeginSnapshot);
+            Assert.AreEqual("2025-11-19T15:00:00.000Z", round.EndSnapshot);
+            Assert.AreEqual(100, round.BeginCvId);
+            Assert.AreEqual(200, round.EndCvId);
+        }
+
+        #endregion ShareChangeFeedSnapshotCursor reset fields
+
+        #region ResolveEffectivePolicy
+
+        [Test]
+        public void ResolveEffectivePolicy_NoOptions_DefaultsToPerApi()
+        {
+            ShareChangeFeedClient client = new ShareChangeFeedClient(
+                new Uri("https://account.file.core.windows.net"),
+                "myshare");
+
+            Assert.AreEqual(ShareChangeFeedResetPolicy.ThrowOnReset, client.ResolveEffectivePolicy(isBatched: true));
+            Assert.AreEqual(ShareChangeFeedResetPolicy.ContinueOnReset, client.ResolveEffectivePolicy(isBatched: false));
+        }
+
+        [Test]
+        public void ResolveEffectivePolicy_ExplicitOverride_AppliesToAllApis()
+        {
+            ShareChangeFeedClient client = new ShareChangeFeedClient(
+                new Uri("https://account.file.core.windows.net"),
+                "myshare",
+                new ShareChangeFeedClientOptions
+                {
+                    ResetPolicy = ShareChangeFeedResetPolicy.ContinueOnReset,
+                });
+
+            Assert.AreEqual(ShareChangeFeedResetPolicy.ContinueOnReset, client.ResolveEffectivePolicy(isBatched: true));
+            Assert.AreEqual(ShareChangeFeedResetPolicy.ContinueOnReset, client.ResolveEffectivePolicy(isBatched: false));
+        }
+
+        [Test]
+        public void ResolveEffectivePolicy_ExplicitThrow_AppliesToStreaming()
+        {
+            ShareChangeFeedClient client = new ShareChangeFeedClient(
+                new Uri("https://account.file.core.windows.net"),
+                "myshare",
+                new ShareChangeFeedClientOptions
+                {
+                    ResetPolicy = ShareChangeFeedResetPolicy.ThrowOnReset,
+                });
+
+            Assert.AreEqual(ShareChangeFeedResetPolicy.ThrowOnReset, client.ResolveEffectivePolicy(isBatched: false));
+            Assert.AreEqual(ShareChangeFeedResetPolicy.ThrowOnReset, client.ResolveEffectivePolicy(isBatched: true));
+        }
+
+        #endregion ResolveEffectivePolicy
+
+        #region Helpers
+
+        private static Mock<BlobContainerClient> MockContainer()
+        {
+            Mock<BlobContainerClient> container = new Mock<BlobContainerClient>(MockBehavior.Loose);
+            container.Setup(c => c.Uri).Returns(ChangeFeedContainerUri);
+            return container;
+        }
+
+        private static void SetupBlob(
+            Mock<BlobContainerClient> container,
+            string path,
+            bool exists,
+            string json)
+        {
+            Mock<BlobClient> blob = new Mock<BlobClient>(MockBehavior.Loose);
+            container.Setup(c => c.GetBlobClient(path)).Returns(blob.Object);
+
+            if (exists)
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes(json);
+                blob.Setup(b => b.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => Task.FromResult(Response.FromValue(
+                        BlobsModelFactory.BlobDownloadStreamingResult(content: new MemoryStream(bytes)),
+                        (Response)null)));
+                blob.Setup(b => b.DownloadStreaming(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => Response.FromValue(
+                        BlobsModelFactory.BlobDownloadStreamingResult(content: new MemoryStream(bytes)),
+                        (Response)null));
+            }
+            else
+            {
+                RequestFailedException notFound = new RequestFailedException(
+                    status: 404,
+                    message: "The specified blob does not exist.",
+                    errorCode: BlobErrorCode.BlobNotFound.ToString(),
+                    innerException: null);
+                blob.Setup(b => b.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(notFound);
+                blob.Setup(b => b.DownloadStreaming(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                    .Throws(notFound);
+            }
+        }
+
+        private static string BuildPointerJson()
+            => JsonSerializer.Serialize(new
+            {
+                schemaVersion = 1,
+                latestResetId = ResetIdFixture.ToString(),
+                latestResetFileTime = ResetFileTimeFixture,
+                latestResetTimeUtc = ResetTimeUtcFixture.ToString("O"),
+                latestMarkerPath = ResetMarkerPathFixture,
+                accountName = AccountNameFixture,
+                containerName = ContainerNameFixture,
+                reason = ResetReasonFixture,
+            });
+
+        private static string BuildPerEventJson()
+            => JsonSerializer.Serialize(new
+            {
+                schemaVersion = 1,
+                resetId = ResetIdFixture.ToString(),
+                resetFileTime = ResetFileTimeFixture,
+                resetTimeUtc = ResetTimeUtcFixture.ToString("O"),
+                accountName = AccountNameFixture,
+                containerName = ContainerNameFixture,
+                reason = ResetReasonFixture,
+            });
+
+        private static ShareChangeFeedResetPointer BuildPointer()
+            => new ShareChangeFeedResetPointer
+            {
+                SchemaVersion = 1,
+                LatestResetId = ResetIdFixture,
+                LatestResetFileTime = ResetFileTimeFixture,
+                LatestResetTimeUtc = ResetTimeUtcFixture,
+                LatestMarkerPath = ResetMarkerPathFixture,
+                AccountName = AccountNameFixture,
+                ContainerName = ContainerNameFixture,
+                Reason = ResetReasonFixture,
+            };
+
+        private static ShareChangeFeedResetMarker BuildPerEvent()
+            => new ShareChangeFeedResetMarker
+            {
+                SchemaVersion = 1,
+                ResetId = ResetIdFixture,
+                ResetFileTime = ResetFileTimeFixture,
+                ResetTimeUtc = ResetTimeUtcFixture,
+                AccountName = AccountNameFixture,
+                ContainerName = ContainerNameFixture,
+                Reason = ResetReasonFixture,
+            };
+
+        #endregion Helpers
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedResetTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedResetTests.cs
@@ -250,6 +250,50 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
         }
 
         [Test]
+        public void ShareChangeFeedCursor_SerializeThenDeserialize_PreservesRangeAndBatchedIntent()
+        {
+            ChangeFeedCursor inner = new ChangeFeedCursor(
+                urlHost: ChangeFeedContainerUri.Host,
+                endDateTime: new DateTimeOffset(2025, 11, 20, 0, 0, 0, TimeSpan.Zero),
+                currentSegmentCursor: new SegmentCursor("idx/segments/2025/11/19/1500/meta.json", null, null));
+
+            DateTimeOffset rangeStart = new DateTimeOffset(2025, 11, 19, 13, 0, 0, TimeSpan.Zero);
+            DateTimeOffset rangeEnd = new DateTimeOffset(2025, 11, 19, 15, 0, 0, TimeSpan.Zero);
+
+            ShareChangeFeedCursor original = new ShareChangeFeedCursor(
+                urlHost: ChangeFeedContainerUri.Host,
+                innerCursor: inner,
+                lastSeenResetId: ResetIdFixture,
+                lastSeenResetFileTime: ResetFileTimeFixture,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+                isBatched: true);
+
+            string serialized = ShareChangeFeedCursorSerializer.Serialize(original);
+            ShareChangeFeedCursor round = ShareChangeFeedCursorSerializer.Deserialize(serialized);
+
+            Assert.AreEqual(rangeStart, round.RangeStart);
+            Assert.AreEqual(rangeEnd, round.RangeEnd);
+            Assert.IsTrue(round.IsBatched);
+        }
+
+        [Test]
+        public void ShareChangeFeedCursor_Deserialize_OlderTokenWithoutRangeFields_DefaultsToNullAndFalse()
+        {
+            // A token produced before RangeStart/RangeEnd/IsBatched were added must still
+            // deserialize: the new fields simply default to null/false.
+            string legacyToken =
+                @"{""CursorVersion"":1,""UrlHost"":""" + ChangeFeedContainerUri.Host + @""",""InnerCursor"":{""UrlHost"":""" +
+                ChangeFeedContainerUri.Host + @""",""EndTime"":null,""CurrentSegmentCursor"":null},""LastSeenResetId"":null,""LastSeenResetFileTime"":null}";
+
+            ShareChangeFeedCursor round = ShareChangeFeedCursorSerializer.Deserialize(legacyToken);
+
+            Assert.IsNull(round.RangeStart);
+            Assert.IsNull(round.RangeEnd);
+            Assert.IsFalse(round.IsBatched);
+        }
+
+        [Test]
         public void ShareChangeFeedCursor_Deserialize_NullOrGarbage_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => ShareChangeFeedCursorSerializer.Deserialize(null));
@@ -369,6 +413,24 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
             Assert.AreEqual(ShareChangeFeedResetPolicy.ThrowOnReset, client.ResolveEffectivePolicy(isBatched: true));
         }
 
+        [Test]
+        public void ResolveEffectivePolicy_BatchedResume_PreservesThrowDefault()
+        {
+            // A batched query resumed via GetChanges(continuationToken) must reuse the batched
+            // default (ThrowOnReset) rather than flipping to the streaming default. The pageable
+            // resolves the effective policy from the token's persisted IsBatched intent, so this
+            // asserts the resolution the resume path relies on.
+            ShareChangeFeedClient client = new ShareChangeFeedClient(
+                new Uri("https://account.file.core.windows.net"),
+                "myshare");
+
+            // Batched intent recovered from the token -> ThrowOnReset (unchanged from the
+            // original GetChanges(start, end) default).
+            Assert.AreEqual(ShareChangeFeedResetPolicy.ThrowOnReset, client.ResolveEffectivePolicy(isBatched: true));
+            // Streaming intent recovered from the token -> ContinueOnReset.
+            Assert.AreEqual(ShareChangeFeedResetPolicy.ContinueOnReset, client.ResolveEffectivePolicy(isBatched: false));
+        }
+
         #endregion ResolveEffectivePolicy
 
         #region ResetDetector surface/dedup
@@ -478,6 +540,30 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
                 lastSeenResetId: Guid.NewGuid(),
                 rangeStart: null,
                 rangeEnd: null);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ShouldSurface_BatchedResume_RecoveredRange_SuppressesStalePreWindowReset()
+        {
+            // Repro from PR review: latest reset sits at Jun30 23:00Z, caller runs
+            // GetChanges(Jul1 00:00Z, Jul1 01:00Z). Page 1 (bounded) correctly filters the reset
+            // by range. On resume the range MUST be recovered from the token so detection still
+            // gates on the lower bound instead of degrading to unbounded (which would surface the
+            // stale pre-window reset).
+            DateTimeOffset start = new DateTimeOffset(2025, 7, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset end = new DateTimeOffset(2025, 7, 1, 1, 0, 0, TimeSpan.Zero);
+            DateTimeOffset resetTime = new DateTimeOffset(2025, 6, 30, 23, 0, 0, TimeSpan.Zero);
+
+            bool result = ResetDetector.ShouldSurface(
+                resetTime,
+                resetFileTime: ResetFileTimeFixture,
+                resetId: ResetIdFixture,
+                lastSeenResetFileTime: null,
+                lastSeenResetId: null,
+                rangeStart: start,
+                rangeEnd: end);
 
             Assert.IsFalse(result);
         }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedResetTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ShareChangeFeedResetTests.cs
@@ -371,6 +371,119 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
 
         #endregion ResolveEffectivePolicy
 
+        #region ResetDetector surface/dedup
+
+        [Test]
+        public void ShouldSurface_ResetInRange_NewerPointerPastEnd_Surfaces()
+        {
+            // Requested range [start, end]. An in-range reset must be surfaced even when the
+            // pointer's latest reset lands past the end of the range.
+            DateTimeOffset start = new DateTimeOffset(2025, 11, 19, 13, 0, 0, TimeSpan.Zero);
+            DateTimeOffset end = new DateTimeOffset(2025, 11, 19, 15, 0, 0, TimeSpan.Zero);
+            DateTimeOffset resetTime = new DateTimeOffset(2025, 11, 19, 13, 30, 0, TimeSpan.Zero);
+
+            bool result = ResetDetector.ShouldSurface(
+                resetTime,
+                resetFileTime: ResetFileTimeFixture,
+                resetId: ResetIdFixture,
+                lastSeenResetFileTime: null,
+                lastSeenResetId: null,
+                rangeStart: start,
+                rangeEnd: end);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void ShouldSurface_ResetAfterRangeStart_PastEnd_StillSurfaces()
+        {
+            // A reset at or after the range start surfaces regardless of the upper bound: the
+            // pointer only ever references the latest reset.
+            DateTimeOffset start = new DateTimeOffset(2025, 11, 19, 13, 0, 0, TimeSpan.Zero);
+            DateTimeOffset end = new DateTimeOffset(2025, 11, 19, 15, 0, 0, TimeSpan.Zero);
+            DateTimeOffset resetTime = new DateTimeOffset(2025, 11, 19, 16, 0, 0, TimeSpan.Zero);
+
+            bool result = ResetDetector.ShouldSurface(
+                resetTime,
+                resetFileTime: ResetFileTimeFixture,
+                resetId: ResetIdFixture,
+                lastSeenResetFileTime: null,
+                lastSeenResetId: null,
+                rangeStart: start,
+                rangeEnd: end);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void ShouldSurface_ResetBeforeRangeStart_DoesNotSurface()
+        {
+            DateTimeOffset start = new DateTimeOffset(2025, 11, 19, 13, 0, 0, TimeSpan.Zero);
+            DateTimeOffset end = new DateTimeOffset(2025, 11, 19, 15, 0, 0, TimeSpan.Zero);
+            DateTimeOffset resetTime = new DateTimeOffset(2025, 11, 19, 12, 0, 0, TimeSpan.Zero);
+
+            bool result = ResetDetector.ShouldSurface(
+                resetTime,
+                resetFileTime: ResetFileTimeFixture,
+                resetId: ResetIdFixture,
+                lastSeenResetFileTime: null,
+                lastSeenResetId: null,
+                rangeStart: start,
+                rangeEnd: end);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ShouldSurface_Streaming_Unbounded_SurfacesWhenNewer()
+        {
+            bool result = ResetDetector.ShouldSurface(
+                ResetTimeUtcFixture,
+                resetFileTime: ResetFileTimeFixture,
+                resetId: ResetIdFixture,
+                lastSeenResetFileTime: null,
+                lastSeenResetId: null,
+                rangeStart: null,
+                rangeEnd: null);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void ShouldSurface_SameResetId_DoesNotSurface()
+        {
+            // Resuming with a token whose LastSeenResetId equals the pointer's LatestResetId:
+            // the reset was already surfaced, so it must not be re-emitted even when the
+            // FILETIME comparison alone would not distinguish it.
+            bool result = ResetDetector.ShouldSurface(
+                ResetTimeUtcFixture,
+                resetFileTime: ResetFileTimeFixture,
+                resetId: ResetIdFixture,
+                lastSeenResetFileTime: ResetFileTimeFixture - 1,
+                lastSeenResetId: ResetIdFixture,
+                rangeStart: null,
+                rangeEnd: null);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ShouldSurface_NotNewer_DoesNotSurface()
+        {
+            bool result = ResetDetector.ShouldSurface(
+                ResetTimeUtcFixture,
+                resetFileTime: ResetFileTimeFixture,
+                resetId: ResetIdFixture,
+                lastSeenResetFileTime: ResetFileTimeFixture,
+                lastSeenResetId: Guid.NewGuid(),
+                rangeStart: null,
+                rangeEnd: null);
+
+            Assert.IsFalse(result);
+        }
+
+        #endregion ResetDetector surface/dedup
+
         #region Helpers
 
         private static Mock<BlobContainerClient> MockContainer()


### PR DESCRIPTION
## Files Change Feed — Reset Marker Support

Adds customer-facing reset-marker handling to `Azure.Storage.Files.Shares.ChangeFeed` only. `Azure.Storage.Blobs.ChangeFeed` and the shared `Azure.Storage.ChangeFeed.Common` cursor are untouched — reset state lives in a new Files-only outer envelope. Since `Azure.Storage.Files.Shares.ChangeFeed` is still `12.0.0-beta.1` (unreleased), small breaking changes to the continuation-token wire format and to the pageables' public throw surface are made without a version bump.

### Design decisions

1. **In-band model.** `ShareChangeFeedResetEvent : ShareChangeFeedEvent` flows through `Pageable<ShareChangeFeedEvent>`. A new well-known value `ShareChangeFeedReasonType.Reset` marks it on the base type; the base `Id` carries the reset GUID (string form) and the base `EventTime` carries the reset time.
2. **Detection timing.** The reset pointer (`meta/reset-latest.json`) is read once at the start of each `AsPages()` call — no between-page re-polling.
3. **Range detection (lower-bound only).** The pointer only ever references the *latest* reset. A reset is surfaced when its time is at or after the range start (`resetTime >= start`); the upper bound is intentionally not checked, so an in-range reset is not missed when a newer reset lands past the range end. For snapshot APIs the anchor is the begin-snapshot timestamp; for streaming (unbounded) APIs any reset strictly newer than the resume state surfaces.
4. **De-duplication.** On resume, the continuation token carries `LastSeenResetId` / `LastSeenResetFileTime`. A reset is suppressed when it is not strictly newer than the last-seen FILETIME, or when its `LatestResetId` equals the token's `LastSeenResetId` (guards against re-emitting a reset already surfaced).
5. **Shared decision logic.** The surface/dedup rule lives in a single pure helper, `ResetDetector.ShouldSurface(...)`, called by all four pageables (streaming/snapshot × sync/async) so behavior stays consistent and is directly unit-testable.
6. **Policy surface.** New `ShareChangeFeedResetPolicy` enum (`ThrowOnReset`, `ContinueOnReset`) exposed as a nullable `ResetPolicy` on `ShareChangeFeedClientOptions`. When `null`, per-API smart defaults apply: `ThrowOnReset` for batched (`GetChanges(start,end)`, `GetChangesBetweenSnapshots(begin,end)`, and their `continuationToken` overloads) and `ContinueOnReset` for streaming (`GetChanges()`, `GetChanges(continuationToken)`). Setting the property explicitly overrides the default for every method.
7. **Cursor.** New Files-only outer envelope `ShareChangeFeedCursor` wraps the Common `ChangeFeedCursor` plus `LastSeenResetId` / `LastSeenResetFileTime` + `UrlHost` + `CursorVersion`. `ShareChangeFeedSnapshotCursor` gains the same two reset fields. `Azure.Storage.ChangeFeed.Common.ChangeFeedCursor` is not modified.
8. **Testing.** Mocked unit tests only (`Moq` / injected `BlobContainerClient`); no live/recording tests.

### Reset event yield semantics (ContinueOnReset)

Reset is emitted at its correct time position in the ordered stream:

- Capture `resetTime = pointer.LatestResetTimeUtc` at the start of `AsPages()`.
- Wrap each raw page: if the reset hasn't been emitted yet and `evt.EventTime >= resetTime`, prepend the synthesized `ShareChangeFeedResetEvent` before `evt` and mark it emitted.
- If the reset sits after every event (or the feed is empty), emit it on a terminal tail page.
- Under `ThrowOnReset`, at the same detection boundary, throw `ShareChangeFeedResetException` instead of yielding.
- For `continuationToken` overloads, the token carries `LastSeenResetId` / `LastSeenResetFileTime`; a newer/different reset is detected at start.

### Public API added

- `ShareChangeFeedResetEvent : ShareChangeFeedEvent` — adds `ResetId`, `ResetFileTime`, `AccountName`, `ContainerName`, `ResetReason`, and `ToString()`.
- `ShareChangeFeedResetException : Exception` — carries the `ShareChangeFeedResetEvent` (`ResetEvent`), with message/inner-exception overloads.
- `ShareChangeFeedResetPolicy` enum — `ThrowOnReset`, `ContinueOnReset`.
- `ShareChangeFeedReasonType.Reset` — new static well-known value.
- `ShareChangeFeedClientOptions.ResetPolicy` — nullable policy property.
- `ShareChangeFeedModelFactory.ShareChangeFeedResetEvent(...)` — public mocking factory.
- Regenerated API listings (`api/Azure.Storage.Files.Shares.ChangeFeed.{net10.0,net8.0,netstandard2.0}.cs`).

### Internal files added

- `ResetDetector.cs` — pure static `ShouldSurface(...)` surface/dedup decision shared by all four pageables.
- `ResetMarkerReader.cs` — `TryReadPointerAsync`, `ReadPerEventAsync`, `BuildResetEvent`.
- `ShareChangeFeedResetPointer.cs` / `ShareChangeFeedResetMarker.cs` — internal DTOs for `meta/reset-latest.json` and `meta/resets/<FILETIME>.json`.
- `ShareChangeFeedCursor.cs` + `ShareChangeFeedCursorSerializer.cs` — Files-only outer envelope and its `Serialize` / `Deserialize` / `Validate` helpers (mirrors `SnapshotCursorSerializer`).

### Files modified

- `sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs` — extend `FilesChangeFeed`: `ResetLatestJsonPath`, `ResetEventPrefix`, and nested `ResetPointer` / `ResetMarker` field-name classes.
- `ShareChangeFeedClientOptions.cs` — nullable `ResetPolicy` property.
- `ShareChangeFeedReasonType.cs` — add static `Reset` well-known value.
- `ShareChangeFeedSnapshotCursor.cs` — add `LastSeenResetId` / `LastSeenResetFileTime`.
- `ShareChangeFeedClient.cs` — `ResolveEffectivePolicy(bool isBatched)` and forwarding to all four pageables; xmldoc updates.
- `ShareChangeFeedPageable.cs` / `ShareChangeFeedAsyncPageable.cs` — read pointer in `AsPages`, decide via `ResetDetector.ShouldSurface` (lower-bound range + id dedup), inject/throw at the ordered boundary, re-emit continuation via `ShareChangeFeedCursorSerializer`.
- `ShareChangeFeedSnapshotPageable.cs` / `ShareChangeFeedSnapshotAsyncPageable.cs` — same detection against the begin-snapshot timestamp anchor; inject/throw; wrap inner cursor with reset fields.
- `ShareChangeFeedSnapshotIteration.cs` — carries `LastSeenResetId` / `LastSeenResetFileTime` through setup and `WrapInnerCursor`.
- `ShareChangeFeedModelFactory.cs` — public `ShareChangeFeedResetEvent(...)` factory.

### Tests

- `ShareChangeFeedResetTests.cs` — mocked-container unit tests covering `ResetMarkerReader` parsing (`BlobNotFound`, malformed pointer / invalid GUID / missing field, per-event path validation), `BuildResetEvent` field population, `ShareChangeFeedResetException` population, `ShareChangeFeedCursor` / `ShareChangeFeedSnapshotCursor` round-trip and validation, per-API default-policy resolution, and `ResetDetector.ShouldSurface` surface/dedup semantics — including an in-range reset surfaced when the pointer's latest reset is past the range end, before-start suppression, streaming unbounded, and the `LastSeenResetId`-match dedup guard.

### Risks / edge cases

- **FILETIME → DateTimeOffset conversion.** JSON `latestResetTimeUtc` is the readable source of truth for the event time; `latestResetFileTime` is the monotonic ordering/dedup anchor.
- **Missing per-event blob.** If the pointer exists but `latestMarkerPath` is `BlobNotFound`, surface as `InvalidOperationException` (reset in progress), not as a reset detection.
- **Schema evolution.** Accept unknown pointer fields; fail only on missing required fields.
- **Legacy tokens.** Package is unreleased, so bare Common `ChangeFeedCursor` strings are rejected with a clear `ArgumentException`.
- **Naming.** Free-form JSON `reason` is exposed as `ResetReason` on the subclass to avoid shadowing the base `Reason` (`ShareChangeFeedReasonType`).
