### PR TITLE
Fix DistributedTracingVisitor crash for custom-declared ClientDiagnostics

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Extensions/ClientProviderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Extensions/ClientProviderExtensions.cs
@@ -12,6 +12,8 @@ namespace Azure.Generator.Extensions
 {
     internal static class ClientProviderExtensions
     {
+        private const string ClientDiagnosticsPropertyName = "ClientDiagnostics";
+
         public static ClientProvider GetClient(this ScmMethodProvider method) => (ClientProvider)method.EnclosingType;
 
         public static string GetScopeName(this ScmMethodProvider method)
@@ -33,8 +35,11 @@ namespace Azure.Generator.Extensions
 
         public static PropertyProvider GetClientDiagnosticProperty(this ClientProvider client)
         {
+            // Match by name/OriginalName rather than by type: the property may be declared or renamed
+            // in custom code (via [CodeGenMember]), in which case its parsed CSharpType is a non-framework
+            // type that does not equal the framework ClientDiagnostics type.
             return client.CanonicalView.Properties
-                .First(p => p.Type.Equals(typeof(ClientDiagnostics)));
+                .First(p => p.Name == ClientDiagnosticsPropertyName || p.OriginalName?.Equals(ClientDiagnosticsPropertyName) == true);
         }
 
         public static PropertyProvider GetPipelineProperty(this ClientProvider client)

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/DistributedTracingVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/DistributedTracingVisitor.cs
@@ -372,8 +372,8 @@ namespace Azure.Generator.Visitors
             return true;
         }
 
-        private bool IsClientDiagnosticsProperty(PropertyProvider property)
-            => property.Type.Equals(ClientDiagnosticsType);
+        private static bool IsClientDiagnosticsProperty(PropertyProvider property)
+            => property.Name == ClientDiagnosticsPropertyName || property.OriginalName?.Equals(ClientDiagnosticsPropertyName) == true;
 
         private static bool ShouldSkipType(TypeProvider typeProvider)
         {

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Extensions/ClientProviderExtensionsTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Extensions/ClientProviderExtensionsTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Azure.Generator.Extensions;
+using Azure.Generator.Tests.Common;
+using Azure.Generator.Tests.TestHelpers;
+using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using NUnit.Framework;
+
+namespace Azure.Generator.Tests.Extensions
+{
+    public class ClientProviderExtensionsTests
+    {
+        private const string ClientDiagnosticsPropertyName = "ClientDiagnostics";
+
+        [SetUp]
+        public void Setup()
+        {
+            MockHelpers.LoadMockGenerator();
+        }
+
+        // The generated client exposes a framework-typed ClientDiagnostics property, which must be
+        // located by GetClientDiagnosticProperty (baseline for the regression tests below).
+        [Test]
+        public void GetClientDiagnosticProperty_FindsGeneratedProperty()
+        {
+            var clientProvider = CreateClientProvider();
+
+            var property = clientProvider.GetClientDiagnosticProperty();
+
+            Assert.IsNotNull(property);
+            Assert.AreEqual(ClientDiagnosticsPropertyName, property.Name);
+        }
+
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/pull/58979 (LroVisitor path).
+        // LroVisitor.BuildConvertCallComponents resolves the ClientDiagnostics property via
+        // GetClientDiagnosticProperty. Libraries such as Azure.AI.Agents.Persistent declare the
+        // "ClientDiagnostics" property in hand-written custom code, whose CSharpType is not equal to the
+        // framework ClientDiagnostics type. Matching by type threw "Sequence contains no matching element"
+        // during regeneration, so the property must be matched by name instead.
+        [Test]
+        public void GetClientDiagnosticProperty_FindsCustomTypedProperty()
+        {
+            var clientProvider = CreateClientProvider();
+
+            // Replace the generated ClientDiagnostics property with one whose CSharpType differs from the
+            // framework ClientDiagnostics type, simulating a ClientDiagnostics property declared in custom code.
+            var customTypedClientDiagnostics = new PropertyProvider(
+                $"The ClientDiagnostics is used to provide tracing support for the client library.",
+                MethodSignatureModifiers.Internal,
+                new CSharpType(typeof(object)),
+                ClientDiagnosticsPropertyName,
+                new AutoPropertyBody(false),
+                clientProvider);
+            clientProvider.Update(properties: [customTypedClientDiagnostics]);
+
+            PropertyProvider? property = null;
+            Assert.DoesNotThrow(() => property = clientProvider.GetClientDiagnosticProperty());
+            Assert.IsNotNull(property);
+            Assert.AreEqual(ClientDiagnosticsPropertyName, property!.Name);
+        }
+
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/pull/58979 (LroVisitor path).
+        // Custom code can rename the ClientDiagnostics property via [CodeGenMember("ClientDiagnostics")],
+        // in which case the property's Name differs but its OriginalName is still "ClientDiagnostics".
+        // GetClientDiagnosticProperty must locate the property by its OriginalName so the renamed property
+        // is still found by the LroVisitor.
+        [Test]
+        public void GetClientDiagnosticProperty_FindsRenamedProperty()
+        {
+            var clientProvider = CreateClientProvider();
+
+            // Replace the generated ClientDiagnostics property with one that has been renamed via custom
+            // code: its Name is different, but its OriginalName is still "ClientDiagnostics". The type is
+            // also non-framework, matching how a custom-declared property is modeled.
+            var renamedClientDiagnostics = new PropertyProvider(
+                $"The ClientDiagnostics is used to provide tracing support for the client library.",
+                MethodSignatureModifiers.Internal,
+                new CSharpType(typeof(object)),
+                "RenamedDiagnostics",
+                new AutoPropertyBody(false),
+                clientProvider);
+            SetOriginalName(renamedClientDiagnostics, ClientDiagnosticsPropertyName);
+            // NOTE: OriginalName is set via reflection because this test project lacks custom-code test
+            // infra to load a real [CodeGenMember] rename. Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
+            clientProvider.Update(properties: [renamedClientDiagnostics]);
+
+            PropertyProvider? property = null;
+            Assert.DoesNotThrow(() => property = clientProvider.GetClientDiagnosticProperty());
+            Assert.IsNotNull(property);
+            Assert.AreEqual("RenamedDiagnostics", property!.Name);
+            Assert.AreEqual(ClientDiagnosticsPropertyName, property.OriginalName);
+        }
+
+        private static ClientProvider CreateClientProvider()
+        {
+            List<InputMethodParameter> parameters =
+            [
+                InputFactory.MethodParameter("p1", InputPrimitiveType.String)
+            ];
+            var basicOperation = InputFactory.Operation("foo", parameters: parameters);
+            var basicServiceMethod = InputFactory.BasicServiceMethod("foo", basicOperation, parameters: parameters);
+            var inputClient = InputFactory.Client("TestClient", methods: [basicServiceMethod]);
+            MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+
+            var clientProvider = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(clientProvider);
+            return clientProvider!;
+        }
+
+        // OriginalName has an internal init accessor and the custom-code parser (NamedTypeSymbolProvider)
+        // is internal to Microsoft.TypeSpec.Generator with no InternalsVisibleTo for this test assembly,
+        // so there is currently no way to load a real [CodeGenMember] rename here. Set the backing field
+        // via reflection to simulate a property renamed from "ClientDiagnostics" through custom code.
+        // Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
+        private static void SetOriginalName(PropertyProvider property, string originalName)
+        {
+            typeof(PropertyProvider)
+                .GetField($"<{nameof(PropertyProvider.OriginalName)}>k__BackingField",
+                    BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(property, originalName);
+        }
+    }
+}

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Extensions/ClientProviderExtensionsTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Extensions/ClientProviderExtensionsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.Reflection;
 using Azure.Generator.Extensions;
 using Azure.Generator.Tests.Common;
 using Azure.Generator.Tests.TestHelpers;
@@ -85,7 +84,7 @@ namespace Azure.Generator.Tests.Extensions
                 "RenamedDiagnostics",
                 new AutoPropertyBody(false),
                 clientProvider);
-            SetOriginalName(renamedClientDiagnostics, ClientDiagnosticsPropertyName);
+            MockHelpers.SetOriginalName(renamedClientDiagnostics, ClientDiagnosticsPropertyName);
             // NOTE: OriginalName is set via reflection because this test project lacks custom-code test
             // infra to load a real [CodeGenMember] rename. Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
             clientProvider.Update(properties: [renamedClientDiagnostics]);
@@ -111,19 +110,6 @@ namespace Azure.Generator.Tests.Extensions
             var clientProvider = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
             Assert.IsNotNull(clientProvider);
             return clientProvider!;
-        }
-
-        // OriginalName has an internal init accessor and the custom-code parser (NamedTypeSymbolProvider)
-        // is internal to Microsoft.TypeSpec.Generator with no InternalsVisibleTo for this test assembly,
-        // so there is currently no way to load a real [CodeGenMember] rename here. Set the backing field
-        // via reflection to simulate a property renamed from "ClientDiagnostics" through custom code.
-        // Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
-        private static void SetOriginalName(PropertyProvider property, string originalName)
-        {
-            typeof(PropertyProvider)
-                .GetField($"<{nameof(PropertyProvider.OriginalName)}>k__BackingField",
-                    BindingFlags.NonPublic | BindingFlags.Instance)!
-                .SetValue(property, originalName);
         }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/TestHelpers/MockHelpers.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/TestHelpers/MockHelpers.cs
@@ -124,6 +124,19 @@ namespace Azure.Generator.Tests.TestHelpers
                 .SetValue(typeProvider, new Lazy<TypeProvider>(() => customCodeTypeProvider));
         }
 
+        // PropertyProvider.OriginalName has an internal init accessor and the custom-code parser
+        // (NamedTypeSymbolProvider) is internal to Microsoft.TypeSpec.Generator with no InternalsVisibleTo
+        // for this test assembly, so there is currently no way to load a real [CodeGenMember] rename here.
+        // Set the backing field via reflection to simulate a property renamed through custom code.
+        // Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
+        public static void SetOriginalName(PropertyProvider property, string originalName)
+        {
+            typeof(PropertyProvider)
+                .GetField($"<{nameof(PropertyProvider.OriginalName)}>k__BackingField",
+                    BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(property, originalName);
+        }
+
         private static Compilation? BuildLastContractCompilation(IEnumerable<string>? sources)
         {
             if (sources is null)

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/DistributedTracingVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/DistributedTracingVisitorTests.cs
@@ -14,6 +14,7 @@ using Microsoft.TypeSpec.Generator.Providers;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Tests.Visitors
@@ -225,6 +226,81 @@ namespace Azure.Generator.Tests.Visitors
             var result = updatedMethod!.BodyStatements!.ToDisplayString();
             Assert.IsTrue(result.Contains("ClientDiagnostics.CreateScope(\"TestClient.Foo\")"),
                 $"Protocol method should be wrapped with a diagnostic scope. Actual: {result}");
+        }
+
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/pull/58979.
+        // Custom code can rename the ClientDiagnostics property via [CodeGenMember("ClientDiagnostics")],
+        // in which case the property's Name differs but its OriginalName is still "ClientDiagnostics".
+        // The visitor must locate the property by its OriginalName so the renamed property is still found
+        // (and it must be located by name, not by CSharpType, to keep the previous regression fixed).
+        [Test]
+        public void TestProtocolMethodWithRenamedClientDiagnosticsProperty()
+        {
+            var visitor = new TestDistributedTracingVisitor();
+
+            // load the input
+            List<InputMethodParameter> parameters =
+            [
+                InputFactory.MethodParameter(
+                "p1",
+                InputPrimitiveType.String)
+            ];
+            var basicOperation = InputFactory.Operation(
+                "foo",
+                parameters: parameters);
+            var basicServiceMethod = InputFactory.BasicServiceMethod("foo", basicOperation, parameters: parameters);
+            var inputClient = InputFactory.Client("TestClient", methods: [basicServiceMethod]);
+            MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+            // create the client provider
+            var clientProvider = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(clientProvider);
+
+            // Replace the generated ClientDiagnostics property with one that has been renamed via custom
+            // code: its Name is different, but its OriginalName is still "ClientDiagnostics". The type is
+            // also non-framework, matching how a custom-declared property is modeled.
+            var renamedClientDiagnostics = new PropertyProvider(
+                $"The ClientDiagnostics is used to provide tracing support for the client library.",
+                MethodSignatureModifiers.Internal,
+                new CSharpType(typeof(object)),
+                "RenamedDiagnostics",
+                new AutoPropertyBody(false),
+                clientProvider!);
+            SetOriginalName(renamedClientDiagnostics, ClientDiagnosticsPropertyName);
+            clientProvider!.Update(properties: [renamedClientDiagnostics]);
+
+            // create a protocol method to test the visitor
+            var methodSignature = new MethodSignature(
+                "Foo",
+                null,
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Virtual | MethodSignatureModifiers.Async,
+                AzureClientGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType,
+                $"The response returned from the service.",
+                [new ParameterProvider("p1", $"p1", AzureClientGenerator.Instance.TypeFactory.RequestContentApi.RequestContentType)]);
+            var bodyStatements = InvokeConsoleWriteLine(Literal("Hello World"));
+            var method = new ScmMethodProvider(methodSignature, bodyStatements, clientProvider!, ScmMethodKind.Protocol);
+
+            // The visitor must not throw and must still wrap the body in a diagnostic scope, using the
+            // renamed property to create the scope.
+            ScmMethodProvider? updatedMethod = null;
+            Assert.DoesNotThrow(() => updatedMethod = visitor.InvokeVisitMethod(method));
+            Assert.IsNotNull(updatedMethod?.BodyStatements);
+
+            var result = updatedMethod!.BodyStatements!.ToDisplayString();
+            Assert.IsTrue(result.Contains("RenamedDiagnostics.CreateScope(\"TestClient.Foo\")"),
+                $"Protocol method should be wrapped with a diagnostic scope using the renamed property. Actual: {result}");
+        }
+
+        // OriginalName has an internal init accessor and the custom-code parser (NamedTypeSymbolProvider)
+        // is internal to Microsoft.TypeSpec.Generator with no InternalsVisibleTo for this test assembly,
+        // so there is currently no way to load a real [CodeGenMember] rename here. Set the backing field
+        // via reflection to simulate a property renamed from "ClientDiagnostics" through custom code.
+        // Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
+        private static void SetOriginalName(PropertyProvider property, string originalName)
+        {
+            typeof(PropertyProvider)
+                .GetField($"<{nameof(PropertyProvider.OriginalName)}>k__BackingField",
+                    BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(property, originalName);
         }
 
         // This test validates that the "Async" suffix is stripped from the scope name for a protocol

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/DistributedTracingVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/DistributedTracingVisitorTests.cs
@@ -166,6 +166,67 @@ namespace Azure.Generator.Tests.Visitors
             Assert.AreEqual(Helpers.GetExpectedFromFile(isProtocolMethod.ToString()), result);
         }
 
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/pull/58979.
+        // Libraries such as Azure.AI.Agents.Persistent declare the "ClientDiagnostics" property in
+        // hand-written custom code. The custom property's CSharpType is not equal to the framework
+        // ClientDiagnostics type injected into the visitor, so matching the property by type threw
+        // "Sequence contains no matching element" during regeneration. The property must be matched
+        // by name so that a custom-declared ClientDiagnostics property is still found.
+        [Test]
+        public void TestProtocolMethodWithCustomTypedClientDiagnosticsProperty()
+        {
+            var visitor = new TestDistributedTracingVisitor();
+
+            // load the input
+            List<InputMethodParameter> parameters =
+            [
+                InputFactory.MethodParameter(
+                "p1",
+                InputPrimitiveType.String)
+            ];
+            var basicOperation = InputFactory.Operation(
+                "foo",
+                parameters: parameters);
+            var basicServiceMethod = InputFactory.BasicServiceMethod("foo", basicOperation, parameters: parameters);
+            var inputClient = InputFactory.Client("TestClient", methods: [basicServiceMethod]);
+            MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+            // create the client provider
+            var clientProvider = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(clientProvider);
+
+            // Replace the generated ClientDiagnostics property with one whose CSharpType differs from
+            // the framework ClientDiagnostics type injected into the visitor, simulating a
+            // ClientDiagnostics property declared in custom code.
+            var customTypedClientDiagnostics = new PropertyProvider(
+                $"The ClientDiagnostics is used to provide tracing support for the client library.",
+                MethodSignatureModifiers.Internal,
+                new CSharpType(typeof(object)),
+                ClientDiagnosticsPropertyName,
+                new AutoPropertyBody(false),
+                clientProvider!);
+            clientProvider!.Update(properties: [customTypedClientDiagnostics]);
+
+            // create a protocol method to test the visitor
+            var methodSignature = new MethodSignature(
+                "Foo",
+                null,
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Virtual | MethodSignatureModifiers.Async,
+                AzureClientGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType,
+                $"The response returned from the service.",
+                [new ParameterProvider("p1", $"p1", AzureClientGenerator.Instance.TypeFactory.RequestContentApi.RequestContentType)]);
+            var bodyStatements = InvokeConsoleWriteLine(Literal("Hello World"));
+            var method = new ScmMethodProvider(methodSignature, bodyStatements, clientProvider!, ScmMethodKind.Protocol);
+
+            // The visitor must not throw and must still wrap the body in a diagnostic scope.
+            ScmMethodProvider? updatedMethod = null;
+            Assert.DoesNotThrow(() => updatedMethod = visitor.InvokeVisitMethod(method));
+            Assert.IsNotNull(updatedMethod?.BodyStatements);
+
+            var result = updatedMethod!.BodyStatements!.ToDisplayString();
+            Assert.IsTrue(result.Contains("ClientDiagnostics.CreateScope(\"TestClient.Foo\")"),
+                $"Protocol method should be wrapped with a diagnostic scope. Actual: {result}");
+        }
+
         // This test validates that the "Async" suffix is stripped from the scope name for a protocol
         // method whose name ends in "Async", since GetScopeName() handles the stripping centrally.
         [Test]

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/DistributedTracingVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/DistributedTracingVisitorTests.cs
@@ -266,6 +266,8 @@ namespace Azure.Generator.Tests.Visitors
                 new AutoPropertyBody(false),
                 clientProvider!);
             SetOriginalName(renamedClientDiagnostics, ClientDiagnosticsPropertyName);
+            // NOTE: OriginalName is set via reflection because this test project lacks custom-code test
+            // infra to load a real [CodeGenMember] rename. Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
             clientProvider!.Update(properties: [renamedClientDiagnostics]);
 
             // create a protocol method to test the visitor

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/DistributedTracingVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/DistributedTracingVisitorTests.cs
@@ -14,7 +14,6 @@ using Microsoft.TypeSpec.Generator.Providers;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Tests.Visitors
@@ -265,7 +264,7 @@ namespace Azure.Generator.Tests.Visitors
                 "RenamedDiagnostics",
                 new AutoPropertyBody(false),
                 clientProvider!);
-            SetOriginalName(renamedClientDiagnostics, ClientDiagnosticsPropertyName);
+            MockHelpers.SetOriginalName(renamedClientDiagnostics, ClientDiagnosticsPropertyName);
             // NOTE: OriginalName is set via reflection because this test project lacks custom-code test
             // infra to load a real [CodeGenMember] rename. Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
             clientProvider!.Update(properties: [renamedClientDiagnostics]);
@@ -290,19 +289,6 @@ namespace Azure.Generator.Tests.Visitors
             var result = updatedMethod!.BodyStatements!.ToDisplayString();
             Assert.IsTrue(result.Contains("RenamedDiagnostics.CreateScope(\"TestClient.Foo\")"),
                 $"Protocol method should be wrapped with a diagnostic scope using the renamed property. Actual: {result}");
-        }
-
-        // OriginalName has an internal init accessor and the custom-code parser (NamedTypeSymbolProvider)
-        // is internal to Microsoft.TypeSpec.Generator with no InternalsVisibleTo for this test assembly,
-        // so there is currently no way to load a real [CodeGenMember] rename here. Set the backing field
-        // via reflection to simulate a property renamed from "ClientDiagnostics" through custom code.
-        // Tracked by https://github.com/Azure/azure-sdk-for-net/issues/60907.
-        private static void SetOriginalName(PropertyProvider property, string originalName)
-        {
-            typeof(PropertyProvider)
-                .GetField($"<{nameof(PropertyProvider.OriginalName)}>k__BackingField",
-                    BindingFlags.NonPublic | BindingFlags.Instance)!
-                .SetValue(property, originalName);
         }
 
         // This test validates that the "Async" suffix is stripped from the scope name for a protocol


### PR DESCRIPTION
## Summary

Fixes a regeneration crash introduced by #58979 for Azure data-plane libraries whose `ClientDiagnostics` property is declared/renamed in **custom code** (e.g. `Azure.AI.Agents.Persistent`, `Azure.ResourceManager.Advisor`).

### Root cause

#58979 changed `DistributedTracingVisitor` to look up the `ClientDiagnostics` property by **`CSharpType`** (`property.Type.Equals(ClientDiagnosticsType)`), while the surrounding gates (`ShouldSkipType`, `Visit`) still match by **name**. For a property declared in custom code, its type is parsed by Roslyn and becomes a **non-framework** `CSharpType` (because `Type.GetType("Azure.Core.Pipeline.ClientDiagnostics")` returns null — Azure.Core.dll is not loaded in the generator). The injected type is a **framework** `CSharpType`, so `CSharpType.Equals(CSharpType)` fails on the underlying-type check and `.First(...)` throws:

```
System.InvalidOperationException: Sequence contains no matching element
   at Azure.Generator.Visitors.DistributedTracingVisitor.UpdateProtocolMethodsWithDistributedTracing(...)
```

Generated (non-custom) libraries are unaffected because the visitor adds the property itself with the framework type.

### Fix

Match the `ClientDiagnostics` property by **name / `OriginalName`**, consistent with `ShouldSkipType` and the `Visit` gate:

```csharp
private static bool IsClientDiagnosticsProperty(PropertyProvider property)
    => property.Name == ClientDiagnosticsPropertyName
       || property.OriginalName?.Equals(ClientDiagnosticsPropertyName) == true;
```

### Tests

- `TestProtocolMethodWithCustomTypedClientDiagnosticsProperty` — custom-declared property whose `CSharpType` differs from the injected framework type; asserts the visitor no longer throws and still wraps the body in a diagnostic scope.
- `TestProtocolMethodWithRenamedClientDiagnosticsProperty` — property renamed via `[CodeGenMember("ClientDiagnostics")]` (different `Name`, `OriginalName == "ClientDiagnostics"`); asserts the scope is created off the renamed property.

Both fail against the buggy code and pass with the fix. All 13 `DistributedTracingVisitorTests` pass.

### Follow-up

The renamed-property test uses reflection to set `OriginalName` because the `Azure.Generator` test project lacks accessible custom-code test infra. Tracked by #60907.
