### PR TITLE
Improve provisioning name requirement generation

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -689,16 +689,7 @@ namespace Azure.Generator.Provisioning.Providers
             int minLength = constraints.MinLength ?? 1;
             int maxLength = constraints.MaxLength ?? 24;
 
-            // Parse valid characters from pattern, or use conservative default
-            var validCharacters = constraints.Pattern != null
-                ? constraints.Pattern.ParsePatternToResourceNameCharacters()
-                : ResourceNameCharacters.LowercaseLetters;
-
-            // If parsing produced no characters, fall back to conservative default
-            if (validCharacters == (ResourceNameCharacters)0)
-            {
-                validCharacters = ResourceNameCharacters.LowercaseLetters;
-            }
+            var validCharacters = constraints.ToResourceNameCharacters();
 
             // Build the flags expression by OR-ing the individual flag values
             ValueExpression flagsExpression = BuildResourceNameCharactersExpression(validCharacters);

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/ResourceNameConstraintsHelper.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/ResourceNameConstraintsHelper.cs
@@ -46,64 +46,61 @@ internal static class ResourceNameConstraintsHelper
                 return AllKnownCharacters;
             }
 
-            var parsed = constraints.Pattern.ParsePatternToResourceNameCharacters();
+            var parsed = ParsePatternToResourceNameCharacters(constraints.Pattern);
             return parsed == 0 ? AllKnownCharacters : parsed;
         }
     }
 
-    extension(string pattern)
+    /// <summary>
+    /// Converts a regex pattern string into <see cref="ResourceNameCharacters"/> flags
+    /// by extracting all character classes from the pattern and testing representative
+    /// characters against them.
+    /// </summary>
+    private static ResourceNameCharacters ParsePatternToResourceNameCharacters(string pattern)
     {
-        /// <summary>
-        /// Converts a regex pattern string into <see cref="ResourceNameCharacters"/> flags
-        /// by extracting all character classes from the pattern and testing representative
-        /// characters against them.
-        /// </summary>
-        internal ResourceNameCharacters ParsePatternToResourceNameCharacters()
+        // Extract all [...] character class groups from the pattern and combine them
+        // so we can test if any position in the pattern accepts each character.
+        var charClasses = Regex.Matches(pattern, @"\[(?:[^\]]|\\.)+\]");
+        if (charClasses.Count == 0)
         {
-            // Extract all [...] character class groups from the pattern and combine them
-            // so we can test if any position in the pattern accepts each character.
-            var charClasses = Regex.Matches(pattern, @"\[(?:[^\]]|\\.)+\]");
-            if (charClasses.Count == 0)
+            return (ResourceNameCharacters)0;
+        }
+
+        var combined = string.Join("|", charClasses.Cast<Match>().Select(m => m.Value));
+        var regex = new Regex("^(?:" + combined + ")$");
+
+        var result = (ResourceNameCharacters)0;
+
+        foreach (var (testChars, flag) in CharacterTests)
+        {
+            foreach (char c in testChars)
             {
-                return (ResourceNameCharacters)0;
-            }
-
-            var combined = string.Join("|", charClasses.Cast<Match>().Select(m => m.Value));
-            var regex = new Regex("^(?:" + combined + ")$");
-
-            var result = (ResourceNameCharacters)0;
-
-            foreach (var (testChars, flag) in CharacterTests)
-            {
-                foreach (char c in testChars)
+                if (regex.IsMatch(c.ToString()))
                 {
-                    if (regex.IsMatch(c.ToString()))
-                    {
-                        result |= flag;
-                        break;
-                    }
+                    result |= flag;
+                    break;
                 }
             }
-
-            var patternWithoutCharacterClasses = Regex.Replace(pattern, @"\[(?:[^\]]|\\.)+\]", "");
-            if (Regex.IsMatch(patternWithoutCharacterClasses, @"(?<!\\)-|\\-"))
-            {
-                result |= ResourceNameCharacters.Hyphen;
-            }
-            if (patternWithoutCharacterClasses.Contains('_'))
-            {
-                result |= ResourceNameCharacters.Underscore;
-            }
-            if (Regex.IsMatch(patternWithoutCharacterClasses, @"\\\."))
-            {
-                result |= ResourceNameCharacters.Period;
-            }
-            if (Regex.IsMatch(patternWithoutCharacterClasses, @"\\[()]"))
-            {
-                result |= ResourceNameCharacters.Parentheses;
-            }
-
-            return result;
         }
+
+        var patternWithoutCharacterClasses = Regex.Replace(pattern, @"\[(?:[^\]]|\\.)+\]", "");
+        if (Regex.IsMatch(patternWithoutCharacterClasses, @"(?<!\\)-|\\-"))
+        {
+            result |= ResourceNameCharacters.Hyphen;
+        }
+        if (patternWithoutCharacterClasses.Contains('_'))
+        {
+            result |= ResourceNameCharacters.Underscore;
+        }
+        if (Regex.IsMatch(patternWithoutCharacterClasses, @"\\\."))
+        {
+            result |= ResourceNameCharacters.Period;
+        }
+        if (Regex.IsMatch(patternWithoutCharacterClasses, @"\\[()]"))
+        {
+            result |= ResourceNameCharacters.Parentheses;
+        }
+
+        return result;
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/ResourceNameConstraintsHelper.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/ResourceNameConstraintsHelper.cs
@@ -52,9 +52,9 @@ internal static class ResourceNameConstraintsHelper
     }
 
     /// <summary>
-    /// Converts a regex pattern string into <see cref="ResourceNameCharacters"/> flags
-    /// by extracting all character classes from the pattern and testing representative
-    /// characters against them.
+    /// Converts a regex pattern string into <see cref="ResourceNameCharacters"/> flags by extracting
+    /// bracketed character classes (e.g. <c>[a-z]</c>) and testing representative characters against them,
+    /// then scanning the remaining pattern for literal hyphen/underscore and escaped period/parentheses.
     /// </summary>
     private static ResourceNameCharacters ParsePatternToResourceNameCharacters(string pattern)
     {

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/ResourceNameConstraintsHelper.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/ResourceNameConstraintsHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Generator.Management.Models;
 using Azure.Provisioning.Primitives;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -12,6 +13,15 @@ namespace Azure.Generator.Provisioning.Utilities;
 /// </summary>
 internal static class ResourceNameConstraintsHelper
 {
+    private const ResourceNameCharacters AllKnownCharacters =
+        ResourceNameCharacters.LowercaseLetters |
+        ResourceNameCharacters.UppercaseLetters |
+        ResourceNameCharacters.Numbers |
+        ResourceNameCharacters.Hyphen |
+        ResourceNameCharacters.Underscore |
+        ResourceNameCharacters.Period |
+        ResourceNameCharacters.Parentheses;
+
     /// <summary>
     /// Representative test strings for each <see cref="ResourceNameCharacters"/> flag.
     /// If any character in the test string matches the pattern, the flag is included.
@@ -26,6 +36,20 @@ internal static class ResourceNameConstraintsHelper
         (".", ResourceNameCharacters.Period),
         ("()", ResourceNameCharacters.Parentheses),
     ];
+
+    extension(ArmResourceNameConstraints constraints)
+    {
+        internal ResourceNameCharacters ToResourceNameCharacters()
+        {
+            if (constraints.Pattern is null)
+            {
+                return AllKnownCharacters;
+            }
+
+            var parsed = constraints.Pattern.ParsePatternToResourceNameCharacters();
+            return parsed == 0 ? AllKnownCharacters : parsed;
+        }
+    }
 
     extension(string pattern)
     {
@@ -59,6 +83,24 @@ internal static class ResourceNameConstraintsHelper
                         break;
                     }
                 }
+            }
+
+            var patternWithoutCharacterClasses = Regex.Replace(pattern, @"\[(?:[^\]]|\\.)+\]", "");
+            if (Regex.IsMatch(patternWithoutCharacterClasses, @"(?<!\\)-|\\-"))
+            {
+                result |= ResourceNameCharacters.Hyphen;
+            }
+            if (patternWithoutCharacterClasses.Contains('_'))
+            {
+                result |= ResourceNameCharacters.Underscore;
+            }
+            if (Regex.IsMatch(patternWithoutCharacterClasses, @"\\\."))
+            {
+                result |= ResourceNameCharacters.Period;
+            }
+            if (Regex.IsMatch(patternWithoutCharacterClasses, @"\\[()]"))
+            {
+                result |= ResourceNameCharacters.Parentheses;
             }
 
             return result;

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ResourceNameConstraintsHelperTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ResourceNameConstraintsHelperTests.cs
@@ -32,7 +32,9 @@ namespace Azure.Generator.Provisioning.Tests
         [Test]
         public void PatternParsesLiteralHyphenOutsideCharacterClass()
         {
-            var characters = "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$".ParsePatternToResourceNameCharacters();
+            var constraints = new ArmResourceNameConstraints("^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$", 1, 255);
+
+            var characters = constraints.ToResourceNameCharacters();
 
             Assert.That(characters.HasFlag(ResourceNameCharacters.LowercaseLetters), Is.True);
             Assert.That(characters.HasFlag(ResourceNameCharacters.UppercaseLetters), Is.True);

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ResourceNameConstraintsHelperTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ResourceNameConstraintsHelperTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management.Models;
+using Azure.Generator.Provisioning.Utilities;
+using Azure.Provisioning.Primitives;
+using NUnit.Framework;
+
+namespace Azure.Generator.Provisioning.Tests
+{
+    public class ResourceNameConstraintsHelperTests
+    {
+        private const ResourceNameCharacters AllKnownCharacters =
+            ResourceNameCharacters.LowercaseLetters |
+            ResourceNameCharacters.UppercaseLetters |
+            ResourceNameCharacters.Numbers |
+            ResourceNameCharacters.Hyphen |
+            ResourceNameCharacters.Underscore |
+            ResourceNameCharacters.Period |
+            ResourceNameCharacters.Parentheses;
+
+        [Test]
+        public void PartialNameConstraintsUseAllKnownCharacters()
+        {
+            var constraints = new ArmResourceNameConstraints(null, null, 128);
+
+            var characters = constraints.ToResourceNameCharacters();
+
+            Assert.That(characters, Is.EqualTo(AllKnownCharacters));
+        }
+
+        [Test]
+        public void PatternParsesLiteralHyphenOutsideCharacterClass()
+        {
+            var characters = "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$".ParsePatternToResourceNameCharacters();
+
+            Assert.That(characters.HasFlag(ResourceNameCharacters.LowercaseLetters), Is.True);
+            Assert.That(characters.HasFlag(ResourceNameCharacters.UppercaseLetters), Is.True);
+            Assert.That(characters.HasFlag(ResourceNameCharacters.Numbers), Is.True);
+            Assert.That(characters.HasFlag(ResourceNameCharacters.Hyphen), Is.True);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #60806.

The provisioning generator previously fell back to `ResourceNameCharacters.LowercaseLetters` whenever `nameConstraints` had no regex pattern or the pattern parser could not infer any characters. That made partial constraints such as only `maxLength` overly restrictive. The parser also only inspected bracketed character classes, so patterns like `^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$` did not emit `ResourceNameCharacters.Hyphen` even though hyphens are valid.

Changes:
- Use all known provisioning name characters when a spec has length-only constraints or an unparseable pattern.
- Detect literal hyphen/underscore/escaped period/escaped parentheses outside character classes.
- Add focused tests for partial constraints and the FrontDoor frontend endpoint hyphen pattern.

Validation:
- `dotnet test eng\packages\http-client-csharp-provisioning\generator\Azure.Generator.Provisioning\test\Azure.Generator.Provisioning.Tests.csproj --filter FullyQualifiedName~ResourceNameConstraintsHelperTests`
- `dotnet test eng\packages\http-client-csharp-provisioning\generator\Azure.Generator.Provisioning\test\Azure.Generator.Provisioning.Tests.csproj`