### PR TITLE
Allow overriding ARM provider schema

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
@@ -305,7 +305,7 @@ namespace Azure.Generator.Management
         private IReadOnlyDictionary<string, (string ResourceName, bool IsAlsoUsedInCreate)> ResourceUpdateModelToResourceNameMap => _resourceUpdateModelToResourceNameMap ??= BuildResourceUpdateModelToResourceNameMap();
 
         /// <summary> Gets the ARM provider schema containing all resource metadata and non-resource methods. </summary>
-        public ArmProviderSchema ArmProviderSchema => _providerSchema ??= BuildArmProviderSchema();
+        public virtual ArmProviderSchema ArmProviderSchema => _providerSchema ??= BuildArmProviderSchema();
 
         private IReadOnlyDictionary<string, (string ResourceName, bool IsAlsoUsedInCreate)> BuildResourceUpdateModelToResourceNameMap()
         {


### PR DESCRIPTION
Makes ManagementInputLibrary.ArmProviderSchema virtual so specialized generators can supply a schema built from a different input namespace while reusing management input-library behavior.