### PR TITLE
Remove duplicate template CI trigger block

### DIFF
--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -26,13 +26,6 @@ trigger:
     - eng/common/
 #endif
 
-#if (false)
-    # The following paths should only be included in template/ci.yml, and removed from any other SDKs which copy this file.
-    # The surrounding conditions should accomplish that when installed with `dotnet new azsdk`.
-    # eng/common code changes trigger template pipeline for basic checking.
-    - eng/common/
-#endif
-
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -1,5 +1,5 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
-
+# test comment
 parameters:
   - name: ReleaseToDevOpsOnly
     displayName: 'Release package to DevOps feed instead of Nuget.org'


### PR DESCRIPTION
## Summary
- Remove the duplicate template-only `eng/common/` CI trigger block from `sdk/template/ci.yml`.
- Add a test comment near the top of the template CI file.