### PR TITLE
[CodeTransparency] Release 1.0.0-beta.11

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.0.0-beta.11 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.0-beta.11 (2026-07-15)
 
 ### Bugs Fixed
 
 - Hardened receipt verification to reject empty inclusion-proof collections.
-
-### Other Changes
 
 ## 1.0.0-beta.10 (2026-07-14)
 


### PR DESCRIPTION
Prepares `Azure.Security.CodeTransparency` `1.0.0-beta.11` for release after the receipt-verification fix merged in #61017.

### Changes

- Set the beta.11 changelog date to `2026-07-15`.
- Remove empty changelog sections from the beta.11 entry.

### Validation

- `Verify-ChangeLog.ps1 -ForRelease $true` passes for `Azure.Security.CodeTransparency`.
- `git diff --check` passes.

Related:

- MSRC #126975
- IcM #31000000661854
- [ADO Bug #38799730](https://msazure.visualstudio.com/One/_workitems/edit/38799730)
- #61017
