### PR TITLE
Remove test comment from template CI

### DIFF
--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -1,5 +1,4 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
-# test comment
 parameters:
   - name: ReleaseToDevOpsOnly
     displayName: 'Release package to DevOps feed instead of Nuget.org'


### PR DESCRIPTION
## Summary
- Remove the temporary test comment from `sdk/template/ci.yml`.
- To test the 'auto-release' flow.