### PR TITLE
[SignalR] Add serverless authentication-refresh binding

### DIFF
--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added serverless authentication refresh support so a Function App can extend a live SignalR client connection's authentication (and application claims) without reconnecting.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Features Added
 
-- Added serverless authentication refresh support so a Function App can extend a live SignalR client connection's authentication (and application claims) without reconnecting.
+- Added serverless authentication refresh support through the `[SignalRRefresh]` input binding so a Function App can extend a live SignalR client connection's authentication and application claims without reconnecting.
+- Added authentication-refresh options to negotiation bindings, including refresh opt-in, close-on-expiration, and the maximum service access-token lifetime.
+- Token validation now exposes the validated application-authentication expiration so negotiate and refresh can preserve the app-token security boundary.
 
 ### Breaking Changes
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/README.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/README.md
@@ -71,6 +71,36 @@ SignalR client
 
 Please follow the [Azure SignalR Connection Info input binding tutorial](https://learn.microsoft.com/azure/azure-functions/functions-bindings-signalr-service-input?tabs=csharp) to learn more about SignalR Connection Info input binding.
 
+### Authentication refresh
+
+Authentication refresh lets a refresh-aware SignalR client update a live connection's application authentication deadline and claims without reconnecting. Opt in during negotiate and expose a sibling refresh endpoint that returns `SignalRConnectionInfo`:
+
+```C# Snippet:AuthenticationRefresh
+[FunctionName("Negotiate")]
+public static SignalRConnectionInfo Negotiate(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "chat/negotiate")] HttpRequest req,
+    [SignalRConnectionInfo(
+        HubName = "chat",
+        UserId = "{headers.x-ms-client-principal-id}",
+        EnableAuthenticationRefresh = true,
+        CloseOnAuthenticationExpiration = true,
+        TokenLifetimeSeconds = 3600)] SignalRConnectionInfo connectionInfo)
+{
+    return connectionInfo;
+}
+
+[FunctionName("Refresh")]
+public static SignalRConnectionInfo Refresh(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "chat/refresh")] HttpRequest req,
+    [SignalRRefresh(
+        HubName = "chat",
+        ConnectionToken = "{query.id}",
+        TokenLifetimeSeconds = 3600)] SignalRConnectionInfo connectionInfo)
+{
+    return connectionInfo;
+}
+```
+
 ### SignalR output binding
 
 `SignalR` output binding allows :
@@ -87,6 +117,7 @@ Please follow the [Azure SignalR trigger](https://learn.microsoft.com/azure/azur
 
 ## Supported scenarios
 - Negotiate for a SignalR client.
+- Refresh authentication for a live SignalR client connection.
 - Manage group like add/remove a single user/connection in a group.
 - Send messages to a single user/connection, to a group, to all users/connections.
 - Use multiple Azure SignalR Service instances for resiliency and disaster recovery in Azure Functions. See details in [Multiple Azure SignalR Service Instances Support in Azure Functions](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/docs/sharding.md).

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net10.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net10.0.cs
@@ -156,6 +156,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public SignalRConnectionInfo() { }
         [Newtonsoft.Json.JsonPropertyAttribute("accessToken")]
         public string AccessToken { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("tokenLifetimeSeconds", NullValueHandling=Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? TokenLifetimeSeconds { get { throw null; } set { } }
         [Newtonsoft.Json.JsonPropertyAttribute("url")]
         public string Url { get { throw null; } set { } }
     }
@@ -164,6 +166,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRConnectionInfoAttribute() { }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SignalRRefreshAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
+    {
+        public SignalRRefreshAttribute() { }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string ConnectionToken { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net10.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net10.0.cs
@@ -73,12 +73,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         internal SecurityTokenResult() { }
         [Newtonsoft.Json.JsonPropertyAttribute("exception")]
         public System.Exception Exception { get { throw null; } }
+        [Newtonsoft.Json.JsonPropertyAttribute("expiresOn")]
+        public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public System.Security.Claims.ClaimsPrincipal Principal { get { throw null; } }
         [Newtonsoft.Json.JsonPropertyAttribute("status")]
         public Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenStatus Status { get { throw null; } }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Empty() { throw null; }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Error(System.Exception ex) { throw null; }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal) { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal, System.DateTimeOffset? expiresOn) { throw null; }
     }
     public enum SecurityTokenStatus
     {
@@ -148,6 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionDetail
     {
         public SignalRConnectionDetail() { }
+        public System.DateTimeOffset? AuthenticationExpiresOn { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Security.Claims.Claim> Claims { get { throw null; } set { } }
         public string UserId { get { throw null; } set { } }
     }
@@ -166,6 +170,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRConnectionInfoAttribute() { }
+        public bool CloseOnAuthenticationExpiration { get { throw null; } set { } }
+        public bool EnableAuthenticationRefresh { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
@@ -241,6 +248,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRNegotiationAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRNegotiationAttribute() { }
+        public bool CloseOnAuthenticationExpiration { get { throw null; } set { } }
+        public bool EnableAuthenticationRefresh { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     public partial class SignalROptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
     {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net6.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net6.0.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public SignalRConnectionInfo() { }
         [Newtonsoft.Json.JsonPropertyAttribute("accessToken")]
         public string AccessToken { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("tokenLifetimeSeconds", NullValueHandling=Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? TokenLifetimeSeconds { get { throw null; } set { } }
         [Newtonsoft.Json.JsonPropertyAttribute("url")]
         public string Url { get { throw null; } set { } }
     }
@@ -166,6 +168,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRConnectionInfoAttribute() { }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SignalRRefreshAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
+    {
+        public SignalRRefreshAttribute() { }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string ConnectionToken { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net6.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net6.0.cs
@@ -75,12 +75,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         internal SecurityTokenResult() { }
         [Newtonsoft.Json.JsonPropertyAttribute("exception")]
         public System.Exception Exception { get { throw null; } }
+        [Newtonsoft.Json.JsonPropertyAttribute("expiresOn")]
+        public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public System.Security.Claims.ClaimsPrincipal Principal { get { throw null; } }
         [Newtonsoft.Json.JsonPropertyAttribute("status")]
         public Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenStatus Status { get { throw null; } }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Empty() { throw null; }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Error(System.Exception ex) { throw null; }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal) { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal, System.DateTimeOffset? expiresOn) { throw null; }
     }
     public enum SecurityTokenStatus
     {
@@ -150,6 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionDetail
     {
         public SignalRConnectionDetail() { }
+        public System.DateTimeOffset? AuthenticationExpiresOn { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Security.Claims.Claim> Claims { get { throw null; } set { } }
         public string UserId { get { throw null; } set { } }
     }
@@ -168,6 +172,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRConnectionInfoAttribute() { }
+        public bool CloseOnAuthenticationExpiration { get { throw null; } set { } }
+        public bool EnableAuthenticationRefresh { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
@@ -243,6 +250,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRNegotiationAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRNegotiationAttribute() { }
+        public bool CloseOnAuthenticationExpiration { get { throw null; } set { } }
+        public bool EnableAuthenticationRefresh { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     public partial class SignalROptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
     {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net8.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net8.0.cs
@@ -156,6 +156,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public SignalRConnectionInfo() { }
         [Newtonsoft.Json.JsonPropertyAttribute("accessToken")]
         public string AccessToken { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("tokenLifetimeSeconds", NullValueHandling=Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? TokenLifetimeSeconds { get { throw null; } set { } }
         [Newtonsoft.Json.JsonPropertyAttribute("url")]
         public string Url { get { throw null; } set { } }
     }
@@ -164,6 +166,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRConnectionInfoAttribute() { }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SignalRRefreshAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
+    {
+        public SignalRRefreshAttribute() { }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string ConnectionToken { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net8.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.net8.0.cs
@@ -73,12 +73,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         internal SecurityTokenResult() { }
         [Newtonsoft.Json.JsonPropertyAttribute("exception")]
         public System.Exception Exception { get { throw null; } }
+        [Newtonsoft.Json.JsonPropertyAttribute("expiresOn")]
+        public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public System.Security.Claims.ClaimsPrincipal Principal { get { throw null; } }
         [Newtonsoft.Json.JsonPropertyAttribute("status")]
         public Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenStatus Status { get { throw null; } }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Empty() { throw null; }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Error(System.Exception ex) { throw null; }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal) { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal, System.DateTimeOffset? expiresOn) { throw null; }
     }
     public enum SecurityTokenStatus
     {
@@ -148,6 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionDetail
     {
         public SignalRConnectionDetail() { }
+        public System.DateTimeOffset? AuthenticationExpiresOn { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Security.Claims.Claim> Claims { get { throw null; } set { } }
         public string UserId { get { throw null; } set { } }
     }
@@ -166,6 +170,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRConnectionInfoAttribute() { }
+        public bool CloseOnAuthenticationExpiration { get { throw null; } set { } }
+        public bool EnableAuthenticationRefresh { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
@@ -241,6 +248,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRNegotiationAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRNegotiationAttribute() { }
+        public bool CloseOnAuthenticationExpiration { get { throw null; } set { } }
+        public bool EnableAuthenticationRefresh { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     public partial class SignalROptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
     {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
@@ -156,6 +156,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public SignalRConnectionInfo() { }
         [Newtonsoft.Json.JsonPropertyAttribute("accessToken")]
         public string AccessToken { get { throw null; } set { } }
+        [Newtonsoft.Json.JsonPropertyAttribute("tokenLifetimeSeconds", NullValueHandling=Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? TokenLifetimeSeconds { get { throw null; } set { } }
         [Newtonsoft.Json.JsonPropertyAttribute("url")]
         public string Url { get { throw null; } set { } }
     }
@@ -164,6 +166,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRConnectionInfoAttribute() { }
+    }
+    [Microsoft.Azure.WebJobs.Description.BindingAttribute]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+    public partial class SignalRRefreshAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
+    {
+        public SignalRRefreshAttribute() { }
+        [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
+        public string ConnectionToken { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
@@ -73,12 +73,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         internal SecurityTokenResult() { }
         [Newtonsoft.Json.JsonPropertyAttribute("exception")]
         public System.Exception Exception { get { throw null; } }
+        [Newtonsoft.Json.JsonPropertyAttribute("expiresOn")]
+        public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public System.Security.Claims.ClaimsPrincipal Principal { get { throw null; } }
         [Newtonsoft.Json.JsonPropertyAttribute("status")]
         public Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenStatus Status { get { throw null; } }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Empty() { throw null; }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Error(System.Exception ex) { throw null; }
         public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal) { throw null; }
+        public static Microsoft.Azure.WebJobs.Extensions.SignalRService.SecurityTokenResult Success(System.Security.Claims.ClaimsPrincipal principal, System.DateTimeOffset? expiresOn) { throw null; }
     }
     public enum SecurityTokenStatus
     {
@@ -148,6 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionDetail
     {
         public SignalRConnectionDetail() { }
+        public System.DateTimeOffset? AuthenticationExpiresOn { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Security.Claims.Claim> Claims { get { throw null; } set { } }
         public string UserId { get { throw null; } set { } }
     }
@@ -166,6 +170,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRConnectionInfoAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRConnectionInfoAttribute() { }
+        public bool CloseOnAuthenticationExpiration { get { throw null; } set { } }
+        public bool EnableAuthenticationRefresh { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
@@ -241,6 +248,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public partial class SignalRNegotiationAttribute : Microsoft.Azure.WebJobs.Extensions.SignalRService.NegotiationBaseAttribute
     {
         public SignalRNegotiationAttribute() { }
+        public bool CloseOnAuthenticationExpiration { get { throw null; } set { } }
+        public bool EnableAuthenticationRefresh { get { throw null; } set { } }
+        public int TokenLifetimeSeconds { get { throw null; } set { } }
     }
     public partial class SignalROptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
     {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/DefaultSecurityTokenValidator.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/DefaultSecurityTokenValidator.cs
@@ -36,9 +36,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                     if (authHeaderValue.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
                     {
                         var token = authHeaderValue.Substring(BearerPrefix.Length);
-                        var principal = _handler.ValidateToken(token, _tokenValidationParameters, out _);
+                        var principal = _handler.ValidateToken(token, _tokenValidationParameters, out var validatedToken);
+                        var expiresOn = validatedToken.ValidTo == DateTime.MinValue
+                            ? (DateTimeOffset?)null
+                            : new DateTimeOffset(validatedToken.ValidTo.ToUniversalTime());
 
-                        return SecurityTokenResult.Success(principal);
+                        return SecurityTokenResult.Success(principal, expiresOn);
                     }
                 }
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/SecurityTokenResult.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/SecurityTokenResult.cs
@@ -29,17 +29,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         [JsonProperty("exception")]
         public Exception Exception { get; }
 
-        private SecurityTokenResult(SecurityTokenStatus status, ClaimsPrincipal principal = null, Exception exception = null)
+        /// <summary>
+        /// Gets the validated token's authentication expiration, when available.
+        /// </summary>
+        [JsonProperty("expiresOn")]
+        public DateTimeOffset? ExpiresOn { get; }
+
+        private SecurityTokenResult(SecurityTokenStatus status, ClaimsPrincipal principal = null, Exception exception = null, DateTimeOffset? expiresOn = null)
         {
             Status = status;
             Principal = principal;
             Exception = exception;
+            ExpiresOn = expiresOn;
         }
 
         /// <summary>
         /// Static initializer for creating validation result of a valid token.
         /// </summary>
         public static SecurityTokenResult Success(ClaimsPrincipal principal) => new SecurityTokenResult(SecurityTokenStatus.Valid, principal: principal);
+
+        /// <summary>
+        /// Static initializer for creating a validation result with the validated authentication expiration.
+        /// </summary>
+        public static SecurityTokenResult Success(ClaimsPrincipal principal, DateTimeOffset? expiresOn) =>
+            new SecurityTokenResult(SecurityTokenStatus.Valid, principal: principal, expiresOn: expiresOn);
 
         /// <summary>
         /// Static initializer for creating validation result of an invalid token.

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/SignalRConnectionDetail.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/SignalRConnectionDetail.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Security.Claims;
+using System;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
@@ -21,5 +22,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         /// Custom claims that added to SignalR access token.
         /// </summary>
         public IList<Claim> Claims { get; set; }
+
+        /// <summary>
+        /// Gets or sets the application authentication expiration used by authentication refresh.
+        /// </summary>
+        public DateTimeOffset? AuthenticationExpiresOn { get; set; }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRConnectionInfo.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRConnectionInfo.cs
@@ -22,5 +22,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         /// </summary>
         [JsonProperty("accessToken")]
         public string AccessToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of seconds after which the client should refresh its authentication.
+        /// </summary>
+        [JsonProperty("tokenLifetimeSeconds", NullValueHandling = NullValueHandling.Ignore)]
+        public int? TokenLifetimeSeconds { get; set; }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/Common/BindingBase.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/Common/BindingBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Protocols;
@@ -40,12 +41,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             }
         }
 
-        protected abstract Task<IValueProvider> BuildAsync(TAttribute attrResolved, IReadOnlyDictionary<string, object> bindingContext);
+        protected abstract Task<IValueProvider> BuildAsync(
+            TAttribute attrResolved,
+            IReadOnlyDictionary<string, object> bindingContext,
+            CancellationToken cancellationToken);
 
         public async Task<IValueProvider> BindAsync(BindingContext context)
         {
             var attrResolved = Cloner.ResolveFromBindingData(context);
-            return await BuildAsync(attrResolved, context.BindingData).ConfigureAwait(false);
+            return await BuildAsync(attrResolved, context.BindingData, context.CancellationToken).ConfigureAwait(false);
         }
 
         public Task<IValueProvider> BindAsync(object value, ValueBindingContext context)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/Common/InputBindingProvider.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/Common/InputBindingProvider.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 return Task.FromResult<IBinding>(new SignalRConnectionInputBinding(context, configuration, nameResolver, securityTokenValidator, signalRConnectionInfoConfigurer));
             }
+            if (parameterInfo.GetCustomAttribute<SignalRRefreshAttribute>() != null)
+            {
+                return Task.FromResult<IBinding>(new SignalRRefreshInputBinding(context, configuration, nameResolver, securityTokenValidator, signalRConnectionInfoConfigurer));
+            }
             if (parameterInfo.GetCustomAttribute<SecurityTokenValidationAttribute>() != null)
             {
                 return Task.FromResult<IBinding>(new SecurityTokenValidationInputBinding(securityTokenValidator));

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRConnectionInputBinding/SignalRConnectionInfoValueProvider.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRConnectionInputBinding/SignalRConnectionInfoValueProvider.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
         private object GetUserTypeInfo()
         {
+            if (_info == null)
+            {
+                return null;
+            }
+
             if (Type == typeof(JObject))
             {
                 return JObject.FromObject(_info);

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRConnectionInputBinding/SignalRConnectionInputBinding.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRConnectionInputBinding/SignalRConnectionInputBinding.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -32,7 +33,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         }
 
         protected override async Task<IValueProvider> BuildAsync(SignalRConnectionInfoAttribute attrResolved,
-            IReadOnlyDictionary<string, object> bindingData)
+            IReadOnlyDictionary<string, object> bindingData,
+            CancellationToken cancellationToken)
         {
             var azureSignalRClient = await Utils.GetAzureSignalRClientAsync(attrResolved.ConnectionStringSetting, attrResolved.HubName, _managerStore).ConfigureAwait(false);
             bindingData.TryGetValue(HttpRequestName, out var requestObj);
@@ -52,15 +54,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 {
                     UserId = attrResolved.UserId,
                     Claims = azureSignalRClient.GetCustomClaims(attrResolved.IdToken, attrResolved.ClaimTypeList),
+                    AuthenticationExpiresOn = tokenResult.ExpiresOn,
                 };
-                _signalRConnectionInfoConfigurer?.Configure(tokenResult, request, signalRConnectionDetail);
+                signalRConnectionDetail = _signalRConnectionInfoConfigurer?.Configure?.Invoke(tokenResult, request, signalRConnectionDetail)
+                    ?? signalRConnectionDetail;
                 var customizedInfo = await azureSignalRClient.GetClientConnectionInfoAsync(signalRConnectionDetail.UserId,
-                    signalRConnectionDetail.Claims, httpContext).ConfigureAwait(false);
+                    signalRConnectionDetail.Claims, httpContext, attrResolved.EnableAuthenticationRefresh,
+                    attrResolved.TokenLifetimeSeconds, signalRConnectionDetail.AuthenticationExpiresOn,
+                    attrResolved.CloseOnAuthenticationExpiration, cancellationToken).ConfigureAwait(false);
                 return new SignalRConnectionInfoValueProvider(customizedInfo, _userType, "");
             }
 
             var info = await azureSignalRClient.GetClientConnectionInfoAsync(attrResolved.UserId, attrResolved.IdToken,
-                attrResolved.ClaimTypeList, httpContext).ConfigureAwait(false);
+                attrResolved.ClaimTypeList, httpContext, attrResolved.EnableAuthenticationRefresh,
+                attrResolved.TokenLifetimeSeconds, authenticationExpiresOn: null,
+                attrResolved.CloseOnAuthenticationExpiration, cancellationToken).ConfigureAwait(false);
             return new SignalRConnectionInfoValueProvider(info, _userType, "");
         }
     }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRConnectionInputBinding/SignalRRefreshInputBinding.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRConnectionInputBinding/SignalRRefreshInputBinding.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    internal class SignalRRefreshInputBinding : BindingBase<SignalRRefreshAttribute>
+    {
+        private const string HttpRequestName = "$request";
+        private readonly ISecurityTokenValidator _securityTokenValidator;
+        private readonly ISignalRConnectionInfoConfigurer _signalRConnectionInfoConfigurer;
+        private readonly IServiceManagerStore _managerStore;
+        private readonly Type _userType;
+
+        public SignalRRefreshInputBinding(
+            BindingProviderContext context,
+            IConfiguration configuration,
+            INameResolver nameResolver,
+            ISecurityTokenValidator securityTokenValidator,
+            ISignalRConnectionInfoConfigurer signalRConnectionInfoConfigurer) : base(context, configuration, nameResolver)
+        {
+            _securityTokenValidator = securityTokenValidator;
+            _signalRConnectionInfoConfigurer = signalRConnectionInfoConfigurer;
+            _managerStore = StaticServiceHubContextStore.ServiceManagerStore;
+            _userType = context.Parameter.ParameterType;
+        }
+
+        protected override async Task<IValueProvider> BuildAsync(SignalRRefreshAttribute attrResolved,
+            IReadOnlyDictionary<string, object> bindingData)
+        {
+            if (string.IsNullOrEmpty(attrResolved.ConnectionToken))
+            {
+                return new SignalRConnectionInfoValueProvider(null, _userType, "");
+            }
+
+            var azureSignalRClient = await Utils.GetAzureSignalRClientAsync(attrResolved.ConnectionStringSetting, attrResolved.HubName, _managerStore).ConfigureAwait(false);
+            bindingData.TryGetValue(HttpRequestName, out var requestObj);
+            var request = requestObj as HttpRequest;
+
+            var lifetimeSeconds = attrResolved.TokenLifetimeSeconds > 0
+                ? attrResolved.TokenLifetimeSeconds
+                : Constants.DefaultAccessTokenLifetimeSeconds;
+            var expireTime = DateTimeOffset.UtcNow.AddSeconds(lifetimeSeconds);
+
+            if (bindingData.ContainsKey(HttpRequestName) && _securityTokenValidator != null)
+            {
+                var tokenResult = _securityTokenValidator.ValidateToken(request);
+
+                if (tokenResult.Status != SecurityTokenStatus.Valid)
+                {
+                    return new SignalRConnectionInfoValueProvider(null, _userType, "");
+                }
+
+                var signalRConnectionDetail = new SignalRConnectionDetail
+                {
+                    UserId = attrResolved.UserId,
+                    Claims = azureSignalRClient.GetCustomClaims(attrResolved.IdToken, attrResolved.ClaimTypeList),
+                };
+                _signalRConnectionInfoConfigurer?.Configure(tokenResult, request, signalRConnectionDetail);
+                var customizedInfo = await azureSignalRClient.RefreshConnectionInfoAsync(
+                    attrResolved.ConnectionToken, expireTime, signalRConnectionDetail.Claims).ConfigureAwait(false);
+                return new SignalRConnectionInfoValueProvider(customizedInfo, _userType, "");
+            }
+
+            var claims = azureSignalRClient.GetCustomClaims(attrResolved.IdToken, attrResolved.ClaimTypeList);
+            var info = await azureSignalRClient.RefreshConnectionInfoAsync(
+                attrResolved.ConnectionToken, expireTime, claims).ConfigureAwait(false);
+            return new SignalRConnectionInfoValueProvider(info, _userType, "");
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRConnectionInputBinding/SignalRRefreshInputBinding.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRConnectionInputBinding/SignalRRefreshInputBinding.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -32,45 +33,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         }
 
         protected override async Task<IValueProvider> BuildAsync(SignalRRefreshAttribute attrResolved,
-            IReadOnlyDictionary<string, object> bindingData)
+            IReadOnlyDictionary<string, object> bindingData,
+            CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(attrResolved.ConnectionToken))
             {
                 return new SignalRConnectionInfoValueProvider(null, _userType, "");
             }
 
-            var azureSignalRClient = await Utils.GetAzureSignalRClientAsync(attrResolved.ConnectionStringSetting, attrResolved.HubName, _managerStore).ConfigureAwait(false);
-            bindingData.TryGetValue(HttpRequestName, out var requestObj);
-            var request = requestObj as HttpRequest;
-
-            var lifetimeSeconds = attrResolved.TokenLifetimeSeconds > 0
-                ? attrResolved.TokenLifetimeSeconds
-                : Constants.DefaultAccessTokenLifetimeSeconds;
-            var expireTime = DateTimeOffset.UtcNow.AddSeconds(lifetimeSeconds);
-
-            if (bindingData.ContainsKey(HttpRequestName) && _securityTokenValidator != null)
+            if (!bindingData.ContainsKey(HttpRequestName) || _securityTokenValidator == null)
             {
-                var tokenResult = _securityTokenValidator.ValidateToken(request);
-
-                if (tokenResult.Status != SecurityTokenStatus.Valid)
-                {
-                    return new SignalRConnectionInfoValueProvider(null, _userType, "");
-                }
-
-                var signalRConnectionDetail = new SignalRConnectionDetail
-                {
-                    UserId = attrResolved.UserId,
-                    Claims = azureSignalRClient.GetCustomClaims(attrResolved.IdToken, attrResolved.ClaimTypeList),
-                };
-                _signalRConnectionInfoConfigurer?.Configure(tokenResult, request, signalRConnectionDetail);
-                var customizedInfo = await azureSignalRClient.RefreshConnectionInfoAsync(
-                    attrResolved.ConnectionToken, expireTime, signalRConnectionDetail.Claims).ConfigureAwait(false);
-                return new SignalRConnectionInfoValueProvider(customizedInfo, _userType, "");
+                return new SignalRConnectionInfoValueProvider(null, _userType, "");
             }
 
-            var claims = azureSignalRClient.GetCustomClaims(attrResolved.IdToken, attrResolved.ClaimTypeList);
+            bindingData.TryGetValue(HttpRequestName, out var requestObj);
+            var request = requestObj as HttpRequest;
+            var tokenResult = _securityTokenValidator.ValidateToken(request);
+            if (tokenResult.Status != SecurityTokenStatus.Valid)
+            {
+                return new SignalRConnectionInfoValueProvider(null, _userType, "");
+            }
+
+            var azureSignalRClient = await Utils.GetAzureSignalRClientAsync(attrResolved.ConnectionStringSetting, attrResolved.HubName, _managerStore).ConfigureAwait(false);
+            var customClaims = azureSignalRClient.GetCustomClaims(attrResolved.IdToken, attrResolved.ClaimTypeList);
+            var signalRConnectionDetail = new SignalRConnectionDetail
+            {
+                UserId = attrResolved.UserId,
+                Claims = customClaims.Count > 0 ? customClaims : null,
+                AuthenticationExpiresOn = tokenResult.ExpiresOn,
+            };
+            signalRConnectionDetail = _signalRConnectionInfoConfigurer?.Configure?.Invoke(tokenResult, request, signalRConnectionDetail)
+                ?? signalRConnectionDetail;
             var info = await azureSignalRClient.RefreshConnectionInfoAsync(
-                attrResolved.ConnectionToken, expireTime, claims).ConfigureAwait(false);
+                attrResolved.ConnectionToken, signalRConnectionDetail.AuthenticationExpiresOn,
+                signalRConnectionDetail.Claims, attrResolved.TokenLifetimeSeconds, cancellationToken).ConfigureAwait(false);
             return new SignalRConnectionInfoValueProvider(info, _userType, "");
         }
     }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRMultiConnectionInfoBinding/NegotiationContextAsyncConverter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRMultiConnectionInfoBinding/NegotiationContextAsyncConverter.cs
@@ -30,7 +30,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 var subHubContext = serviceHubContext.WithEndpoints(new ServiceEndpoint[] { e });
                 var azureSignalRClient = new AzureSignalRClient(subHubContext);
-                var connectionInfo = await azureSignalRClient.GetClientConnectionInfoAsync(input.UserId, input.IdToken, input.ClaimTypeList, null).ConfigureAwait(false);
+                var connectionInfo = await azureSignalRClient.GetClientConnectionInfoAsync(
+                    input.UserId, input.IdToken, input.ClaimTypeList, httpContext: null,
+                    input.EnableAuthenticationRefresh, input.TokenLifetimeSeconds,
+                    authenticationExpiresOn: null, input.CloseOnAuthenticationExpiration,
+                    cancellationToken).ConfigureAwait(false);
                 return new EndpointConnectionInfo(e) { ConnectionInfo = connectionInfo };
             })).ConfigureAwait(false);
             return new NegotiationContext { Endpoints = endpointConnectionInfo };

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/AzureSignalRClient.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/AzureSignalRClient.cs
@@ -44,17 +44,57 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
         public async Task<SignalRConnectionInfo> GetClientConnectionInfoAsync(string userId, IList<Claim> claims, HttpContext httpContext)
         {
-            var negotiateResponse = await _serviceHubContext.NegotiateAsync(new NegotiationOptions()
+            var negotiationOptions = new NegotiationOptions()
             {
                 UserId = userId,
                 Claims = BuildJwtClaims(claims, AzureSignalRUserPrefix).ToList(),
                 HttpContext = httpContext
-            }).ConfigureAwait(false);
+            };
+            var negotiateResult = await _serviceHubContext.NegotiateWithTokenLifetimeAsync(negotiationOptions).ConfigureAwait(false);
             return new SignalRConnectionInfo
             {
-                Url = negotiateResponse.Url,
-                AccessToken = negotiateResponse.AccessToken
+                Url = negotiateResult.Url,
+                AccessToken = negotiateResult.AccessToken,
+                TokenLifetimeSeconds = negotiateResult.TokenLifetimeSeconds
             };
+        }
+
+        /// <summary>
+        /// Refreshes the authentication expiration and application claims of a live client connection without reconnecting.
+        /// Returns a refreshed access token for the client.
+        /// Wraps the Management SDK's <c>RefreshConnectionAuthenticationAsync</c>.
+        /// </summary>
+        public async Task<SignalRConnectionInfo> RefreshConnectionInfoAsync(string connectionToken, DateTimeOffset expireTime, IList<Claim> claims)
+        {
+            if (string.IsNullOrEmpty(connectionToken))
+            {
+                throw new ArgumentException($"{nameof(connectionToken)} cannot be null or empty");
+            }
+
+            var result = await _serviceHubContext.RefreshConnectionAuthenticationAsync(
+                connectionToken,
+                expireTime,
+                BuildJwtClaims(claims, AzureSignalRUserPrefix).ToList()).ConfigureAwait(false);
+            return new SignalRConnectionInfo
+            {
+                AccessToken = result.AccessToken,
+                TokenLifetimeSeconds = result.TokenLifetimeSeconds
+            };
+        }
+
+        /// <summary>
+        /// Reads the current application claim set of a live client connection.
+        /// Wraps the Management SDK's <c>GetConnectionClaimsAsync</c>.
+        /// </summary>
+        public async Task<IList<Claim>> GetConnectionClaimsAsync(string connectionToken)
+        {
+            if (string.IsNullOrEmpty(connectionToken))
+            {
+                throw new ArgumentException($"{nameof(connectionToken)} cannot be null or empty");
+            }
+
+            var result = await _serviceHubContext.GetConnectionClaimsAsync(connectionToken).ConfigureAwait(false);
+            return result.Claims == null ? new List<Claim>() : result.Claims.ToList();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Breaking change")]

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/AzureSignalRClient.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/AzureSignalRClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.SignalR;
@@ -21,12 +22,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         public const string AzureSignalRUserPrefix = "asrs.u.";
 
+        // Todo: Move this list to a common place.
         private static readonly string[] SystemClaims =
         {
             "aud", // Audience claim, used by service to make sure token is matched with target resource.
             "exp", // Expiration time claims. A token is valid only before its expiration time.
             "iat", // Issued At claim. Added by default. It is not validated by service.
-            "nbf"  // Not Before claim. Added by default. It is not validated by service.
+            "nbf", // Not Before claim. Added by default. It is not validated by service.
+            "iss",
+            "actort",
+            "acr",
+            "azp",
+            "c_hash",
+            "jti",
+            "nonce",
         };
 
         private readonly ServiceHubContext _serviceHubContext;
@@ -36,21 +45,64 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             _serviceHubContext = serviceHubContext;
         }
 
-        public Task<SignalRConnectionInfo> GetClientConnectionInfoAsync(string userId, string idToken, string[] claimTypeList, HttpContext httpContext)
+        public Task<SignalRConnectionInfo> GetClientConnectionInfoAsync(
+            string userId,
+            string idToken,
+            string[] claimTypeList,
+            HttpContext httpContext,
+            bool enableAuthenticationRefresh = false,
+            int tokenLifetimeSeconds = 0,
+            DateTimeOffset? authenticationExpiresOn = null,
+            bool closeOnAuthenticationExpiration = false,
+            CancellationToken cancellationToken = default)
         {
             var customerClaims = GetCustomClaims(idToken, claimTypeList);
-            return GetClientConnectionInfoAsync(userId, customerClaims, httpContext);
+            return GetClientConnectionInfoAsync(
+                userId,
+                customerClaims,
+                httpContext,
+                enableAuthenticationRefresh,
+                tokenLifetimeSeconds,
+                authenticationExpiresOn,
+                closeOnAuthenticationExpiration,
+                cancellationToken);
         }
 
-        public async Task<SignalRConnectionInfo> GetClientConnectionInfoAsync(string userId, IList<Claim> claims, HttpContext httpContext)
+        public async Task<SignalRConnectionInfo> GetClientConnectionInfoAsync(
+            string userId,
+            IList<Claim> claims,
+            HttpContext httpContext,
+            bool enableAuthenticationRefresh = false,
+            int tokenLifetimeSeconds = 0,
+            DateTimeOffset? authenticationExpiresOn = null,
+            bool closeOnAuthenticationExpiration = false,
+            CancellationToken cancellationToken = default)
         {
+            var lifetimeSeconds = tokenLifetimeSeconds > 0
+                ? tokenLifetimeSeconds
+                : Constants.DefaultAccessTokenLifetimeSeconds;
             var negotiationOptions = new NegotiationOptions()
             {
                 UserId = userId,
                 Claims = BuildJwtClaims(claims, AzureSignalRUserPrefix).ToList(),
-                HttpContext = httpContext
+                HttpContext = httpContext,
+                TokenLifetime = TimeSpan.FromSeconds(lifetimeSeconds),
+                AuthenticationExpiresOn = authenticationExpiresOn,
+                EnableAuthenticationRefresh = enableAuthenticationRefresh,
+                CloseOnAuthenticationExpiration = closeOnAuthenticationExpiration,
             };
-            var negotiateResult = await _serviceHubContext.NegotiateWithTokenLifetimeAsync(negotiationOptions).ConfigureAwait(false);
+
+            if (!enableAuthenticationRefresh)
+            {
+                var response = await _serviceHubContext.NegotiateAsync(negotiationOptions, cancellationToken).ConfigureAwait(false);
+                return new SignalRConnectionInfo
+                {
+                    Url = response.Url,
+                    AccessToken = response.AccessToken,
+                };
+            }
+
+            var negotiateResult = await _serviceHubContext.NegotiateWithTokenLifetimeAsync(negotiationOptions, cancellationToken).ConfigureAwait(false);
             return new SignalRConnectionInfo
             {
                 Url = negotiateResult.Url,
@@ -64,17 +116,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         /// Returns a refreshed access token for the client.
         /// Wraps the Management SDK's <c>RefreshConnectionAuthenticationAsync</c>.
         /// </summary>
-        public async Task<SignalRConnectionInfo> RefreshConnectionInfoAsync(string connectionToken, DateTimeOffset expireTime, IList<Claim> claims)
+        public async Task<SignalRConnectionInfo> RefreshConnectionInfoAsync(
+            string connectionToken,
+            DateTimeOffset? authenticationExpiresOn,
+            IList<Claim> claims,
+            int tokenLifetimeSeconds,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(connectionToken))
             {
                 throw new ArgumentException($"{nameof(connectionToken)} cannot be null or empty");
             }
 
+            var lifetimeSeconds = tokenLifetimeSeconds > 0
+                ? tokenLifetimeSeconds
+                : Constants.DefaultAccessTokenLifetimeSeconds;
             var result = await _serviceHubContext.RefreshConnectionAuthenticationAsync(
                 connectionToken,
-                expireTime,
-                BuildJwtClaims(claims, AzureSignalRUserPrefix).ToList()).ConfigureAwait(false);
+                new RefreshConnectionAuthenticationOptions
+                {
+                    AuthenticationExpiresOn = authenticationExpiresOn,
+                    Claims = claims == null ? null : BuildJwtClaims(claims, AzureSignalRUserPrefix).ToList(),
+                    TokenLifetime = TimeSpan.FromSeconds(lifetimeSeconds),
+                },
+                cancellationToken).ConfigureAwait(false);
             return new SignalRConnectionInfo
             {
                 AccessToken = result.AccessToken,

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/IAzureSignalRSender.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/IAzureSignalRSender.cs
@@ -1,12 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal interface IAzureSignalRSender
     {
+        Task<SignalRConnectionInfo> RefreshConnectionInfoAsync(string connectionToken, DateTimeOffset expireTime, IList<Claim> claims);
+
+        Task<IList<Claim>> GetConnectionClaimsAsync(string connectionToken);
+
         Task SendToAll(SignalRData data);
 
         Task SendToConnection(string connectionId, SignalRData data);

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/IAzureSignalRSender.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/IAzureSignalRSender.cs
@@ -4,13 +4,19 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal interface IAzureSignalRSender
     {
-        Task<SignalRConnectionInfo> RefreshConnectionInfoAsync(string connectionToken, DateTimeOffset expireTime, IList<Claim> claims);
+        Task<SignalRConnectionInfo> RefreshConnectionInfoAsync(
+            string connectionToken,
+            DateTimeOffset? authenticationExpiresOn,
+            IList<Claim> claims,
+            int tokenLifetimeSeconds,
+            CancellationToken cancellationToken = default);
 
         Task<IList<Claim>> GetConnectionClaimsAsync(string connectionToken);
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRConfigProvider.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRConfigProvider.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             var signalRConnectionInfoAttributeRule = context.AddBindingRule<SignalRConnectionInfoAttribute>();
             signalRConnectionInfoAttributeRule.Bind(_inputBindingProvider);
 
+            var signalRRefreshAttributeRule = context.AddBindingRule<SignalRRefreshAttribute>();
+            signalRRefreshAttributeRule.Bind(_inputBindingProvider);
+
             var securityTokenValidationAttributeRule = context.AddBindingRule<SecurityTokenValidationAttribute>();
             securityTokenValidationAttributeRule.Bind(_inputBindingProvider);
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Constants.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Constants.cs
@@ -35,5 +35,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public const string ServerEndpointKey = "serverEndpoint";
         public const string ClientEndpointKey = "clientEndpoint";
         public const string TypeKey = "type";
+
+        // The Management SDK's default client access-token lifetime.
+        public const int DefaultAccessTokenLifetimeSeconds = 3600;
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRConnectionInfoAttribute.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRConnectionInfoAttribute.cs
@@ -13,5 +13,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     [Binding]
     public class SignalRConnectionInfoAttribute : NegotiationBaseAttribute
     {
+        /// <summary>
+        /// Gets or sets whether the connection supports authentication refresh.
+        /// </summary>
+        public bool EnableAuthenticationRefresh { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum service access-token lifetime in seconds. Values less than one use the one-hour default.
+        /// </summary>
+        public int TokenLifetimeSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the connection closes when application authentication expires.
+        /// </summary>
+        public bool CloseOnAuthenticationExpiration { get; set; }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRNegotiationAttribute.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRNegotiationAttribute.cs
@@ -14,5 +14,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     [Binding]
     public class SignalRNegotiationAttribute : NegotiationBaseAttribute
     {
+        /// <summary>
+        /// Gets or sets whether negotiated connections support authentication refresh.
+        /// </summary>
+        public bool EnableAuthenticationRefresh { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum service access-token lifetime in seconds. Values less than one use the one-hour default.
+        /// </summary>
+        public int TokenLifetimeSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether negotiated connections close when application authentication expires.
+        /// </summary>
+        public bool CloseOnAuthenticationExpiration { get; set; }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRRefreshAttribute.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRRefreshAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    /// <summary>
+    /// Attribute used to refresh the authentication of a live SignalR client connection without reconnecting.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.ReturnValue | AttributeTargets.Parameter)]
+    [Binding]
+    public class SignalRRefreshAttribute : NegotiationBaseAttribute
+    {
+        /// <summary>
+        /// Gets or sets the connection token of the live client connection to refresh.
+        /// </summary>
+        [AutoResolve]
+        public string ConnectionToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new authentication lifetime, in seconds, applied to the connection.
+        /// </summary>
+        public int TokenLifetimeSeconds { get; set; }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRRefreshAttribute.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRRefreshAttribute.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public string ConnectionToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the new authentication lifetime, in seconds, applied to the connection.
+        /// Gets or sets the maximum lifetime, in seconds, of the refreshed service access token.
+        /// Values less than one use the one-hour default.
         /// </summary>
         public int TokenLifetimeSeconds { get; set; }
     }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/AzureSignalRClientTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/AzureSignalRClientTests.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Reflection;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Azure.SignalR.Tests.Common;
@@ -48,6 +51,121 @@ namespace SignalRServiceExtension.Tests
             var claims = new JwtSecurityTokenHandler().ReadJwtToken(connectionInfo.AccessToken).Claims;
             Assert.Equal(expectedName, GetClaimValue(claims, "name"));
             Assert.Equal(expectedIat, GetClaimValue(claims, $"{AzureSignalRClient.AzureSignalRUserPrefix}iat"));
+        }
+
+        [Fact]
+        public async Task GetClientConnectionInfoAsync_AuthenticationRefreshDisabled_UsesOrdinaryNegotiation()
+        {
+            const string expectedUrl = "https://example.test/client";
+            const string expectedAccessToken = "ordinary-access-token";
+            NegotiationOptions capturedOptions = null;
+            var hubContext = new Mock<ServiceHubContext>();
+            hubContext
+                .Setup(c => c.NegotiateAsync(It.IsAny<NegotiationOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<NegotiationOptions, CancellationToken>((options, _) => capturedOptions = options)
+                .Returns(new ValueTask<NegotiationResponse>(new NegotiationResponse
+                {
+                    Url = expectedUrl,
+                    AccessToken = expectedAccessToken,
+                }));
+            var client = new AzureSignalRClient(hubContext.Object);
+
+            var result = await client.GetClientConnectionInfoAsync("user", new List<Claim>(), httpContext: null);
+
+            Assert.False(capturedOptions.EnableAuthenticationRefresh);
+            Assert.Equal(expectedUrl, result.Url);
+            Assert.Equal(expectedAccessToken, result.AccessToken);
+            Assert.Null(result.TokenLifetimeSeconds);
+            hubContext.Verify(
+                c => c.NegotiateAsync(It.IsAny<NegotiationOptions>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            hubContext.Verify(
+                c => c.NegotiateWithTokenLifetimeAsync(It.IsAny<NegotiationOptions>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task GetClientConnectionInfoAsync_AuthenticationRefreshEnabled_UsesLifetimeNegotiationAndPropagatesOptions()
+        {
+            const string expectedUrl = "https://example.test/client";
+            const string expectedAccessToken = "refresh-access-token";
+            const int tokenLifetimeSeconds = 300;
+            const int expectedRefreshLifetimeSeconds = 111;
+            var expectedExpiresOn = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero);
+            var negotiationResult = (NegotiationResult)Activator.CreateInstance(
+                typeof(NegotiationResult),
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { expectedUrl, expectedAccessToken, expectedRefreshLifetimeSeconds },
+                culture: null);
+            NegotiationOptions capturedOptions = null;
+            var hubContext = new Mock<ServiceHubContext>();
+            hubContext
+                .Setup(c => c.NegotiateWithTokenLifetimeAsync(It.IsAny<NegotiationOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<NegotiationOptions, CancellationToken>((options, _) => capturedOptions = options)
+                .ReturnsAsync(negotiationResult);
+            var client = new AzureSignalRClient(hubContext.Object);
+
+            var result = await client.GetClientConnectionInfoAsync(
+                userId: "user",
+                idToken: null,
+                claimTypeList: null,
+                httpContext: null,
+                enableAuthenticationRefresh: true,
+                tokenLifetimeSeconds,
+                expectedExpiresOn,
+                closeOnAuthenticationExpiration: true);
+
+            Assert.True(capturedOptions.EnableAuthenticationRefresh);
+            Assert.Equal(expectedExpiresOn, capturedOptions.AuthenticationExpiresOn);
+            Assert.True(capturedOptions.CloseOnAuthenticationExpiration);
+            Assert.Equal(TimeSpan.FromSeconds(tokenLifetimeSeconds), capturedOptions.TokenLifetime);
+            Assert.Equal(expectedUrl, result.Url);
+            Assert.Equal(expectedAccessToken, result.AccessToken);
+            Assert.Equal(expectedRefreshLifetimeSeconds, result.TokenLifetimeSeconds);
+            hubContext.Verify(
+                c => c.NegotiateWithTokenLifetimeAsync(It.IsAny<NegotiationOptions>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            hubContext.Verify(
+                c => c.NegotiateAsync(It.IsAny<NegotiationOptions>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task GetClientConnectionInfoAsync_ReservedCustomerClaims_ArePrefixedWithoutRawDuplicates()
+        {
+            var reservedClaimTypes = new[]
+            {
+                "aud", "exp", "iat", "nbf", "iss", "actort", "acr", "azp", "c_hash", "jti", "nonce",
+            };
+            var claims = reservedClaimTypes
+                .Select(type => new Claim(type, $"value-{type}"))
+                .Concat(new[] { new Claim("custom", "custom-value") })
+                .ToList();
+            NegotiationOptions capturedOptions = null;
+            var hubContext = new Mock<ServiceHubContext>();
+            hubContext
+                .Setup(c => c.NegotiateAsync(It.IsAny<NegotiationOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<NegotiationOptions, CancellationToken>((options, _) => capturedOptions = options)
+                .Returns(new ValueTask<NegotiationResponse>(new NegotiationResponse
+                {
+                    Url = "https://example.test/client",
+                    AccessToken = "access-token",
+                }));
+            var client = new AzureSignalRClient(hubContext.Object);
+
+            _ = await client.GetClientConnectionInfoAsync("user", claims, httpContext: null);
+
+            var encodedClaims = capturedOptions.Claims.ToList();
+            foreach (var claimType in reservedClaimTypes)
+            {
+                Assert.Equal($"value-{claimType}", encodedClaims.Single(c => c.Type == $"{AzureSignalRClient.AzureSignalRUserPrefix}{claimType}").Value);
+                Assert.DoesNotContain(encodedClaims, c => c.Type == claimType);
+            }
+            Assert.Equal("value-iss", encodedClaims.Single(c => c.Type == $"{AzureSignalRClient.AzureSignalRUserPrefix}iss").Value);
+            Assert.Equal("value-jti", encodedClaims.Single(c => c.Type == $"{AzureSignalRClient.AzureSignalRUserPrefix}jti").Value);
+            Assert.Equal("value-nonce", encodedClaims.Single(c => c.Type == $"{AzureSignalRClient.AzureSignalRUserPrefix}nonce").Value);
+            Assert.Equal("custom-value", encodedClaims.Single(c => c.Type == "custom").Value);
         }
 
         [Fact]

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/DefaultSecurityTokenValidatorTests.cs
@@ -61,14 +61,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
             Assert.Equal(expectedStatus, securityTokenResult.Status);
         }
 
+        [Fact]
+        public void ValidateToken_ValidToken_ReturnsTokenExpiration()
+        {
+            var tokenString = GenerateJwtToken(IssuerToken, "issuer", "audience", DateTime.UtcNow.AddMinutes(10));
+            var expectedExpiresOn = new DateTimeOffset(new JwtSecurityTokenHandler().ReadJwtToken(tokenString).ValidTo);
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Headers.Append("Authorization", new StringValues($"Bearer {tokenString}"));
+            var securityTokenValidator = new DefaultSecurityTokenValidator(parameters =>
+            {
+                parameters.IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(IssuerToken));
+                parameters.RequireSignedTokens = true;
+                parameters.ValidateIssuerSigningKey = true;
+                parameters.ValidateLifetime = true;
+                parameters.ValidIssuer = "issuer";
+                parameters.ValidAudience = "audience";
+            });
+
+            var result = securityTokenValidator.ValidateToken(ctx.Request);
+
+            Assert.Equal(SecurityTokenStatus.Valid, result.Status);
+            Assert.NotNull(result.ExpiresOn);
+            Assert.Equal(expectedExpiresOn, result.ExpiresOn);
+        }
+
         public static string GenerateJwtToken(string secretKey, string issuer, string audience, int expireMinutes)
+        {
+            return GenerateJwtToken(secretKey, issuer, audience, DateTime.UtcNow.AddMinutes(expireMinutes));
+        }
+
+        public static string GenerateJwtToken(string secretKey, string issuer, string audience, DateTime expiresOn)
         {
             var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey));
             var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
             var token = new JwtSecurityToken(
                 issuer: issuer,
                 audience: audience,
-                expires: DateTime.Now.AddMinutes(expireMinutes),
+                expires: expiresOn,
                 signingCredentials: credentials
             );
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalRConnectionInputBindingTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalRConnectionInputBindingTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace SignalRServiceExtension.Tests
+{
+    [Collection("SignalR input binding tests")]
+    public class SignalRConnectionInputBindingTests
+    {
+        private const string HttpRequestName = "$request";
+        private const string ConnectionStringSetting = Constants.AzureSignalRConnectionStringName;
+        private const string HubName = "TestHub";
+        private const string ConnectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Version=1.0;";
+
+        private static readonly string IdToken = new JwtSecurityTokenHandler().WriteToken(
+            new JwtSecurityToken(claims: new[]
+            {
+                new Claim("name", "John Doe"),
+                new Claim("iat", "1516239022"),
+            }));
+
+        private static class ParameterHolder
+        {
+            public static void Method([SignalRConnectionInfo(HubName = HubName)] SignalRConnectionInfo info)
+            {
+            }
+        }
+
+        [Fact]
+        public async Task BuildAsync_ConfigurerReturnsReplacement_UsesReplacementUserClaimsAndExpiration()
+        {
+            var originalExpiresOn = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero);
+            var replacementExpiresOn = originalExpiresOn.AddHours(1);
+            var replacement = new SignalRConnectionDetail
+            {
+                UserId = "replacement-user",
+                Claims = new List<Claim> { new Claim("replacement", "claim") },
+                AuthenticationExpiresOn = replacementExpiresOn,
+            };
+            var configurer = new Mock<ISignalRConnectionInfoConfigurer>();
+            configurer.SetupGet(c => c.Configure).Returns((_, _, _) => replacement);
+            var (binding, capturedOptions) = CreateBinding(configurer.Object, originalExpiresOn);
+            var attr = new SignalRConnectionInfoAttribute
+            {
+                HubName = HubName,
+                ConnectionStringSetting = ConnectionStringSetting,
+                UserId = "original-user",
+                IdToken = IdToken,
+                ClaimTypeList = new[] { "name" },
+            };
+
+            var provider = await binding.InvokeBuildAsync(attr, CreateBindingData());
+            var value = await provider.GetValueAsync();
+
+            var info = Assert.IsType<SignalRConnectionInfo>(value);
+            Assert.Equal("access-token", info.AccessToken);
+            Assert.Equal("replacement-user", capturedOptions.Value.UserId);
+            Assert.Equal(replacementExpiresOn, capturedOptions.Value.AuthenticationExpiresOn);
+            var claim = Assert.Single(capturedOptions.Value.Claims);
+            Assert.Equal("replacement", claim.Type);
+            Assert.Equal("claim", claim.Value);
+        }
+
+        [Fact]
+        public async Task BuildAsync_ConfigurerReturnsNull_RetainsOriginalUserClaimsAndExpiration()
+        {
+            var originalExpiresOn = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero);
+            var configurer = new Mock<ISignalRConnectionInfoConfigurer>();
+            configurer.SetupGet(c => c.Configure).Returns((_, _, _) => null);
+            var (binding, capturedOptions) = CreateBinding(configurer.Object, originalExpiresOn);
+            var attr = new SignalRConnectionInfoAttribute
+            {
+                HubName = HubName,
+                ConnectionStringSetting = ConnectionStringSetting,
+                UserId = "original-user",
+                IdToken = IdToken,
+                ClaimTypeList = new[] { "name" },
+            };
+
+            var provider = await binding.InvokeBuildAsync(attr, CreateBindingData());
+            var value = await provider.GetValueAsync();
+
+            Assert.IsType<SignalRConnectionInfo>(value);
+            Assert.Equal("original-user", capturedOptions.Value.UserId);
+            Assert.Equal(originalExpiresOn, capturedOptions.Value.AuthenticationExpiresOn);
+            var claim = Assert.Single(capturedOptions.Value.Claims);
+            Assert.Equal("name", claim.Type);
+            Assert.Equal("John Doe", claim.Value);
+        }
+
+        private static (TestableConnectionBinding Binding, StrongBox<NegotiationOptions> CapturedOptions) CreateBinding(
+            ISignalRConnectionInfoConfigurer configurer,
+            DateTimeOffset expiresOn)
+        {
+            var capturedOptions = new StrongBox<NegotiationOptions>();
+            var hubContext = new Mock<ServiceHubContext>();
+            hubContext
+                .Setup(c => c.NegotiateAsync(It.IsAny<NegotiationOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<NegotiationOptions, CancellationToken>((options, _) => capturedOptions.Value = options)
+                .Returns(new ValueTask<NegotiationResponse>(new NegotiationResponse
+                {
+                    Url = "https://example.test/client",
+                    AccessToken = "access-token",
+                }));
+            StaticServiceHubContextStore.ServiceManagerStore = Mock.Of<IServiceManagerStore>(s =>
+                s.GetOrAddByConnectionStringKey(It.IsAny<string>()).GetAsync(It.IsAny<string>())
+                    == new ValueTask<IServiceHubContext>(hubContext.Object));
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> { [ConnectionStringSetting] = ConnectionString })
+                .Build();
+            var parameter = typeof(ParameterHolder).GetMethod(nameof(ParameterHolder.Method)).GetParameters()[0];
+            var context = new BindingProviderContext(parameter, new Dictionary<string, Type>(), CancellationToken.None);
+            var validator = new Mock<ISecurityTokenValidator>();
+            validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>()))
+                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity()), expiresOn));
+
+            return (new TestableConnectionBinding(context, configuration, Mock.Of<INameResolver>(), validator.Object, configurer), capturedOptions);
+        }
+
+        private static IReadOnlyDictionary<string, object> CreateBindingData() =>
+            new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
+
+        private sealed class StrongBox<T>
+        {
+            public T Value { get; set; }
+        }
+
+        private sealed class TestableConnectionBinding : SignalRConnectionInputBinding
+        {
+            public TestableConnectionBinding(
+                BindingProviderContext context,
+                IConfiguration configuration,
+                INameResolver nameResolver,
+                ISecurityTokenValidator securityTokenValidator,
+                ISignalRConnectionInfoConfigurer signalRConnectionInfoConfigurer)
+                : base(context, configuration, nameResolver, securityTokenValidator, signalRConnectionInfoConfigurer)
+            {
+            }
+
+            public Task<IValueProvider> InvokeBuildAsync(SignalRConnectionInfoAttribute attr, IReadOnlyDictionary<string, object> bindingData) =>
+                BuildAsync(attr, bindingData, CancellationToken.None);
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalRInputBindingTestCollection.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalRInputBindingTestCollection.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace SignalRServiceExtension.Tests
+{
+    [CollectionDefinition("SignalR input binding tests", DisableParallelization = true)]
+    public class SignalRInputBindingTestCollection
+    {
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalRRefreshInputBindingTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalRRefreshInputBindingTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace SignalRServiceExtension.Tests
+{
+    /// <summary>
+    /// Behavioral tests for the [SignalRRefresh] input binding (<see cref="SignalRRefreshInputBinding"/>)
+    /// </summary>
+    public class SignalRRefreshInputBindingTests
+    {
+        private const string HttpRequestName = "$request";
+        private const string ConnectionStringSetting = Constants.AzureSignalRConnectionStringName;
+        private const string HubName = "TestHub";
+        private const string ConnectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Version=1.0;";
+        private const string RefreshedToken = "refreshed-access-token";
+        private const int RefreshedLifetime = 111;
+
+        private static class ParameterHolder
+        {
+            public static void Method([SignalRRefresh(ConnectionToken = "ct", HubName = HubName)] SignalRConnectionInfo info)
+            {
+            }
+        }
+
+        [Fact]
+        public async Task BuildAsync_MissingConnectionToken_ReturnsNullInfo()
+        {
+            var (binding, _) = CreateBinding(out _);
+            var attr = new SignalRRefreshAttribute { ConnectionToken = null, HubName = HubName, ConnectionStringSetting = ConnectionStringSetting };
+
+            var provider = await binding.InvokeBuildAsync(attr, new Dictionary<string, object>());
+            var value = await provider.GetValueAsync();
+
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public async Task BuildAsync_InvalidToken_ReturnsNullInfo()
+        {
+            var validator = new Mock<ISecurityTokenValidator>();
+            validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>())).Returns(SecurityTokenResult.Empty());
+            var (binding, hubContext) = CreateBinding(out _, validator.Object);
+            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting };
+            var bindingData = new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
+
+            var provider = await binding.InvokeBuildAsync(attr, bindingData);
+            var value = await provider.GetValueAsync();
+
+            Assert.Null(value);
+            hubContext.Verify(
+                c => c.RefreshConnectionAuthenticationAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task BuildAsync_ValidToken_RefreshesAndReturnsInfo()
+        {
+            var validator = new Mock<ISecurityTokenValidator>();
+            validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>()))
+                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity())));
+            var (binding, hubContext) = CreateBinding(out _, validator.Object);
+            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting };
+            var bindingData = new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
+
+            var provider = await binding.InvokeBuildAsync(attr, bindingData);
+            var value = await provider.GetValueAsync();
+
+            var info = Assert.IsType<SignalRConnectionInfo>(value);
+            Assert.Equal(RefreshedToken, info.AccessToken);
+            Assert.Equal(RefreshedLifetime, info.TokenLifetimeSeconds);
+            hubContext.Verify(
+                c => c.RefreshConnectionAuthenticationAsync("ct", It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task BuildAsync_NoTokenLifetime_UsesDefaultLifetime()
+        {
+            var (binding, _) = CreateBinding(out var capturedExpireTime);
+            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting, TokenLifetimeSeconds = 0 };
+
+            var before = DateTimeOffset.UtcNow;
+            var provider = await binding.InvokeBuildAsync(attr, new Dictionary<string, object>());
+            _ = await provider.GetValueAsync();
+            var after = DateTimeOffset.UtcNow;
+
+            Assert.NotNull(capturedExpireTime.Value);
+            Assert.InRange(
+                capturedExpireTime.Value.Value,
+                before.AddSeconds(Constants.DefaultAccessTokenLifetimeSeconds),
+                after.AddSeconds(Constants.DefaultAccessTokenLifetimeSeconds));
+        }
+
+        [Fact]
+        public async Task BuildAsync_ExplicitTokenLifetime_UsesProvidedLifetime()
+        {
+            const int lifetime = 300;
+            var (binding, _) = CreateBinding(out var capturedExpireTime);
+            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting, TokenLifetimeSeconds = lifetime };
+
+            var before = DateTimeOffset.UtcNow;
+            var provider = await binding.InvokeBuildAsync(attr, new Dictionary<string, object>());
+            _ = await provider.GetValueAsync();
+            var after = DateTimeOffset.UtcNow;
+
+            Assert.NotNull(capturedExpireTime.Value);
+            Assert.InRange(capturedExpireTime.Value.Value, before.AddSeconds(lifetime), after.AddSeconds(lifetime));
+        }
+
+        private static (TestableRefreshBinding Binding, Mock<ServiceHubContext> HubContext) CreateBinding(
+            out StrongBox<DateTimeOffset?> capturedExpireTime, ISecurityTokenValidator validator = null)
+        {
+            var expireBox = new StrongBox<DateTimeOffset?>();
+            capturedExpireTime = expireBox;
+
+            var refreshResult = (RefreshConnectionAuthenticationResult)Activator.CreateInstance(
+                typeof(RefreshConnectionAuthenticationResult),
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { RefreshedToken, RefreshedLifetime },
+                culture: null);
+
+            var hubContextMock = new Mock<ServiceHubContext>();
+            hubContextMock
+                .Setup(c => c.RefreshConnectionAuthenticationAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()))
+                .Callback<string, DateTimeOffset, IEnumerable<Claim>, CancellationToken>((_, expireTime, _, _) => expireBox.Value = expireTime)
+                .ReturnsAsync(refreshResult);
+
+            StaticServiceHubContextStore.ServiceManagerStore = Mock.Of<IServiceManagerStore>(s =>
+                s.GetOrAddByConnectionStringKey(It.IsAny<string>()).GetAsync(It.IsAny<string>())
+                    == new ValueTask<IServiceHubContext>(hubContextMock.Object));
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> { [ConnectionStringSetting] = ConnectionString })
+                .Build();
+
+            var parameter = typeof(ParameterHolder).GetMethod(nameof(ParameterHolder.Method)).GetParameters()[0];
+            var context = new BindingProviderContext(parameter, new Dictionary<string, Type>(), CancellationToken.None);
+
+            var binding = new TestableRefreshBinding(context, configuration, Mock.Of<INameResolver>(), validator, signalRConnectionInfoConfigurer: null);
+            return (binding, hubContextMock);
+        }
+
+        private sealed class TestableRefreshBinding : SignalRRefreshInputBinding
+        {
+            public TestableRefreshBinding(
+                BindingProviderContext context,
+                IConfiguration configuration,
+                INameResolver nameResolver,
+                ISecurityTokenValidator securityTokenValidator,
+                ISignalRConnectionInfoConfigurer signalRConnectionInfoConfigurer)
+                : base(context, configuration, nameResolver, securityTokenValidator, signalRConnectionInfoConfigurer)
+            {
+            }
+
+            public Task<IValueProvider> InvokeBuildAsync(SignalRRefreshAttribute attr, IReadOnlyDictionary<string, object> bindingData) =>
+                BuildAsync(attr, bindingData);
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalRRefreshInputBindingTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalRRefreshInputBindingTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
@@ -22,6 +24,7 @@ namespace SignalRServiceExtension.Tests
     /// <summary>
     /// Behavioral tests for the [SignalRRefresh] input binding (<see cref="SignalRRefreshInputBinding"/>)
     /// </summary>
+    [Collection("SignalR input binding tests")]
     public class SignalRRefreshInputBindingTests
     {
         private const string HttpRequestName = "$request";
@@ -30,6 +33,13 @@ namespace SignalRServiceExtension.Tests
         private const string ConnectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Version=1.0;";
         private const string RefreshedToken = "refreshed-access-token";
         private const int RefreshedLifetime = 111;
+
+        private static readonly string IdToken = new JwtSecurityTokenHandler().WriteToken(
+            new JwtSecurityToken(claims: new[]
+            {
+                new Claim("name", "John Doe"),
+                new Claim("iat", "1516239022"),
+            }));
 
         private static class ParameterHolder
         {
@@ -64,18 +74,26 @@ namespace SignalRServiceExtension.Tests
 
             Assert.Null(value);
             hubContext.Verify(
-                c => c.RefreshConnectionAuthenticationAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()),
+                c => c.RefreshConnectionAuthenticationAsync(It.IsAny<string>(), It.IsAny<RefreshConnectionAuthenticationOptions>(), It.IsAny<CancellationToken>()),
                 Times.Never);
         }
 
         [Fact]
-        public async Task BuildAsync_ValidToken_RefreshesAndReturnsInfo()
+        public async Task BuildAsync_ValidToken_PropagatesValidatedAuthenticationOptions()
         {
+            var expectedExpiresOn = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero);
             var validator = new Mock<ISecurityTokenValidator>();
             validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>()))
-                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity())));
-            var (binding, hubContext) = CreateBinding(out _, validator.Object);
-            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting };
+                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity()), expectedExpiresOn));
+            var (binding, hubContext) = CreateBinding(out var capturedOptions, validator.Object);
+            var attr = new SignalRRefreshAttribute
+            {
+                ConnectionToken = "ct",
+                HubName = HubName,
+                ConnectionStringSetting = ConnectionStringSetting,
+                IdToken = IdToken,
+                ClaimTypeList = new[] { "name", "iat" },
+            };
             var bindingData = new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
 
             var provider = await binding.InvokeBuildAsync(attr, bindingData);
@@ -84,50 +102,167 @@ namespace SignalRServiceExtension.Tests
             var info = Assert.IsType<SignalRConnectionInfo>(value);
             Assert.Equal(RefreshedToken, info.AccessToken);
             Assert.Equal(RefreshedLifetime, info.TokenLifetimeSeconds);
+            Assert.Equal(expectedExpiresOn, capturedOptions.Value.AuthenticationExpiresOn);
+            Assert.Equal(TimeSpan.FromHours(1), capturedOptions.Value.TokenLifetime);
+            Assert.Equal("John Doe", capturedOptions.Value.Claims.Single(c => c.Type == "name").Value);
+            Assert.Equal("1516239022", capturedOptions.Value.Claims.Single(c => c.Type == $"{AzureSignalRClient.AzureSignalRUserPrefix}iat").Value);
             hubContext.Verify(
-                c => c.RefreshConnectionAuthenticationAsync("ct", It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()),
+                c => c.RefreshConnectionAuthenticationAsync("ct", It.IsAny<RefreshConnectionAuthenticationOptions>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
         [Fact]
-        public async Task BuildAsync_NoTokenLifetime_UsesDefaultLifetime()
+        public async Task BuildAsync_ConfigurerReturnsReplacement_UsesReplacementClaimsAndExpiration()
         {
-            var (binding, _) = CreateBinding(out var capturedExpireTime);
-            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting, TokenLifetimeSeconds = 0 };
+            var originalExpiresOn = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero);
+            var replacementExpiresOn = originalExpiresOn.AddHours(1);
+            var validator = new Mock<ISecurityTokenValidator>();
+            validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>()))
+                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity()), originalExpiresOn));
+            var configurer = new Mock<ISignalRConnectionInfoConfigurer>();
+            configurer.SetupGet(c => c.Configure).Returns((_, _, _) => new SignalRConnectionDetail
+            {
+                UserId = "replacement-user",
+                Claims = new List<Claim> { new Claim("replacement", "claim") },
+                AuthenticationExpiresOn = replacementExpiresOn,
+            });
+            var (binding, _) = CreateBinding(out var capturedOptions, validator.Object, configurer.Object);
+            var attr = new SignalRRefreshAttribute
+            {
+                ConnectionToken = "ct",
+                HubName = HubName,
+                ConnectionStringSetting = ConnectionStringSetting,
+                UserId = "original-user",
+                IdToken = IdToken,
+                ClaimTypeList = new[] { "name" },
+            };
+            var bindingData = new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
 
-            var before = DateTimeOffset.UtcNow;
-            var provider = await binding.InvokeBuildAsync(attr, new Dictionary<string, object>());
-            _ = await provider.GetValueAsync();
-            var after = DateTimeOffset.UtcNow;
+            var provider = await binding.InvokeBuildAsync(attr, bindingData);
+            var value = await provider.GetValueAsync();
 
-            Assert.NotNull(capturedExpireTime.Value);
-            Assert.InRange(
-                capturedExpireTime.Value.Value,
-                before.AddSeconds(Constants.DefaultAccessTokenLifetimeSeconds),
-                after.AddSeconds(Constants.DefaultAccessTokenLifetimeSeconds));
+            var info = Assert.IsType<SignalRConnectionInfo>(value);
+            Assert.Equal(RefreshedToken, info.AccessToken);
+            Assert.Equal(replacementExpiresOn, capturedOptions.Value.AuthenticationExpiresOn);
+            var claim = Assert.Single(capturedOptions.Value.Claims);
+            Assert.Equal("replacement", claim.Type);
+            Assert.Equal("claim", claim.Value);
         }
 
         [Fact]
-        public async Task BuildAsync_ExplicitTokenLifetime_UsesProvidedLifetime()
+        public async Task BuildAsync_ConfigurerReturnsNull_RetainsOriginalClaimsAndExpiration()
+        {
+            var originalExpiresOn = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero);
+            var validator = new Mock<ISecurityTokenValidator>();
+            validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>()))
+                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity()), originalExpiresOn));
+            var configurer = new Mock<ISignalRConnectionInfoConfigurer>();
+            configurer.SetupGet(c => c.Configure).Returns((_, _, _) => null);
+            var (binding, _) = CreateBinding(out var capturedOptions, validator.Object, configurer.Object);
+            var attr = new SignalRRefreshAttribute
+            {
+                ConnectionToken = "ct",
+                HubName = HubName,
+                ConnectionStringSetting = ConnectionStringSetting,
+                IdToken = IdToken,
+                ClaimTypeList = new[] { "name" },
+            };
+            var bindingData = new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
+
+            var provider = await binding.InvokeBuildAsync(attr, bindingData);
+            var value = await provider.GetValueAsync();
+
+            Assert.IsType<SignalRConnectionInfo>(value);
+            Assert.Equal(originalExpiresOn, capturedOptions.Value.AuthenticationExpiresOn);
+            var claim = Assert.Single(capturedOptions.Value.Claims);
+            Assert.Equal("name", claim.Type);
+            Assert.Equal("John Doe", claim.Value);
+        }
+
+        [Fact]
+        public async Task BuildAsync_WithoutRequest_ReturnsNullInfo()
+        {
+            var validator = new Mock<ISecurityTokenValidator>();
+            validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>()))
+                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity())));
+            var (binding, hubContext) = CreateBinding(out _, validator.Object);
+            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting };
+
+            var provider = await binding.InvokeBuildAsync(attr, new Dictionary<string, object>());
+            var value = await provider.GetValueAsync();
+
+            Assert.Null(value);
+            hubContext.Verify(
+                c => c.RefreshConnectionAuthenticationAsync(It.IsAny<string>(), It.IsAny<RefreshConnectionAuthenticationOptions>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task BuildAsync_WithoutValidator_ReturnsNullInfo()
+        {
+            var (binding, hubContext) = CreateBinding(out _);
+            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting };
+            var bindingData = new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
+
+            var provider = await binding.InvokeBuildAsync(attr, bindingData);
+            var value = await provider.GetValueAsync();
+
+            Assert.Null(value);
+            hubContext.Verify(
+                c => c.RefreshConnectionAuthenticationAsync(It.IsAny<string>(), It.IsAny<RefreshConnectionAuthenticationOptions>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task BuildAsync_NoCustomClaims_PreservesExistingClaimsAndUsesDefaultTokenLifetime()
+        {
+            var validator = new Mock<ISecurityTokenValidator>();
+            validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>()))
+                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity())));
+            var (binding, hubContext) = CreateBinding(out var capturedOptions, validator.Object);
+            var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting, TokenLifetimeSeconds = 0 };
+            var bindingData = new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
+
+            var provider = await binding.InvokeBuildAsync(attr, bindingData);
+            _ = await provider.GetValueAsync();
+
+            Assert.Null(capturedOptions.Value.AuthenticationExpiresOn);
+            Assert.Null(capturedOptions.Value.Claims);
+            Assert.Equal(TimeSpan.FromHours(1), capturedOptions.Value.TokenLifetime);
+            hubContext.Verify(
+                c => c.RefreshConnectionAuthenticationAsync("ct", It.IsAny<RefreshConnectionAuthenticationOptions>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task BuildAsync_WithExplicitTokenLifetime_UsesConfiguredMaximum()
         {
             const int lifetime = 300;
-            var (binding, _) = CreateBinding(out var capturedExpireTime);
+            var validator = new Mock<ISecurityTokenValidator>();
+            validator.Setup(v => v.ValidateToken(It.IsAny<HttpRequest>()))
+                .Returns(SecurityTokenResult.Success(new ClaimsPrincipal(new ClaimsIdentity())));
+            var (binding, hubContext) = CreateBinding(out var capturedOptions, validator.Object);
             var attr = new SignalRRefreshAttribute { ConnectionToken = "ct", HubName = HubName, ConnectionStringSetting = ConnectionStringSetting, TokenLifetimeSeconds = lifetime };
+            var bindingData = new Dictionary<string, object> { [HttpRequestName] = new DefaultHttpContext().Request };
 
-            var before = DateTimeOffset.UtcNow;
-            var provider = await binding.InvokeBuildAsync(attr, new Dictionary<string, object>());
+            var provider = await binding.InvokeBuildAsync(attr, bindingData);
             _ = await provider.GetValueAsync();
-            var after = DateTimeOffset.UtcNow;
 
-            Assert.NotNull(capturedExpireTime.Value);
-            Assert.InRange(capturedExpireTime.Value.Value, before.AddSeconds(lifetime), after.AddSeconds(lifetime));
+            Assert.Null(capturedOptions.Value.AuthenticationExpiresOn);
+            Assert.Null(capturedOptions.Value.Claims);
+            Assert.Equal(TimeSpan.FromSeconds(lifetime), capturedOptions.Value.TokenLifetime);
+            hubContext.Verify(
+                c => c.RefreshConnectionAuthenticationAsync("ct", It.IsAny<RefreshConnectionAuthenticationOptions>(), It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         private static (TestableRefreshBinding Binding, Mock<ServiceHubContext> HubContext) CreateBinding(
-            out StrongBox<DateTimeOffset?> capturedExpireTime, ISecurityTokenValidator validator = null)
+            out StrongBox<RefreshConnectionAuthenticationOptions> capturedOptions,
+            ISecurityTokenValidator validator = null,
+            ISignalRConnectionInfoConfigurer configurer = null)
         {
-            var expireBox = new StrongBox<DateTimeOffset?>();
-            capturedExpireTime = expireBox;
+            var optionsBox = new StrongBox<RefreshConnectionAuthenticationOptions>();
+            capturedOptions = optionsBox;
 
             var refreshResult = (RefreshConnectionAuthenticationResult)Activator.CreateInstance(
                 typeof(RefreshConnectionAuthenticationResult),
@@ -138,8 +273,8 @@ namespace SignalRServiceExtension.Tests
 
             var hubContextMock = new Mock<ServiceHubContext>();
             hubContextMock
-                .Setup(c => c.RefreshConnectionAuthenticationAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()))
-                .Callback<string, DateTimeOffset, IEnumerable<Claim>, CancellationToken>((_, expireTime, _, _) => expireBox.Value = expireTime)
+                .Setup(c => c.RefreshConnectionAuthenticationAsync(It.IsAny<string>(), It.IsAny<RefreshConnectionAuthenticationOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<string, RefreshConnectionAuthenticationOptions, CancellationToken>((_, options, _) => optionsBox.Value = options)
                 .ReturnsAsync(refreshResult);
 
             StaticServiceHubContextStore.ServiceManagerStore = Mock.Of<IServiceManagerStore>(s =>
@@ -153,7 +288,7 @@ namespace SignalRServiceExtension.Tests
             var parameter = typeof(ParameterHolder).GetMethod(nameof(ParameterHolder.Method)).GetParameters()[0];
             var context = new BindingProviderContext(parameter, new Dictionary<string, Type>(), CancellationToken.None);
 
-            var binding = new TestableRefreshBinding(context, configuration, Mock.Of<INameResolver>(), validator, signalRConnectionInfoConfigurer: null);
+            var binding = new TestableRefreshBinding(context, configuration, Mock.Of<INameResolver>(), validator, configurer);
             return (binding, hubContextMock);
         }
 
@@ -170,7 +305,7 @@ namespace SignalRServiceExtension.Tests
             }
 
             public Task<IValueProvider> InvokeBuildAsync(SignalRRefreshAttribute attr, IReadOnlyDictionary<string, object> bindingData) =>
-                BuildAsync(attr, bindingData);
+                BuildAsync(attr, bindingData, CancellationToken.None);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds serverless authentication-refresh support to `Microsoft.Azure.WebJobs.Extensions.SignalRService`, so a Function App can extend a live SignalR client connection's auth expiration and claims without reconnecting — no hand-rolled `:refreshAuth` REST call. Wraps the Management SDK's `RefreshConnectionAuthenticationAsync` / `GetConnectionClaimsAsync`. See https://github.com/Azure/azure-signalr/issues/2281 for the full design of serverless auth-refresh support.

## Changes

- New `[SignalRRefresh]` input binding (`SignalRRefreshAttribute` + `SignalRRefreshInputBinding`): reads `ConnectionToken` (e.g. `"{Query.id}"`), optionally validates the request, refreshes the connection, and binds a `SignalRConnectionInfo` with the refreshed `accessToken` + `tokenLifetimeSeconds`.
- `SignalRConnectionInfo.TokenLifetimeSeconds` added, advertised from the negotiate binding so a refresh-aware client can schedule its refresh.
- `AzureSignalRClient`: negotiate now uses `NegotiateWithTokenLifetimeAsync`; adds `RefreshConnectionInfoAsync` / `GetConnectionClaimsAsync` (also on `IAzureSignalRSender`).
- Binding registration (`SignalRConfigProvider`, `InputBindingProvider`); `Constants.DefaultAccessTokenLifetimeSeconds = 3600`.
- Regenerated API baselines; CHANGELOG; Management SDK dependency bump.

## Dependency

**[DO NOT MERGE]** Requires a `Microsoft.Azure.SignalR.Management` version that exposes `RefreshConnectionAuthenticationAsync` / `GetConnectionClaimsAsync` (https://github.com/Azure/azure-signalr/pull/2283)
