### PR TITLE
Enable Python CodeQL analysis in internal CI

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -138,7 +138,7 @@ jobs:
               enabled: true
             codeql:
               # Need to specify the language because we clone after the codeql initialize step
-              language: csharp, javascript
+              language: csharp, javascript, python
               compiled:
                 enabled: true
 


### PR DESCRIPTION
## Summary
- Enable Python in the internal CodeQL task language list alongside C# and JavaScript.
- Addresses the [S360 action item](https://liquid.microsoft.com/Web/Compliance/Run/?product=PRD-132703&requirement=Microsoft.Security.CodeQL.10000&collection=MS.Security&copilot_promptid=C3DAE81E-CE96-46ED-BC94-840F0284B72C&view=1080296&editing=1) by ensuring Python files are included in CodeQL analysis.

CC: @MrJustinB 