### PR TITLE
[Core] Fix `RequestFailedException` masking failed responses with `ArgumentNullException`

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where `RequestFailedException` could throw a secondary `ArgumentNullException` while formatting a failed response that had a text content-type header but an empty body, masking the actual service failure. The exception now preserves the original HTTP status, reason phrase, and headers, and no longer formats empty response content.
+
 ### Other Changes
 
 ## 1.60.0 (2026-06-30)

--- a/sdk/core/Azure.Core/src/RequestFailedException.cs
+++ b/sdk/core/Azure.Core/src/RequestFailedException.cs
@@ -195,12 +195,24 @@ namespace Azure
 
         private static void AppendContentAndHeaders(Response response, StringBuilder messageBuilder)
         {
-            if (response.ContentStream is MemoryStream && ContentTypeUtilities.TryGetTextEncoding(response.Headers.ContentType, out Encoding _))
+            // Formatting the diagnostic message must never throw: a failure here would replace the
+            // meaningful RequestFailedException with a misleading secondary exception and mask the
+            // real service failure. Guard the content section (which reads the response body) so the
+            // exception still carries the status, reason phrase, and headers if reading content fails.
+            if (response.ContentStream is MemoryStream contentStream && contentStream is { Length: > 0 } && ContentTypeUtilities.TryGetTextEncoding(response.Headers.ContentType, out Encoding _))
             {
-                messageBuilder
-                    .AppendLine()
-                    .AppendLine("Content:")
-                    .AppendLine(response.Content.ToString());
+                try
+                {
+                    messageBuilder
+                        .AppendLine()
+                        .AppendLine("Content:")
+                        .AppendLine(response.Content.ToString());
+                }
+                catch (Exception)
+                {
+                    messageBuilder
+                        .AppendLine("   (response content could not be read)");
+                }
             }
 
             messageBuilder

--- a/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
+++ b/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
@@ -216,6 +216,64 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public void DoesNotFormatEmptyResponseContentForTextContentTypes(
+            [Values(true, false)] bool responseIsError)
+        {
+            // An error response can carry a text Content-Type header but an empty body (e.g. a
+            // gateway/proxy 401/403/5xx). The Content section must be skipped so that reading an
+            // empty body cannot throw while formatting the exception message.
+            var formattedResponse = responseIsError ?
+                "Service request failed." + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
+                "Headers:" + s_nl +
+                "Content-Type: text/json" + s_nl +
+                "x-ms-requestId: 123" + s_nl
+                :
+                "Service request failed." + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
+                RequestFailedException.NoContentOnSuccessMessage + s_nl;
+
+            var response = new MockResponse(210, "Reason");
+            response.SetIsError(responseIsError);
+            response.AddHeader(new HttpHeader("Content-Type", "text/json"));
+            response.AddHeader(new HttpHeader("x-ms-requestId", "123"));
+            response.SetContent(string.Empty);
+            response.Sanitizer = Sanitizer;
+
+            RequestFailedException exception = null;
+            Assert.DoesNotThrow(() => exception = new RequestFailedException(response));
+            Assert.AreEqual(formattedResponse, exception.Message);
+            Assert.IsFalse(exception.Message.Contains("Content:"));
+            Assert.AreEqual(210, exception.Status);
+        }
+
+        [Test]
+        public void DoesNotThrowWhenContentFormattingFails()
+        {
+            // If reading the response content throws (for example, an older BinaryData.ToString()
+            // on .NET Framework throwing ArgumentNullException for empty content), the original
+            // failed response must still surface as a RequestFailedException carrying status,
+            // reason phrase, and headers rather than the secondary formatting exception.
+            var response = new ThrowingContentResponse(403, "Forbidden");
+            response.SetIsError(true);
+            response.AddHeader(new HttpHeader("Content-Type", "text/plain"));
+            response.AddHeader(new HttpHeader("x-ms-requestId", "abc"));
+            response.SetContent("this content read will throw");
+            response.Sanitizer = Sanitizer;
+
+            RequestFailedException exception = null;
+            Assert.DoesNotThrow(() => exception = new RequestFailedException(response));
+            Assert.AreEqual(403, exception.Status);
+            StringAssert.Contains("Status: 403 (Forbidden)", exception.Message);
+            StringAssert.Contains("Headers:", exception.Message);
+            StringAssert.Contains("Content-Type: text/plain", exception.Message);
+            StringAssert.Contains("x-ms-requestId: abc", exception.Message);
+            StringAssert.Contains("response content could not be read", exception.Message);
+        }
+
+        [Test]
         public void DoesntFormatsResponseContentForNonTextContentTypes(
             [Values(true, false)] bool responseIsError)
         {
@@ -766,6 +824,16 @@ namespace Azure.Core.Tests
                 data = response.Content.ToObjectFromJson<IDictionary<string, string>>();
                 return true;
             }
+        }
+
+        private class ThrowingContentResponse : MockResponse
+        {
+            public ThrowingContentResponse(int status, string reasonPhrase)
+                : base(status, reasonPhrase)
+            {
+            }
+
+            public override BinaryData Content => throw new ArgumentNullException("bytes");
         }
     }
 }


### PR DESCRIPTION
Fixes #60811

## Summary

When a service request failed and the response had a **text content-type header but an empty body**, `RequestFailedException` could throw a secondary `ArgumentNullException` (`Parameter 'bytes'`) while formatting its message. That secondary exception replaced the real `RequestFailedException`, hiding the actual HTTP status and service error and making failures hard to diagnose.

This was originally reported through `Azure.ResourceManager.AppContainers` while enumerating Container Apps secrets (an intermittent gateway/proxy non-success response with no body):


System.ArgumentNullException: Value cannot be null. (Parameter 'bytes') at Azure.RequestFailedException.AppendContentAndHeaders(Response response, StringBuilder messageBuilder) at Azure.RequestFailedException.CreateExceptionDetails(Response response, RequestFailedDetailsParser parser) at Azure.RequestFailedException..ctor(Response response, Exception innerException, RequestFailedDetailsParser detailsParser) at Azure.Core.PageableHelpers.PageableImplementation`1.GetResponse(HttpMessage message)


## Root cause

`RequestFailedException.AppendContentAndHeaders` formats the response body by calling `response.Content.ToString()` (that is, `BinaryData.ToString()`) whenever the buffered `ContentStream` is a non-null `MemoryStream` and the content-type is textual, with no guard for empty content and no protection against a formatting exception escaping the constructor.

`BinaryData.ToString()` over an **empty** buffer decodes via `Encoding.GetString` using a `fixed` pointer to an empty span, which is a null pointer. On **.NET Framework**, `Encoding.GetString` rejects a null pointer even for a length of 0 and throws `ArgumentNullException("bytes")`. Some `BinaryData` builds special-case empty and some do not.

Reproduced on .NET Framework 4.8:

| `System.Memory.Data` | empty `BinaryData.ToString()` |
|---|---|
| 6.0.0 / 6.0.1 | **throws** `ArgumentNullException("bytes")` (matches the report) |
| 1.0.2, 8.0.1, in-box .NET 10 | safe |

All of the following must hold to trigger it:
1. `response.IsError == true`.
2. The response carries a **text** content-type header.
3. The response body is **empty** after buffering.
4. The consumer resolves a throwing `BinaryData` (for example `System.Memory.Data` 6.0.x) on .NET Framework.

The code path is byte-for-byte identical between the reported `Azure.Core 1.44.1` and `main`, so the defect is still present.

## Fix

Two complementary changes in `AppendContentAndHeaders` (private helper, no public API change):

1. **Do not format empty content.** The content section now requires non-empty content (`contentStream is { Length: > 0 }`), so an empty body is never passed to `BinaryData.ToString()` and no empty `Content:` section is emitted.
2. **Never let formatting mask the real failure.** The content read is wrapped in `try`/`catch`. If reading content ever throws, the exception still carries the HTTP status, reason phrase, and headers, with a short `(response content could not be read)` note instead of the misleading secondary exception.

This mirrors the existing defensive pattern in `DefaultRequestFailedDetailsParser.TryParseDetails`, which already swallows exceptions when reading content. The parser was therefore already safe; `AppendContentAndHeaders` was the only unguarded content read in the construction path.

## Tests

Added to `FailedResponseExceptionTests`:

- **`DoesNotFormatEmptyResponseContentForTextContentTypes`** — an error response with a text content-type header and an empty body does not throw, omits the `Content:` section, and preserves `Status` and `Headers`.
- **`DoesNotThrowWhenContentFormattingFails`** — a response whose content read throws still yields a valid `RequestFailedException` carrying status, reason phrase, and headers.

Both assertions are deterministic across runtimes because they exercise the code path (empty content skipped / formatting guarded) rather than the runtime-specific `BinaryData` throw.