### PR TITLE
Prepare ServiceFabric provisioning release

### DIFF
--- a/sdk/servicefabric/Azure.Provisioning.ServiceFabric/CHANGELOG.md
+++ b/sdk/servicefabric/Azure.Provisioning.ServiceFabric/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2026-07-10)
 
 ### Features Added
 


### PR DESCRIPTION
Updates `Azure.Provisioning.ServiceFabric` release date to `2026-07-10` for the first beta release after onboarding.

Validation: changelog-only change.
