### PR TITLE
Add ServiceLabel owners for Communication - Common

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -228,6 +228,9 @@
 # PRLabel: %Communication - Common
 /sdk/communication/Azure.Communication.Common/    @alvinjiang-msft @anjulgarg @Joeleniqs @jorge-beauregard
 
+# ServiceLabel: %Communication - Common
+# ServiceOwners: @alvinjiang-msft @anjulgarg
+
 # PRLabel: %Communication - Identity
 /sdk/communication/Azure.Communication.Identity/    @alvinjiang-msft @anjulgarg @Joeleniqs @jorge-beauregard
 


### PR DESCRIPTION
Add '# ServiceLabel: %Communication - Common' with individual service owners so release readiness check-package resolves >=2 unique service owners.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
