### PR TITLE
[CodeTransparency] Release 1.0.0-beta.10

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0 (2026-07-15)
+## 1.0.0-beta.10 (2026-07-14)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Azure.Security.CodeTransparency.csproj
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Azure.Security.CodeTransparency.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the Azure.Security.CodeTransparency client library for developing .NET applications with rich experience.</Description>
     <AssemblyTitle>Azure.Security.CodeTransparency client library</AssemblyTitle>
-    <Version>1.0.0</Version>
+    <Version>1.0.0-beta.10</Version>
     <PackageTags>Azure.Security.CodeTransparency;scitt;cose;ccf;receipt;countersignature;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>


### PR DESCRIPTION
Changes `Azure.Security.CodeTransparency` from GA `1.0.0` to beta `1.0.0-beta.10` and sets the release date to 2026-07-14.

Releasing as a beta avoids the GA APIView architect-approval gate, allowing the release to proceed.

### Changes
- CHANGELOG.md: `## 1.0.0-beta.10 (2026-07-14)`
- .csproj: `<Version>1.0.0-beta.10</Version>`