### PR TITLE
Remove redundant auto-release label condition

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -72,7 +72,6 @@ stages:
                   ne(variables['SetDevVersion'], 'true'),
                   ne(variables['Skip.Release'], 'true'),
                   ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr'),
-                  eq(dependencies.AutoReleasePrepare.outputs['ResolveAutoReleasePackages.resolve.AutoReleaseLabelPresent'], 'true'),
                   eq(dependencies.AutoReleasePrepare.outputs['ResolveAutoReleasePackages.resolve.ReleaseArtifact_${{artifact.safeName}}'], 'true'))
           ${{ else }}:
             # Manual release path: unchanged existing behavior.


### PR DESCRIPTION
## Description

Removes the redundant auto-release label condition from the .NET release stage. The auto-release preparation stage already receives the shared release gate, and release stages continue to gate on the per-artifact auto-release output.

## Testing

Not run (pipeline YAML cleanup only).