### PR TITLE
[CodeTransparency] Harden receipt proof validation

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Hardened receipt verification to reject empty inclusion-proof collections.
+
 ### Other Changes
 
 ## 1.0.0-beta.10 (2026-07-14)

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceiptVerifier.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceiptVerifier.cs
@@ -113,7 +113,7 @@ namespace Azure.Security.CodeTransparency
             proofsReader.ReadStartArray();
             if (proofsReader.PeekState() == CborReaderState.EndArray)
             {
-                throw new InvalidOperationException("At least one inclusion proof is required");
+                throw new InvalidOperationException("At least one inclusion proof is expected");
             }
             while (proofsReader.PeekState() != CborReaderState.EndArray)
             {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceiptVerifier.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceiptVerifier.cs
@@ -107,15 +107,14 @@ namespace Azure.Security.CodeTransparency
                 throw new InvalidOperationException("Inclusion proof is required");
             }
 
-            if (proofs == null || proofs.Length == 0)
-            {
-                throw new InvalidOperationException("At least one inclusion proof is required");
-            }
-
             // InclusionProofs is an array of cbor bytestr
             List<byte[]> inclusionProofs = new List<byte[]>();
             CborReader proofsReader = new CborReader(proofs);
             proofsReader.ReadStartArray();
+            if (proofsReader.PeekState() == CborReaderState.EndArray)
+            {
+                throw new InvalidOperationException("At least one inclusion proof is required");
+            }
             while (proofsReader.PeekState() != CborReaderState.EndArray)
             {
                 inclusionProofs.Add(proofsReader.ReadByteString());

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
+using System.Security.Cryptography.Cose;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -134,6 +135,38 @@ namespace Azure.Security.CodeTransparency.Tests
                 IdentityClientEndpoint = "https://some.identity.com"
             };
             return (mockTransport, options);
+        }
+
+        private (byte[] Receipt, byte[] SignedStatement, byte[] TransparentStatement) createStatementWithEmptyInclusionProof()
+        {
+            CoseSign1Message transparentStatement = CoseMessage.DecodeSign1(readFileBytes("transparent_statement.cose"));
+            CoseHeaderValue embeddedReceipts = transparentStatement.UnprotectedHeaders[
+                new CoseHeaderLabel(CcfReceipt.CoseHeaderEmbeddedReceipts)];
+            CborReader receiptsReader = new(embeddedReceipts.EncodedValue);
+            receiptsReader.ReadStartArray();
+            CoseSign1Message receipt = CoseMessage.DecodeSign1(receiptsReader.ReadByteString());
+            receiptsReader.ReadEndArray();
+
+            CborWriter proofWriter = new();
+            proofWriter.WriteStartMap(1);
+            proofWriter.WriteInt32(CcfReceipt.CoseReceiptInclusionProofLabel);
+            proofWriter.WriteStartArray(0);
+            proofWriter.WriteEndArray();
+            proofWriter.WriteEndMap();
+            receipt.UnprotectedHeaders[new CoseHeaderLabel(CcfReceipt.CosePhdrVdpLabel)] =
+                CoseHeaderValue.FromEncodedValue(proofWriter.Encode());
+            byte[] receiptBytes = receipt.Encode();
+
+            CborWriter receiptsWriter = new();
+            receiptsWriter.WriteStartArray(1);
+            receiptsWriter.WriteByteString(receiptBytes);
+            receiptsWriter.WriteEndArray();
+            transparentStatement.UnprotectedHeaders[new CoseHeaderLabel(CcfReceipt.CoseHeaderEmbeddedReceipts)] =
+                CoseHeaderValue.FromEncodedValue(receiptsWriter.Encode());
+            byte[] transparentStatementBytes = transparentStatement.Encode();
+
+            transparentStatement.UnprotectedHeaders.Clear();
+            return (receiptBytes, transparentStatement.Encode(), transparentStatementBytes);
         }
 
         public CodeTransparencyClientUnitTests(bool isAsync) : base(isAsync)
@@ -388,6 +421,46 @@ namespace Azure.Security.CodeTransparency.Tests
             byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
 
             CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
+#endif
+        }
+
+        [Test]
+        public void VerifyTransparentStatementReceipt_EmptyInclusionProofs_ThrowsInvalidOperationException()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            var (_, options) = createClientOptionsWithValidPublicKeyResponse();
+            var client = new CodeTransparencyClient(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
+            Response<JwksDocument> keys = client.GetPublicKeys();
+            var statement = createStatementWithEmptyInclusionProof();
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CcfReceiptVerifier.VerifyTransparentStatementReceipt(keys.Value.Keys[0], statement.Receipt, statement.SignedStatement));
+
+            StringAssert.Contains("At least one inclusion proof is required", exception.Message);
+#endif
+        }
+
+        [Test]
+        public void VerifyTransparentStatement_EmptyInclusionProofs_ThrowsAggregateException()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            var (_, options) = createClientOptionsWithValidPublicKeyResponse();
+            var statement = createStatementWithEmptyInclusionProof();
+            var verificationOptions = new CodeTransparencyVerificationOptions
+            {
+                AuthorizedDomains = new string[] { "foo.bar.com" },
+                AuthorizedReceiptBehavior = AuthorizedReceiptBehavior.RequireAll,
+                UnauthorizedReceiptBehavior = UnauthorizedReceiptBehavior.FailIfPresent
+            };
+
+            var exception = Assert.Throws<AggregateException>(() =>
+                CodeTransparencyClient.VerifyTransparentStatement(statement.TransparentStatement, verificationOptions, options));
+
+            StringAssert.Contains("At least one inclusion proof is required", exception.Message);
 #endif
         }
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -438,7 +438,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 CcfReceiptVerifier.VerifyTransparentStatementReceipt(keys.Value.Keys[0], statement.Receipt, statement.SignedStatement));
 
-            StringAssert.Contains("At least one inclusion proof is required", exception.Message);
+            StringAssert.Contains("At least one inclusion proof is expected", exception.Message);
 #endif
         }
 
@@ -460,7 +460,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var exception = Assert.Throws<AggregateException>(() =>
                 CodeTransparencyClient.VerifyTransparentStatement(statement.TransparentStatement, verificationOptions, options));
 
-            StringAssert.Contains("At least one inclusion proof is required", exception.Message);
+            StringAssert.Contains("At least one inclusion proof is expected", exception.Message);
 #endif
         }
 


### PR DESCRIPTION
### Packages impacted by this PR

`Azure.Security.CodeTransparency` (`1.0.0-beta.11`)

### Issues associated with this PR

- MSRC #126975
- IcM #31000000661854
- [ADO Bug #38799730](https://msazure.visualstudio.com/One/_workitems/edit/38799730)

### Describe the problem that is addressed by this PR

Receipt verification checked the byte length of the encoded CBOR inclusion-proof value rather than the number of decoded proofs. An empty CBOR array still has an encoded byte, so it passed that guard. Because the cryptographic checks run once per decoded proof, an empty collection performed no proof verification.

### What are the possible designs available to address the problem?

**Keep checking encoded bytes** was rejected because encoded length does not represent collection cardinality.

**Track whether the proof loop executes** would work, but detects the invalid shape after entering the verification flow.

**Validate the decoded array at the parser boundary** was chosen. It is the smallest shared fix and rejects the invalid receipt before any per-proof processing.

### Describe the solution

- Reject an inclusion-proof array when its first decoded state is `EndArray`.
- Remove the ineffective encoded-byte-length check.
- Add low-level `CcfReceiptVerifier` regression coverage.
- Add high-level `CodeTransparencyClient.VerifyTransparentStatement` regression coverage using the documented strict receipt options.
- Add the fix to the `1.0.0-beta.11` changelog.

The change adds no API surface, dependency, configuration, or generator modification.

### Are there test cases added in this PR?

Yes. The regression fixture starts from an existing valid transparent statement and changes only its inclusion-proof collection. Both the low-level verifier and the documented high-level API must reject it with the expected validation error.

### Validation

- .NET 8: 204 passed, 38 skipped, 0 failed
- .NET 9: 204 passed, 38 skipped, 0 failed
- .NET 10: 204 passed, 38 skipped, 0 failed
- .NET Framework 4.6.2: 162 passed, 80 expected crypto skips, 0 failed
- Valid-receipt canary smoke: submitted the existing `synthetics.cose` payload to `synth-canary-mst`, downloaded transparent statement entry `36.29528`, and verified it successfully with the rebased local SDK
- Changed-file whitespace verification and `git diff --check` passed
- Independent Claude Opus 4.8 review found no Critical or Important issue
- Ponytail minimalism review: `Lean already. Ship.`

### Related PRs

- #48627 introduced the current receipt-verification flow
- #60983 released `1.0.0-beta.10`
- #60984 advanced the package to the current `1.0.0-beta.11` development version

### Checklists

- [x] Added the impacted package name
- [x] Added focused regression tests
- [x] Added a changelog entry
- [x] No SDK generator change is required
- [x] MSRC approved public branch and PR timing
