### PR TITLE
fix(agentserver-core): align in-repo version to published beta.26 to unblock Responses release

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.27 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.26 (2026-06-28)
 
 ### Features Added

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Release History
 
-## 1.0.0-beta.27 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.0.0-beta.26 (2026-06-28)
 
 ### Features Added

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
@@ -3,7 +3,7 @@
     <RequiredTargetFrameworks>$(RequiredRunnableTargetFrameworks)</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Azure.AI.AgentServer.Core</RootNamespace>
-    <Version>1.0.0-beta.27</Version>
+    <Version>1.0.0-beta.26</Version>
     <Description>Shared foundation for Azure AI Agent Server packages — provides port binding, health probes, OpenTelemetry, graceful shutdown, and the composable AgentHostBuilder.</Description>
     <PackageTags>Microsoft Azure AI Agent Server Core ASP.NET Core OpenTelemetry</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Problem

The `Azure.AI.AgentServer.Responses` release is failing, and so is the `Azure.AI.AgentServer.Core` changelog verification.

Root cause: after `Core 1.0.0-beta.26` shipped, the Azure SDK Bot's routine post-release auto-increment (commit `c8ed5685fe5`, "Increment version for agentserver releases") bumped Core's in-repo `<Version>` to `1.0.0-beta.27 (Unreleased)` with an empty changelog template.

Because `Responses` references `Core` via a **`ProjectReference`**, packing `Responses` stamps its NuGet dependency as `Azure.AI.AgentServer.Core >= 1.0.0-beta.27`. But `beta.27` was never published (latest on the feed is `beta.26`), so:

- The Responses release `InstallationCheck` fails: `NU1102: Unable to find package Azure.AI.AgentServer.Core (>= 1.0.0-beta.27)`.
- The Core release trips `Verify-ChangeLog` because the `beta.27` entry has no date and only empty sections.

`Core` has **no code changes** since `beta.26` (only the auto-increment commit touched it).

## Fix

Since Core has nothing to release, align its in-repo version with the last published one:

- `Azure.AI.AgentServer.Core.csproj`: `<Version>` `1.0.0-beta.27` → `1.0.0-beta.26`.
- `Core/CHANGELOG.md`: remove the empty `## 1.0.0-beta.27 (Unreleased)` placeholder so the top entry is the released `## 1.0.0-beta.26 (2026-06-28)`.

With this, `Responses` packs a dependency on the published `Core >= 1.0.0-beta.26`, so `InstallationCheck` restores successfully, and Core (now at its already-published version) is skipped by the release tooling rather than shipping an empty package.

## Note

This intentionally reverts below the bot's auto-increment. The next real Core change should bump back to `beta.27`.
