### PR TITLE
[Network] Fix issue #60969

### DIFF
--- a/sdk/network/Azure.ResourceManager.Network/CHANGELOG.md
+++ b/sdk/network/Azure.ResourceManager.Network/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed double Base64 encoding when using the legacy `BinaryData` representation for certificate data after the TypeSpec migration.
+
 ### Other Changes
 
 ## 1.16.1 (2026-06-30)

--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/WritableSubResourceCollectionCompatibility.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/WritableSubResourceCollectionCompatibility.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
 using Azure.Core;
 using Azure.ResourceManager.Network.Models;
 using Azure.ResourceManager.Resources.Models;
@@ -34,11 +36,40 @@ namespace Azure.ResourceManager.Network
         /// <summary> Invokes the FormatUri compatibility operation. </summary>
         public static Uri FormatUri(Uri value) => value;
         /// <summary> Invokes the ParseBinaryData compatibility operation. </summary>
-        public static BinaryData ParseBinaryData(string value) => value is null ? default : BinaryData.FromString(value);
+        public static BinaryData ParseBinaryData(string value) => value is null ? default : FormatJsonString(value);
         /// <summary> Invokes the ParseBinaryData compatibility operation. </summary>
-        public static BinaryData ParseBinaryData(BinaryData value) => value;
+        public static BinaryData ParseBinaryData(BinaryData value) => value is null ? default : FormatJsonString(Convert.ToBase64String(value.ToArray()));
         /// <summary> Invokes the FormatBinaryData compatibility operation. </summary>
-        public static BinaryData FormatBinaryData(BinaryData value) => value;
+        public static BinaryData FormatBinaryData(BinaryData value)
+        {
+            if (value is null)
+            {
+                return default;
+            }
+
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(value);
+                if (document.RootElement.ValueKind != JsonValueKind.String)
+                {
+                    return value;
+                }
+                return BinaryData.FromBytes(Convert.FromBase64String(document.RootElement.GetString()));
+            }
+            catch (JsonException)
+            {
+                return value;
+            }
+        }
+        private static BinaryData FormatJsonString(string value)
+        {
+            using MemoryStream stream = new MemoryStream();
+            using (Utf8JsonWriter writer = new Utf8JsonWriter(stream))
+            {
+                writer.WriteStringValue(value);
+            }
+            return BinaryData.FromBytes(stream.ToArray());
+        }
         internal static WritableSubResource ToWritable(NetworkSubResource value) => value is null ? default : new WritableSubResource { Id = value.Id };
         internal static NetworkSubResource ToNetwork(WritableSubResource value) => value is null ? default : new NetworkSubResource { Id = value.Id };
     }

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/ApplicationGatewayTests.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/ApplicationGatewayTests.cs
@@ -60,7 +60,7 @@ namespace Azure.ResourceManager.Network.Tests
 
             List<ApplicationGatewaySslCertificate> sslCertList = new List<ApplicationGatewaySslCertificate>{
                 new ApplicationGatewaySslCertificate()
-                {Data = BinaryData.FromString(Convert.ToBase64String(cert.Export(X509ContentType.Pfx, password))),
+                {Data = BinaryData.FromObjectAsJson(Convert.ToBase64String(cert.Export(X509ContentType.Pfx, password))),
                     Password = password
                 }
             };
@@ -79,7 +79,7 @@ namespace Azure.ResourceManager.Network.Tests
             return
                 new ApplicationGatewayAuthenticationCertificate()
                 {
-                    Data = BinaryData.FromString(Convert.ToBase64String(cert.Export(X509ContentType.Cert)))
+                    Data = BinaryData.FromObjectAsJson(Convert.ToBase64String(cert.Export(X509ContentType.Cert)))
                 };
         }
 

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/UnitTest.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/UnitTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.ClientModel.Primitives;
 using System.IO;
 using System.Text.Json;
@@ -39,6 +40,62 @@ namespace Azure.ResourceManager.Network.Tests
             Assert.AreEqual("920130", data.Rules[3]); // Originally number
             Assert.AreEqual("920140", data.Rules[4]); // Originally string
             Assert.AreEqual("920150", data.Rules[5]); // Originally number
+        }
+
+        [Test]
+        public void ApplicationGatewaySslCertificateSerializesLegacyBinaryDataOnce()
+        {
+            byte[] pfxContent = new byte[] { 0x30, 0x82, 0x01, 0x02, 0x00, 0xFF };
+            var applicationGateway = new ApplicationGatewayData();
+            applicationGateway.SslCertificates.Add(new ApplicationGatewaySslCertificate
+            {
+                Data = BinaryData.FromObjectAsJson(Convert.ToBase64String(pfxContent)),
+                Password = "password"
+            });
+
+            BinaryData wire = ModelReaderWriter.Write(applicationGateway, ModelSerializationExtensions.WireOptions, AzureResourceManagerNetworkContext.Default);
+
+            using JsonDocument document = JsonDocument.Parse(wire);
+            string serializedData = document.RootElement
+                .GetProperty("properties")
+                .GetProperty("sslCertificates")[0]
+                .GetProperty("properties")
+                .GetProperty("data")
+                .GetString();
+            CollectionAssert.AreEqual(pfxContent, Convert.FromBase64String(serializedData));
+        }
+
+        [Test]
+        public void ApplicationGatewaySslCertificateDeserializationPreservesLegacyBinaryData()
+        {
+            BinaryData wire = BinaryData.FromString("""
+                {
+                  "properties": {
+                    "data": "AQID",
+                    "password": "password"
+                  }
+                }
+                """);
+
+            ApplicationGatewaySslCertificate certificate = ModelReaderWriter.Read<ApplicationGatewaySslCertificate>(wire, ModelSerializationExtensions.WireOptions, AzureResourceManagerNetworkContext.Default);
+
+            using JsonDocument document = JsonDocument.Parse(certificate.Data);
+            Assert.AreEqual("AQID", document.RootElement.GetString());
+        }
+
+        [Test]
+        public void ApplicationGatewaySslCertificateSerializesRawBytes()
+        {
+            var certificate = new ApplicationGatewaySslCertificate
+            {
+                Data = BinaryData.FromBytes(new byte[] { 1, 2, 3 }),
+                Password = "password"
+            };
+
+            BinaryData wire = ModelReaderWriter.Write(certificate, ModelSerializationExtensions.WireOptions, AzureResourceManagerNetworkContext.Default);
+
+            using JsonDocument document = JsonDocument.Parse(wire);
+            Assert.AreEqual("AQID", document.RootElement.GetProperty("properties").GetProperty("data").GetString());
         }
     }
 }


### PR DESCRIPTION
Fix issue #60969 

## Version comparison and root cause

Version 1.16.0 migrated the package from AutoRest to TypeSpec and upgraded the API version from 2025-05-01 to 2025-07-01.

In 1.15.0, `ApplicationGatewaySslCertificate.Data` represented a complete JSON value. The documented usage was:

```csharp
Data = BinaryData.FromObjectAsJson(Convert.ToBase64String(pfxBytes));
```

The AutoRest serializer used `WriteRawValue(Data)`, producing the expected Base64 string on the wire.

In 1.16.0, TypeSpec maps the service's string property to C# `bytes`. The generated serializer therefore correctly uses `WriteBase64StringValue` and expects raw certificate bytes. However, the migration compatibility property forwarded the legacy `BinaryData` value through an identity conversion. This caused the JSON string bytes, including quotation marks, to be Base64 encoded again.

For example:

- Original bytes: `3082010200FF`
- Expected wire value: `MIIBAgD/`
- 1.16.x wire value: `Ik1JSUJBZ0QvIg==`
- Decoded 1.16.x value: `224D4949424167442F22`

The 2025-05-01 and 2025-07-01 REST schemas both define `data` and `password` as strings, and password serialization did not change. Therefore, this is a migration compatibility-shim regression, not a service API change or a core TypeSpec bytes-serialization bug.

The fix converts the legacy JSON-string `BinaryData` to raw bytes before the TypeSpec-generated serializer runs, and performs the inverse conversion for the public getter.

### Regression tests verify:

- The issue's original usage through the complete `ApplicationGatewayData` request body.
- The wire Base64 value decodes exactly to the original PFX bytes.
- Deserialization preserves the legacy getter semantics.
- `BinaryData.FromBytes` remains supported.
