### PR TITLE
Handle internal provisioning resource constructors

### DIFF
--- a/.github/workflows/provisioning-review/Get-ProvisioningSchema.ps1
+++ b/.github/workflows/provisioning-review/Get-ProvisioningSchema.ps1
@@ -141,7 +141,7 @@ function Get-ResourceInfo
     }
 
     $combinedSource = $classSources -join [Environment]::NewLine
-    $constructorPattern = '(?ms)public\s+' + [regex]::Escape($className) + '\s*\(\s*string\s+bicepIdentifier\s*,\s*string\??\s+resourceVersion\s*=\s*(?:default|null)\s*\)\s*:\s*base\(\s*bicepIdentifier\s*,\s*"(?<resourceType>[^"]+)"\s*,\s*resourceVersion\s*\?\?\s*"(?<defaultApiVersion>[^"]+)"\s*\)'
+    $constructorPattern = '(?ms)(?:public|internal)\s+' + [regex]::Escape($className) + '\s*\(\s*string\s+bicepIdentifier\s*,\s*string\??\s+resourceVersion\s*=\s*(?:default|null)\s*\)\s*:\s*base\(\s*bicepIdentifier\s*,\s*"(?<resourceType>[^"]+)"\s*,\s*resourceVersion\s*\?\?\s*"(?<defaultApiVersion>[^"]+)"\s*\)'
     $constructorMatch = [regex]::Match($source, $constructorPattern)
 
     $apiVersions = [System.Collections.Generic.List[string]]::new()


### PR DESCRIPTION
Fixes the provisioning schema extractor so generated resources with internal constructors still report their ARM resource type and default API version. This covers read-only provisioning resources that are referenced via FromExisting and intentionally do not expose a public deployable constructor.