### PR TITLE
CTS SDK GA addressing reviewer comments

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Features Added
 
-- General availability release targetting REST API version `2026-03-26`
-- Added a utility method `CcfReceipt.GetRegistrationTransactionId(receipt)` to extract the entry ID (registration transaction id) from a receipt
+- General availability release targeting REST API version `2026-03-26`
+- Added a utility method `CcfReceipt.GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes)` to extract the entry ID (registration transaction id) from a receipt
 
 ### Other Changes
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0 (2026-07-13)
+## 1.0.0 (2026-07-15)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Features Added
 
-- General availability release.
+- General availability release targetting REST API version `2026-03-26`
+- Added a utility method `CcfReceipt.GetRegistrationTransactionId(receipt)` to extract the entry ID (registration transaction id) from a receipt
+
+### Other Changes
+
+- Removed namespace `Azure.Security.CodeTransparency.Receipt`, all classes have been moved to `Azure.Security.CodeTransparency`.
+- Updated `CodeTransparencyRedirectPolicy` to also allow 303 redirects which is returned in the case of the entry create operation.
 
 ## 1.0.0-beta.9 (2026-05-26)
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net10.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net10.0.cs
@@ -18,6 +18,31 @@ namespace Azure.Security.CodeTransparency
         public static string GetStringValueFromCborMapByKey(byte[] cborBytes, int key) { throw null; }
         public static string GetStringValueFromCborMapByKey(byte[] cborBytes, string key) { throw null; }
     }
+    public partial class CcfReceipt
+    {
+        public static readonly int CcfProofLeafLabel;
+        public static readonly int CcfProofPathLabel;
+        public static readonly int CcfTreeAlgLabel;
+        public static readonly int CoseHeaderEmbeddedReceipts;
+        public static readonly int CosePhdrVdpLabel;
+        public static readonly int CosePhdrVdsLabel;
+        public static readonly int CoseReceiptCwtIssLabel;
+        public static readonly int CoseReceiptCwtMapLabel;
+        public static readonly int CoseReceiptInclusionProofLabel;
+        public static readonly ulong ReceiptHeaderIssuer;
+        public static readonly ulong ReceiptHeaderKeyId;
+        public static readonly string ReceiptHeaderRegistrationTime;
+        public static readonly string ReceiptHeaderServiceId;
+        public static readonly string ReceiptHeaderTreeAlgorithm;
+        public static readonly string SupportedTreeAlgorithm;
+        public CcfReceipt() { }
+        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
+    }
+    public partial class CcfReceiptVerifier
+    {
+        public CcfReceiptVerifier() { }
+        public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
+    }
     public partial class CodeTransparencyCertificateClient
     {
         protected CodeTransparencyCertificateClient() { }
@@ -219,33 +244,5 @@ namespace Azure.Security.CodeTransparency
         VerifyAll = 0,
         IgnoreAll = 1,
         FailIfPresent = 2,
-    }
-}
-namespace Azure.Security.CodeTransparency.Receipt
-{
-    public partial class CcfReceipt
-    {
-        public static readonly int CcfProofLeafLabel;
-        public static readonly int CcfProofPathLabel;
-        public static readonly int CcfTreeAlgLabel;
-        public static readonly int CoseHeaderEmbeddedReceipts;
-        public static readonly int CosePhdrVdpLabel;
-        public static readonly int CosePhdrVdsLabel;
-        public static readonly int CoseReceiptCwtIssLabel;
-        public static readonly int CoseReceiptCwtMapLabel;
-        public static readonly int CoseReceiptInclusionProofLabel;
-        public static readonly ulong ReceiptHeaderIssuer;
-        public static readonly ulong ReceiptHeaderKeyId;
-        public static readonly string ReceiptHeaderRegistrationTime;
-        public static readonly string ReceiptHeaderServiceId;
-        public static readonly string ReceiptHeaderTreeAlgorithm;
-        public static readonly string SupportedTreeAlgorithm;
-        public CcfReceipt() { }
-        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
-    }
-    public partial class CcfReceiptVerifier
-    {
-        public CcfReceiptVerifier() { }
-        public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
@@ -18,6 +18,31 @@ namespace Azure.Security.CodeTransparency
         public static string GetStringValueFromCborMapByKey(byte[] cborBytes, int key) { throw null; }
         public static string GetStringValueFromCborMapByKey(byte[] cborBytes, string key) { throw null; }
     }
+    public partial class CcfReceipt
+    {
+        public static readonly int CcfProofLeafLabel;
+        public static readonly int CcfProofPathLabel;
+        public static readonly int CcfTreeAlgLabel;
+        public static readonly int CoseHeaderEmbeddedReceipts;
+        public static readonly int CosePhdrVdpLabel;
+        public static readonly int CosePhdrVdsLabel;
+        public static readonly int CoseReceiptCwtIssLabel;
+        public static readonly int CoseReceiptCwtMapLabel;
+        public static readonly int CoseReceiptInclusionProofLabel;
+        public static readonly ulong ReceiptHeaderIssuer;
+        public static readonly ulong ReceiptHeaderKeyId;
+        public static readonly string ReceiptHeaderRegistrationTime;
+        public static readonly string ReceiptHeaderServiceId;
+        public static readonly string ReceiptHeaderTreeAlgorithm;
+        public static readonly string SupportedTreeAlgorithm;
+        public CcfReceipt() { }
+        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
+    }
+    public partial class CcfReceiptVerifier
+    {
+        public CcfReceiptVerifier() { }
+        public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
+    }
     public partial class CodeTransparencyCertificateClient
     {
         protected CodeTransparencyCertificateClient() { }
@@ -219,33 +244,5 @@ namespace Azure.Security.CodeTransparency
         VerifyAll = 0,
         IgnoreAll = 1,
         FailIfPresent = 2,
-    }
-}
-namespace Azure.Security.CodeTransparency.Receipt
-{
-    public partial class CcfReceipt
-    {
-        public static readonly int CcfProofLeafLabel;
-        public static readonly int CcfProofPathLabel;
-        public static readonly int CcfTreeAlgLabel;
-        public static readonly int CoseHeaderEmbeddedReceipts;
-        public static readonly int CosePhdrVdpLabel;
-        public static readonly int CosePhdrVdsLabel;
-        public static readonly int CoseReceiptCwtIssLabel;
-        public static readonly int CoseReceiptCwtMapLabel;
-        public static readonly int CoseReceiptInclusionProofLabel;
-        public static readonly ulong ReceiptHeaderIssuer;
-        public static readonly ulong ReceiptHeaderKeyId;
-        public static readonly string ReceiptHeaderRegistrationTime;
-        public static readonly string ReceiptHeaderServiceId;
-        public static readonly string ReceiptHeaderTreeAlgorithm;
-        public static readonly string SupportedTreeAlgorithm;
-        public CcfReceipt() { }
-        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
-    }
-    public partial class CcfReceiptVerifier
-    {
-        public CcfReceiptVerifier() { }
-        public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
@@ -18,6 +18,31 @@ namespace Azure.Security.CodeTransparency
         public static string GetStringValueFromCborMapByKey(byte[] cborBytes, int key) { throw null; }
         public static string GetStringValueFromCborMapByKey(byte[] cborBytes, string key) { throw null; }
     }
+    public partial class CcfReceipt
+    {
+        public static readonly int CcfProofLeafLabel;
+        public static readonly int CcfProofPathLabel;
+        public static readonly int CcfTreeAlgLabel;
+        public static readonly int CoseHeaderEmbeddedReceipts;
+        public static readonly int CosePhdrVdpLabel;
+        public static readonly int CosePhdrVdsLabel;
+        public static readonly int CoseReceiptCwtIssLabel;
+        public static readonly int CoseReceiptCwtMapLabel;
+        public static readonly int CoseReceiptInclusionProofLabel;
+        public static readonly ulong ReceiptHeaderIssuer;
+        public static readonly ulong ReceiptHeaderKeyId;
+        public static readonly string ReceiptHeaderRegistrationTime;
+        public static readonly string ReceiptHeaderServiceId;
+        public static readonly string ReceiptHeaderTreeAlgorithm;
+        public static readonly string SupportedTreeAlgorithm;
+        public CcfReceipt() { }
+        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
+    }
+    public partial class CcfReceiptVerifier
+    {
+        public CcfReceiptVerifier() { }
+        public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
+    }
     public partial class CodeTransparencyCertificateClient
     {
         protected CodeTransparencyCertificateClient() { }
@@ -216,33 +241,5 @@ namespace Azure.Security.CodeTransparency
         VerifyAll = 0,
         IgnoreAll = 1,
         FailIfPresent = 2,
-    }
-}
-namespace Azure.Security.CodeTransparency.Receipt
-{
-    public partial class CcfReceipt
-    {
-        public static readonly int CcfProofLeafLabel;
-        public static readonly int CcfProofPathLabel;
-        public static readonly int CcfTreeAlgLabel;
-        public static readonly int CoseHeaderEmbeddedReceipts;
-        public static readonly int CosePhdrVdpLabel;
-        public static readonly int CosePhdrVdsLabel;
-        public static readonly int CoseReceiptCwtIssLabel;
-        public static readonly int CoseReceiptCwtMapLabel;
-        public static readonly int CoseReceiptInclusionProofLabel;
-        public static readonly ulong ReceiptHeaderIssuer;
-        public static readonly ulong ReceiptHeaderKeyId;
-        public static readonly string ReceiptHeaderRegistrationTime;
-        public static readonly string ReceiptHeaderServiceId;
-        public static readonly string ReceiptHeaderTreeAlgorithm;
-        public static readonly string SupportedTreeAlgorithm;
-        public CcfReceipt() { }
-        public static string GetRegistrationTransactionId(byte[] receiptCoseSign1Bytes) { throw null; }
-    }
-    public partial class CcfReceiptVerifier
-    {
-        public CcfReceiptVerifier() { }
-        public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceipt.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceipt.cs
@@ -7,7 +7,7 @@ using System.Formats.Cbor;
 using System.Security.Cryptography.Cose;
 
 // cspell:ignore bstr
-namespace Azure.Security.CodeTransparency.Receipt
+namespace Azure.Security.CodeTransparency
 {
     /// <summary>
     /// CcfReceipt class which enables encoding, decoding and verification of receipts issued from the Signing Transparency Service.

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceiptVerifier.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceiptVerifier.cs
@@ -9,9 +9,9 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.Cose;
 using System.Text;
 using Azure.Core;
-using static Azure.Security.CodeTransparency.Receipt.CcfReceipt;
+using static Azure.Security.CodeTransparency.CcfReceipt;
 
-namespace Azure.Security.CodeTransparency.Receipt
+namespace Azure.Security.CodeTransparency
 {
     /// <summary>
     /// CcfReceiptVerifier class contains the methods to verify the CCF SCITT receipt

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Security.CodeTransparency.Receipt;
 using Microsoft.TypeSpec.Generator.Customizations;
 
 namespace Azure.Security.CodeTransparency

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CcfReceiptVerifierTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CcfReceiptVerifierTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Azure.Core.TestFramework;
-using Azure.Security.CodeTransparency.Receipt;
 using NUnit.Framework;
 
 namespace Azure.Security.CodeTransparency.Tests

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Identity;
-using Azure.Security.CodeTransparency.Receipt;
 using NUnit.Framework;
 
 namespace Azure.Security.CodeTransparency.Tests


### PR DESCRIPTION
Addressing comments in https://spa.apiview.dev/review/02c4a28fc696407e8b3242a7210e74df?activeApiRevisionId=7be9038146c54ee2a466c0760a52cc51 

- Removing namespace `Azure.Security.CodeTransparency.Receipt` in favor of `Azure.Security.CodeTransparency`
- Updated release notes to reflect what changed in this release

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
