### PR TITLE
Add exact name Spector coverage

### DIFF
--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Azure/ClientGeneratorCore/ExactName/ExactNameTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Azure/ClientGeneratorCore/ExactName/ExactNameTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Specs.Azure.ClientGenerator.Core.ExactName;
+using Specs.Azure.ClientGenerator.Core.ExactName._EnumValue;
+using Specs.Azure.ClientGenerator.Core.ExactName._Model;
+using Specs.Azure.ClientGenerator.Core.ExactName._Property;
+
+namespace TestProjects.Spector.Tests.Http.Azure.ClientGeneratorCore.ExactName
+{
+    public class ExactNameTests : SpectorTestBase
+    {
+        [SpectorTest]
+        public Task Azure_ClientGenerator_Core_ExactName_Model() => Test(async (host) =>
+        {
+            var response = await new ExactNameClient(host, null).GetModelClient().SendAsync(new my_model("test"));
+
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.AreEqual("test", response.Value.Name);
+        });
+
+        [SpectorTest]
+        public Task Azure_ClientGenerator_Core_ExactName_Property() => Test(async (host) =>
+        {
+            var response = await new ExactNameClient(host, null).GetPropertyClient().SendAsync(new ScopedModel("test"));
+
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.AreEqual("test", response.Value._MyName);
+        });
+
+        [SpectorTest]
+        public Task Azure_ClientGenerator_Core_ExactName_EnumValue() => Test(async (host) =>
+        {
+            var response = await new ExactNameClient(host, null).GetEnumValueClient().SendAsync(
+                new EndpointConfig(AgentEndpointProtocol.A2A));
+
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.AreEqual(AgentEndpointProtocol.A2A, response.Value.Protocol);
+        });
+
+        [SpectorTest]
+        public Task Azure_ClientGenerator_Core_ExactName_Operation() => Test(async (host) =>
+        {
+            var response = await new ExactNameClient(host, null).GetOperationClient().myOpAsync();
+
+            Assert.AreEqual(204, response.Status);
+        });
+
+        [SpectorTest]
+        public Task Azure_ClientGenerator_Core_ExactName_Parameter() => Test(async (host) =>
+        {
+            var response = await new ExactNameClient(host, null).GetParameterClient().SendAsync(myParam: "hello");
+
+            Assert.AreEqual(204, response.Status);
+        });
+    }
+}

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Spector\http\azure\client-generator-core\client-initialization\default\src\Specs.Azure.Tcgc.ClientInit.Default.csproj" />
     <ProjectReference Include="..\Spector\http\azure\client-generator-core\client-initialization\individually\src\Specs.Azure.Tcgc.ClientInit.Individually.csproj" />
     <ProjectReference Include="..\Spector\http\azure\client-generator-core\client-initialization\individuallyParent\src\Specs.Azure.Tcgc.ClientInit.Both.csproj" />
+    <ProjectReference Include="..\Spector\http\azure\client-generator-core\exact-name\src\_Specs_.Azure.ClientGenerator.Core.ExactName.csproj" />
     <ProjectReference Include="..\Spector\http\azure\client-generator-core\next-link-verb\src\_Specs_.Azure.ClientGenerator.Core.NextLinkVerb.csproj" />
     <ProjectReference Include="..\Spector\http\azure\client-generator-core\response-as-bool\src\_Specs_.Azure.ClientGenerator.Core.ResponseAsBool.csproj" />
     <ProjectReference Include="..\Spector\http\azure\client-generator-core\usage\src\_Specs_.Azure.ClientGenerator.Core.Usage.csproj" />


### PR DESCRIPTION
## Summary
- add Spector tests for exact model and property names
- cover exact enum value, operation, and parameter names
- reference the generated exact-name test project

## Testing
- `pwsh eng/scripts/Test-Spector.ps1 -filter "http/azure/client-generator-core/exact-name"`
