### PR TITLE
fix: avoid duplicate backcompat methods for ResourceSerializationProvider

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceSerializationProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceSerializationProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using System;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -108,6 +109,11 @@ namespace Azure.Generator.Management.Providers
                 this);
 
             return [jsonModelWriteMethod, jsonModelCreatemethod, persistableWriteMethod, persistableCreateMethod, persistableGetFormatMethod];
+        }
+
+        protected override IReadOnlyList<MethodProvider> BuildMethodsForBackCompatibility(IEnumerable<MethodProvider> originalMethods)
+        {
+            return [.. originalMethods];
         }
     }
 }


### PR DESCRIPTION
This PR adds a fix as part of https://github.com/microsoft/typespec/pull/10988/ which will generalize the back compat support and allow the mgmt generator to consume the functionality. The ResourceSerializationProvider is being added the the mgmt output library which could unintentionally cause the same back compat methods to be added more than once to the same type.