### PR TITLE
Fix minor issues in Azure.Identity credential types

### DIFF
--- a/sdk/core/Azure.Core/src/Identity/Credentials/ClientAssertionCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/ClientAssertionCredential.cs
@@ -72,7 +72,7 @@ namespace Azure.Identity
             ClientId = clientId;
 
             Client = options?.MsalClient ?? new MsalConfidentialClient(options?.Pipeline ?? CredentialPipeline.GetInstance(options), tenantId, clientId, assertionCallback, options);
-            Pipeline = options?.Pipeline ?? options?.Pipeline ?? CredentialPipeline.GetInstance(options);
+            Pipeline = options?.Pipeline ?? CredentialPipeline.GetInstance(options);
             TenantIdResolver = options?.TenantIdResolver ?? TenantIdResolverBase.Default;
             AdditionallyAllowedTenantIds = TenantIdResolver.ResolveAddionallyAllowedTenantIds((options as ISupportsAdditionallyAllowedTenants)?.AdditionallyAllowedTenants);
         }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/EnvironmentCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/EnvironmentCredentialOptions.cs
@@ -21,22 +21,22 @@ namespace Azure.Identity
         internal string TenantId { get; set; } = EnvironmentVariables.TenantId;
 
         /// <summary>
-        /// The client ID (app ID) of the service pricipal the credential will authenticate. This value defaults to the value of the environment variable AZURE_CLIENT_ID.
+        /// The client ID (app ID) of the service principal the credential will authenticate. This value defaults to the value of the environment variable AZURE_CLIENT_ID.
         /// </summary>
         internal string ClientId { get; set; } = EnvironmentVariables.ClientId;
 
         /// <summary>
-        /// The client secret used to authenticate the service pricipal. This value defaults to the value of the environment variable AZURE_CLIENT_SECRET.
+        /// The client secret used to authenticate the service principal. This value defaults to the value of the environment variable AZURE_CLIENT_SECRET.
         /// </summary>
         internal string ClientSecret { get; set; } = EnvironmentVariables.ClientSecret;
 
         /// <summary>
-        /// The path to the client certificate used to authenticate the service pricipal. This value defaults to the value of the environment variable AZURE_CLIENT_CERTIFICATE_PATH.
+        /// The path to the client certificate used to authenticate the service principal. This value defaults to the value of the environment variable AZURE_CLIENT_CERTIFICATE_PATH.
         /// </summary>
         internal string ClientCertificatePath { get; set; } = EnvironmentVariables.ClientCertificatePath;
 
         /// <summary>
-        /// The password of the client certificate used to authenticate the service pricipal. This value defaults to the value of the environment variable AZURE_CLIENT_CERTIFICATE_PASSWORD.
+        /// The password of the client certificate used to authenticate the service principal. This value defaults to the value of the environment variable AZURE_CLIENT_CERTIFICATE_PASSWORD.
         /// </summary>
         internal string ClientCertificatePassword { get; set; } = EnvironmentVariables.ClientCertificatePassword;
 

--- a/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredential.cs
@@ -209,7 +209,7 @@ namespace Azure.Identity
                 not null => client,
                 _ when clientAssertionCallback is not null => new MsalConfidentialClient(_pipeline, _tenantId, _clientId, clientAssertionCallback, options),
                 _ when clientAssertionCallbackAsync is not null => new MsalConfidentialClient(_pipeline, _tenantId, _clientId, clientAssertionCallbackAsync, options),
-                _ => throw new ArgumentNullException($"nameof(clientAssertionCallback)")
+                _ => throw new ArgumentNullException(nameof(clientAssertionCallback))
             };
 
             TenantIdResolver = options?.TenantIdResolver ?? TenantIdResolverBase.Default;

--- a/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/OnBehalfOfCredentialOptions.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace Azure.Identity
 {
     /// <summary>
-    ///
+    /// Options used to configure the <see cref="OnBehalfOfCredential"/>.
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [TypeForwardedFrom("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]


### PR DESCRIPTION
## Summary

Four small, self-contained fixes to the Azure.Identity credential types (which now
live in `Azure.Core/src/Identity/Credentials/`). One is a real bug fix; the rest are a
public-doc fix, a doc typo, and a no-op simplification. **No public API surface changes.**

## Changes

- **`OnBehalfOfCredential`** — the fallback arm of the client-assertion-callback
  constructor threw `new ArgumentNullException($"nameof(clientAssertionCallback)")`.
  The stray `$` turned it into an interpolated string literal, so the exception's
  `ParamName` was the literal text `nameof(clientAssertionCallback)` instead of the
  parameter name. Removed the interpolation → `nameof(clientAssertionCallback)`.
- **`OnBehalfOfCredentialOptions`** — filled the empty class-level `<summary>`.
- **`ClientAssertionCredential`** — removed a duplicated `?? options?.Pipeline`
  operand (`options?.Pipeline ?? options?.Pipeline ?? …`).
- **`EnvironmentCredentialOptions`** — fixed a repeated `pricipal` → `principal`
  typo (4×) in the XML doc comments.

## Impact

- **`OnBehalfOfCredential` (bug — user-visible diagnostics):** When an
  `OnBehalfOfCredential` is created via the assertion-callback path with a null
  callback, it throws `ArgumentNullException`. Previously the message read
  `Value cannot be null. (Parameter 'nameof(clientAssertionCallback)')` — confusing,
  and useless to code that inspects `ex.ParamName`. It now correctly reports
  `clientAssertionCallback`. The change affects only the parameter name/message on an
  already-throwing path; no successful code path changes.
- **`OnBehalfOfCredentialOptions` (public docs):** This is a **public** type whose
  class `<summary>` was empty, so it surfaced no description in IntelliSense or on
  learn.microsoft.com. It now has one, consistent with sibling `*CredentialOptions`.
- **`ClientAssertionCredential` (none / clarity):** The duplicated operand is logically
  a no-op (`x ?? x == x`); removing it is behavior-preserving and just improves clarity.
- **`EnvironmentCredentialOptions` (docs):** Spelling fix only. These docs are on
  `internal` members, so the benefit is source readability rather than shipped IntelliSense.