### PR TITLE
Fix spelling typos in doc comments and an error message

### DIFF
--- a/sdk/core/Azure.Core/src/Identity/UnsafeTokenCacheOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/UnsafeTokenCacheOptions.cs
@@ -31,7 +31,7 @@ namespace Azure.Identity
 
         /// <summary>
         /// Returns the bytes used to initialize the token cache. This would most likely have come from the <see cref="TokenCacheUpdatedArgs"/>.
-        /// It is recommended that if this method is overriden, there is no need to provide a duplicate implementation for the parameterless <see cref="RefreshCacheAsync()"/>.
+        /// It is recommended that if this method is overridden, there is no need to provide a duplicate implementation for the parameterless <see cref="RefreshCacheAsync()"/>.
         /// </summary>
         /// <param name="args">The <see cref="TokenCacheRefreshArgs"/> containing information about the current state of the cache.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> controlling the lifetime of this operation.</param>

--- a/sdk/core/Azure.Core/src/Messaging/MessageContent.cs
+++ b/sdk/core/Azure.Core/src/Messaging/MessageContent.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging
         }
 
         /// <summary>
-        /// For inheriting types that have a string ContentType property, this property should be overriden to forward
+        /// For inheriting types that have a string ContentType property, this property should be overridden to forward
         /// the <see cref="ContentType"/> property into the inheriting type's string property, and vice versa.
         /// For types that have a <see cref="Azure.Core.ContentType"/> ContentType property, it is not necessary to override this member.
         /// </summary>
@@ -36,7 +36,7 @@ namespace Azure.Messaging
 
         /// <summary>
         /// Gets whether the message is read only or not. This
-        /// can be overriden by inheriting classes to specify whether or
+        /// can be overridden by inheriting classes to specify whether or
         /// not the message can be modified.
         /// </summary>
         public virtual bool IsReadOnly { get; }

--- a/sdk/core/Azure.Core/src/Pipeline/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RetryPolicy.cs
@@ -12,7 +12,7 @@ using Azure.Core.Diagnostics;
 namespace Azure.Core.Pipeline
 {
     /// <summary>
-    /// Represents a policy that can be overriden to customize whether or not a request will be retried and how long to wait before retrying.
+    /// Represents a policy that can be overridden to customize whether or not a request will be retried and how long to wait before retrying.
     /// </summary>
     public class RetryPolicy : HttpPipelinePolicy
     {
@@ -35,7 +35,7 @@ namespace Azure.Core.Pipeline
         }
 
         /// <summary>
-        /// This method can be overriden to take full control over the retry policy. If this is overriden and the base method isn't called,
+        /// This method can be overridden to take full control over the retry policy. If this is overridden and the base method isn't called,
         /// it is the implementer's responsibility to populate the <see cref="HttpMessage.ProcessingContext"/> property.
         /// This method will only be called for async methods.
         /// </summary>
@@ -48,7 +48,7 @@ namespace Azure.Core.Pipeline
         }
 
         /// <summary>
-        /// This method can be overriden to take full control over the retry policy. If this is overriden and the base method isn't called,
+        /// This method can be overridden to take full control over the retry policy. If this is overridden and the base method isn't called,
         /// it is the implementer's responsibility to populate the <see cref="HttpMessage.ProcessingContext"/> property.
         /// This method will only be called for sync methods.
         /// </summary>
@@ -176,7 +176,7 @@ namespace Azure.Core.Pipeline
         }
 
         /// <summary>
-        /// This method can be overriden to control whether a request should be retried. It will be called for any response where
+        /// This method can be overridden to control whether a request should be retried. It will be called for any response where
         /// <see cref="Response.IsError"/> is true, or if an exception is thrown from any subsequent pipeline policies or the transport.
         /// This method will only be called for sync methods.
         /// </summary>
@@ -186,7 +186,7 @@ namespace Azure.Core.Pipeline
         protected internal virtual bool ShouldRetry(HttpMessage message, Exception? exception) => ShouldRetryInternal(message, exception);
 
         /// <summary>
-        /// This method can be overriden to control whether a request should be retried.  It will be called for any response where
+        /// This method can be overridden to control whether a request should be retried.  It will be called for any response where
         /// <see cref="Response.IsError"/> is true, or if an exception is thrown from any subsequent pipeline policies or the transport.
         /// This method will only be called for async methods.
         /// </summary>
@@ -213,7 +213,7 @@ namespace Azure.Core.Pipeline
         }
 
         /// <summary>
-        /// This method can be overriden to control how long to delay before retrying. This method will only be called for sync methods.
+        /// This method can be overridden to control how long to delay before retrying. This method will only be called for sync methods.
         /// </summary>
         /// <param name="message">The message containing the request and response.</param>
         /// <param name="retryAfter">The Retry-After header value, if any, returned from the service.</param>
@@ -221,7 +221,7 @@ namespace Azure.Core.Pipeline
         internal TimeSpan GetNextDelay(HttpMessage message, TimeSpan? retryAfter) => GetNextDelayInternal(message);
 
         /// <summary>
-        /// This method can be overriden to control how long to delay before retrying. This method will only be called for async methods.
+        /// This method can be overridden to control how long to delay before retrying. This method will only be called for async methods.
         /// </summary>
         /// <param name="message">The message containing the request and response.</param>
         /// <param name="retryAfter">The Retry-After header value, if any, returned from the service.</param>
@@ -238,7 +238,7 @@ namespace Azure.Core.Pipeline
         }
 
         /// <summary>
-        /// This method can be overriden to introduce logic that runs before the request is sent. This will run even for the first attempt.
+        /// This method can be overridden to introduce logic that runs before the request is sent. This will run even for the first attempt.
         /// This method will only be called for async methods.
         /// </summary>
         /// <param name="message">The message containing the request and response.</param>

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
@@ -51,7 +51,7 @@ namespace Azure.Storage
             => new ArgumentException($"Cannot transfer {streamLength} bytes with a maximum transfer size of {statedMaxBlockSize} bytes per block. Please increase the TransferOptions.MaximumTransferChunkSize to at least {necessaryMinBlockSize}.");
 
         public static InvalidDataException HashMismatch(string hashHeaderName)
-            => new InvalidDataException($"{hashHeaderName} did not match hash of recieved data.");
+            => new InvalidDataException($"{hashHeaderName} did not match hash of received data.");
 
         public static InvalidDataException ChecksumMismatch(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER

--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -703,7 +703,7 @@ namespace Azure.Data.Tables
         /// <typeparam name="T">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity"/>.</typeparam>
         /// <param name="partitionKey">The partitionKey that identifies the table entity.</param>
         /// <param name="rowKey">The rowKey that identifies the table entity.</param>
-        /// <param name="select">Selects which set of entity properties to return in the result set. Pass <c>null</c> to retreive all properties.</param>
+        /// <param name="select">Selects which set of entity properties to return in the result set. Pass <c>null</c> to retrieve all properties.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns> The <see cref="NullableResponse{T}"/> whose <c>HasValue</c> property will return <c>true</c> if the entity existed, otherwise <c>false</c>.</returns>
         /// <exception cref="RequestFailedException">Exception thrown if an unexpected error occurs.</exception>
@@ -720,7 +720,7 @@ namespace Azure.Data.Tables
         /// <typeparam name="T">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity"/>.</typeparam>
         /// <param name="partitionKey">The partitionKey that identifies the table entity.</param>
         /// <param name="rowKey">The rowKey that identifies the table entity.</param>
-        /// <param name="select">Selects which set of entity properties to return in the result set. Pass <c>null</c> to retreive all properties.</param>
+        /// <param name="select">Selects which set of entity properties to return in the result set. Pass <c>null</c> to retrieve all properties.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns> The <see cref="NullableResponse{T}"/> whose <c>HasValue</c> property will return <c>true</c> if the entity existed, otherwise <c>false</c>.</returns>
         /// <exception cref="RequestFailedException">Exception thrown if an unexpected error occurs.</exception>


### PR DESCRIPTION
## Summary

Fixes a handful of long-standing spelling typos in public XML documentation
comments, plus one runtime exception message. These are documentation/message-only
changes — **no API surface or behavior changes.**

## Changes

**`Azure.Core`** — `overriden` → `overridden` (13 occurrences)
- `src/Pipeline/RetryPolicy.cs`
- `src/Messaging/MessageContent.cs`
- `src/Identity/UnsafeTokenCacheOptions.cs`

**`Azure.Storage.Common`** — `recieved` → `received`
- `src/Shared/Errors.cs` — the `HashMismatch` `InvalidDataException` message
  (`"... did not match hash of received data."`)

**`Azure.Data.Tables`** — `retreive` → `retrieve` (2 occurrences)
- `src/TableClient.cs` — the `<param name="select">` docs on
  `GetEntity<T>` and `GetEntityIfExists<T>`

## Why / impact

- The `overriden` typo sits on XML doc comments for **public, overridable members**
  (e.g. `RetryPolicy.ShouldRetry`, `MessageContent.ContentTypeCore`), so it shows up
  directly in IntelliSense for anyone extending these types.
- While in `RetryPolicy`, I noticed the async `OnSendingRequest` doc used `overriden`
  while its **sync twin a few lines up already used the correct `overridden`** — so this
  also removes an inconsistency within the same file.
- **No public API change:** the `api/*.cs` surface files track signatures only, not doc
  text, so they're unaffected.
- **No behavior change:** the single non-doc edit is a user-facing exception message
  string, and no tests assert on its text.

---

cc @JonathanCrd — you're listed in `CODEOWNERS`. 
Would appreciate a quick review when you have a moment. Thanks! 🙏