### PR TITLE
Remove bool-specific flatten property naming

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/PropertyHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/PropertyHelpers.cs
@@ -243,6 +243,10 @@ namespace Azure.Generator.Management.Utilities
             if (immediateParentPropertyName.EndsWith(innerProperty.Name, StringComparison.Ordinal))
                 return immediateParentPropertyName;
 
+            var nameWords = innerProperty.Name.SplitByCamelCase().ToArray();
+            if (nameWords.Length > 1 && nameWords[0].Equals("Is", StringComparison.Ordinal))
+                return $"Is{immediateParentPropertyName}{string.Join("", nameWords.Skip(1))}";
+
             var parentWords = immediateParentPropertyName.SplitByCamelCase();
             bool suffixStripped = false;
             if (immediateParentPropertyName.EndsWith("Profile", StringComparison.Ordinal) ||
@@ -257,7 +261,6 @@ namespace Azure.Generator.Management.Utilities
 
             var parentWordArray = parentWords.ToArray();
             var parentWordsHash = new HashSet<string>(parentWordArray);
-            var nameWords = innerProperty.Name.SplitByCamelCase().ToArray();
             var lastWord = string.Empty;
             for (int i = 0; i < nameWords.Length; i++)
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/PropertyHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/PropertyHelpers.cs
@@ -237,11 +237,6 @@ namespace Azure.Generator.Management.Utilities
         {
             var immediateParentPropertyName = GetPropertyName(immediateParentProperty);
 
-            if (innerProperty.Type.Equals(typeof(bool)) || innerProperty.Type.Equals(typeof(bool?)))
-            {
-                return innerProperty.Name.Equals("Enabled", StringComparison.Ordinal) ? $"{immediateParentPropertyName}{innerProperty.Name}" : innerProperty.Name;
-            }
-
             if (innerProperty.Name.Equals("Id", StringComparison.Ordinal))
                 return $"{immediateParentPropertyName}{innerProperty.Name}";
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Utilities/PropertyHelpersTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Utilities/PropertyHelpersTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management.Utilities;
+using Azure.Generator.Management.Tests.TestHelpers;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using NUnit.Framework;
+
+namespace Azure.Generator.Mgmt.Tests.Utilities
+{
+    internal class PropertyHelpersTests
+    {
+        [Test]
+        public void GetCombinedPropertyNameInsertsOuterNameAfterIsPrefix()
+        {
+            ManagementMockHelpers.LoadMockPlugin();
+            var enclosingType = new TestTypeProvider();
+            var innerProperty = new PropertyProvider(null, MethodSignatureModifiers.Public, typeof(bool), "IsEnabled", new AutoPropertyBody(true), enclosingType);
+            var outerProperty = new PropertyProvider(null, MethodSignatureModifiers.Public, typeof(object), "Bar", new AutoPropertyBody(true), enclosingType);
+
+            var result = PropertyHelpers.GetCombinedPropertyName(innerProperty, outerProperty);
+
+            Assert.That(result, Is.EqualTo("IsBarEnabled"));
+        }
+
+        [Test]
+        public void GetCombinedPropertyNameDoesNotTreatIsolationAsIsPrefix()
+        {
+            ManagementMockHelpers.LoadMockPlugin();
+            var enclosingType = new TestTypeProvider();
+            var innerProperty = new PropertyProvider(null, MethodSignatureModifiers.Public, typeof(string), "IsolationMode", new AutoPropertyBody(true), enclosingType);
+            var outerProperty = new PropertyProvider(null, MethodSignatureModifiers.Public, typeof(object), "Network", new AutoPropertyBody(true), enclosingType);
+
+            var result = PropertyHelpers.GetCombinedPropertyName(innerProperty, outerProperty);
+
+            Assert.That(result, Is.EqualTo("NetworkIsolationMode"));
+        }
+
+        private class TestTypeProvider : TypeProvider
+        {
+            protected override string BuildName() => nameof(TestTypeProvider);
+
+            protected override string BuildRelativeFilePath() => $"{Name}.cs";
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResourceData.cs
@@ -106,7 +106,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         /// <summary> enabled. </summary>
         [WirePath("properties.isEnabled")]
-        public bool? BarIsEnabled
+        public bool? IsBarSettingsEnabled
         {
             get
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarSettingsResourceData.cs
@@ -106,7 +106,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         /// <summary> enabled. </summary>
         [WirePath("properties.isEnabled")]
-        public bool? IsEnabled
+        public bool? BarIsEnabled
         {
             get
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
@@ -156,10 +156,10 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 systemData,
                 tags ?? new ChangeTrackingDictionary<string, string>(),
                 location,
-                boolValue is null && nestedPropertyProperties is null && flattenedProperty is null && computeFleetVmCapacityReservationGroupId is null ? default : new FooProperties(
+                nestedPropertyProperties is null && flattenedProperty is null && computeFleetVmCapacityReservationGroupId is null ? default : new FooProperties(
                     default,
                     default,
-                    boolValue,
+                    default,
                     default,
                     default,
                     default,


### PR DESCRIPTION
## Description
Remove the bool/bool? special case from management-plane safe-flatten property naming so flattened property names are not selected based on the leaf property's CLR type.

This keeps the management generator aligned with provisioning when a bool leaf is wrapped, and regenerates the affected management test project output.

Fixes #60921

## Validation
- eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1
- dotnet test eng/packages/http-client-csharp-mgmt/generator --logger "trx;LogFileName=debug.trx"