### PR TITLE
Update MST spec commit ID, release date, fix backward compatibility

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0 (2026-07-09)
+## 1.0.0 (2026-07-10)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- General availability release.
 
 ## 1.0.0-beta.9 (2026-05-26)
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0 (Unreleased)
+## 1.0.0 (2026-07-09)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0 (2026-07-10)
+## 1.0.0 (2026-07-13)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/README.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/README.md
@@ -15,6 +15,12 @@ Ensure you have access to the correct NuGet feed.
 Install the client library via NuGet:
 
 ```dotnetcli
+dotnet add package Azure.Security.CodeTransparency
+```
+
+To install a preview release, use the `--prerelease` flag:
+
+```dotnetcli
 dotnet add package Azure.Security.CodeTransparency --prerelease
 ```
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net10.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net10.0.cs
@@ -25,7 +25,9 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyCertificateClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public virtual Azure.Response GetServiceIdentity(string ledgerId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult> GetServiceIdentity(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetServiceIdentityAsync(string ledgerId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult>> GetServiceIdentityAsync(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class CodeTransparencyClient
@@ -38,71 +40,87 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyClient(System.Uri endpoint, Azure.AzureKeyCredential credential, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public CodeTransparencyClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options = null) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
-        [System.ObsoleteAttribute("Use CreateEntryV09 instead.")]
         public virtual Azure.Response CreateEntry(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.ObsoleteAttribute("Use CreateEntry(BinaryData, bool, CancellationToken) instead.")]
         public virtual Azure.Operation<System.BinaryData> CreateEntry(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09 instead.")]
         public virtual Azure.Response<System.BinaryData> CreateEntry(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryAsync(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("Use CreateEntryAsync(BinaryData, bool, CancellationToken) instead.")]
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateEntryAsync(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryAsync(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response CreateEntryV09(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntryV09(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryV09Async(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryV09Async(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09 instead.")]
         public virtual Azure.Response GetEntry(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09 instead.")]
         public virtual Azure.Response<System.BinaryData> GetEntry(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09 instead.")]
+        public static string GetEntryIdFromLocation(Azure.Response response) { throw null; }
         public virtual Azure.Response GetEntryStatement(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09 instead.")]
         public virtual Azure.Response<System.BinaryData> GetEntryStatement(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryStatementV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatementV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementV09Async(string entryId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryV09Async(string entryId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09 instead.")]
+        [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response GetOperation(string operationId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09 instead.")]
+        [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response<System.BinaryData> GetOperation(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationAsync(string operationId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationAsync(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetOperationV09(string operationId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetOperationV09(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationV09Async(string operationId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationV09Async(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetPublicKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.JwksDocument> GetPublicKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetPublicKeysAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.JwksDocument>> GetPublicKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKey(string kid, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKey(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeyAsync(string kid, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeyAsync(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeysAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetTransparencyConfigCbor(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetTransparencyConfigCbor(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetTransparencyConfigCborAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetTransparencyConfigCborAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("Use the static VerifyTransparentStatement method with options instead.")]
         public virtual void RunTransparentStatementVerification(byte[] transparentStatementCoseSign1Bytes) { }
@@ -250,6 +268,7 @@ namespace Azure.Security.CodeTransparency.Receipt
         public static readonly string ReceiptHeaderTreeAlgorithm;
         public static readonly string SupportedTreeAlgorithm;
         public CcfReceipt() { }
+        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
     }
     public partial class CcfReceiptVerifier
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net10.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net10.0.cs
@@ -25,9 +25,7 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyCertificateClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public virtual Azure.Response GetServiceIdentity(string ledgerId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult> GetServiceIdentity(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetServiceIdentityAsync(string ledgerId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult>> GetServiceIdentityAsync(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class CodeTransparencyClient
@@ -44,83 +42,58 @@ namespace Azure.Security.CodeTransparency
         [System.ObsoleteAttribute("Use CreateEntry(BinaryData, bool, CancellationToken) instead.")]
         public virtual Azure.Operation<System.BinaryData> CreateEntry(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntry(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryAsync(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("Use CreateEntryAsync(BinaryData, bool, CancellationToken) instead.")]
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateEntryAsync(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryAsync(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response CreateEntryV09(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntryV09(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryV09Async(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryV09Async(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntry(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntry(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static string GetEntryIdFromLocation(Azure.Response response) { throw null; }
         public virtual Azure.Response GetEntryStatement(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatement(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryStatementV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatementV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementV09Async(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryV09Async(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response GetOperation(string operationId, Azure.RequestContext context) { throw null; }
         [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response<System.BinaryData> GetOperation(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationAsync(string operationId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationAsync(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetOperationV09(string operationId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetOperationV09(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationV09Async(string operationId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationV09Async(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetPublicKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.JwksDocument> GetPublicKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetPublicKeysAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.JwksDocument>> GetPublicKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKey(string kid, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKey(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeyAsync(string kid, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeyAsync(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeysAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetTransparencyConfigCbor(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetTransparencyConfigCbor(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetTransparencyConfigCborAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetTransparencyConfigCborAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("Use the static VerifyTransparentStatement method with options instead.")]
         public virtual void RunTransparentStatementVerification(byte[] transparentStatementCoseSign1Bytes) { }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
@@ -25,7 +25,9 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyCertificateClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public virtual Azure.Response GetServiceIdentity(string ledgerId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult> GetServiceIdentity(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetServiceIdentityAsync(string ledgerId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult>> GetServiceIdentityAsync(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class CodeTransparencyClient
@@ -38,71 +40,87 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyClient(System.Uri endpoint, Azure.AzureKeyCredential credential, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public CodeTransparencyClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options = null) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
-        [System.ObsoleteAttribute("Use CreateEntryV09 instead.")]
         public virtual Azure.Response CreateEntry(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.ObsoleteAttribute("Use CreateEntry(BinaryData, bool, CancellationToken) instead.")]
         public virtual Azure.Operation<System.BinaryData> CreateEntry(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09 instead.")]
         public virtual Azure.Response<System.BinaryData> CreateEntry(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryAsync(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("Use CreateEntryAsync(BinaryData, bool, CancellationToken) instead.")]
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateEntryAsync(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryAsync(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response CreateEntryV09(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntryV09(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryV09Async(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryV09Async(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09 instead.")]
         public virtual Azure.Response GetEntry(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09 instead.")]
         public virtual Azure.Response<System.BinaryData> GetEntry(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09 instead.")]
+        public static string GetEntryIdFromLocation(Azure.Response response) { throw null; }
         public virtual Azure.Response GetEntryStatement(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09 instead.")]
         public virtual Azure.Response<System.BinaryData> GetEntryStatement(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryStatementV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatementV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementV09Async(string entryId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryV09Async(string entryId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09 instead.")]
+        [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response GetOperation(string operationId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09 instead.")]
+        [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response<System.BinaryData> GetOperation(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationAsync(string operationId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationAsync(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetOperationV09(string operationId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetOperationV09(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationV09Async(string operationId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationV09Async(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetPublicKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.JwksDocument> GetPublicKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetPublicKeysAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.JwksDocument>> GetPublicKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKey(string kid, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKey(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeyAsync(string kid, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeyAsync(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeysAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetTransparencyConfigCbor(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetTransparencyConfigCbor(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetTransparencyConfigCborAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetTransparencyConfigCborAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("Use the static VerifyTransparentStatement method with options instead.")]
         public virtual void RunTransparentStatementVerification(byte[] transparentStatementCoseSign1Bytes) { }
@@ -250,6 +268,7 @@ namespace Azure.Security.CodeTransparency.Receipt
         public static readonly string ReceiptHeaderTreeAlgorithm;
         public static readonly string SupportedTreeAlgorithm;
         public CcfReceipt() { }
+        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
     }
     public partial class CcfReceiptVerifier
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
@@ -25,9 +25,7 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyCertificateClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public virtual Azure.Response GetServiceIdentity(string ledgerId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult> GetServiceIdentity(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetServiceIdentityAsync(string ledgerId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult>> GetServiceIdentityAsync(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class CodeTransparencyClient
@@ -44,83 +42,58 @@ namespace Azure.Security.CodeTransparency
         [System.ObsoleteAttribute("Use CreateEntry(BinaryData, bool, CancellationToken) instead.")]
         public virtual Azure.Operation<System.BinaryData> CreateEntry(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntry(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryAsync(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("Use CreateEntryAsync(BinaryData, bool, CancellationToken) instead.")]
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateEntryAsync(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryAsync(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response CreateEntryV09(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntryV09(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryV09Async(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryV09Async(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntry(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntry(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static string GetEntryIdFromLocation(Azure.Response response) { throw null; }
         public virtual Azure.Response GetEntryStatement(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatement(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryStatementV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatementV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementV09Async(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryV09Async(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response GetOperation(string operationId, Azure.RequestContext context) { throw null; }
         [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response<System.BinaryData> GetOperation(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationAsync(string operationId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationAsync(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetOperationV09(string operationId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetOperationV09(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationV09Async(string operationId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationV09Async(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetPublicKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.JwksDocument> GetPublicKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetPublicKeysAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.JwksDocument>> GetPublicKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKey(string kid, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKey(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeyAsync(string kid, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeyAsync(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeysAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetTransparencyConfigCbor(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetTransparencyConfigCbor(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetTransparencyConfigCborAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetTransparencyConfigCborAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("Use the static VerifyTransparentStatement method with options instead.")]
         public virtual void RunTransparentStatementVerification(byte[] transparentStatementCoseSign1Bytes) { }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
@@ -25,9 +25,7 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyCertificateClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public virtual Azure.Response GetServiceIdentity(string ledgerId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult> GetServiceIdentity(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetServiceIdentityAsync(string ledgerId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult>> GetServiceIdentityAsync(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class CodeTransparencyClient
@@ -43,83 +41,58 @@ namespace Azure.Security.CodeTransparency
         [System.ObsoleteAttribute("Use CreateEntry(BinaryData, bool, CancellationToken) instead.")]
         public virtual Azure.Operation<System.BinaryData> CreateEntry(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntry(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryAsync(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("Use CreateEntryAsync(BinaryData, bool, CancellationToken) instead.")]
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateEntryAsync(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryAsync(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response CreateEntryV09(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntryV09(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryV09Async(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryV09Async(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntry(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntry(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static string GetEntryIdFromLocation(Azure.Response response) { throw null; }
         public virtual Azure.Response GetEntryStatement(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatement(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryStatementV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatementV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementV09Async(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryV09Async(string entryId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response GetOperation(string operationId, Azure.RequestContext context) { throw null; }
         [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response<System.BinaryData> GetOperation(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationAsync(string operationId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationAsync(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetOperationV09(string operationId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetOperationV09(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationV09Async(string operationId, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationV09Async(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetPublicKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.JwksDocument> GetPublicKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetPublicKeysAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.JwksDocument>> GetPublicKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKey(string kid, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKey(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeyAsync(string kid, Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeyAsync(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeysAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetTransparencyConfigCbor(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetTransparencyConfigCbor(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetTransparencyConfigCborAsync(Azure.RequestContext context) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetTransparencyConfigCborAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("Use the static VerifyTransparentStatement method with options instead.")]
         public virtual void RunTransparentStatementVerification(byte[] transparentStatementCoseSign1Bytes) { }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
@@ -25,7 +25,9 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyCertificateClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public virtual Azure.Response GetServiceIdentity(string ledgerId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult> GetServiceIdentity(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetServiceIdentityAsync(string ledgerId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.ServiceIdentityResult>> GetServiceIdentityAsync(string ledgerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class CodeTransparencyClient
@@ -37,71 +39,87 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyClient(System.Uri endpoint, Azure.AzureKeyCredential credential, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options) { }
         public CodeTransparencyClient(System.Uri endpoint, Azure.Security.CodeTransparency.CodeTransparencyClientOptions options = null) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
-        [System.ObsoleteAttribute("Use CreateEntryV09 instead.")]
         public virtual Azure.Response CreateEntry(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.ObsoleteAttribute("Use CreateEntry(BinaryData, bool, CancellationToken) instead.")]
         public virtual Azure.Operation<System.BinaryData> CreateEntry(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09 instead.")]
         public virtual Azure.Response<System.BinaryData> CreateEntry(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryAsync(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("Use CreateEntryAsync(BinaryData, bool, CancellationToken) instead.")]
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateEntryAsync(Azure.WaitUntil waitUntil, System.BinaryData body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use CreateEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryAsync(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response CreateEntryV09(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response<System.BinaryData> CreateEntryV09(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEntryV09Async(Azure.Core.RequestContent content, bool? waitForCommit = default(bool?), Azure.RequestContext context = null) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> CreateEntryV09Async(System.BinaryData body, bool? waitForCommit = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09 instead.")]
         public virtual Azure.Response GetEntry(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09 instead.")]
         public virtual Azure.Response<System.BinaryData> GetEntry(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09 instead.")]
+        public static string GetEntryIdFromLocation(Azure.Response response) { throw null; }
         public virtual Azure.Response GetEntryStatement(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09 instead.")]
         public virtual Azure.Response<System.BinaryData> GetEntryStatement(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementAsync(string entryId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetEntryStatementV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementAsync(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryStatementV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryStatementV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryStatementV09Async(string entryId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryStatementV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEntryV09(string entryId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetEntryV09(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetEntryV09Async(string entryId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetEntryV09Async(string entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09 instead.")]
+        [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response GetOperation(string operationId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09 instead.")]
+        [System.ObsoleteAttribute("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Azure.Response<System.BinaryData> GetOperation(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationAsync(string operationId, Azure.RequestContext context) { throw null; }
-        [System.ObsoleteAttribute("Use GetOperationV09Async instead.")]
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        [System.ObsoleteAttribute("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationAsync(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetOperationV09(string operationId, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetOperationV09(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetOperationV09Async(string operationId, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetOperationV09Async(string operationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetPublicKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Security.CodeTransparency.JwksDocument> GetPublicKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetPublicKeysAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.CodeTransparency.JwksDocument>> GetPublicKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKey(string kid, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKey(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeyAsync(string kid, Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeyAsync(string kid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetScittKeys(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetScittKeys(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScittKeysAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetScittKeysAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetTransparencyConfigCbor(Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<System.BinaryData> GetTransparencyConfigCbor(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response> GetTransparencyConfigCborAsync(Azure.RequestContext context) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.BinaryData>> GetTransparencyConfigCborAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ObsoleteAttribute("Use the static VerifyTransparentStatement method with options instead.")]
         public virtual void RunTransparentStatementVerification(byte[] transparentStatementCoseSign1Bytes) { }
@@ -247,6 +265,7 @@ namespace Azure.Security.CodeTransparency.Receipt
         public static readonly string ReceiptHeaderTreeAlgorithm;
         public static readonly string SupportedTreeAlgorithm;
         public CcfReceipt() { }
+        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
     }
     public partial class CcfReceiptVerifier
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/samples/Sample1_HelloWorld.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/samples/Sample1_HelloWorld.md
@@ -18,30 +18,38 @@ CodeTransparencyClient client = new(new Uri("https://<< service name >>.confiden
 
 ## Submit the file
 
-The most basic usage submits a valid signature file to the service. Accepting the submission is a long-running operation, so the response contains the operation ID.
+The most basic usage submits a valid signature file to the service. The response will contain the receipt bytes.
 
-```C# Snippet:CodeTransparencySubmission
+```C# Snippet:CodeTransparencySubmissionSyncReceipt
 CodeTransparencyClient client = new(new Uri("https://<< service name >>.confidential-ledger.azure.com"));
 FileStream fileStream = File.OpenRead("signature.cose");
 BinaryData content = BinaryData.FromStream(fileStream);
-Operation<BinaryData> operation = await client.CreateEntryAsync(WaitUntil.Started, content);
+bool waitForCommit = true;
+Response<BinaryData> receiptResponse = await client.CreateEntryAsync(content, waitForCommit);
 ```
 
-## Verify the operation was successful
+## Transparent statement
 
-To ensure the submission completes successfully, check the status of the operation. A successful operation means the service has accepted and countersigned the signed statement, which in turn allows you to obtain the cryptographic receipt.
+Once you have the receipt it can be added to the unprotected header of the signed statement to create a transparent statement. The embedded-receipts header value is a CBOR array of receipts. The transparent statement can be distributed to verify this registration.
 
-Checking the operation also returns an identifier (entry ID) used to retrieve the transparent statement or a transaction receipt.
-
-```C# Snippet:CodeTransparencySample1_WaitForResult
-Response<BinaryData> operationResult = await operation.WaitForCompletionAsync();
-string entryId = CborUtils.GetStringValueFromCborMapByKey(operationResult.Value.ToArray(), "EntryId");
-Console.WriteLine($"The entry ID to use to retrieve the receipt and transparent statement is {{{entryId}}}");
+```C# Snippet:CodeTransparencySample1_CreateStatement
+BinaryData receipt = receiptResponse.Value;
+// Add the receipt to the embedded-receipts unprotected header of the signed statement to create a transparent statement.
+CoseSign1Message signedStatement = CoseMessage.DecodeSign1(content.ToArray());
+CborWriter cborWriter = new CborWriter();
+cborWriter.WriteStartArray(1);
+cborWriter.WriteByteString(receipt.ToArray());
+cborWriter.WriteEndArray();
+signedStatement.UnprotectedHeaders[new CoseHeaderLabel(CcfReceipt.CoseHeaderEmbeddedReceipts)] =
+    CoseHeaderValue.FromEncodedValue(cborWriter.Encode());
+byte[] transparentStatement = signedStatement.Encode();
 ```
 
-## Download the transparent statement
+Alternatively you can use the entry ID to retrieve the transparent statement from the service. The entry ID (registration transaction id) can be extracted directly from the receipt, which works regardless of whether the service committed the entry inline or via a `303 See Other` redirect.
 
-Once the operation is complete, you can download the transparent statement so you can distribute it to verify this registration.
+```C# Snippet:CodeTransparencySample1_ExtractEntryId
+string entryId = CcfReceipt.GetRegistrationTransactionId(receipt.ToArray());
+```
 
 ```C# Snippet:CodeTransparencySample1_DownloadStatement
 Response<BinaryData> transparentStatementResponse = client.GetEntryStatement(entryId);

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -200,42 +200,16 @@ namespace Azure.Security.CodeTransparency
         /// <param name="body"> CoseSign1 signature envelope. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
+        [Obsolete("Use CreateEntry(BinaryData, bool, CancellationToken) instead.")]
         public virtual Operation<BinaryData> CreateEntry(WaitUntil waitUntil, BinaryData body, CancellationToken cancellationToken = default)
         {
-            using RequestContent content = body ?? throw new ArgumentNullException(nameof(body));
-            RequestContext context = cancellationToken.ToRequestContext();
+            Argument.AssertNotNull(body, nameof(body));
             using DiagnosticScope scope = ClientDiagnostics.CreateScope("CodeTransparencyClient.CreateEntry");
             scope.Start();
             try
             {
-                using HttpMessage message = CreateCreateEntryRequest(content, context);
-                Response response = Pipeline.ProcessMessage(message, context, cancellationToken);
-
-                string operationId = string.Empty;
-                try
-                {
-                    operationId = CborUtils.GetStringValueFromCborMapByKey(response.Content.ToArray(), "OperationId");
-                }
-                catch (Exception ex)
-                {
-                    throw new RequestFailedException("Failed to parse the Cbor response.", ex);
-                }
-
-                if (string.IsNullOrEmpty(operationId))
-                {
-                    throw new RequestFailedException(response);
-                }
-                else
-                {
-                    var entryOperation = new CreateEntryOperation(this, operationId);
-
-                    if (waitUntil == WaitUntil.Completed)
-                    {
-                        entryOperation.WaitForCompletionResponse(cancellationToken);
-                    }
-
-                    return entryOperation;
-                }
+                Response<BinaryData> response = CreateEntry(body, waitForCommit: true, cancellationToken);
+                return CreateCompletedEntryOperation(response.GetRawResponse());
             }
             catch (Exception e)
             {
@@ -249,48 +223,65 @@ namespace Azure.Security.CodeTransparency
         /// <param name="body"> CoseSign1 signature envelope. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="body"/> is null. </exception>
+        [Obsolete("Use CreateEntryAsync(BinaryData, bool, CancellationToken) instead.")]
         public virtual async Task<Operation<BinaryData>> CreateEntryAsync(WaitUntil waitUntil, BinaryData body, CancellationToken cancellationToken = default)
         {
-            using RequestContent content = body ?? throw new ArgumentNullException(nameof(body));
-            RequestContext context = cancellationToken.ToRequestContext();
+            Argument.AssertNotNull(body, nameof(body));
             using DiagnosticScope scope = ClientDiagnostics.CreateScope("CodeTransparencyClient.CreateEntryAsync");
             scope.Start();
             try
             {
-                using HttpMessage message = CreateCreateEntryRequest(content, context);
-                Response response = await Pipeline.ProcessMessageAsync(message, context, cancellationToken).ConfigureAwait(false);
-
-                string operationId = string.Empty;
-                try
-                {
-                    operationId = CborUtils.GetStringValueFromCborMapByKey(response.Content.ToArray(), "OperationId");
-                }
-                catch (Exception ex)
-                {
-                    throw new RequestFailedException("Failed to parse the Cbor response.", ex);
-                }
-
-                if (string.IsNullOrEmpty(operationId))
-                {
-                    throw new RequestFailedException(response);
-                }
-                else
-                {
-                    var entryOperation = new CreateEntryOperation(this, operationId);
-
-                    if (waitUntil == WaitUntil.Completed)
-                    {
-                        await entryOperation.WaitForCompletionResponseAsync(cancellationToken).ConfigureAwait(false);
-                    }
-
-                    return entryOperation;
-                }
+                Response<BinaryData> response = await CreateEntryAsync(body, waitForCommit: true, cancellationToken).ConfigureAwait(false);
+                return CreateCompletedEntryOperation(response.GetRawResponse());
             }
             catch (Exception e)
             {
                 scope.Failed(e);
                 throw;
             }
+        }
+
+        private static CreateEntryOperation CreateCompletedEntryOperation(Response rawResponse)
+        {
+            string entryId = GetEntryIdFromLocation(rawResponse);
+            BinaryData value = CreateEntryIdCborValue(entryId);
+            return new CreateEntryOperation(entryId, rawResponse, value);
+        }
+
+        private static string GetEntryIdFromLocation(Response response)
+        {
+            if (!response.Headers.TryGetValue("Location", out string location) || string.IsNullOrEmpty(location))
+            {
+                throw new RequestFailedException(response);
+            }
+
+            const string entriesSegment = "/entries/";
+            int index = location.LastIndexOf(entriesSegment, StringComparison.OrdinalIgnoreCase);
+            string entryId = index >= 0 ? location.Substring(index + entriesSegment.Length) : location;
+
+            int queryIndex = entryId.IndexOf('?');
+            if (queryIndex >= 0)
+            {
+                entryId = entryId.Substring(0, queryIndex);
+            }
+
+            entryId = entryId.Trim('/');
+            if (string.IsNullOrEmpty(entryId))
+            {
+                throw new RequestFailedException(response);
+            }
+
+            return entryId;
+        }
+
+        private static BinaryData CreateEntryIdCborValue(string entryId)
+        {
+            CborWriter writer = new CborWriter();
+            writer.WriteStartMap(1);
+            writer.WriteTextString("EntryId");
+            writer.WriteTextString(entryId);
+            writer.WriteEndMap();
+            return BinaryData.FromBytes(writer.Encode());
         }
 
         /// <summary>
@@ -662,70 +653,58 @@ namespace Azure.Security.CodeTransparency
             return message;
         }
 
-        // Backward-compatible wrapper methods delegating to the V09 generated methods.
+        // Pretty method names delegating to the V09 generated methods.
 
         /// <summary> Post an entry to be registered on the CodeTransparency instance. </summary>
-        [Obsolete("Use CreateEntryV09 instead.")]
         public virtual Response CreateEntry(RequestContent content, bool? waitForCommit = default, RequestContext context = null) => CreateEntryV09(content, waitForCommit, context);
 
         /// <summary> Post an entry to be registered on the CodeTransparency instance. </summary>
-        [Obsolete("Use CreateEntryV09Async instead.")]
         public virtual async Task<Response> CreateEntryAsync(RequestContent content, bool? waitForCommit = default, RequestContext context = null) => await CreateEntryV09Async(content, waitForCommit, context).ConfigureAwait(false);
 
         /// <summary> Post an entry to be registered on the CodeTransparency instance. </summary>
-        [Obsolete("Use CreateEntryV09 instead.")]
         public virtual Response<BinaryData> CreateEntry(BinaryData body, bool? waitForCommit = default, CancellationToken cancellationToken = default) => CreateEntryV09(body, waitForCommit, cancellationToken);
 
         /// <summary> Post an entry to be registered on the CodeTransparency instance. </summary>
-        [Obsolete("Use CreateEntryV09Async instead.")]
         public virtual async Task<Response<BinaryData>> CreateEntryAsync(BinaryData body, bool? waitForCommit = default, CancellationToken cancellationToken = default) => await CreateEntryV09Async(body, waitForCommit, cancellationToken).ConfigureAwait(false);
 
         /// <summary> Get receipt. </summary>
-        [Obsolete("Use GetEntryV09 instead.")]
         public virtual Response GetEntry(string entryId, RequestContext context) => GetEntryV09(entryId, context);
 
         /// <summary> Get receipt. </summary>
-        [Obsolete("Use GetEntryV09Async instead.")]
         public virtual async Task<Response> GetEntryAsync(string entryId, RequestContext context) => await GetEntryV09Async(entryId, context).ConfigureAwait(false);
 
         /// <summary> Get receipt. </summary>
-        [Obsolete("Use GetEntryV09 instead.")]
         public virtual Response<BinaryData> GetEntry(string entryId, CancellationToken cancellationToken = default) => GetEntryV09(entryId, cancellationToken);
 
         /// <summary> Get receipt. </summary>
-        [Obsolete("Use GetEntryV09Async instead.")]
         public virtual async Task<Response<BinaryData>> GetEntryAsync(string entryId, CancellationToken cancellationToken = default) => await GetEntryV09Async(entryId, cancellationToken).ConfigureAwait(false);
 
         /// <summary> Get the transparent statement. </summary>
-        [Obsolete("Use GetEntryStatementV09 instead.")]
         public virtual Response GetEntryStatement(string entryId, RequestContext context) => GetEntryStatementV09(entryId, context);
 
         /// <summary> Get the transparent statement. </summary>
-        [Obsolete("Use GetEntryStatementV09Async instead.")]
         public virtual async Task<Response> GetEntryStatementAsync(string entryId, RequestContext context) => await GetEntryStatementV09Async(entryId, context).ConfigureAwait(false);
 
         /// <summary> Get the transparent statement. </summary>
-        [Obsolete("Use GetEntryStatementV09 instead.")]
         public virtual Response<BinaryData> GetEntryStatement(string entryId, CancellationToken cancellationToken = default) => GetEntryStatementV09(entryId, cancellationToken);
 
         /// <summary> Get the transparent statement. </summary>
-        [Obsolete("Use GetEntryStatementV09Async instead.")]
         public virtual async Task<Response<BinaryData>> GetEntryStatementAsync(string entryId, CancellationToken cancellationToken = default) => await GetEntryStatementV09Async(entryId, cancellationToken).ConfigureAwait(false);
 
         /// <summary> Get operation status. </summary>
-        [Obsolete("Use GetOperationV09 instead.")]
+        [Obsolete("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Response GetOperation(string operationId, RequestContext context) => GetOperationV09(operationId, context);
 
         /// <summary> Get operation status. </summary>
-        [Obsolete("Use GetOperationV09Async instead.")]
+        [Obsolete("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual async Task<Response> GetOperationAsync(string operationId, RequestContext context) => await GetOperationV09Async(operationId, context).ConfigureAwait(false);
 
         /// <summary> Get operation status. </summary>
-        [Obsolete("Use GetOperationV09 instead.")]
+        [Obsolete("GetOperation is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual Response<BinaryData> GetOperation(string operationId, CancellationToken cancellationToken = default) => GetOperationV09(operationId, cancellationToken);
 
         /// <summary> Get operation status. </summary>
-        [Obsolete("Use GetOperationV09Async instead.")]
+        [Obsolete("GetOperationAsync is deprecated as it was removed from the recent IETF SCITT draft.")]
         public virtual async Task<Response<BinaryData>> GetOperationAsync(string operationId, CancellationToken cancellationToken = default) => await GetOperationV09Async(operationId, cancellationToken).ConfigureAwait(false);
 
         private static ResponseClassifier _responseClassifier200;

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -239,16 +239,42 @@ namespace Azure.Security.CodeTransparency
 
         private static CreateEntryOperation CreateCompletedEntryOperation(Response rawResponse)
         {
-            string entryId = GetEntryIdFromLocation(rawResponse);
+            // Prefer the Location header when the service committed the entry inline; otherwise the
+            // redirect policy followed the 303 See Other to the entry resource (consuming the
+            // Location header) and the entry id is recovered from the returned receipt.
+            string entryId = TryGetEntryIdFromLocation(rawResponse)
+                ?? CcfReceipt.GetRegistrationTransactionId(rawResponse.Content?.ToArray());
+
+            if (string.IsNullOrEmpty(entryId))
+            {
+                throw new RequestFailedException(rawResponse);
+            }
+
             BinaryData value = CreateEntryIdCborValue(entryId);
             return new CreateEntryOperation(entryId, rawResponse, value);
         }
 
-        private static string GetEntryIdFromLocation(Response response)
+        /// <summary>
+        /// Extracts the entry id from the Location header of a response.
+        /// </summary>
+        /// <param name="response">The response to extract the entry id from.</param>
+        /// <returns>The entry id.</returns>
+        public static string GetEntryIdFromLocation(Response response)
+        {
+            string entryId = TryGetEntryIdFromLocation(response);
+            if (string.IsNullOrEmpty(entryId))
+            {
+                throw new RequestFailedException(response);
+            }
+
+            return entryId;
+        }
+
+        private static string TryGetEntryIdFromLocation(Response response)
         {
             if (!response.Headers.TryGetValue("Location", out string location) || string.IsNullOrEmpty(location))
             {
-                throw new RequestFailedException(response);
+                return null;
             }
 
             const string entriesSegment = "/entries/";
@@ -262,12 +288,7 @@ namespace Azure.Security.CodeTransparency
             }
 
             entryId = entryId.Trim('/');
-            if (string.IsNullOrEmpty(entryId))
-            {
-                throw new RequestFailedException(response);
-            }
-
-            return entryId;
+            return string.IsNullOrEmpty(entryId) ? null : entryId;
         }
 
         private static BinaryData CreateEntryIdCborValue(string entryId)

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -22,10 +22,6 @@ namespace Azure.Security.CodeTransparency
     [CodeGenSuppress("CreateEntryAsync", typeof(BinaryData), typeof(CancellationToken))]
     [CodeGenSuppress("CreateGetTransparencyConfigCborRequest", typeof(RequestContext))]
     [CodeGenSuppress("CreateGetPublicKeysRequest", typeof(RequestContext))]
-    [CodeGenSuppress("CreateGetOperationRequest", typeof(string), typeof(RequestContext))]
-    [CodeGenSuppress("CreateGetEntryRequest", typeof(string), typeof(RequestContext))]
-    [CodeGenSuppress("CreateGetEntryStatementRequest", typeof(string), typeof(RequestContext))]
-    [CodeGenSuppress("CreateCreateEntryRequest", typeof(RequestContent), typeof(RequestContext))]
     public partial class CodeTransparencyClient
     {
         /// <summary>
@@ -588,68 +584,6 @@ namespace Azure.Security.CodeTransparency
             uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
-            return message;
-        }
-
-        internal HttpMessage CreateCreateEntryRequest(RequestContent content, RequestContext context)
-        {
-            var message = Pipeline.CreateMessage(context, ResponseClassifier201202);
-            var request = message.Request;
-            request.Method = RequestMethod.Post;
-            var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
-            uri.AppendPath("/entries", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/cose; application/cbor");
-            request.Headers.Add("Content-Type", "application/cose");
-            request.Content = content;
-            return message;
-        }
-
-        internal HttpMessage CreateGetOperationRequest(string operationId, RequestContext context)
-        {
-            var message = Pipeline.CreateMessage(context, PipelineMessageClassifier200202);
-            var request = message.Request;
-            request.Method = RequestMethod.Get;
-            var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
-            uri.AppendPath("/operations/", false);
-            uri.AppendPath(operationId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/cbor");
-            return message;
-        }
-
-        internal HttpMessage CreateGetEntryRequest(string entryId, RequestContext context)
-        {
-            var message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
-            var request = message.Request;
-            request.Method = RequestMethod.Get;
-            var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
-            uri.AppendPath("/entries/", false);
-            uri.AppendPath(entryId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/cose");
-            return message;
-        }
-
-        internal HttpMessage CreateGetEntryStatementRequest(string entryId, RequestContext context)
-        {
-            var message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
-            var request = message.Request;
-            request.Method = RequestMethod.Get;
-            var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
-            uri.AppendPath("/entries/", false);
-            uri.AppendPath(entryId, true);
-            uri.AppendPath("/statement", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/cose");
             return message;
         }
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -11,17 +11,20 @@ using Azure.Core.Pipeline;
 namespace Azure.Security.CodeTransparency
 {
     /// <summary>
-    /// An <see cref="HttpPipelinePolicy"/> that follows HTTP 307 and 308 redirect responses
+    /// An <see cref="HttpPipelinePolicy"/> that follows HTTP 303, 307 and 308 redirect responses
     /// while preserving the Authorization header, but only when the redirect target stays
     /// within the configured endpoint's trust boundary.
     /// </summary>
     /// <remarks>
     /// <para>
     /// Code Transparency Service nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect)
-    /// responses to route write operations to the primary node. The standard redirect behavior in .NET
+    /// responses to route write operations to the primary node, and 303 (See Other) responses to point
+    /// a completed write at the created resource (for example, the committed entry that carries the
+    /// receipt). The standard redirect behavior in .NET
     /// strips the Authorization header on cross-domain redirects for security reasons. This policy
     /// preserves the Authorization header for redirects to trusted targets — the configured endpoint
-    /// host or a subdomain of it on HTTPS with the same port.
+    /// host or a subdomain of it on HTTPS with the same port. A 303 redirect is followed with a GET
+    /// request and without the original request body, per HTTP semantics.
     /// </para>
     /// <para>
     /// Redirects to untrusted targets are refused by throwing <see cref="InvalidOperationException"/>
@@ -35,6 +38,7 @@ namespace Azure.Security.CodeTransparency
     internal sealed class CodeTransparencyRedirectPolicy : HttpPipelinePolicy
     {
         private const int MaxRedirects = 5;
+        private const int SeeOtherStatusCode = 303;
 
         /// <summary>
         /// Status codes that must never cause a cache commit. Broader than
@@ -146,10 +150,28 @@ namespace Azure.Security.CodeTransparency
                         $"Confidential Ledger refused to follow redirect to untrusted target origin: {origin}");
                 }
 
-                // Stage cache candidate for non-GET trusted hops.
-                if (message.Request.Method != RequestMethod.Get)
+                // A 303 See Other instructs the client to retrieve the redirect target with a
+                // GET request and without the original request body. This is a resource redirect
+                // (for example, from a completed write to the created entry), not a primary-node redirect.
+                bool isSeeOther = message.Response.Status == SeeOtherStatusCode;
+
+                // Stage cache candidate for non-GET trusted hops. A 303 must not update the
+                // primary-node cache because its target is a resource, not a primary node.
+                if (!isSeeOther && message.Request.Method != RequestMethod.Get)
                 {
                     pendingCacheUri = GetPrimaryNodeBaseUri(redirectUri);
+                }
+
+                if (isSeeOther)
+                {
+                    message.Request.Method = RequestMethod.Get;
+                    message.Request.Content = null;
+                    message.Request.Headers.Remove("Content-Type");
+
+                    // The followed GET returns the target resource (for example, 200 with the
+                    // entry receipt), a status the request's original classifier does not recognize.
+                    // Apply standard success semantics (2xx succeeds) to the followed response.
+                    message.ResponseClassifier = FollowedRedirectResponseClassifier.Instance;
                 }
 
                 // Preserve the Authorization header on trusted redirects.
@@ -257,7 +279,7 @@ namespace Azure.Security.CodeTransparency
 
         private static bool IsRedirectResponse(int statusCode)
         {
-            return statusCode == 307 || statusCode == 308;
+            return statusCode == SeeOtherStatusCode || statusCode == 307 || statusCode == 308;
         }
 
         private static Uri BuildRedirectUri(Uri requestUri, string location)
@@ -330,6 +352,23 @@ namespace Azure.Security.CodeTransparency
             };
 
             return builder.Uri;
+        }
+
+        /// <summary>
+        /// Classifies the response of a followed 303 See Other redirect using standard HTTP
+        /// semantics: any 2xx status is a success, everything else is an error. This replaces
+        /// the originating request's classifier, which only recognizes the pre-redirect status
+        /// codes (for example, 201/303 for a write).
+        /// </summary>
+        private sealed class FollowedRedirectResponseClassifier : ResponseClassifier
+        {
+            public static readonly FollowedRedirectResponseClassifier Instance = new FollowedRedirectResponseClassifier();
+
+            public override bool IsErrorResponse(HttpMessage message)
+            {
+                int status = message.Response.Status;
+                return status < 200 || status >= 300;
+            }
         }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CreateEntryOperation.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CreateEntryOperation.cs
@@ -18,6 +18,7 @@ namespace Azure.Security.CodeTransparency
     {
         private readonly CodeTransparencyClient _client;
         private readonly OperationInternal _operationInternal;
+        private readonly BinaryData _value;
 
         /// <summary>
         /// A constructor for mocking.
@@ -35,6 +36,20 @@ namespace Azure.Security.CodeTransparency
             _client = client;
             Id = operationId;
             _operationInternal = new(this, _client.ClientDiagnostics, rawResponse: null, nameof(CreateEntryOperation));
+        }
+
+        /// <summary>
+        /// Initializes a completed operation for an entry that has already been committed by the service
+        /// (for example, when the entry was created with waitForCommit set to true).
+        /// </summary>
+        /// <param name="entryId"> The id of the committed entry. </param>
+        /// <param name="rawResponse"> The final response returned by the create entry call. </param>
+        /// <param name="value"> The value exposed by the completed operation. </param>
+        public CreateEntryOperation(string entryId, Response rawResponse, BinaryData value)
+        {
+            Id = entryId;
+            _value = value;
+            _operationInternal = OperationInternal.Succeeded(rawResponse);
         }
 
         /// <summary>
@@ -60,7 +75,7 @@ namespace Azure.Security.CodeTransparency
         public override bool HasValue => _operationInternal.HasCompleted && _operationInternal.RawResponse != null;
 
         /// <inheritdoc />
-        public override BinaryData Value => _operationInternal.RawResponse.Content;
+        public override BinaryData Value => _value ?? _operationInternal.RawResponse.Content;
 
         // Part of IOperation which is used in _operationInternal
         async ValueTask<OperationState> IOperation.UpdateStateAsync(bool async, CancellationToken cancellationToken)

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Receipt/CcfReceipt.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Receipt/CcfReceipt.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Formats.Cbor;
+using System.Security.Cryptography.Cose;
 
 // cspell:ignore bstr
 namespace Azure.Security.CodeTransparency.Receipt
@@ -76,6 +77,67 @@ namespace Azure.Security.CodeTransparency.Receipt
         /// Protected header key for the tree algorithm
         /// </summary>
         public static readonly int CcfTreeAlgLabel = 2;
+
+        /// <summary>
+        /// Extracts the registration transaction id (the entry id) from a raw CCF SCITT receipt.
+        /// The id is encoded in the internal-evidence field of the inclusion proof leaf as the
+        /// second ':'-separated field (for example, <c>ce:2.15:...</c> yields <c>2.15</c>).
+        /// </summary>
+        /// <param name="receiptCoseSign1Bytes">The receipt as COSE_Sign1 cbor bytes.</param>
+        /// <returns>The registration transaction id, or <c>null</c> if it cannot be found.</returns>
+        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes)
+        {
+            if (receiptCoseSign1Bytes == null || receiptCoseSign1Bytes.Length == 0)
+            {
+                return null;
+            }
+
+            CoseSign1Message receipt;
+            try
+            {
+                receipt = CoseMessage.DecodeSign1(receiptCoseSign1Bytes);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            // The verifiable data proof (inclusion proof) lives in the unprotected headers.
+            if (!receipt.UnprotectedHeaders.TryGetValue(new CoseHeaderLabel(CosePhdrVdpLabel), out CoseHeaderValue vdp))
+            {
+                return null;
+            }
+
+            Dictionary<int, byte[]> proof = ReadCborMap(new CborReader(vdp.EncodedValue.ToArray()));
+            if (!proof.TryGetValue(CoseReceiptInclusionProofLabel, out byte[] proofs) || proofs == null || proofs.Length == 0)
+            {
+                return null;
+            }
+
+            // The inclusion proofs are a cbor array of bstr; use the first one.
+            CborReader proofsReader = new CborReader(proofs);
+            proofsReader.ReadStartArray();
+            if (proofsReader.PeekState() == CborReaderState.EndArray)
+            {
+                return null;
+            }
+            byte[] inclusionProofBytes = proofsReader.ReadByteString();
+
+            Dictionary<int, byte[]> inclusionProof = ReadCborMap(new CborReader(inclusionProofBytes));
+            if (!inclusionProof.TryGetValue(CcfProofLeafLabel, out byte[] leafBytes))
+            {
+                return null;
+            }
+
+            Leaf leaf = GetLeaf(leafBytes);
+            if (string.IsNullOrEmpty(leaf.InternalEvidence))
+            {
+                return null;
+            }
+
+            string[] parts = leaf.InternalEvidence.Split(':');
+            return parts.Length >= 2 ? parts[1] : null;
+        }
 
         internal static Dictionary<int, byte[]> ReadCborMap(CborReader reader)
         {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CcfReceiptVerifierTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CcfReceiptVerifierTests.cs
@@ -107,5 +107,23 @@ namespace Azure.Security.CodeTransparency.Tests
             StringAssert.Contains(expected: "Claim digest mismatch", exception.Message);
 #endif
         }
+
+        [Test]
+        public void GetRegistrationTransactionId_ReturnsEntryIdFromReceipt()
+        {
+            byte[] receiptBytes = readFileBytes("receipt.cose");
+
+            string entryId = CcfReceipt.GetRegistrationTransactionId(receiptBytes);
+
+            Assert.AreEqual("8.198", entryId);
+        }
+
+        [Test]
+        public void GetRegistrationTransactionId_ReturnsNullForInvalidInput()
+        {
+            Assert.IsNull(CcfReceipt.GetRegistrationTransactionId(null));
+            Assert.IsNull(CcfReceipt.GetRegistrationTransactionId(Array.Empty<byte>()));
+            Assert.IsNull(CcfReceipt.GetRegistrationTransactionId(new byte[] { 0x01, 0x02, 0x03 }));
+        }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -156,23 +156,12 @@ namespace Azure.Security.CodeTransparency.Tests
         [Test]
         public async Task CreateEntryAsync_sendsBytes_receives_bytes()
         {
-            // Create a CBOR writer
-            var writer = new CborWriter();
-
-            // Write a CBOR map with sample content
-            writer.WriteStartMap(2);
-            writer.WriteTextString("OperationId");
-            writer.WriteTextString("12.345");
-            writer.WriteTextString("Status");
-            writer.WriteTextString("Succeeded");
-            writer.WriteEndMap();
-
-            // Get the CBOR encoded bytes
-            byte[] cborBytes = writer.Encode();
-
+            // With waitForCommit the service returns the committed entry; the entry id comes
+            // from the Location header and the returned operation is already completed.
             var mockedResponse = new MockResponse(201);
             mockedResponse.AddHeader("Content-Type", "application/cose");
-            mockedResponse.SetContent(cborBytes);
+            mockedResponse.AddHeader("Location", "https://foo.bar.com/entries/12.345");
+            mockedResponse.SetContent(new byte[] { 0x01, 0x02, 0x03 });
             var mockTransport = new MockTransport(mockedResponse);
             var options = new CodeTransparencyClientOptions
             {
@@ -184,30 +173,18 @@ namespace Azure.Security.CodeTransparency.Tests
             BinaryData content = BinaryData.FromString("Hello World!");
             Operation<BinaryData> response = await client.CreateEntryAsync(WaitUntil.Started, content);
 
-            Assert.AreEqual("https://foo.bar.com/entries?api-version=2026-03-26", mockTransport.Requests[0].Uri.ToString());
-            Assert.AreEqual(false, response.HasCompleted);
+            Assert.AreEqual("https://foo.bar.com/entries?api-version=2026-03-26&waitForCommit=true", mockTransport.Requests[0].Uri.ToString());
+            Assert.IsTrue(response.HasCompleted);
             Assert.AreEqual("12.345", response.Id);
         }
 
         [Test]
         public async Task CreateEntryAsync_request_accepted()
         {
-            // Create a CBOR writer
-            var writer = new CborWriter();
-
-            // Write a CBOR map with sample content
-            writer.WriteStartMap(2);
-            writer.WriteTextString("OperationId");
-            writer.WriteTextString("12.345");
-            writer.WriteTextString("Status");
-            writer.WriteTextString("Succeeded");
-            writer.WriteEndMap();
-
-            // Get the CBOR encoded bytes
-            byte[] cborBytes = writer.Encode();
-
-            var mockedResponse = new MockResponse(202);
-            mockedResponse.SetContent(cborBytes);
+            // The create request is sent with waitForCommit=true and the service responds with
+            // the committed entry location, producing an already-completed operation.
+            var mockedResponse = new MockResponse(201);
+            mockedResponse.AddHeader("Location", "https://foo.bar.com/entries/12.345");
             var mockTransport = new MockTransport(mockedResponse);
             var options = new CodeTransparencyClientOptions
             {
@@ -219,28 +196,17 @@ namespace Azure.Security.CodeTransparency.Tests
             BinaryData content = BinaryData.FromString("Hello World!");
             Operation<BinaryData> response = await client.CreateEntryAsync(WaitUntil.Started, content);
 
-            Assert.AreEqual("https://foo.bar.com/entries?api-version=2026-03-26", mockTransport.Requests[0].Uri.ToString());
+            Assert.AreEqual("https://foo.bar.com/entries?api-version=2026-03-26&waitForCommit=true", mockTransport.Requests[0].Uri.ToString());
             Assert.AreEqual(1, mockTransport.Requests.Count);
-            Assert.AreEqual(false, response.HasCompleted);
+            Assert.IsTrue(response.HasCompleted);
             Assert.AreEqual("12.345", response.Id);
         }
 
         [Test]
         public async Task CreateEntryAsync_unsuccessful_post_success_after_retry()
         {
-            // Create a CBOR writer
-            var writer = new CborWriter();
-
-            // Write a CBOR map with sample content
-            writer.WriteStartMap(2);
-            writer.WriteTextString("OperationId");
-            writer.WriteTextString("12.345");
-            writer.WriteTextString("Status");
-            writer.WriteTextString("Running");
-            writer.WriteEndMap();
-
             var mockedResponse = new MockResponse(201);
-            mockedResponse.SetContent(writer.Encode());
+            mockedResponse.AddHeader("Location", "https://foo.bar.com/entries/12.345");
 
             var mockTransport = new MockTransport(new MockResponse(503), mockedResponse);
             var options = new CodeTransparencyClientOptions
@@ -253,55 +219,19 @@ namespace Azure.Security.CodeTransparency.Tests
             Operation<BinaryData> response = await client.CreateEntryAsync(WaitUntil.Started, content);
 
             Assert.AreEqual(2, mockTransport.Requests.Count);
-            Assert.AreEqual("https://foo.bar.com/entries?api-version=2026-03-26", mockTransport.Requests[1].Uri.ToString());
+            Assert.AreEqual("https://foo.bar.com/entries?api-version=2026-03-26&waitForCommit=true", mockTransport.Requests[1].Uri.ToString());
             Assert.AreEqual("12.345", response.Id);
         }
 
         [Test]
         public async Task CreateEntryAsync_waits_for_operation_success()
         {
-            // Create a CBOR writer
-            var createCborWriter = new CborWriter();
-
-            // Write a CBOR map with sample content
-            createCborWriter.WriteStartMap(1);
-            createCborWriter.WriteTextString("OperationId");
-            createCborWriter.WriteTextString("123.45");
-            createCborWriter.WriteEndMap();
-
+            // With waitForCommit the create call returns an already-completed operation whose
+            // value is a CBOR map containing the committed entry id (taken from the Location header).
             var createResponse = new MockResponse(201);
-            createResponse.SetContent(createCborWriter.Encode());
+            createResponse.AddHeader("Location", "https://foo.bar.com/entries/123.23");
 
-            // Create a CBOR writer
-            var cborWriter = new CborWriter();
-
-            // Write a CBOR map with sample content
-            cborWriter.WriteStartMap(2);
-            cborWriter.WriteTextString("OperationId");
-            cborWriter.WriteTextString("1.345");
-            cborWriter.WriteTextString("Status");
-            cborWriter.WriteTextString("Running");
-            cborWriter.WriteEndMap();
-
-            var pendingResponse = new MockResponse(202);
-            pendingResponse.SetContent(cborWriter.Encode());
-
-            var succeededCborWriter = new CborWriter();
-
-            // Write a CBOR map with sample content
-            succeededCborWriter.WriteStartMap(3);
-            succeededCborWriter.WriteTextString("OperationId");
-            succeededCborWriter.WriteTextString("1.345");
-            succeededCborWriter.WriteTextString("EntryId");
-            succeededCborWriter.WriteTextString("123.23");
-            succeededCborWriter.WriteTextString("Status");
-            succeededCborWriter.WriteTextString("Succeeded");
-            succeededCborWriter.WriteEndMap();
-
-            var succeededResponse = new MockResponse(202);
-            succeededResponse.SetContent(succeededCborWriter.Encode());
-
-            var mockTransport = new MockTransport(createResponse, pendingResponse, succeededResponse);
+            var mockTransport = new MockTransport(createResponse);
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
@@ -312,51 +242,22 @@ namespace Azure.Security.CodeTransparency.Tests
             Operation<BinaryData> result = await client.CreateEntryAsync(WaitUntil.Started, BinaryData.FromString("Hello World!"));
 
             Assert.NotNull(result);
-
-            Response<BinaryData> response = await result.WaitForCompletionAsync();
-            BinaryData value = response.Value;
-
-            CborReader cborReader = new CborReader(value);
-            cborReader.ReadStartMap();
-            while (cborReader.PeekState() != CborReaderState.EndMap)
-            {
-                string key = cborReader.ReadTextString();
-                if (key == "Status")
-                {
-                    Assert.AreEqual(expected: "Succeeded", cborReader.ReadTextString());
-                }
-                else if (key == "OperationId")
-                {
-                    Assert.AreEqual(expected: "1.345", cborReader.ReadTextString());
-                }
-                else if (key == "EntryId")
-                {
-                    Assert.AreEqual(expected: "123.23", cborReader.ReadTextString());
-                }
-            }
-            cborReader.ReadEndMap();
-
-            Assert.AreEqual(3, mockTransport.Requests.Count);
             Assert.IsTrue(result.HasCompleted);
             Assert.IsTrue(result.HasValue);
+            Assert.AreEqual("123.23", result.Id);
+
+            Response<BinaryData> response = await result.WaitForCompletionAsync();
+            string entryId = CborUtils.GetStringValueFromCborMapByKey(response.Value.ToArray(), "EntryId");
+            Assert.AreEqual("123.23", entryId);
+
+            Assert.AreEqual(1, mockTransport.Requests.Count);
         }
 
         [Test]
         public void CreateEntry_ShouldReturnResponse()
         {
-            // Create a CBOR writer
-            var writer = new CborWriter();
-
-            // Write a CBOR map with sample content
-            writer.WriteStartMap(2);
-            writer.WriteTextString("OperationId");
-            writer.WriteTextString("12.345");
-            writer.WriteTextString("Status");
-            writer.WriteTextString("Running");
-            writer.WriteEndMap();
-
             var mockedResponse = new MockResponse(201);
-            mockedResponse.SetContent(writer.Encode());
+            mockedResponse.AddHeader("Location", "https://foo.bar.com/entries/12.345");
 
             var mockTransport = new MockTransport(mockedResponse);
             var options = new CodeTransparencyClientOptions
@@ -369,7 +270,8 @@ namespace Azure.Security.CodeTransparency.Tests
             Operation<BinaryData> result = client.CreateEntry(WaitUntil.Started, BinaryData.FromString("test-body"));
 
             Assert.AreEqual(1, mockTransport.Requests.Count);
-            Assert.IsFalse(result.HasCompleted);
+            Assert.IsTrue(result.HasCompleted);
+            Assert.AreEqual("12.345", result.Id);
         }
 
         [Test]

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
@@ -90,7 +90,63 @@ namespace Azure.Security.CodeTransparency.Tests
         }
 
         [Test]
-        public async Task DoesNotFollowNonRedirectStatusCodes([Values(200, 201, 400, 404, 500, 301, 302, 303)] int statusCode)
+        public async Task Follows303RedirectWithinDomainAsGetWithoutBody()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(303).AddHeader("Location", "https://myledger.confidential-ledger.azure.com/entries/123"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/entries"));
+                message.Request.Content = RequestContent.Create(new byte[] { 1, 2, 3 });
+                message.Request.Headers.SetValue("Content-Type", "application/cose");
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual("https://myledger.confidential-ledger.azure.com/entries/123", mockTransport.Requests[1].Uri.ToString());
+            // A 303 See Other must be followed with GET and without the original body.
+            Assert.AreEqual(RequestMethod.Get, mockTransport.Requests[1].Method);
+            Assert.IsNull(mockTransport.Requests[1].Content);
+        }
+
+        [Test]
+        public async Task Follows303RedirectToTrustedSubdomain()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(303).AddHeader("Location", "https://primary-node.myledger.confidential-ledger.azure.com/entries/123"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/entries"));
+            }, new CodeTransparencyRedirectPolicy(s_endpoint));
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual(RequestMethod.Get, mockTransport.Requests[1].Method);
+        }
+
+        [Test]
+        public void RefusesToFollow303RedirectToUntrustedDomain()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(303).AddHeader("Location", "https://other.host/entries/123"),
+                new MockResponse(200));
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await SendRequestAsync(mockTransport, message =>
+                {
+                    message.Request.Method = RequestMethod.Post;
+                    message.Request.Uri.Reset(new Uri("https://myledger.confidential-ledger.azure.com/entries"));
+                }, new CodeTransparencyRedirectPolicy(s_endpoint)));
+        }
+
+        [Test]
+        public async Task DoesNotFollowNonRedirectStatusCodes([Values(200, 201, 400, 404, 500, 301, 302)] int statusCode)
         {
             var mockTransport = new MockTransport(
                 new MockResponse(statusCode).AddHeader("Location", "https://other.host/"),

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
@@ -51,38 +51,16 @@ namespace Azure.Security.CodeTransparency.Tests
         [Test]
         public async Task Snippet_Readme_CodeTransparencySubmission_Test()
         {
-            // Create a CBOR writer
-            var createCborWriter = new CborWriter();
-
-            // Write a CBOR map with sample content
-            createCborWriter.WriteStartMap(1);
-            createCborWriter.WriteTextString("OperationId");
-            createCborWriter.WriteTextString("123.45");
-            createCborWriter.WriteEndMap();
-
+            // With waitForCommit the create call returns the committed entry; the entry id is
+            // taken from the Location header and the returned operation is already completed.
             var createResponse = new MockResponse(201);
-            createResponse.SetContent(createCborWriter.Encode());
+            createResponse.AddHeader("Location", "https://foo.bar.com/entries/123.23");
 
-            var succeededCborWriter = new CborWriter();
+            var statementResponse = new MockResponse(200);
+            statementResponse.AddHeader("Content-Type", "application/cose");
+            statementResponse.SetContent(new byte[] { 0x01, 0x02, 0x03 });
 
-            // Write a CBOR map with sample content
-            succeededCborWriter.WriteStartMap(3);
-            succeededCborWriter.WriteTextString("OperationId");
-            succeededCborWriter.WriteTextString("1.345");
-            succeededCborWriter.WriteTextString("EntryId");
-            succeededCborWriter.WriteTextString("123.23");
-            succeededCborWriter.WriteTextString("Status");
-            succeededCborWriter.WriteTextString("Succeeded");
-            succeededCborWriter.WriteEndMap();
-
-            var succeededResponse = new MockResponse(202);
-            succeededResponse.SetContent(succeededCborWriter.Encode());
-
-            var entryResponse = new MockResponse(200);
-            entryResponse.AddHeader("Content-Type", "application/cose");
-            entryResponse.SetContent(new byte[] { 0x01, 0x02, 0x03 });
-
-            var mockTransport = new MockTransport(createResponse, succeededResponse, entryResponse, entryResponse);
+            var mockTransport = new MockTransport(createResponse, statementResponse);
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
@@ -87,11 +87,9 @@ namespace Azure.Security.CodeTransparency.Tests
             #endregion Snippet:CodeTransparencySubmission
 
             #region Snippet:CodeTransparencyDownloadTransparentStatement
-            #region Snippet:CodeTransparencySample1_WaitForResult
             Response<BinaryData> operationResult = await operation.WaitForCompletionAsync();
             string entryId = CborUtils.GetStringValueFromCborMapByKey(operationResult.Value.ToArray(), "EntryId");
             Console.WriteLine($"The entry ID to use to retrieve the receipt and transparent statement is {{{entryId}}}");
-            #endregion Snippet:CodeTransparencySample1_WaitForResult
             #region Snippet:CodeTransparencySample2_GetEntryStatement
             Response<BinaryData> transparentStatementResponse = await client.GetEntryStatementAsync(entryId);
             byte[] transparentStatementBytes = transparentStatementResponse.Value.ToArray();
@@ -112,6 +110,66 @@ namespace Azure.Security.CodeTransparency.Tests
             Response<BinaryData> transparentStatementResponse = client.GetEntryStatement(entryId);
 #endif
             #endregion Snippet:CodeTransparencySample1_DownloadStatement
+        }
+
+        [Test]
+        public async Task Snippet_Sample1_HelloWorld_SyncReceipt_Test()
+        {
+            byte[] receiptBytes = readFileBytes("receipt.cose");
+            byte[] signedStatementBytes = readFileBytes("input_signed_claims");
+
+            var createResponse = new MockResponse(201);
+            createResponse.AddHeader("Content-Type", "application/cose");
+            createResponse.AddHeader("Location", "https://foo.bar.com/entries/8.198");
+            createResponse.SetContent(receiptBytes);
+
+            var statementResponse = new MockResponse(200);
+            statementResponse.AddHeader("Content-Type", "application/cose");
+            statementResponse.SetContent(new byte[] { 0x01, 0x02, 0x03 });
+
+            var mockTransport = new MockTransport(createResponse, statementResponse);
+            var options = new CodeTransparencyClientOptions
+            {
+                Transport = mockTransport,
+                IdentityClientEndpoint = "https://foo.bar.com"
+            };
+
+            #region Snippet:CodeTransparencySubmissionSyncReceipt
+#if !SNIPPET
+            CodeTransparencyClient client = new(new Uri("https://foo.bar.com"), options);
+            BinaryData content = BinaryData.FromBytes(signedStatementBytes);
+#endif
+#if SNIPPET
+            CodeTransparencyClient client = new(new Uri("https://<< service name >>.confidential-ledger.azure.com"));
+            FileStream fileStream = File.OpenRead("signature.cose");
+            BinaryData content = BinaryData.FromStream(fileStream);
+#endif
+            bool waitForCommit = true;
+            Response<BinaryData> receiptResponse = await client.CreateEntryAsync(content, waitForCommit);
+            #endregion Snippet:CodeTransparencySubmissionSyncReceipt
+
+            #region Snippet:CodeTransparencySample1_CreateStatement
+            BinaryData receipt = receiptResponse.Value;
+            // Add the receipt to the embedded-receipts unprotected header of the signed statement to create a transparent statement.
+            CoseSign1Message signedStatement = CoseMessage.DecodeSign1(content.ToArray());
+            CborWriter cborWriter = new CborWriter();
+            cborWriter.WriteStartArray(1);
+            cborWriter.WriteByteString(receipt.ToArray());
+            cborWriter.WriteEndArray();
+            signedStatement.UnprotectedHeaders[new CoseHeaderLabel(CcfReceipt.CoseHeaderEmbeddedReceipts)] =
+                CoseHeaderValue.FromEncodedValue(cborWriter.Encode());
+            byte[] transparentStatement = signedStatement.Encode();
+            #endregion Snippet:CodeTransparencySample1_CreateStatement
+
+            #region Snippet:CodeTransparencySample1_ExtractEntryId
+            string entryId = CcfReceipt.GetRegistrationTransactionId(receipt.ToArray());
+            #endregion Snippet:CodeTransparencySample1_ExtractEntryId
+
+            Response<BinaryData> transparentStatementResponse = client.GetEntryStatement(entryId);
+
+            Assert.AreEqual("8.198", entryId);
+            Assert.IsNotNull(transparentStatement);
+            Assert.IsNotNull(transparentStatementResponse.Value);
         }
 
         [Test]

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tsp-location.yaml
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/confidentialledger/Microsoft.CodeTransparency
-commit: f2444a9c1e033c9cbde367d7b708eca303311c98
+commit: 5b7d94b2e640022323b5da6dbf568f2fdfca2ab8
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 
 


### PR DESCRIPTION
1. Trying to release the stable version but the CI complains with 2 errors:

    - Please ensure to set a release date with format 'yyyy-MM-dd'. See https://aka.ms/azsdk/guideline/changelogs for more info
    - Commit f2444a9c1e033c9cbde367d7b708eca303311c98 doesn't exist in 'main' branch of Azure/azure-rest-api-specs repository. ServiceDir:confidentialledger, PackageName:Azure.Security.CodeTransparency, please check the config file:D:\a\_work\1\s\sdk\confidentialledger\Azure.Security.CodeTransparency\tsp-location.yaml. The spec used to release SDK should be from the main branch of Azure/azure-rest-api-specs repository

    To address I set the version to today and the commit ID to point to the merge commit in the main branch when stable API was merged. The commit apparently points to another repo where the PR originated from hence the error.

2. Backwards compatibility is broken. Update the methods used currently by various teams to make sure they can work with the changed API.
    - Update hello world sample to reflect the changed code
    - Use the new API to submit the statement and create a synthetic operation object as a response
4. Remove some dead code and update incorrect "Obsolete" annotations
5. Update redirect policy to be able to get the receipt after the 303 redirect as otherwise the existing SDK policy would not do it

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
