### PR TITLE
Refactor provisioning input analysis into emitter

### DIFF
--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260715.3</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20260713.2</AzureGeneratorVersion>
-    <AzureManagementGeneratorVersion>1.0.0-alpha.20260701.2</AzureManagementGeneratorVersion>
+    <AzureManagementGeneratorVersion>1.0.0-alpha.20260719.1</AzureManagementGeneratorVersion>
   </PropertyGroup>
 
   <!-- Packages used by the TypeSpec generators -->

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/emitter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/emitter.ts
@@ -25,8 +25,18 @@ import type {
   CodeModelMutator,
   CSharpEmitterContext
 } from "./code-model-types.js";
+import { ArmProviderSchema } from "./resource-metadata.js";
 
-export async function $onEmit(context: EmitContext<AzureMgmtEmitterOptions>) {
+export type ManagementCodeModelTransformer = (
+  codeModel: CodeModel,
+  sdkContext: CSharpEmitterContext,
+  armProviderSchema: ArmProviderSchema
+) => CodeModel;
+
+export async function emitManagementCodeModel(
+  context: EmitContext<AzureMgmtEmitterOptions>,
+  transform?: ManagementCodeModelTransformer
+) {
   context.options["generator-name"] ??= "ManagementClientGenerator";
   context.options["emitter-extension-path"] ??= import.meta.url;
   context.options["sdk-context-options"] ??= azureSDKContextOptions;
@@ -52,11 +62,19 @@ export async function $onEmit(context: EmitContext<AzureMgmtEmitterOptions>) {
     // inherit from parents. In mgmt SDK we flatten the hierarchy, so we infer from methods instead.
     fixClientApiVersions(codeModel, sdkContext);
 
-    updateClients(codeModel, sdkContext, context.options);
+    const armProviderSchema = updateClients(
+      codeModel,
+      sdkContext,
+      context.options
+    );
     setFlattenProperty(codeModel, sdkContext);
     setHasClientNameOverride(codeModel, sdkContext);
-    return codeModel;
+    return transform?.(codeModel, sdkContext, armProviderSchema) ?? codeModel;
   }
+}
+
+export async function $onEmit(context: EmitContext<AzureMgmtEmitterOptions>) {
+  return emitManagementCodeModel(context);
 }
 
 function setFlattenProperty(

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/index.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/index.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 export { $lib } from "./lib/lib.js";
-export { $onEmit } from "./emitter.js";
+export {
+  $onEmit,
+  emitManagementCodeModel,
+  ManagementCodeModelTransformer
+} from "./emitter.js";
 export {
   AzureMgmtEmitterOptions,
   AzureMgmtEmitterOptionsSchema

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -62,11 +62,11 @@ import { AzureMgmtEmitterOptions } from "./options.js";
 import { getAllSdkClients, traverseClient } from "./sdk-client-utils.js";
 import { $lib } from "./lib/lib.js";
 
-export async function updateClients(
+export function updateClients(
   codeModel: CodeModel,
   sdkContext: CSharpEmitterContext,
   options: AzureMgmtEmitterOptions
-) {
+): ArmProviderSchema {
   let armProviderSchema: ArmProviderSchema;
 
   if (options?.["use-legacy-resource-detection"] === false) {
@@ -76,6 +76,7 @@ export async function updateClients(
   }
 
   applyArmProviderSchemaDecorator(codeModel, armProviderSchema);
+  return armProviderSchema;
 }
 
 /**
@@ -526,11 +527,11 @@ function assignRemainingOperations(
       const scope = buildScopeInfoFromPath(operationPath);
       const isCollectionAction = isResourceCollectionAction(sdkMethod);
       const target = isCollectionAction
-        ? (findCollectionActionTargetResource(
+        ? findCollectionActionTargetResource(
             resources,
             operationPath,
             actionTarget
-          ) ?? actionTarget)
+          ) ?? actionTarget
         : actionTarget;
       target.metadata.methods.push({
         methodId,

--- a/eng/packages/http-client-csharp-provisioning/emitter/src/emitter.ts
+++ b/eng/packages/http-client-csharp-provisioning/emitter/src/emitter.ts
@@ -3,8 +3,9 @@
 
 import { EmitContext } from "@typespec/compiler";
 
-import { $onEmit as $onMgmtEmit } from "@azure-typespec/http-client-csharp-mgmt";
+import { emitManagementCodeModel } from "@azure-typespec/http-client-csharp-mgmt";
 import { AzureProvisioningEmitterOptions } from "./options.js";
+import { updateProvisioningCodeModel } from "./provisioning-code-model.js";
 
 export async function $onEmit(
   context: EmitContext<AzureProvisioningEmitterOptions>
@@ -13,5 +14,7 @@ export async function $onEmit(
   context.options["emitter-extension-path"] ??= import.meta.url;
   // Provisioning libraries use a flat namespace (no .Models sub-namespace)
   context.options["model-namespace"] = false;
-  await $onMgmtEmit(context);
+  await emitManagementCodeModel(context, (codeModel, _, armProviderSchema) =>
+    updateProvisioningCodeModel(codeModel, armProviderSchema)
+  );
 }

--- a/eng/packages/http-client-csharp-provisioning/emitter/src/provisioning-code-model.ts
+++ b/eng/packages/http-client-csharp-provisioning/emitter/src/provisioning-code-model.ts
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { ManagementCodeModelTransformer } from "@azure-typespec/http-client-csharp-mgmt";
+import { CodeModel, InputModelType } from "@typespec/http-client-csharp";
+
+type ArmProviderSchema = Parameters<ManagementCodeModelTransformer>[2];
+type ArmResourceSchema = ArmProviderSchema["resources"][number];
+type InputModelProperty = InputModelType["properties"][number];
+type InputType = InputModelProperty["type"];
+type InputEnumType = Extract<InputType, { kind: "enum" }>;
+
+const provisioningProviderSchema =
+  "Azure.ClientGenerator.Core.@provisioningProviderSchema";
+
+interface ResourceProjection {
+  resources: ArmResourceSchema[];
+  resourceModel: InputModelType;
+  isSettable: boolean;
+}
+
+export function updateProvisioningCodeModel(
+  codeModel: CodeModel,
+  armProviderSchema: ArmProviderSchema
+): CodeModel {
+  const projections = buildResourceProjections(codeModel, armProviderSchema);
+  const { models, enums, modelSettableUsage } =
+    collectReachableTypes(projections);
+
+  codeModel.models = codeModel.models.filter((model) => models.has(model));
+  codeModel.enums = codeModel.enums.filter((inputEnum) => enums.has(inputEnum));
+
+  const rootClient = codeModel.clients[0];
+  if (rootClient) {
+    rootClient.decorators ??= [];
+    rootClient.decorators.push({
+      name: provisioningProviderSchema,
+      arguments: {
+        resourceProjections: projections.map((projection) => ({
+          resourceIdPatterns: projection.resources.map(
+            (resource) => resource.metadata.resourceIdPattern.path
+          )
+        })),
+        modelSettableUsage: Array.from(
+          modelSettableUsage,
+          ([modelId, isSettable]) => ({ modelId, isSettable })
+        )
+      }
+    });
+  }
+
+  return codeModel;
+}
+
+function buildResourceProjections(
+  codeModel: CodeModel,
+  armProviderSchema: ArmProviderSchema
+): ResourceProjection[] {
+  const modelsById = new Map(
+    codeModel.models.map((model) => [model.crossLanguageDefinitionId, model])
+  );
+  const groups = new Map<string, ArmResourceSchema[]>();
+
+  for (const resource of armProviderSchema.resources) {
+    const key = `${resource.metadata.resourceType}\0${resource.resourceModelId}`;
+    const group = groups.get(key);
+    if (group) {
+      group.push(resource);
+    } else {
+      groups.set(key, [resource]);
+    }
+  }
+
+  return Array.from(groups.values(), (resources) => {
+    const resourceModel = modelsById.get(resources[0].resourceModelId);
+    if (!resourceModel) {
+      throw new Error(
+        `Resource model '${resources[0].resourceModelId}' was not found in the code model.`
+      );
+    }
+
+    return {
+      resources,
+      resourceModel,
+      isSettable: resources.some((resource) =>
+        resource.metadata.methods.some((method) => method.kind === "Create")
+      )
+    };
+  });
+}
+
+function collectReachableTypes(projections: ResourceProjection[]) {
+  const models = new Set<InputModelType>();
+  const enums = new Set<InputEnumType>();
+  const modelSettableUsage = new Map<string, boolean>();
+  const readOnlyVisited = new Set<InputType>();
+  const settableVisited = new Set<InputType>();
+  const projectionsByModel = new Map<InputModelType, ResourceProjection[]>();
+  const queue: { type: InputType; isSettable: boolean }[] = [];
+  let queueIndex = 0;
+
+  for (const projection of projections) {
+    const modelProjections =
+      projectionsByModel.get(projection.resourceModel) ?? [];
+    modelProjections.push(projection);
+    projectionsByModel.set(projection.resourceModel, modelProjections);
+    queue.push({
+      type: projection.resourceModel,
+      isSettable: projection.isSettable
+    });
+  }
+
+  while (queueIndex < queue.length) {
+    const item = queue[queueIndex++];
+    const visited = item.isSettable ? settableVisited : readOnlyVisited;
+    if (visited.has(item.type)) {
+      continue;
+    }
+    visited.add(item.type);
+
+    switch (item.type.kind) {
+      case "model": {
+        const model = item.type;
+        const resourceProjections = projectionsByModel.get(model);
+        const isSettable =
+          item.isSettable ||
+          resourceProjections?.some((projection) => projection.isSettable) ===
+            true;
+
+        models.add(model);
+        modelSettableUsage.set(
+          model.crossLanguageDefinitionId,
+          isSettable ||
+            modelSettableUsage.get(model.crossLanguageDefinitionId) === true
+        );
+        enqueueModelHierarchy(model, isSettable, queue);
+
+        const properties = resourceProjections
+          ? getResourceProperties(model)
+          : model.properties;
+        for (const property of properties) {
+          queue.push({
+            type: property.type,
+            isSettable: isSettable && !property.readOnly
+          });
+        }
+        if (!resourceProjections && model.additionalProperties) {
+          queue.push({ type: model.additionalProperties, isSettable });
+        }
+        break;
+      }
+      case "array":
+        queue.push({ type: item.type.valueType, isSettable: item.isSettable });
+        break;
+      case "dict":
+        queue.push(
+          { type: item.type.keyType, isSettable: item.isSettable },
+          { type: item.type.valueType, isSettable: item.isSettable }
+        );
+        break;
+      case "nullable":
+        queue.push({ type: item.type.type, isSettable: item.isSettable });
+        break;
+      case "constant":
+        queue.push({ type: item.type.valueType, isSettable: item.isSettable });
+        break;
+      case "union":
+        for (const variant of item.type.variantTypes) {
+          queue.push({ type: variant, isSettable: item.isSettable });
+        }
+        break;
+      case "enum":
+        enums.add(item.type);
+        break;
+    }
+  }
+
+  return { models, enums, modelSettableUsage };
+}
+
+function enqueueModelHierarchy(
+  model: InputModelType,
+  isSettable: boolean,
+  queue: { type: InputType; isSettable: boolean }[]
+): void {
+  if (model.baseModel) {
+    queue.push({ type: model.baseModel, isSettable });
+  }
+  for (const derived of Object.values(model.discriminatedSubtypes ?? {})) {
+    queue.push({ type: derived, isSettable });
+  }
+}
+
+function getResourceProperties(
+  resourceModel: InputModelType
+): InputModelProperty[] {
+  const hierarchy: InputModelType[] = [];
+  let model: InputModelType | undefined = resourceModel;
+  while (model) {
+    hierarchy.push(model);
+    model = model.baseModel;
+  }
+  return hierarchy.reverse().flatMap((type) => type.properties);
+}

--- a/eng/packages/http-client-csharp-provisioning/emitter/src/provisioning-code-model.ts
+++ b/eng/packages/http-client-csharp-provisioning/emitter/src/provisioning-code-model.ts
@@ -56,11 +56,17 @@ function buildResourceProjections(
   codeModel: CodeModel,
   armProviderSchema: ArmProviderSchema
 ): ResourceProjection[] {
+  // Resource metadata identifies body models by cross-language ID, while the
+  // reachability analysis below needs the actual model instances.
   const modelsById = new Map(
     codeModel.models.map((model) => [model.crossLanguageDefinitionId, model])
   );
   const groups = new Map<string, ArmResourceSchema[]>();
 
+  // A logical provisioning resource can have multiple ARM metadata entries,
+  // such as different request paths or scopes. Collapse entries only when both
+  // the serialized resource type and body model match; the C# generator later
+  // resolves the complete set through their resource ID patterns.
   for (const resource of armProviderSchema.resources) {
     const key = `${resource.metadata.resourceType}\0${resource.resourceModelId}`;
     const group = groups.get(key);
@@ -79,6 +85,9 @@ function buildResourceProjections(
       );
     }
 
+    // Like Bicep, treat the projection as deployable/settable only when at
+    // least one grouped resource has a Create (PUT) operation. PATCH-only
+    // resources remain reachable for existing-resource scenarios.
     return {
       resources,
       resourceModel,

--- a/eng/packages/http-client-csharp-provisioning/emitter/src/provisioning-code-model.ts
+++ b/eng/packages/http-client-csharp-provisioning/emitter/src/provisioning-code-model.ts
@@ -6,17 +6,35 @@ import { CodeModel, InputModelType } from "@typespec/http-client-csharp";
 
 type ArmProviderSchema = Parameters<ManagementCodeModelTransformer>[2];
 type ArmResourceSchema = ArmProviderSchema["resources"][number];
+type ArmResourceMetadata = ArmResourceSchema["metadata"];
+type ResourceScopeKind = ArmResourceMetadata["scope"]["kind"];
+type ResourceNameConstraints = ArmResourceMetadata["nameConstraints"];
+type ResourceRbacRole = ArmResourceMetadata["rbacRoles"][number];
+type ResourcePath = ArmResourceMetadata["resourceIdPattern"];
 type InputModelProperty = InputModelType["properties"][number];
 type InputType = InputModelProperty["type"];
 type InputEnumType = Extract<InputType, { kind: "enum" }>;
+type ProjectionScopeOperation = "Create" | "Read";
 
 const provisioningProviderSchema =
   "Azure.ClientGenerator.Core.@provisioningProviderSchema";
 
 interface ResourceProjection {
-  resources: ArmResourceSchema[];
   resourceModel: InputModelType;
   isSettable: boolean;
+  resourceModelId: string;
+  resourceName: string;
+  resourceType: string;
+  singletonResourceName?: string;
+  parentResourceId?: string;
+  nameConstraints: ResourceNameConstraints;
+  resourceIdPatterns: string[];
+  apiVersions: string[];
+  methodIds: string[];
+  rbacRoles: ResourceRbacRole[];
+  readableScopes: ResourceScopeKind[];
+  writableScopes: ResourceScopeKind[];
+  isExtensionResource: boolean;
 }
 
 export function updateProvisioningCodeModel(
@@ -37,9 +55,19 @@ export function updateProvisioningCodeModel(
       name: provisioningProviderSchema,
       arguments: {
         resourceProjections: projections.map((projection) => ({
-          resourceIdPatterns: projection.resources.map(
-            (resource) => resource.metadata.resourceIdPattern.path
-          )
+          resourceModelId: projection.resourceModelId,
+          resourceName: projection.resourceName,
+          resourceType: projection.resourceType,
+          singletonResourceName: projection.singletonResourceName,
+          parentResourceId: projection.parentResourceId,
+          nameConstraints: projection.nameConstraints,
+          resourceIdPatterns: projection.resourceIdPatterns,
+          apiVersions: projection.apiVersions,
+          methodIds: projection.methodIds,
+          rbacRoles: projection.rbacRoles,
+          readableScopes: projection.readableScopes,
+          writableScopes: projection.writableScopes,
+          isExtensionResource: projection.isExtensionResource
         })),
         modelSettableUsage: Array.from(
           modelSettableUsage,
@@ -88,14 +116,140 @@ function buildResourceProjections(
     // Like Bicep, treat the projection as deployable/settable only when at
     // least one grouped resource has a Create (PUT) operation. PATCH-only
     // resources remain reachable for existing-resource scenarios.
-    return {
+    const projection = buildResourceProjectionMetadata(
       resources,
+      resourceModel.name
+    );
+    return {
+      ...projection,
       resourceModel,
-      isSettable: resources.some((resource) =>
-        resource.metadata.methods.some((method) => method.kind === "Create")
-      )
+      isSettable: projection.writableScopes.length > 0
     };
   });
+}
+
+export function buildResourceProjectionMetadata(
+  resources: ArmResourceSchema[],
+  defaultResourceName: string
+): Omit<ResourceProjection, "resourceModel" | "isSettable"> {
+  const first = resources[0];
+  const writableScopes = collectScopes(resources, "Create");
+
+  return {
+    resourceModelId: first.resourceModelId,
+    resourceName: getConsistentValue(
+      resources.map((resource) => resource.metadata.resourceName),
+      defaultResourceName
+    ),
+    resourceType: first.metadata.resourceType,
+    singletonResourceName: getConsistentValue(
+      resources.map((resource) => resource.metadata.singletonResourceName),
+      undefined
+    ),
+    parentResourceId: getConsistentValue(
+      resources.map((resource) => resource.metadata.parentResourceId),
+      undefined,
+      resourcePathsEqual
+    )?.path,
+    nameConstraints: getConsistentValue(
+      resources.map((resource) => resource.metadata.nameConstraints),
+      {},
+      nameConstraintsEqual
+    ),
+    resourceIdPatterns: distinctResourcePaths(
+      resources.map((resource) => resource.metadata.resourceIdPattern)
+    ).map((path) => path.path),
+    apiVersions: distinct(
+      resources.flatMap((resource) => resource.metadata.apiVersions)
+    ),
+    methodIds: distinct(
+      resources.flatMap((resource) =>
+        resource.metadata.methods.map((method) => method.methodId)
+      )
+    ),
+    rbacRoles: distinctBy(
+      resources.flatMap((resource) => resource.metadata.rbacRoles),
+      (role) => `${role.name}\0${role.value}`
+    ),
+    readableScopes: collectScopes(resources, "Read"),
+    writableScopes,
+    isExtensionResource: writableScopes.some(isExtensionScope)
+  };
+}
+
+function resourcePathsEqual(
+  left: ResourcePath | undefined,
+  right: ResourcePath | undefined
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+  return left.equals(right);
+}
+
+function distinctResourcePaths(paths: ResourcePath[]): ResourcePath[] {
+  const distinctPaths: ResourcePath[] = [];
+  for (const path of paths) {
+    if (!distinctPaths.some((existing) => existing.equals(path))) {
+      distinctPaths.push(path);
+    }
+  }
+  return distinctPaths;
+}
+
+function isExtensionScope(scope: ResourceScopeKind): boolean {
+  return scope.toString() === "Extension";
+}
+
+function getConsistentValue<T>(
+  values: T[],
+  fallback: T,
+  equals: (left: T, right: T) => boolean = Object.is
+): T {
+  const first = values[0];
+  return values.every((value) => equals(value, first)) ? first : fallback;
+}
+
+function nameConstraintsEqual(
+  left: ResourceNameConstraints,
+  right: ResourceNameConstraints
+): boolean {
+  return (
+    left.pattern === right.pattern &&
+    left.minLength === right.minLength &&
+    left.maxLength === right.maxLength
+  );
+}
+
+function distinct<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+function distinctBy<T>(values: T[], getKey: (value: T) => string): T[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = getKey(value);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function collectScopes(
+  resources: ArmResourceSchema[],
+  operationKind: ProjectionScopeOperation
+): ResourceScopeKind[] {
+  return distinct(
+    resources
+      .filter((resource) =>
+        resource.metadata.methods.some(
+          (method) => method.kind === operationKind
+        )
+      )
+      .map((resource) => resource.metadata.scope.kind)
+  );
 }
 
 function collectReachableTypes(projections: ResourceProjection[]) {

--- a/eng/packages/http-client-csharp-provisioning/emitter/test/provisioning-code-model.test.ts
+++ b/eng/packages/http-client-csharp-provisioning/emitter/test/provisioning-code-model.test.ts
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { deepStrictEqual, strictEqual } from "assert";
+import { describe, it } from "vitest";
+import {
+  RequestPath,
+  ResourceOperationKind,
+  ResourceScopeKind,
+  type NameConstraints,
+  type RbacRole,
+  type ValidArmResourceSchema
+} from "../../../http-client-csharp-mgmt/emitter/src/resource-metadata.js";
+import { buildResourceProjectionMetadata } from "../src/provisioning-code-model.js";
+
+describe("resource projection metadata", () => {
+  it("collapses resources and preserves distinct aggregate values", () => {
+    const first = createResource({
+      path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+      scope: ResourceScopeKind.ResourceGroup,
+      apiVersions: ["2024-01-01"],
+      methodKinds: [ResourceOperationKind.Read, ResourceOperationKind.Create],
+      rbacRoles: [{ name: "FirstRole", value: "11111111" }]
+    });
+    const second = createResource({
+      path: "/subscriptions/{subscriptionId}/providers/Microsoft.Test/widgets/{widgetName}",
+      scope: ResourceScopeKind.Subscription,
+      apiVersions: ["2024-01-01", "2024-02-01"],
+      methodKinds: [ResourceOperationKind.Read],
+      rbacRoles: [
+        { name: "FirstRole", value: "11111111" },
+        { name: "SecondRole", value: "22222222" }
+      ]
+    });
+
+    const projection = buildResourceProjectionMetadata(
+      [first, second],
+      "Widget"
+    );
+
+    strictEqual(projection.resourceName, "Widget");
+    strictEqual(projection.resourceType, "Microsoft.Test/widgets");
+    deepStrictEqual(projection.resourceIdPatterns, [
+      first.metadata.resourceIdPattern.path,
+      second.metadata.resourceIdPattern.path
+    ]);
+    deepStrictEqual(projection.apiVersions, ["2024-01-01", "2024-02-01"]);
+    deepStrictEqual(projection.rbacRoles, [
+      { name: "FirstRole", value: "11111111" },
+      { name: "SecondRole", value: "22222222" }
+    ]);
+    deepStrictEqual(projection.readableScopes, [
+      ResourceScopeKind.ResourceGroup,
+      ResourceScopeKind.Subscription
+    ]);
+    deepStrictEqual(projection.writableScopes, [
+      ResourceScopeKind.ResourceGroup
+    ]);
+    strictEqual(projection.isExtensionResource, false);
+  });
+
+  it("uses conservative defaults for inconsistent per-resource values", () => {
+    const first = createResource({
+      path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/default",
+      resourceName: "FirstResource",
+      singletonResourceName: "default",
+      parentResourceId:
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+      nameConstraints: { pattern: "[a-z]+", minLength: 1, maxLength: 24 }
+    });
+    const second = createResource({
+      path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/current",
+      resourceName: "SecondResource",
+      singletonResourceName: "current",
+      parentResourceId:
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/otherWidgets/{widgetName}",
+      nameConstraints: { pattern: "[0-9]+", minLength: 1, maxLength: 24 }
+    });
+
+    const projection = buildResourceProjectionMetadata(
+      [first, second],
+      "Child"
+    );
+
+    strictEqual(projection.resourceName, "Child");
+    strictEqual(projection.singletonResourceName, undefined);
+    strictEqual(projection.parentResourceId, undefined);
+    deepStrictEqual(projection.nameConstraints, {});
+  });
+
+  it("compares resource and parent paths structurally", () => {
+    const first = createResource({
+      path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+      parentResourceId:
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}"
+    });
+    const second = createResource({
+      path: "/subscriptions/{sub}/resourceGroups/{group}/providers/microsoft.test/widgets/{name}",
+      parentResourceId: "/subscriptions/{sub}/resourceGroups/{group}"
+    });
+
+    const projection = buildResourceProjectionMetadata(
+      [first, second],
+      "Widget"
+    );
+
+    deepStrictEqual(projection.resourceIdPatterns, [
+      first.metadata.resourceIdPattern.path
+    ]);
+    strictEqual(
+      projection.parentResourceId,
+      first.metadata.parentResourceId?.path
+    );
+  });
+
+  it("exposes scope metadata only for createable extension resources", () => {
+    const readOnly = createResource({
+      path: "/{scope}/providers/Microsoft.Test/extensions/{extensionName}",
+      scope: ResourceScopeKind.Extension,
+      methodKinds: [ResourceOperationKind.Read, ResourceOperationKind.Update]
+    });
+    const writable = createResource({
+      path: "/{scope}/providers/Microsoft.Test/extensions/{extensionName}",
+      scope: ResourceScopeKind.Extension,
+      methodKinds: [ResourceOperationKind.Read, ResourceOperationKind.Create]
+    });
+
+    const readOnlyProjection = buildResourceProjectionMetadata(
+      [readOnly],
+      "Extension"
+    );
+    const writableProjection = buildResourceProjectionMetadata(
+      [writable],
+      "Extension"
+    );
+
+    deepStrictEqual(readOnlyProjection.writableScopes, []);
+    strictEqual(readOnlyProjection.isExtensionResource, false);
+    deepStrictEqual(writableProjection.writableScopes, [
+      ResourceScopeKind.Extension
+    ]);
+    strictEqual(writableProjection.isExtensionResource, true);
+  });
+});
+
+interface ResourceOptions {
+  path: string;
+  resourceName?: string;
+  singletonResourceName?: string;
+  parentResourceId?: string;
+  nameConstraints?: NameConstraints;
+  scope?: ResourceScopeKind;
+  apiVersions?: string[];
+  methodKinds?: ResourceOperationKind[];
+  rbacRoles?: RbacRole[];
+}
+
+function createResource(options: ResourceOptions): ValidArmResourceSchema {
+  const scopeKind = options.scope ?? ResourceScopeKind.ResourceGroup;
+  const scope = {
+    kind: scopeKind,
+    scopeIdPattern: new RequestPath(""),
+    scopeResourceType:
+      scopeKind === ResourceScopeKind.Extension
+        ? "Microsoft.Test/widgets"
+        : undefined
+  };
+
+  return {
+    resourceModelId: "Microsoft.Test.Widget",
+    metadata: {
+      resourceIdPattern: new RequestPath(options.path),
+      resourceType: "Microsoft.Test/widgets",
+      methods: (options.methodKinds ?? []).map((kind, index) => ({
+        methodId: `Microsoft.Test.Widget.${kind}.${index}`,
+        kind,
+        operationPath: new RequestPath(options.path),
+        scope
+      })),
+      scope,
+      parentResourceId: options.parentResourceId
+        ? new RequestPath(options.parentResourceId)
+        : undefined,
+      singletonResourceName: options.singletonResourceName,
+      resourceName: options.resourceName ?? "Widget",
+      nameConstraints: options.nameConstraints ?? {},
+      apiVersions: options.apiVersions ?? [],
+      rbacRoles: options.rbacRoles ?? []
+    }
+  };
+}

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Azure.Generator.Provisioning.csproj
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Azure.Generator.Provisioning.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Generator" />
-    <PackageReference Include="Azure.Generator.Management" />
+    <ProjectReference Include="..\..\..\..\http-client-csharp-mgmt\generator\Azure.Generator.Management\src\Azure.Generator.Management.csproj" />
     <!-- Reference Azure.Provisioning for runtime types (ProvisionableConstruct, BicepValue<T>, etc.) -->
     <PackageReference Include="Azure.Provisioning" />
   </ItemGroup>

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Azure.Generator.Provisioning.csproj
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Azure.Generator.Provisioning.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Generator" />
-    <ProjectReference Include="..\..\..\..\http-client-csharp-mgmt\generator\Azure.Generator.Management\src\Azure.Generator.Management.csproj" />
+    <PackageReference Include="Azure.Generator.Management" />
     <!-- Reference Azure.Provisioning for runtime types (ProvisionableConstruct, BicepValue<T>, etc.) -->
     <PackageReference Include="Azure.Provisioning" />
   </ItemGroup>

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -106,7 +106,7 @@ namespace Azure.Generator.Provisioning.Primitives
         /// Gets whether this resource should be emitted as a Bicep extension
         /// resource with a language-level <c>scope</c> relationship.
         /// </summary>
-        internal bool IsExtensionResource => Metadata.Any(resource => resource.Scope.Kind == ResourceScope.Extension);
+        internal bool IsExtensionResource => WritableScopes.Contains(ResourceScope.Extension);
 
         internal static IReadOnlyList<ProvisioningResourceProjection> Create(IReadOnlyList<ArmResourceMetadata> metadata)
         {

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -238,6 +238,6 @@ namespace Azure.Generator.Provisioning.Primitives
             => kind == ResourceOperationKind.Read;
 
         private static bool IsWritableOperation(ResourceOperationKind kind)
-            => kind == ResourceOperationKind.Create || kind == ResourceOperationKind.Update;
+            => kind == ResourceOperationKind.Create;
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -5,7 +5,7 @@ using Azure.Generator.Management.Models;
 using Microsoft.TypeSpec.Generator.Input;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Text.Json;
 
 namespace Azure.Generator.Provisioning.Primitives
 {
@@ -15,30 +15,35 @@ namespace Azure.Generator.Provisioning.Primitives
     /// </summary>
     internal sealed class ProvisioningResourceProjection
     {
-        private ProvisioningResourceProjection(IReadOnlyList<ArmResourceMetadata> metadata)
+        internal ProvisioningResourceProjection(
+            InputModelType resourceModel,
+            string resourceName,
+            string resourceType,
+            string? singletonResourceName,
+            RequestPathPattern? parentResourceId,
+            ArmResourceNameConstraints nameConstraints,
+            IReadOnlyList<RequestPathPattern> resourceIdPatterns,
+            IReadOnlyList<string> apiVersions,
+            IReadOnlyList<ResourceMethod> methods,
+            IReadOnlyList<ArmResourceRbacRole> rbacRoles,
+            IReadOnlyList<ResourceScope> readableScopes,
+            IReadOnlyList<ResourceScope> writableScopes,
+            bool isExtensionResource)
         {
-            Metadata = metadata;
-            ResourceModel = GetSameResourceModel(metadata);
-            ResourceType = GetSameResourceType(metadata);
-            ResourceName = GetSameValueOrDefault(metadata.Select(resource => resource.ResourceName), ResourceModel.Name, StringComparer.Ordinal);
-            SingletonResourceName = GetSameNullableValueOrDefault(metadata.Select(resource => resource.SingletonResourceName), null, StringComparer.Ordinal);
-            ParentResourceId = GetSameNullableValueOrDefault(metadata.Select(resource => resource.ParentResourceId), null);
-            NameConstraints = GetSameValueOrDefault(
-                metadata.Select(resource => resource.NameConstraints),
-                new ArmResourceNameConstraints(null, null, null));
-            ResourceIdPatterns = [.. CollectResourceIdPatterns(metadata)];
-            ApiVersions = [.. CollectApiVersions(metadata)];
-            Methods = [.. CollectMethods(metadata)];
-            RbacRoles = [.. CollectRbacRoles(metadata)];
-            ReadableScopes = CollectScopes(metadata, IsReadableOperation);
-            WritableScopes = CollectScopes(metadata, IsWritableOperation);
+            ResourceModel = resourceModel;
+            ResourceName = resourceName;
+            ResourceType = resourceType;
+            SingletonResourceName = singletonResourceName;
+            ParentResourceId = parentResourceId;
+            NameConstraints = nameConstraints;
+            ResourceIdPatterns = resourceIdPatterns;
+            ApiVersions = apiVersions;
+            Methods = methods;
+            RbacRoles = rbacRoles;
+            ReadableScopes = readableScopes;
+            WritableScopes = writableScopes;
+            IsExtensionResource = isExtensionResource;
         }
-
-        /// <summary>
-        /// Gets the raw management resource metadata entries represented by this
-        /// provisioning resource projection.
-        /// </summary>
-        internal IReadOnlyList<ArmResourceMetadata> Metadata { get; }
 
         /// <summary>
         /// Gets the resource body model shared by all collapsed metadata entries.
@@ -106,138 +111,111 @@ namespace Azure.Generator.Provisioning.Primitives
         /// Gets whether this resource should be emitted as a Bicep extension
         /// resource with a language-level <c>scope</c> relationship.
         /// </summary>
-        internal bool IsExtensionResource => WritableScopes.Contains(ResourceScope.Extension);
+        internal bool IsExtensionResource { get; }
 
-        internal static IReadOnlyList<ProvisioningResourceProjection> Create(IReadOnlyList<ArmResourceMetadata> metadata)
+        internal static ProvisioningResourceProjection Deserialize(
+            JsonElement element,
+            IReadOnlyDictionary<string, InputModelType> modelsById,
+            IReadOnlyDictionary<string, ResourceMethod> methodsById)
         {
-            var groups = new Dictionary<(string ResourceType, InputModelType ResourceModel), List<ArmResourceMetadata>>();
-            var orderedGroups = new List<List<ArmResourceMetadata>>();
-
-            foreach (var resource in metadata)
+            var resourceModelId = GetRequiredString(element, "resourceModelId");
+            if (!modelsById.TryGetValue(resourceModelId, out var resourceModel))
             {
-                var key = (resource.ResourceType.SerializedResourceType, resource.ResourceModel);
-                if (!groups.TryGetValue(key, out var group))
+                throw new JsonException($"Provisioning resource model '{resourceModelId}' was not found in the code model.");
+            }
+
+            var methods = new List<ResourceMethod>();
+            foreach (var methodIdElement in element.GetProperty("methodIds").EnumerateArray())
+            {
+                var methodId = methodIdElement.GetString()
+                    ?? throw new JsonException("A provisioning resource method ID cannot be null.");
+                if (!methodsById.TryGetValue(methodId, out var method))
                 {
-                    group = [];
-                    groups.Add(key, group);
-                    orderedGroups.Add(group);
+                    throw new JsonException($"Provisioning resource method '{methodId}' was not found in the ARM provider schema.");
                 }
-                group.Add(resource);
+                methods.Add(method);
             }
 
-            return [.. orderedGroups.Select(group => new ProvisioningResourceProjection(group))];
-        }
+            var nameConstraintsElement = element.GetProperty("nameConstraints");
+            var nameConstraints = new ArmResourceNameConstraints(
+                GetOptionalString(nameConstraintsElement, "pattern"),
+                GetOptionalInt32(nameConstraintsElement, "minLength"),
+                GetOptionalInt32(nameConstraintsElement, "maxLength"));
 
-        private static InputModelType GetSameResourceModel(IReadOnlyList<ArmResourceMetadata> metadata)
-        {
-            var resourceModel = metadata[0].ResourceModel;
-            if (metadata.Any(resource => !ReferenceEquals(resource.ResourceModel, resourceModel)))
+            var rbacRoles = new List<ArmResourceRbacRole>();
+            foreach (var roleElement in element.GetProperty("rbacRoles").EnumerateArray())
             {
-                throw new InvalidOperationException("Collapsed provisioning resources must share the same resource model.");
+                rbacRoles.Add(new ArmResourceRbacRole(
+                    GetRequiredString(roleElement, "name"),
+                    GetRequiredString(roleElement, "value")));
             }
-            return resourceModel;
+
+            return new(
+                resourceModel,
+                GetRequiredString(element, "resourceName"),
+                GetRequiredString(element, "resourceType"),
+                GetOptionalString(element, "singletonResourceName"),
+                GetOptionalString(element, "parentResourceId") is string parentResourceId
+                    ? new RequestPathPattern(parentResourceId)
+                    : null,
+                nameConstraints,
+                DeserializeRequestPaths(element.GetProperty("resourceIdPatterns")),
+                DeserializeStrings(element.GetProperty("apiVersions")),
+                methods,
+                rbacRoles,
+                DeserializeScopes(element.GetProperty("readableScopes")),
+                DeserializeScopes(element.GetProperty("writableScopes")),
+                element.GetProperty("isExtensionResource").GetBoolean());
         }
 
-        private static string GetSameResourceType(IReadOnlyList<ArmResourceMetadata> metadata)
+        private static IReadOnlyList<RequestPathPattern> DeserializeRequestPaths(JsonElement element)
         {
-            var resourceType = metadata[0].ResourceType;
-            if (metadata.Any(resource => !resource.ResourceType.Equals(resourceType)))
+            var paths = new List<RequestPathPattern>();
+            foreach (var item in element.EnumerateArray())
             {
-                throw new InvalidOperationException("Collapsed provisioning resources must share the same resource type.");
+                paths.Add(new RequestPathPattern(
+                    item.GetString() ?? throw new JsonException("A provisioning resource path cannot be null.")));
             }
-            return resourceType.SerializedResourceType;
+            return paths;
         }
 
-        private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)
-            where T : notnull
+        private static IReadOnlyList<string> DeserializeStrings(JsonElement element)
         {
-            var distinctValues = values.Distinct(comparer).Take(2).ToArray();
-            return distinctValues.Length == 1 ? distinctValues[0] : defaultValue;
-        }
-
-        private static T? GetSameNullableValueOrDefault<T>(IEnumerable<T?> values, T? defaultValue, IEqualityComparer<T?>? comparer = null)
-        {
-            var distinctValues = values.Distinct(comparer).Take(2).ToArray();
-            return distinctValues.Length == 1 ? distinctValues[0] : defaultValue;
-        }
-
-        private static IEnumerable<RequestPathPattern> CollectResourceIdPatterns(IReadOnlyList<ArmResourceMetadata> metadata)
-        {
-            var seen = new HashSet<RequestPathPattern>();
-            foreach (var resource in metadata)
+            var values = new List<string>();
+            foreach (var item in element.EnumerateArray())
             {
-                if (seen.Add(resource.ResourceIdPattern))
-                {
-                    yield return resource.ResourceIdPattern;
-                }
+                values.Add(item.GetString() ?? throw new JsonException("A provisioning string value cannot be null."));
             }
+            return values;
         }
 
-        private static IEnumerable<string> CollectApiVersions(IReadOnlyList<ArmResourceMetadata> metadata)
+        private static IReadOnlyList<ResourceScope> DeserializeScopes(JsonElement element)
         {
-            var seen = new HashSet<string>();
-            foreach (var resource in metadata)
-            {
-                foreach (var apiVersion in resource.ApiVersions)
-                {
-                    if (seen.Add(apiVersion))
-                    {
-                        yield return apiVersion;
-                    }
-                }
-            }
-        }
-
-        private static IEnumerable<ResourceMethod> CollectMethods(IReadOnlyList<ArmResourceMetadata> metadata)
-        {
-            var seen = new HashSet<ResourceMethod>();
-            foreach (var resource in metadata)
-            {
-                foreach (var method in resource.Methods)
-                {
-                    if (seen.Add(method))
-                    {
-                        yield return method;
-                    }
-                }
-            }
-        }
-
-        private static IEnumerable<ArmResourceRbacRole> CollectRbacRoles(IReadOnlyList<ArmResourceMetadata> metadata)
-        {
-            var seen = new HashSet<ArmResourceRbacRole>();
-            foreach (var resource in metadata)
-            {
-                foreach (var role in resource.RbacRoles)
-                {
-                    if (seen.Add(role))
-                    {
-                        yield return role;
-                    }
-                }
-            }
-        }
-
-        private static IReadOnlyList<ResourceScope> CollectScopes(
-            IReadOnlyList<ArmResourceMetadata> metadata,
-            Func<ResourceOperationKind, bool> operationSelector)
-        {
-            var seen = new HashSet<ResourceScope>();
             var scopes = new List<ResourceScope>();
-            foreach (var resource in metadata)
+            foreach (var item in element.EnumerateArray())
             {
-                if (resource.Methods.Any(method => operationSelector(method.Kind)) && seen.Add(resource.Scope.Kind))
+                var value = item.GetString() ?? throw new JsonException("A provisioning resource scope cannot be null.");
+                if (!Enum.TryParse<ResourceScope>(value, out var scope))
                 {
-                    scopes.Add(resource.Scope.Kind);
+                    throw new JsonException($"Provisioning resource scope '{value}' is invalid.");
                 }
+                scopes.Add(scope);
             }
             return scopes;
         }
 
-        private static bool IsReadableOperation(ResourceOperationKind kind)
-            => kind == ResourceOperationKind.Read;
+        private static string GetRequiredString(JsonElement element, string propertyName)
+            => element.GetProperty(propertyName).GetString()
+                ?? throw new JsonException($"Required provisioning property '{propertyName}' cannot be null.");
 
-        private static bool IsWritableOperation(ResourceOperationKind kind)
-            => kind == ResourceOperationKind.Create;
+        private static string? GetOptionalString(JsonElement element, string propertyName)
+            => element.TryGetProperty(propertyName, out var property) && property.ValueKind != JsonValueKind.Null
+                ? property.GetString()
+                : null;
+
+        private static int? GetOptionalInt32(JsonElement element, string propertyName)
+            => element.TryGetProperty(propertyName, out var property) && property.ValueKind != JsonValueKind.Null
+                ? property.GetInt32()
+                : null;
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningResourceProjection.cs
@@ -106,7 +106,7 @@ namespace Azure.Generator.Provisioning.Primitives
         /// Gets whether this resource should be emitted as a Bicep extension
         /// resource with a language-level <c>scope</c> relationship.
         /// </summary>
-        internal bool IsExtensionResource => WritableScopes.Contains(ResourceScope.Extension);
+        internal bool IsExtensionResource => Metadata.Any(resource => resource.Scope.Kind == ResourceScope.Extension);
 
         internal static IReadOnlyList<ProvisioningResourceProjection> Create(IReadOnlyList<ArmResourceMetadata> metadata)
         {
@@ -115,7 +115,7 @@ namespace Azure.Generator.Provisioning.Primitives
 
             foreach (var resource in metadata)
             {
-                var key = (resource.ResourceType, resource.ResourceModel);
+                var key = (resource.ResourceType.SerializedResourceType, resource.ResourceModel);
                 if (!groups.TryGetValue(key, out var group))
                 {
                     group = [];
@@ -141,11 +141,11 @@ namespace Azure.Generator.Provisioning.Primitives
         private static string GetSameResourceType(IReadOnlyList<ArmResourceMetadata> metadata)
         {
             var resourceType = metadata[0].ResourceType;
-            if (metadata.Any(resource => !string.Equals(resource.ResourceType, resourceType, StringComparison.Ordinal)))
+            if (metadata.Any(resource => !resource.ResourceType.Equals(resourceType)))
             {
                 throw new InvalidOperationException("Collapsed provisioning resources must share the same resource type.");
             }
-            return resourceType;
+            return resourceType.SerializedResourceType;
         }
 
         private static T GetSameValueOrDefault<T>(IEnumerable<T> values, T defaultValue, IEqualityComparer<T>? comparer = null)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningInputLibrary.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningInputLibrary.cs
@@ -69,27 +69,27 @@ namespace Azure.Generator.Provisioning
             var arguments = decorator.Arguments
                 ?? throw new InvalidOperationException($"The '{ProvisioningProviderSchemaDecoratorName}' decorator does not contain arguments.");
 
-            var resourcesByIdPattern = ArmProviderSchema.Resources.ToDictionary(
-                resource => resource.ResourceIdPattern.SerializedPath,
-                StringComparer.Ordinal);
+            var modelsById = new Dictionary<string, InputModelType>(StringComparer.Ordinal);
+            foreach (var model in InputNamespace.Models)
+            {
+                modelsById.TryAdd(model.CrossLanguageDefinitionId, model);
+            }
+            var methodsById = new Dictionary<string, ResourceMethod>(StringComparer.Ordinal);
+            foreach (var resource in ArmProviderSchema.Resources)
+            {
+                foreach (var method in resource.Methods)
+                {
+                    methodsById.TryAdd(method.InputMethod.CrossLanguageDefinitionId, method);
+                }
+            }
+
             var projections = new List<ProvisioningResourceProjection>();
             if (arguments.TryGetValue("resourceProjections", out var projectionsData))
             {
                 using var document = JsonDocument.Parse(projectionsData);
                 foreach (var projectionElement in document.RootElement.EnumerateArray())
                 {
-                    var resources = new List<ArmResourceMetadata>();
-                    foreach (var resourceIdElement in projectionElement.GetProperty("resourceIdPatterns").EnumerateArray())
-                    {
-                        var resourceIdPattern = resourceIdElement.GetString()
-                            ?? throw new JsonException("A provisioning resource ID pattern cannot be null.");
-                        if (!resourcesByIdPattern.TryGetValue(resourceIdPattern, out var resource))
-                        {
-                            throw new JsonException($"Provisioning resource ID pattern '{resourceIdPattern}' was not found in the ARM provider schema.");
-                        }
-                        resources.Add(resource);
-                    }
-                    projections.Add(ProvisioningResourceProjection.Create(resources).Single());
+                    projections.Add(ProvisioningResourceProjection.Deserialize(projectionElement, modelsById, methodsById));
                 }
             }
 

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningInputLibrary.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningInputLibrary.cs
@@ -5,22 +5,21 @@ using Azure.Generator.Management;
 using Azure.Generator.Management.Models;
 using Azure.Generator.Provisioning.Primitives;
 using Microsoft.TypeSpec.Generator.Input;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 
 namespace Azure.Generator.Provisioning
 {
     /// <summary>
-    /// Input library for provisioning generator. Prepares resource projections,
-    /// reachable input models/enums, and settable usage before output providers are created.
+    /// Input library for the provisioning generator.
     /// </summary>
     public class ProvisioningInputLibrary : ManagementInputLibrary
     {
+        private const string ProvisioningProviderSchemaDecoratorName = "Azure.ClientGenerator.Core.@provisioningProviderSchema";
         private IReadOnlyList<ProvisioningResourceProjection>? _resourceProjections;
-        private Dictionary<InputModelType, List<ProvisioningResourceProjection>>? _resourceProjectionsByModel;
-        private IReadOnlyList<InputModelType>? _reachableModels;
-        private IReadOnlyList<InputEnumType>? _reachableEnums;
-        private Dictionary<InputModelType, bool>? _modelSettableUsage;
+        private Dictionary<string, bool>? _modelSettableUsage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProvisioningInputLibrary"/> class.
@@ -34,33 +33,15 @@ namespace Azure.Generator.Provisioning
         {
             get
             {
-                EnsureProvisioningInput();
+                EnsureProvisioningMetadata();
                 return _resourceProjections!;
-            }
-        }
-
-        internal IReadOnlyList<InputModelType> ReachableModels
-        {
-            get
-            {
-                EnsureProvisioningInput();
-                return _reachableModels!;
-            }
-        }
-
-        internal IReadOnlyList<InputEnumType> ReachableEnums
-        {
-            get
-            {
-                EnsureProvisioningInput();
-                return _reachableEnums!;
             }
         }
 
         internal bool IsModelSettable(InputModelType model)
         {
-            EnsureProvisioningInput();
-            if (_modelSettableUsage!.TryGetValue(model, out var isSettable))
+            EnsureProvisioningMetadata();
+            if (_modelSettableUsage!.TryGetValue(model.CrossLanguageDefinitionId, out var isSettable))
             {
                 return isSettable;
             }
@@ -70,168 +51,62 @@ namespace Azure.Generator.Provisioning
 
         internal bool IsModelReachable(InputModelType model)
         {
-            EnsureProvisioningInput();
-            return _modelSettableUsage!.ContainsKey(model);
+            EnsureProvisioningMetadata();
+            return _modelSettableUsage!.ContainsKey(model.CrossLanguageDefinitionId);
         }
 
-        private void EnsureProvisioningInput()
+        private void EnsureProvisioningMetadata()
         {
             if (_resourceProjections != null && _modelSettableUsage != null)
+            {
                 return;
-
-            var resourceProjections = _resourceProjections
-                ?? ProvisioningResourceProjection.Create(ArmProviderSchema.Resources);
-            var resourceProjectionsByModel = _resourceProjectionsByModel ?? resourceProjections
-                .GroupBy(projection => projection.ResourceModel)
-                .ToDictionary(group => group.Key, group => group.ToList());
-            var (reachableModels, reachableEnums, modelSettableUsage) = CollectReachableTypes(resourceProjections, resourceProjectionsByModel);
-
-            _resourceProjections = resourceProjections;
-            _resourceProjectionsByModel = resourceProjectionsByModel;
-            _reachableModels = reachableModels;
-            _reachableEnums = reachableEnums;
-            _modelSettableUsage = modelSettableUsage;
-        }
-
-        /// <summary>
-        /// Collects the input models and enums reachable from the resource models'
-        /// property graphs. The same traversal dyes models reachable from settable
-        /// resources through non-output properties as settable.
-        /// Provisioning settable analysis is similar to TCGC usage analysis, but
-        /// provisioning emits only a subset of operations, so TCGC usage cannot be
-        /// used directly here.
-        /// </summary>
-        private static (IReadOnlyList<InputModelType> Models, IReadOnlyList<InputEnumType> Enums, Dictionary<InputModelType, bool> ModelSettableUsage) CollectReachableTypes(
-            IReadOnlyList<ProvisioningResourceProjection> resourceProjections,
-            Dictionary<InputModelType, List<ProvisioningResourceProjection>> resourceProjectionsByModel)
-        {
-            var outputVisited = new HashSet<InputType>();
-            // Visit settable and non-settable paths independently. A model may be reached
-            // by a read-only resource first and by a writable resource later; the writable
-            // path must still propagate so the final modelSettableUsage value can be dyed true.
-            var traversalVisited = new HashSet<(InputType Type, bool IsSettable)>();
-            var models = new List<InputModelType>();
-            var enums = new List<InputEnumType>();
-            var modelSettableUsage = new Dictionary<InputModelType, bool>();
-            var queue = new Queue<(InputType Type, bool IsSettable)>();
-
-            foreach (var resource in resourceProjections)
-            {
-                queue.Enqueue((resource.ResourceModel, resource.WritableScopes.Count > 0));
             }
 
-            while (queue.Count > 0)
+            var rootClient = InputNamespace.RootClients.FirstOrDefault()
+                ?? throw new InvalidOperationException("The provisioning code model does not contain a root client.");
+            var decorator = rootClient.Decorators.SingleOrDefault(d => d.Name == ProvisioningProviderSchemaDecoratorName)
+                ?? throw new InvalidOperationException($"The provisioning code model does not contain the '{ProvisioningProviderSchemaDecoratorName}' decorator.");
+            var arguments = decorator.Arguments
+                ?? throw new InvalidOperationException($"The '{ProvisioningProviderSchemaDecoratorName}' decorator does not contain arguments.");
+
+            var resourcesByIdPattern = ArmProviderSchema.Resources.ToDictionary(
+                resource => resource.ResourceIdPattern.SerializedPath,
+                StringComparer.Ordinal);
+            var projections = new List<ProvisioningResourceProjection>();
+            if (arguments.TryGetValue("resourceProjections", out var projectionsData))
             {
-                Visit(queue.Dequeue(), resourceProjectionsByModel, outputVisited, traversalVisited, models, enums, modelSettableUsage, queue);
-            }
-
-            return (models, enums, modelSettableUsage);
-        }
-
-        private static void EnqueueResourceProperties(ProvisioningResourceProjection resource, bool isSettable, Queue<(InputType Type, bool IsSettable)> queue)
-        {
-            foreach (var property in GetResourceProperties(resource))
-            {
-                queue.Enqueue((property.Type, isSettable && !property.IsReadOnly));
-            }
-        }
-
-        private static void Visit(
-            (InputType Type, bool IsSettable) item,
-            Dictionary<InputModelType, List<ProvisioningResourceProjection>> resourceProjectionInfosByModel,
-            HashSet<InputType> outputVisited,
-            HashSet<(InputType Type, bool IsSettable)> traversalVisited,
-            List<InputModelType> models,
-            List<InputEnumType> enums,
-            Dictionary<InputModelType, bool> modelSettableUsage,
-            Queue<(InputType Type, bool IsSettable)> queue)
-        {
-            if (!traversalVisited.Add(item))
-                return;
-
-            switch (item.Type)
-            {
-                case InputModelType model:
-                    if (resourceProjectionInfosByModel.TryGetValue(model, out var resources))
-                    {
-                        var isResourceSettable = resources.Any(r => r.WritableScopes.Count > 0);
-                        var isSettable = item.IsSettable || isResourceSettable;
-                        modelSettableUsage[model] = isSettable || (modelSettableUsage.TryGetValue(model, out var existingResourceUsage) && existingResourceUsage);
-                        foreach (var resource in resources)
-                        {
-                            EnqueueResourceProperties(resource, isSettable, queue);
-                        }
-                        if (model.BaseModel != null)
-                            queue.Enqueue((model.BaseModel, isSettable));
-                        EnqueueDiscriminatorDerivedModels(model, isSettable, queue);
-                        break;
-                    }
-
-                    if (outputVisited.Add(model))
-                    {
-                        models.Add(model);
-                    }
-                    modelSettableUsage[model] = item.IsSettable || (modelSettableUsage.TryGetValue(model, out var existing) && existing);
-                    if (model.BaseModel != null)
-                        queue.Enqueue((model.BaseModel, item.IsSettable));
-                    EnqueueDiscriminatorDerivedModels(model, item.IsSettable, queue);
-                    foreach (var property in model.Properties)
-                        queue.Enqueue((property.Type, item.IsSettable && !property.IsReadOnly));
-                    if (model.AdditionalProperties != null)
-                        queue.Enqueue((model.AdditionalProperties, item.IsSettable));
-                    break;
-                case InputArrayType arrayType:
-                    queue.Enqueue((arrayType.ValueType, item.IsSettable));
-                    break;
-                case InputDictionaryType dictType:
-                    queue.Enqueue((dictType.KeyType, item.IsSettable));
-                    queue.Enqueue((dictType.ValueType, item.IsSettable));
-                    break;
-                case InputNullableType nullableType:
-                    queue.Enqueue((nullableType.Type, item.IsSettable));
-                    break;
-                case InputLiteralType literalType:
-                    queue.Enqueue((literalType.ValueType, item.IsSettable));
-                    break;
-                case InputUnionType unionType:
-                    foreach (var variant in unionType.VariantTypes)
-                        queue.Enqueue((variant, item.IsSettable));
-                    break;
-                case InputEnumType enumType:
-                    if (outputVisited.Add(enumType))
-                    {
-                        enums.Add(enumType);
-                    }
-                    break;
-            }
-        }
-
-        private static void EnqueueDiscriminatorDerivedModels(InputModelType model, bool isSettable, Queue<(InputType Type, bool IsSettable)> queue)
-        {
-            foreach (var derived in model.DiscriminatedSubtypes.Values)
-            {
-                queue.Enqueue((derived, isSettable));
-            }
-        }
-
-        private static IEnumerable<InputModelProperty> GetResourceProperties(ProvisioningResourceProjection projection)
-        {
-            var chain = new Stack<InputModelType>();
-            chain.Push(projection.ResourceModel);
-            var baseModel = projection.ResourceModel.BaseModel;
-            while (baseModel != null)
-            {
-                chain.Push(baseModel);
-                baseModel = baseModel.BaseModel;
-            }
-
-            foreach (var model in chain)
-            {
-                foreach (var property in model.Properties)
+                using var document = JsonDocument.Parse(projectionsData);
+                foreach (var projectionElement in document.RootElement.EnumerateArray())
                 {
-                    yield return property;
+                    var resources = new List<ArmResourceMetadata>();
+                    foreach (var resourceIdElement in projectionElement.GetProperty("resourceIdPatterns").EnumerateArray())
+                    {
+                        var resourceIdPattern = resourceIdElement.GetString()
+                            ?? throw new JsonException("A provisioning resource ID pattern cannot be null.");
+                        if (!resourcesByIdPattern.TryGetValue(resourceIdPattern, out var resource))
+                        {
+                            throw new JsonException($"Provisioning resource ID pattern '{resourceIdPattern}' was not found in the ARM provider schema.");
+                        }
+                        resources.Add(resource);
+                    }
+                    projections.Add(ProvisioningResourceProjection.Create(resources).Single());
                 }
             }
+
+            var modelSettableUsage = new Dictionary<string, bool>(StringComparer.Ordinal);
+            if (arguments.TryGetValue("modelSettableUsage", out var usageData))
+            {
+                using var document = JsonDocument.Parse(usageData);
+                foreach (var usageElement in document.RootElement.EnumerateArray())
+                {
+                    var modelId = usageElement.GetProperty("modelId").GetString()
+                        ?? throw new JsonException("A provisioning model ID cannot be null.");
+                    modelSettableUsage.Add(modelId, usageElement.GetProperty("isSettable").GetBoolean());
+                }
+            }
+
+            _resourceProjections = projections;
+            _modelSettableUsage = modelSettableUsage;
         }
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
@@ -160,14 +160,20 @@ namespace Azure.Generator.Provisioning
             // Only emit models/enums reachable from resource models' property graphs. This
             // avoids emitting dead types like list-result envelopes, patch/request wrappers,
             // and error models that have no place in a Provisioning library.
-            foreach (var inputModel in ProvisioningGenerator.Instance.InputLibrary.ReachableModels)
+            foreach (var inputModel in ProvisioningGenerator.Instance.InputLibrary.InputNamespace.Models)
             {
+                if (TryGetResourcesByModel(inputModel, out _))
+                {
+                    // Resource providers were pre-created above, but resource models remain in
+                    // InputNamespace so management-plane metadata and customization caches can
+                    // inspect them.
+                    continue;
+                }
+
                 var model = ProvisioningGenerator.Instance.TypeFactory.CreateModel(inputModel);
                 if (model is not null)
                 {
                     providers.Add(model);
-                    // CollectReachableTypes excludes models already backed by ArmProviderSchema.Resources,
-                    // so this does not duplicate the pre-created resource providers added above.
                     // CreateModel can still return a resource provider here for discriminator-derived
                     // models whose base chain is a resource, and those providers must also be kept.
                     if (model is ProvisioningResourceProvider resource)
@@ -177,7 +183,7 @@ namespace Azure.Generator.Provisioning
                 }
             }
 
-            foreach (var inputEnum in ProvisioningGenerator.Instance.InputLibrary.ReachableEnums)
+            foreach (var inputEnum in ProvisioningGenerator.Instance.InputLibrary.InputNamespace.Enums)
             {
                 var enumProvider = ProvisioningGenerator.Instance.TypeFactory.CreateEnum(inputEnum);
                 if (enumProvider != null)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -230,6 +230,25 @@ namespace Azure.Generator.Provisioning.Tests
         }
 
         [Test]
+        public void ReadOnlyExtensionResourceRetainsScopeMetadata()
+        {
+            var model = CreateModel("ReadOnlyExtension");
+            var resource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/providers/Microsoft.Test/extensions/{extensionName}",
+                "Microsoft.Test/extensions",
+                ResourceScope.Extension,
+                ["2024-01-01"],
+                methods: [CreateMethod(ResourceOperationKind.Read, ResourceScope.Extension)]);
+            ProvisioningMockHelpers.LoadMockPlugin(inputModels: () => [model]);
+            var provider = CreateResourceProvider(resource);
+
+            Assert.That(provider.ResourceProjection!.WritableScopes, Is.Empty);
+            Assert.That(provider.ResourceProjection.IsExtensionResource, Is.True);
+            Assert.That(provider.Properties.Any(property => property.Name == "Scope"), Is.True);
+        }
+
+        [Test]
         public void ReadOnlyResourceNameRemainsSettable()
         {
             var nameProperty = CreateProperty("Name", isRequired: true);
@@ -689,7 +708,7 @@ namespace Azure.Generator.Provisioning.Tests
             return new ArmResourceMetadata(
                 path,
                 resourceName ?? model.Name,
-                resourceType,
+                new ResourceTypePattern(resourceType),
                 model,
                 new ArmScopeInfo(scope, RequestPathPattern.GetFromScope(scope, path), null),
                 methods ?? [],

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 
 namespace Azure.Generator.Provisioning.Tests
 {
@@ -25,160 +26,74 @@ namespace Azure.Generator.Provisioning.Tests
         }
 
         [Test]
-        public void SameResourceTypeAndModelCollapse()
+        public void ProjectionDeserializesEmitterMetadata()
         {
             var model = CreateModel("TestResourceData");
-            var resourceGroupResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
-                "Microsoft.Test/widgets",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"]);
-            var subscriptionResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/providers/Microsoft.Test/widgets/{widgetName}",
-                "Microsoft.Test/widgets",
-                ResourceScope.Subscription,
-                ["2024-02-01"],
-                [new ArmResourceRbacRole("SecondRole", "22222222-2222-2222-2222-222222222222")]);
+            var method = CreateMethod(ResourceOperationKind.Create, ResourceScope.Extension);
+            using var document = JsonDocument.Parse(
+                """
+                {
+                  "resourceModelId": "Sample.Models.TestResourceData",
+                  "resourceName": "TestResource",
+                  "resourceType": "Microsoft.Test/widgets",
+                  "singletonResourceName": "default",
+                  "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/parents/{parentName}",
+                  "nameConstraints": {
+                    "pattern": "[a-z]+",
+                    "minLength": 1,
+                    "maxLength": 24
+                  },
+                  "resourceIdPatterns": [
+                    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/default"
+                  ],
+                  "apiVersions": [
+                    "2024-01-01",
+                    "2024-02-01"
+                  ],
+                  "methodIds": [
+                    "Sample.CreateWidget"
+                  ],
+                  "rbacRoles": [
+                    {
+                      "name": "TestRole",
+                      "value": "11111111-1111-1111-1111-111111111111"
+                    }
+                  ],
+                  "readableScopes": [
+                    "ResourceGroup"
+                  ],
+                  "writableScopes": [
+                    "Extension"
+                  ],
+                  "isExtensionResource": true
+                }
+                """);
 
-            var projections = ProvisioningResourceProjection.Create([resourceGroupResource, subscriptionResource]);
+            var projection = ProvisioningResourceProjection.Deserialize(
+                document.RootElement,
+                new Dictionary<string, InputModelType> { [model.CrossLanguageDefinitionId] = model },
+                new Dictionary<string, ResourceMethod> { [method.InputMethod.CrossLanguageDefinitionId] = method });
 
-            Assert.That(projections, Has.Count.EqualTo(1));
-            Assert.That(projections[0].Metadata, Is.EqualTo(new[] { resourceGroupResource, subscriptionResource }));
-            Assert.That(projections[0].ResourceName, Is.EqualTo(resourceGroupResource.ResourceName));
-            Assert.That(projections[0].ResourceType, Is.EqualTo("Microsoft.Test/widgets"));
-            Assert.That(projections[0].ResourceModel, Is.SameAs(model));
-            Assert.That(projections[0].ResourceIdPatterns.Select(p => p.SerializedPath), Is.EqualTo(new[]
+            Assert.That(projection.ResourceModel, Is.SameAs(model));
+            Assert.That(projection.ResourceName, Is.EqualTo("TestResource"));
+            Assert.That(projection.ResourceType, Is.EqualTo("Microsoft.Test/widgets"));
+            Assert.That(projection.SingletonResourceName, Is.EqualTo("default"));
+            Assert.That(projection.ParentResourceId!.SerializedPath, Is.EqualTo(
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/parents/{parentName}"));
+            Assert.That(projection.NameConstraints, Is.EqualTo(new ArmResourceNameConstraints("[a-z]+", 1, 24)));
+            Assert.That(projection.ResourceIdPatterns.Select(p => p.SerializedPath), Is.EqualTo(new[]
             {
-                resourceGroupResource.ResourceIdPattern.SerializedPath,
-                subscriptionResource.ResourceIdPattern.SerializedPath
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/default"
             }));
-            Assert.That(projections[0].ApiVersions, Is.EqualTo(new[] { "2024-01-01", "2024-02-01" }));
-            Assert.That(projections[0].RbacRoles.Select(r => r.Name), Is.EqualTo(new[] { "FirstRole", "SecondRole" }));
-        }
-
-        [Test]
-        public void SameResourceTypeWithDifferentModelsDoesNotCollapse()
-        {
-            var firstModel = CreateModel("FirstResourceData");
-            var secondModel = CreateModel("SecondResourceData");
-            var firstResource = CreateMetadata(
-                firstModel,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
-                "Microsoft.Test/widgets",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"]);
-            var secondResource = CreateMetadata(
-                secondModel,
-                "/subscriptions/{subscriptionId}/providers/Microsoft.Test/widgets/{widgetName}",
-                "Microsoft.Test/widgets",
-                ResourceScope.Subscription,
-                ["2024-01-01"]);
-
-            var projections = ProvisioningResourceProjection.Create([firstResource, secondResource]);
-
-            Assert.That(projections, Has.Count.EqualTo(2));
-            Assert.That(projections[0].ResourceModel, Is.SameAs(firstModel));
-            Assert.That(projections[1].ResourceModel, Is.SameAs(secondModel));
-        }
-
-        [Test]
-        public void CollapsedProjectionDropsInconsistentPerEntryValues()
-        {
-            var model = CreateModel("TestResourceData");
-            var firstResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/default",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"],
-                resourceName: "FirstResource",
-                singletonResourceName: "default",
-                parentResourceId: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
-                nameConstraints: new ArmResourceNameConstraints("[a-z]+", 1, 24));
-            var secondResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/current",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"],
-                resourceName: "SecondResource",
-                singletonResourceName: "current",
-                parentResourceId: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/otherWidgets/{widgetName}",
-                nameConstraints: new ArmResourceNameConstraints("[0-9]+", 1, 24));
-
-            var projection = ProvisioningResourceProjection.Create([firstResource, secondResource])[0];
-
-            Assert.That(projection.ResourceName, Is.EqualTo(model.Name));
-            Assert.That(projection.SingletonResourceName, Is.Null);
-            Assert.That(projection.ParentResourceId, Is.Null);
-            Assert.That(projection.NameConstraints, Is.EqualTo(new ArmResourceNameConstraints(null, null, null)));
-        }
-
-        [Test]
-        public void CollapsedProjectionKeepsOnlyConsistentParentResourceId()
-        {
-            var model = CreateModel("TestResourceData");
-            const string parentResourceId = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-            var firstResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/first",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"],
-                parentResourceId: parentResourceId);
-            var secondResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/second",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"],
-                parentResourceId: parentResourceId);
-            var parentlessResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/third",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"]);
-
-            var consistentProjection = ProvisioningResourceProjection.Create([firstResource, secondResource])[0];
-            var mixedNullProjection = ProvisioningResourceProjection.Create([firstResource, parentlessResource])[0];
-
-            Assert.That(consistentProjection.ParentResourceId, Is.EqualTo(firstResource.ParentResourceId));
-            Assert.That(mixedNullProjection.ParentResourceId, Is.Null);
-        }
-
-        [Test]
-        public void CollapsedProjectionKeepsOnlyConsistentSingletonResourceName()
-        {
-            var model = CreateModel("TestResourceData");
-            var firstResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/children/default",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.ResourceGroup,
-                ["2024-01-01"],
-                singletonResourceName: "default");
-            var secondResource = CreateMetadata(
-                model,
-                "/subscriptions/{subscriptionId}/providers/Microsoft.Test/widgets/{widgetName}/children/default",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.Subscription,
-                ["2024-01-01"],
-                singletonResourceName: "default");
-            var mixedNullResource = CreateMetadata(
-                model,
-                "/providers/Microsoft.Test/widgets/{widgetName}/children/default",
-                "Microsoft.Test/widgets/children",
-                ResourceScope.Tenant,
-                ["2024-01-01"]);
-
-            var consistentProjection = ProvisioningResourceProjection.Create([firstResource, secondResource])[0];
-            var mixedNullProjection = ProvisioningResourceProjection.Create([firstResource, mixedNullResource])[0];
-
-            Assert.That(consistentProjection.SingletonResourceName, Is.EqualTo("default"));
-            Assert.That(mixedNullProjection.SingletonResourceName, Is.Null);
+            Assert.That(projection.ApiVersions, Is.EqualTo(new[] { "2024-01-01", "2024-02-01" }));
+            Assert.That(projection.Methods, Is.EqualTo(new[] { method }));
+            Assert.That(projection.RbacRoles, Is.EqualTo(new[]
+            {
+                new ArmResourceRbacRole("TestRole", "11111111-1111-1111-1111-111111111111")
+            }));
+            Assert.That(projection.ReadableScopes, Is.EqualTo(new[] { ResourceScope.ResourceGroup }));
+            Assert.That(projection.WritableScopes, Is.EqualTo(new[] { ResourceScope.Extension }));
+            Assert.That(projection.IsExtensionResource, Is.True);
         }
 
         [Test]
@@ -954,11 +869,35 @@ namespace Azure.Generator.Provisioning.Tests
 
         private static ProvisioningResourceProvider[] CreateAndRegisterResourceProviders(params ArmResourceMetadata[] metadata)
         {
-            var projections = ProvisioningResourceProjection.Create(metadata);
+            var projections = metadata.Select(CreateProjection).ToArray();
             RegisterResourceProjections(projections);
             var providers = projections.Select(projection => new ProvisioningResourceProvider(projection)).ToArray();
             RegisterResourceProviders(providers);
             return providers;
+        }
+
+        private static ProvisioningResourceProjection CreateProjection(ArmResourceMetadata metadata)
+        {
+            var readableScopes = metadata.Methods.Any(method => method.Kind == ResourceOperationKind.Read)
+                ? new[] { metadata.Scope.Kind }
+                : [];
+            var writableScopes = metadata.Methods.Any(method => method.Kind == ResourceOperationKind.Create)
+                ? new[] { metadata.Scope.Kind }
+                : [];
+            return new(
+                metadata.ResourceModel,
+                metadata.ResourceName,
+                metadata.ResourceType.SerializedResourceType,
+                metadata.SingletonResourceName,
+                metadata.ParentResourceId,
+                metadata.NameConstraints,
+                [metadata.ResourceIdPattern],
+                metadata.ApiVersions,
+                metadata.Methods,
+                metadata.RbacRoles,
+                readableScopes,
+                writableScopes,
+                writableScopes.Contains(ResourceScope.Extension));
         }
 
         private static InputModelProperty CreateProperty(string name, bool isRequired = false, bool isReadOnly = false, bool isDiscriminator = false, InputType? type = null, string? serializedName = null)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -204,6 +204,32 @@ namespace Azure.Generator.Provisioning.Tests
         }
 
         [Test]
+        public void UpdateOnlyResourcePropertiesAreNotSettable()
+        {
+            var writableProperty = CreateProperty("WritableValue");
+            var model = CreateModel("UpdateOnlyWidget", [writableProperty]);
+            var updateOnlyResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+                "Microsoft.Test/widgets",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                methods:
+                [
+                    CreateMethod(ResourceOperationKind.Read, ResourceScope.ResourceGroup),
+                    CreateMethod(ResourceOperationKind.Update, ResourceScope.ResourceGroup)
+                ]);
+            ProvisioningMockHelpers.LoadMockPlugin(inputModels: () => [model]);
+            var provider = CreateResourceProvider(updateOnlyResource);
+
+            var propertyInfo = ((IProvisioningPropertyInfo)provider).GetProvisioningPropertyInfo(writableProperty);
+
+            Assert.That(provider.ResourceProjection!.WritableScopes, Is.Empty);
+            Assert.That(propertyInfo, Is.Not.Null);
+            Assert.That(propertyInfo!.IsSettable, Is.False);
+        }
+
+        [Test]
         public void ReadOnlyResourceNameRemainsSettable()
         {
             var nameProperty = CreateProperty("Name", isRequired: true);
@@ -782,21 +808,95 @@ namespace Azure.Generator.Provisioning.Tests
 
         private static void RegisterResourceProjections(IReadOnlyList<ProvisioningResourceProjection> resourceProjections)
         {
-            var resourceProjectionsByModel = resourceProjections
-                .GroupBy(projection => projection.ResourceModel)
-                .ToDictionary(
-                    group => group.Key,
-                    group => group.ToList());
-
+            var inputLibrary = ProvisioningGenerator.Instance.InputLibrary;
             typeof(ProvisioningInputLibrary)
                 .GetField("_resourceProjections", BindingFlags.Instance | BindingFlags.NonPublic)!
                 .SetValue(ProvisioningGenerator.Instance.InputLibrary, resourceProjections);
             typeof(ProvisioningInputLibrary)
-                .GetField("_resourceProjectionsByModel", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .SetValue(ProvisioningGenerator.Instance.InputLibrary, resourceProjectionsByModel);
-            typeof(ProvisioningInputLibrary)
                 .GetField("_modelSettableUsage", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .SetValue(ProvisioningGenerator.Instance.InputLibrary, null);
+                .SetValue(inputLibrary, CollectModelSettableUsage(resourceProjections));
+        }
+
+        private static Dictionary<string, bool> CollectModelSettableUsage(IReadOnlyList<ProvisioningResourceProjection> projections)
+        {
+            var projectionsByModel = projections
+                .GroupBy(projection => projection.ResourceModel)
+                .ToDictionary(group => group.Key, group => group.ToList());
+            var usage = new Dictionary<string, bool>();
+            var visited = new HashSet<(InputType Type, bool IsSettable)>();
+            var queue = new Queue<(InputType Type, bool IsSettable)>(
+                projections.Select(projection => ((InputType)projection.ResourceModel, projection.WritableScopes.Count > 0)));
+
+            while (queue.TryDequeue(out var item))
+            {
+                if (!visited.Add(item))
+                {
+                    continue;
+                }
+
+                switch (item.Type)
+                {
+                    case InputModelType model:
+                        var isSettable = item.IsSettable ||
+                            (projectionsByModel.TryGetValue(model, out var modelProjections) &&
+                             modelProjections.Any(projection => projection.WritableScopes.Count > 0));
+                        usage[model.CrossLanguageDefinitionId] = isSettable ||
+                            (usage.TryGetValue(model.CrossLanguageDefinitionId, out var existing) && existing);
+                        if (model.BaseModel != null)
+                        {
+                            queue.Enqueue((model.BaseModel, isSettable));
+                        }
+                        foreach (var derived in model.DiscriminatedSubtypes.Values)
+                        {
+                            queue.Enqueue((derived, isSettable));
+                        }
+                        foreach (var property in GetProperties(model, projectionsByModel.ContainsKey(model)))
+                        {
+                            queue.Enqueue((property.Type, isSettable && !property.IsReadOnly));
+                        }
+                        if (!projectionsByModel.ContainsKey(model) && model.AdditionalProperties != null)
+                        {
+                            queue.Enqueue((model.AdditionalProperties, isSettable));
+                        }
+                        break;
+                    case InputArrayType array:
+                        queue.Enqueue((array.ValueType, item.IsSettable));
+                        break;
+                    case InputDictionaryType dictionary:
+                        queue.Enqueue((dictionary.KeyType, item.IsSettable));
+                        queue.Enqueue((dictionary.ValueType, item.IsSettable));
+                        break;
+                    case InputNullableType nullable:
+                        queue.Enqueue((nullable.Type, item.IsSettable));
+                        break;
+                    case InputLiteralType literal:
+                        queue.Enqueue((literal.ValueType, item.IsSettable));
+                        break;
+                    case InputUnionType union:
+                        foreach (var variant in union.VariantTypes)
+                        {
+                            queue.Enqueue((variant, item.IsSettable));
+                        }
+                        break;
+                }
+            }
+
+            return usage;
+        }
+
+        private static IEnumerable<InputModelProperty> GetProperties(InputModelType model, bool includeBaseProperties)
+        {
+            if (!includeBaseProperties)
+            {
+                return model.Properties;
+            }
+
+            var hierarchy = new Stack<InputModelType>();
+            for (var current = model; current != null; current = current.BaseModel)
+            {
+                hierarchy.Push(current);
+            }
+            return hierarchy.SelectMany(type => type.Properties);
         }
 
         private static void AddDiscriminatedSubtype(InputModelType baseModel, InputModelType derivedModel)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -230,7 +230,7 @@ namespace Azure.Generator.Provisioning.Tests
         }
 
         [Test]
-        public void ReadOnlyExtensionResourceRetainsScopeMetadata()
+        public void ReadOnlyExtensionResourceDoesNotExposeScopeMetadata()
         {
             var model = CreateModel("ReadOnlyExtension");
             var resource = CreateMetadata(
@@ -244,6 +244,29 @@ namespace Azure.Generator.Provisioning.Tests
             var provider = CreateResourceProvider(resource);
 
             Assert.That(provider.ResourceProjection!.WritableScopes, Is.Empty);
+            Assert.That(provider.ResourceProjection.IsExtensionResource, Is.False);
+            Assert.That(provider.Properties.Any(property => property.Name == "Scope"), Is.False);
+        }
+
+        [Test]
+        public void WritableExtensionResourceExposesScopeMetadata()
+        {
+            var model = CreateModel("WritableExtension");
+            var resource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/providers/Microsoft.Test/extensions/{extensionName}",
+                "Microsoft.Test/extensions",
+                ResourceScope.Extension,
+                ["2024-01-01"],
+                methods:
+                [
+                    CreateMethod(ResourceOperationKind.Read, ResourceScope.Extension),
+                    CreateMethod(ResourceOperationKind.Create, ResourceScope.Extension)
+                ]);
+            ProvisioningMockHelpers.LoadMockPlugin(inputModels: () => [model]);
+            var provider = CreateResourceProvider(resource);
+
+            Assert.That(provider.ResourceProjection!.WritableScopes, Does.Contain(ResourceScope.Extension));
             Assert.That(provider.ResourceProjection.IsExtensionResource, Is.True);
             Assert.That(provider.Properties.Any(property => property.Name == "Scope"), Is.True);
         }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningTypeFactoryTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningTypeFactoryTests.cs
@@ -387,7 +387,7 @@ namespace Azure.Generator.Provisioning.Tests
             return new ArmResourceMetadata(
                 path,
                 model.Name,
-                resourceType,
+                new ResourceTypePattern(resourceType),
                 model,
                 new ArmScopeInfo(scope, RequestPathPattern.GetFromScope(scope, path), null),
                 methods,

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/TestHelpers/ProvisioningMockHelpers.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/TestHelpers/ProvisioningMockHelpers.cs
@@ -48,7 +48,9 @@ namespace Azure.Generator.Provisioning.Tests.TestHelpers
             {
                 typeof(ProvisioningInputLibrary)
                     .GetField("_resourceProjections", BindingFlags.Instance | BindingFlags.NonPublic)!
-                    .SetValue(mockInputLibrary.Object, ProvisioningResourceProjection.Create(armProviderSchema().Resources));
+                    .SetValue(
+                        mockInputLibrary.Object,
+                        armProviderSchema().Resources.Select(CreateProjection).ToArray());
                 typeof(ProvisioningInputLibrary)
                     .GetField("_modelSettableUsage", BindingFlags.Instance | BindingFlags.NonPublic)!
                     .SetValue(
@@ -67,6 +69,30 @@ namespace Azure.Generator.Provisioning.Tests.TestHelpers
             codeModelInstance!.SetValue(null, mockGenerator.Object);
 
             return mockGenerator;
+        }
+
+        private static ProvisioningResourceProjection CreateProjection(ArmResourceMetadata metadata)
+        {
+            var readableScopes = metadata.Methods.Any(method => method.Kind == ResourceOperationKind.Read)
+                ? new[] { metadata.Scope.Kind }
+                : [];
+            var writableScopes = metadata.Methods.Any(method => method.Kind == ResourceOperationKind.Create)
+                ? new[] { metadata.Scope.Kind }
+                : [];
+            return new(
+                metadata.ResourceModel,
+                metadata.ResourceName,
+                metadata.ResourceType.SerializedResourceType,
+                metadata.SingletonResourceName,
+                metadata.ParentResourceId,
+                metadata.NameConstraints,
+                [metadata.ResourceIdPattern],
+                metadata.ApiVersions,
+                metadata.Methods,
+                metadata.RbacRoles,
+                readableScopes,
+                writableScopes,
+                writableScopes.Contains(ResourceScope.Extension));
         }
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/TestHelpers/ProvisioningMockHelpers.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/TestHelpers/ProvisioningMockHelpers.cs
@@ -8,9 +8,10 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
-using Azure.Generator.Management;
 using Azure.Generator.Management.Models;
+using Azure.Generator.Provisioning.Primitives;
 
 namespace Azure.Generator.Provisioning.Tests.TestHelpers
 {
@@ -45,9 +46,14 @@ namespace Azure.Generator.Provisioning.Tests.TestHelpers
             mockInputLibrary.Setup(p => p.InputNamespace).Returns(mockInputNamespace.Object);
             if (armProviderSchema is not null)
             {
-                typeof(ManagementInputLibrary)
-                    .GetField("_providerSchema", BindingFlags.Instance | BindingFlags.NonPublic)!
-                    .SetValue(mockInputLibrary.Object, armProviderSchema());
+                typeof(ProvisioningInputLibrary)
+                    .GetField("_resourceProjections", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .SetValue(mockInputLibrary.Object, ProvisioningResourceProjection.Create(armProviderSchema().Resources));
+                typeof(ProvisioningInputLibrary)
+                    .GetField("_modelSettableUsage", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .SetValue(
+                        mockInputLibrary.Object,
+                        inputNsModels.ToDictionary(model => model.CrossLanguageDefinitionId, _ => true));
             }
 
             var loadMethod = typeof(Configuration).GetMethod("Load", BindingFlags.Static | BindingFlags.NonPublic);

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
@@ -9,8 +9,8 @@
     {
       "$id": "1",
       "kind": "enum",
-      "name": "Origin",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Origin",
+      "name": "ConfigurationStoreProvisioningState",
+      "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStoreProvisioningState",
       "valueType": {
         "$id": "2",
         "kind": "string",
@@ -22,177 +22,73 @@
         {
           "$id": "3",
           "kind": "enumvalue",
-          "name": "user",
-          "value": "user",
-          "valueType": {
-            "$ref": "2"
-          },
-          "enumType": {
-            "$ref": "1"
-          },
-          "doc": "Indicates the operation is initiated by a user.",
-          "decorators": [],
-          "isExactName": false
-        },
-        {
-          "$id": "4",
-          "kind": "enumvalue",
-          "name": "system",
-          "value": "system",
-          "valueType": {
-            "$ref": "2"
-          },
-          "enumType": {
-            "$ref": "1"
-          },
-          "doc": "Indicates the operation is initiated by a system.",
-          "decorators": [],
-          "isExactName": false
-        },
-        {
-          "$id": "5",
-          "kind": "enumvalue",
-          "name": "user,system",
-          "value": "user,system",
-          "valueType": {
-            "$ref": "2"
-          },
-          "enumType": {
-            "$ref": "1"
-          },
-          "doc": "Indicates the operation is initiated by a user or system.",
-          "decorators": [],
-          "isExactName": false
-        }
-      ],
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "doc": "The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is \"user,system\"",
-      "isFixed": false,
-      "isFlags": false,
-      "usage": "Output,Json",
-      "decorators": [],
-      "isExactName": false
-    },
-    {
-      "$id": "6",
-      "kind": "enum",
-      "name": "ActionType",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ActionType",
-      "valueType": {
-        "$id": "7",
-        "kind": "string",
-        "name": "string",
-        "crossLanguageDefinitionId": "TypeSpec.string",
-        "decorators": []
-      },
-      "values": [
-        {
-          "$id": "8",
-          "kind": "enumvalue",
-          "name": "Internal",
-          "value": "Internal",
-          "valueType": {
-            "$ref": "7"
-          },
-          "enumType": {
-            "$ref": "6"
-          },
-          "doc": "Actions are for internal-only APIs.",
-          "decorators": [],
-          "isExactName": false
-        }
-      ],
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "doc": "Extensible enum. Indicates the action type. \"Internal\" refers to actions that are for internal only APIs.",
-      "isFixed": false,
-      "isFlags": false,
-      "usage": "Output,Json",
-      "decorators": [],
-      "isExactName": false
-    },
-    {
-      "$id": "9",
-      "kind": "enum",
-      "name": "ConfigurationStoreProvisioningState",
-      "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStoreProvisioningState",
-      "valueType": {
-        "$id": "10",
-        "kind": "string",
-        "name": "string",
-        "crossLanguageDefinitionId": "TypeSpec.string",
-        "decorators": []
-      },
-      "values": [
-        {
-          "$id": "11",
-          "kind": "enumvalue",
           "name": "Creating",
           "value": "Creating",
           "valueType": {
-            "$ref": "10"
+            "$ref": "2"
           },
           "enumType": {
-            "$ref": "9"
+            "$ref": "1"
           },
           "doc": "The resource is being created.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "12",
+          "$id": "4",
           "kind": "enumvalue",
           "name": "Succeeded",
           "value": "Succeeded",
           "valueType": {
-            "$ref": "10"
+            "$ref": "2"
           },
           "enumType": {
-            "$ref": "9"
+            "$ref": "1"
           },
           "doc": "The resource has been created.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "13",
+          "$id": "5",
           "kind": "enumvalue",
           "name": "Deleting",
           "value": "Deleting",
           "valueType": {
-            "$ref": "10"
+            "$ref": "2"
           },
           "enumType": {
-            "$ref": "9"
+            "$ref": "1"
           },
           "doc": "The resource is being deleted.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "14",
+          "$id": "6",
           "kind": "enumvalue",
           "name": "Failed",
           "value": "Failed",
           "valueType": {
-            "$ref": "10"
+            "$ref": "2"
           },
           "enumType": {
-            "$ref": "9"
+            "$ref": "1"
           },
           "doc": "The resource creation or deletion has failed.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "15",
+          "$id": "7",
           "kind": "enumvalue",
           "name": "Canceled",
           "value": "Canceled",
           "valueType": {
-            "$ref": "10"
+            "$ref": "2"
           },
           "enumType": {
-            "$ref": "9"
+            "$ref": "1"
           },
           "doc": "The resource creation or deletion has been canceled.",
           "decorators": [],
@@ -208,12 +104,12 @@
       "isExactName": false
     },
     {
-      "$id": "16",
+      "$id": "8",
       "kind": "enum",
       "name": "PublicNetworkAccess",
       "crossLanguageDefinitionId": "ProvisioningTypeSpec.PublicNetworkAccess",
       "valueType": {
-        "$id": "17",
+        "$id": "9",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -221,30 +117,30 @@
       },
       "values": [
         {
-          "$id": "18",
+          "$id": "10",
           "kind": "enumvalue",
           "name": "Enabled",
           "value": "Enabled",
           "valueType": {
-            "$ref": "17"
+            "$ref": "9"
           },
           "enumType": {
-            "$ref": "16"
+            "$ref": "8"
           },
           "doc": "Public network access is enabled.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "19",
+          "$id": "11",
           "kind": "enumvalue",
           "name": "Disabled",
           "value": "Disabled",
           "valueType": {
-            "$ref": "17"
+            "$ref": "9"
           },
           "enumType": {
-            "$ref": "16"
+            "$ref": "8"
           },
           "doc": "Public network access is disabled.",
           "decorators": [],
@@ -260,12 +156,12 @@
       "isExactName": false
     },
     {
-      "$id": "20",
+      "$id": "12",
       "kind": "enum",
       "name": "ConfigurationStoreSkuTier",
       "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStoreSkuTier",
       "valueType": {
-        "$id": "21",
+        "$id": "13",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -273,45 +169,45 @@
       },
       "values": [
         {
-          "$id": "22",
+          "$id": "14",
           "kind": "enumvalue",
           "name": "Free",
           "value": "Free",
           "valueType": {
-            "$ref": "21"
+            "$ref": "13"
           },
           "enumType": {
-            "$ref": "20"
+            "$ref": "12"
           },
           "doc": "The free tier.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "23",
+          "$id": "15",
           "kind": "enumvalue",
           "name": "StandardS1",
           "value": "Standard_S1",
           "valueType": {
-            "$ref": "21"
+            "$ref": "13"
           },
           "enumType": {
-            "$ref": "20"
+            "$ref": "12"
           },
           "doc": "Standard tier with S1 throughput.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "24",
+          "$id": "16",
           "kind": "enumvalue",
           "name": "PremiumP1",
           "value": "Premium_P1",
           "valueType": {
-            "$ref": "21"
+            "$ref": "13"
           },
           "enumType": {
-            "$ref": "20"
+            "$ref": "12"
           },
           "doc": "Premium tier with P1 throughput.",
           "decorators": [],
@@ -327,12 +223,12 @@
       "isExactName": false
     },
     {
-      "$id": "25",
+      "$id": "17",
       "kind": "enum",
       "name": "ConfigurationStoreCreateMode",
       "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStoreCreateMode",
       "valueType": {
-        "$id": "26",
+        "$id": "18",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -340,30 +236,30 @@
       },
       "values": [
         {
-          "$id": "27",
+          "$id": "19",
           "kind": "enumvalue",
           "name": "Default",
           "value": "default",
           "valueType": {
-            "$ref": "26"
+            "$ref": "18"
           },
           "enumType": {
-            "$ref": "25"
+            "$ref": "17"
           },
           "doc": "Create a new configuration store.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "28",
+          "$id": "20",
           "kind": "enumvalue",
           "name": "Recover",
           "value": "recover",
           "valueType": {
-            "$ref": "26"
+            "$ref": "18"
           },
           "enumType": {
-            "$ref": "25"
+            "$ref": "17"
           },
           "doc": "Recover a soft-deleted configuration store.",
           "decorators": [],
@@ -379,12 +275,12 @@
       "isExactName": false
     },
     {
-      "$id": "29",
+      "$id": "21",
       "kind": "enum",
       "name": "createdByType",
       "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.createdByType",
       "valueType": {
-        "$id": "30",
+        "$id": "22",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -392,60 +288,60 @@
       },
       "values": [
         {
-          "$id": "31",
+          "$id": "23",
           "kind": "enumvalue",
           "name": "User",
           "value": "User",
           "valueType": {
-            "$ref": "30"
+            "$ref": "22"
           },
           "enumType": {
-            "$ref": "29"
+            "$ref": "21"
           },
           "doc": "The entity was created by a user.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "32",
+          "$id": "24",
           "kind": "enumvalue",
           "name": "Application",
           "value": "Application",
           "valueType": {
-            "$ref": "30"
+            "$ref": "22"
           },
           "enumType": {
-            "$ref": "29"
+            "$ref": "21"
           },
           "doc": "The entity was created by an application.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "33",
+          "$id": "25",
           "kind": "enumvalue",
           "name": "ManagedIdentity",
           "value": "ManagedIdentity",
           "valueType": {
-            "$ref": "30"
+            "$ref": "22"
           },
           "enumType": {
-            "$ref": "29"
+            "$ref": "21"
           },
           "doc": "The entity was created by a managed identity.",
           "decorators": [],
           "isExactName": false
         },
         {
-          "$id": "34",
+          "$id": "26",
           "kind": "enumvalue",
           "name": "Key",
           "value": "Key",
           "valueType": {
-            "$ref": "30"
+            "$ref": "22"
           },
           "enumType": {
-            "$ref": "29"
+            "$ref": "21"
           },
           "doc": "The entity was created by a key.",
           "decorators": [],
@@ -459,134 +355,17 @@
       "usage": "Output,Json,LroInitial,LroFinalEnvelope",
       "decorators": [],
       "isExactName": false
-    },
-    {
-      "$id": "35",
-      "kind": "enum",
-      "name": "ResourceProvisioningState",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceProvisioningState",
-      "valueType": {
-        "$id": "36",
-        "kind": "string",
-        "name": "string",
-        "crossLanguageDefinitionId": "TypeSpec.string",
-        "decorators": []
-      },
-      "values": [
-        {
-          "$id": "37",
-          "kind": "enumvalue",
-          "name": "Succeeded",
-          "value": "Succeeded",
-          "valueType": {
-            "$ref": "36"
-          },
-          "enumType": {
-            "$ref": "35"
-          },
-          "doc": "Resource has been created.",
-          "decorators": [],
-          "isExactName": false
-        },
-        {
-          "$id": "38",
-          "kind": "enumvalue",
-          "name": "Failed",
-          "value": "Failed",
-          "valueType": {
-            "$ref": "36"
-          },
-          "enumType": {
-            "$ref": "35"
-          },
-          "doc": "Resource creation failed.",
-          "decorators": [],
-          "isExactName": false
-        },
-        {
-          "$id": "39",
-          "kind": "enumvalue",
-          "name": "Canceled",
-          "value": "Canceled",
-          "valueType": {
-            "$ref": "36"
-          },
-          "enumType": {
-            "$ref": "35"
-          },
-          "doc": "Resource creation was canceled.",
-          "decorators": [],
-          "isExactName": false
-        }
-      ],
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "doc": "The provisioning state of a resource type.",
-      "isFixed": false,
-      "isFlags": false,
-      "usage": "LroPolling",
-      "decorators": [],
-      "isExactName": false
-    },
-    {
-      "$id": "40",
-      "kind": "enum",
-      "name": "Versions",
-      "crossLanguageDefinitionId": "ProvisioningTypeSpec.Versions",
-      "valueType": {
-        "$id": "41",
-        "kind": "string",
-        "name": "string",
-        "crossLanguageDefinitionId": "TypeSpec.string",
-        "decorators": []
-      },
-      "values": [
-        {
-          "$id": "42",
-          "kind": "enumvalue",
-          "name": "v2024_04_01",
-          "value": "2024-04-01",
-          "valueType": {
-            "$ref": "41"
-          },
-          "enumType": {
-            "$ref": "40"
-          },
-          "decorators": [],
-          "isExactName": false
-        },
-        {
-          "$id": "43",
-          "kind": "enumvalue",
-          "name": "v2024_05_01",
-          "value": "2024-05-01",
-          "valueType": {
-            "$ref": "41"
-          },
-          "enumType": {
-            "$ref": "40"
-          },
-          "decorators": [],
-          "isExactName": false
-        }
-      ],
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "doc": "The available API versions.",
-      "isFixed": true,
-      "isFlags": false,
-      "usage": "ApiVersionEnum",
-      "decorators": [],
-      "isExactName": false
     }
   ],
   "constants": [
     {
-      "$id": "44",
+      "$id": "27",
       "kind": "constant",
       "name": "PeriodicBackupPolicyKind",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
       "usage": "Input,Output,Json,LroInitial,LroFinalEnvelope",
       "valueType": {
-        "$id": "45",
+        "$id": "28",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -597,13 +376,13 @@
       "isExactName": false
     },
     {
-      "$id": "46",
+      "$id": "29",
       "kind": "constant",
       "name": "ContinuousBackupPolicyKind",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
       "usage": "Input,Output,Json,LroInitial,LroFinalEnvelope",
       "valueType": {
-        "$id": "47",
+        "$id": "30",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -614,13 +393,13 @@
       "isExactName": false
     },
     {
-      "$id": "48",
+      "$id": "31",
       "kind": "constant",
       "name": "ListAccept",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "49",
+        "$id": "32",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -631,13 +410,13 @@
       "isExactName": false
     },
     {
-      "$id": "50",
+      "$id": "33",
       "kind": "constant",
       "name": "ListAccept1",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "51",
+        "$id": "34",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -648,13 +427,13 @@
       "isExactName": false
     },
     {
-      "$id": "52",
+      "$id": "35",
       "kind": "constant",
       "name": "ListAccept2",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "53",
+        "$id": "36",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -665,13 +444,13 @@
       "isExactName": false
     },
     {
-      "$id": "54",
+      "$id": "37",
       "kind": "constant",
       "name": "ListAccept3",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "55",
+        "$id": "38",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -682,13 +461,13 @@
       "isExactName": false
     },
     {
-      "$id": "56",
+      "$id": "39",
       "kind": "constant",
       "name": "ListAccept4",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "57",
+        "$id": "40",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -699,13 +478,13 @@
       "isExactName": false
     },
     {
-      "$id": "58",
+      "$id": "41",
       "kind": "constant",
       "name": "ListAccept5",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "59",
+        "$id": "42",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -716,13 +495,13 @@
       "isExactName": false
     },
     {
-      "$id": "60",
+      "$id": "43",
       "kind": "constant",
       "name": "ListAccept6",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "61",
+        "$id": "44",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -733,13 +512,13 @@
       "isExactName": false
     },
     {
-      "$id": "62",
+      "$id": "45",
       "kind": "constant",
       "name": "ListAccept7",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "63",
+        "$id": "46",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -750,13 +529,13 @@
       "isExactName": false
     },
     {
-      "$id": "64",
+      "$id": "47",
       "kind": "constant",
       "name": "ListAccept8",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "65",
+        "$id": "48",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -767,13 +546,13 @@
       "isExactName": false
     },
     {
-      "$id": "66",
+      "$id": "49",
       "kind": "constant",
       "name": "ListAccept9",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "67",
+        "$id": "50",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -784,13 +563,13 @@
       "isExactName": false
     },
     {
-      "$id": "68",
+      "$id": "51",
       "kind": "constant",
       "name": "ListAccept10",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "69",
+        "$id": "52",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -801,13 +580,13 @@
       "isExactName": false
     },
     {
-      "$id": "70",
+      "$id": "53",
       "kind": "constant",
       "name": "ListAccept11",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "71",
+        "$id": "54",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -818,13 +597,13 @@
       "isExactName": false
     },
     {
-      "$id": "72",
+      "$id": "55",
       "kind": "constant",
       "name": "ListAccept12",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "73",
+        "$id": "56",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -835,13 +614,13 @@
       "isExactName": false
     },
     {
-      "$id": "74",
+      "$id": "57",
       "kind": "constant",
       "name": "ListAccept13",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "75",
+        "$id": "58",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -852,13 +631,13 @@
       "isExactName": false
     },
     {
-      "$id": "76",
+      "$id": "59",
       "kind": "constant",
       "name": "ListAccept14",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "77",
+        "$id": "60",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -869,13 +648,13 @@
       "isExactName": false
     },
     {
-      "$id": "78",
+      "$id": "61",
       "kind": "constant",
       "name": "ListAccept15",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "79",
+        "$id": "62",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -886,13 +665,13 @@
       "isExactName": false
     },
     {
-      "$id": "80",
+      "$id": "63",
       "kind": "constant",
       "name": "ListAccept16",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "81",
+        "$id": "64",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -903,13 +682,13 @@
       "isExactName": false
     },
     {
-      "$id": "82",
+      "$id": "65",
       "kind": "constant",
       "name": "ListAccept17",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "83",
+        "$id": "66",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -920,13 +699,13 @@
       "isExactName": false
     },
     {
-      "$id": "84",
+      "$id": "67",
       "kind": "constant",
       "name": "ListAccept18",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "85",
+        "$id": "68",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -937,13 +716,13 @@
       "isExactName": false
     },
     {
-      "$id": "86",
+      "$id": "69",
       "kind": "constant",
       "name": "ListAccept19",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "87",
+        "$id": "70",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -954,13 +733,13 @@
       "isExactName": false
     },
     {
-      "$id": "88",
+      "$id": "71",
       "kind": "constant",
       "name": "ListAccept20",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "89",
+        "$id": "72",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -971,13 +750,13 @@
       "isExactName": false
     },
     {
-      "$id": "90",
+      "$id": "73",
       "kind": "constant",
       "name": "ListAccept21",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "91",
+        "$id": "74",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -988,13 +767,13 @@
       "isExactName": false
     },
     {
-      "$id": "92",
+      "$id": "75",
       "kind": "constant",
       "name": "ListAccept22",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "93",
+        "$id": "76",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1005,13 +784,13 @@
       "isExactName": false
     },
     {
-      "$id": "94",
+      "$id": "77",
       "kind": "constant",
       "name": "ListAccept23",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "95",
+        "$id": "78",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1022,13 +801,13 @@
       "isExactName": false
     },
     {
-      "$id": "96",
+      "$id": "79",
       "kind": "constant",
       "name": "ListAccept24",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "97",
+        "$id": "80",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1039,13 +818,13 @@
       "isExactName": false
     },
     {
-      "$id": "98",
+      "$id": "81",
       "kind": "constant",
       "name": "ListAccept25",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "99",
+        "$id": "82",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1056,13 +835,13 @@
       "isExactName": false
     },
     {
-      "$id": "100",
+      "$id": "83",
       "kind": "constant",
       "name": "ListAccept26",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "101",
+        "$id": "84",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1073,13 +852,13 @@
       "isExactName": false
     },
     {
-      "$id": "102",
+      "$id": "85",
       "kind": "constant",
       "name": "ListAccept27",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "103",
+        "$id": "86",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1090,13 +869,13 @@
       "isExactName": false
     },
     {
-      "$id": "104",
+      "$id": "87",
       "kind": "constant",
       "name": "ListAccept28",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "105",
+        "$id": "88",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1107,13 +886,13 @@
       "isExactName": false
     },
     {
-      "$id": "106",
+      "$id": "89",
       "kind": "constant",
       "name": "ListAccept29",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "107",
+        "$id": "90",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1124,13 +903,13 @@
       "isExactName": false
     },
     {
-      "$id": "108",
+      "$id": "91",
       "kind": "constant",
       "name": "ListAccept30",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "109",
+        "$id": "92",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1141,13 +920,13 @@
       "isExactName": false
     },
     {
-      "$id": "110",
+      "$id": "93",
       "kind": "constant",
       "name": "ListAccept31",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "111",
+        "$id": "94",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1158,13 +937,13 @@
       "isExactName": false
     },
     {
-      "$id": "112",
+      "$id": "95",
       "kind": "constant",
       "name": "ListAccept32",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "113",
+        "$id": "96",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1175,13 +954,13 @@
       "isExactName": false
     },
     {
-      "$id": "114",
+      "$id": "97",
       "kind": "constant",
       "name": "ListAccept33",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "115",
+        "$id": "98",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1192,13 +971,13 @@
       "isExactName": false
     },
     {
-      "$id": "116",
+      "$id": "99",
       "kind": "constant",
       "name": "ListAccept34",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "117",
+        "$id": "100",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1209,13 +988,13 @@
       "isExactName": false
     },
     {
-      "$id": "118",
+      "$id": "101",
       "kind": "constant",
       "name": "ListAccept35",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "119",
+        "$id": "102",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1226,13 +1005,13 @@
       "isExactName": false
     },
     {
-      "$id": "120",
+      "$id": "103",
       "kind": "constant",
       "name": "ListAccept36",
       "namespace": "",
       "usage": "None",
       "valueType": {
-        "$id": "121",
+        "$id": "104",
         "kind": "string",
         "name": "string",
         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -1245,660 +1024,7 @@
   ],
   "models": [
     {
-      "$id": "122",
-      "kind": "model",
-      "name": "OperationListResult",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationListResult",
-      "usage": "Output,Json",
-      "doc": "A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get the next set of results.",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "OperationListResult"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "123",
-          "kind": "property",
-          "name": "value",
-          "serializedName": "value",
-          "doc": "The Operation items on this page",
-          "type": {
-            "$id": "124",
-            "kind": "array",
-            "name": "ArrayOperation",
-            "valueType": {
-              "$id": "125",
-              "kind": "model",
-              "name": "Operation",
-              "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-              "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation",
-              "usage": "Output,Json",
-              "doc": "Details of a REST API operation, returned from the Resource Provider Operations API",
-              "summary": "REST API Operation",
-              "decorators": [
-                {
-                  "name": "Azure.ResourceManager.@armProviderNamespace",
-                  "arguments": {}
-                }
-              ],
-              "serializationOptions": {
-                "json": {
-                  "name": "Operation"
-                }
-              },
-              "isExactName": false,
-              "properties": [
-                {
-                  "$id": "126",
-                  "kind": "property",
-                  "name": "name",
-                  "serializedName": "name",
-                  "doc": "The name of the operation, as per Resource-Based Access Control (RBAC). Examples: \"Microsoft.Compute/virtualMachines/write\", \"Microsoft.Compute/virtualMachines/capture/action\"",
-                  "type": {
-                    "$id": "127",
-                    "kind": "string",
-                    "name": "string",
-                    "crossLanguageDefinitionId": "TypeSpec.string",
-                    "decorators": []
-                  },
-                  "optional": true,
-                  "readOnly": true,
-                  "discriminator": false,
-                  "flatten": false,
-                  "decorators": [],
-                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.name",
-                  "serializationOptions": {
-                    "json": {
-                      "name": "name"
-                    }
-                  },
-                  "isHttpMetadata": false,
-                  "isExactName": false
-                },
-                {
-                  "$id": "128",
-                  "kind": "property",
-                  "name": "isDataAction",
-                  "serializedName": "isDataAction",
-                  "doc": "Whether the operation applies to data-plane. This is \"true\" for data-plane operations and \"false\" for Azure Resource Manager/control-plane operations.",
-                  "type": {
-                    "$id": "129",
-                    "kind": "boolean",
-                    "name": "boolean",
-                    "crossLanguageDefinitionId": "TypeSpec.boolean",
-                    "decorators": []
-                  },
-                  "optional": true,
-                  "readOnly": true,
-                  "discriminator": false,
-                  "flatten": false,
-                  "decorators": [],
-                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.isDataAction",
-                  "serializationOptions": {
-                    "json": {
-                      "name": "isDataAction"
-                    }
-                  },
-                  "isHttpMetadata": false,
-                  "isExactName": false
-                },
-                {
-                  "$id": "130",
-                  "kind": "property",
-                  "name": "display",
-                  "serializedName": "display",
-                  "doc": "Localized display information for this particular operation.",
-                  "type": {
-                    "$id": "131",
-                    "kind": "model",
-                    "name": "OperationDisplay",
-                    "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-                    "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay",
-                    "usage": "Output,Json",
-                    "doc": "Localized display information for an operation.",
-                    "decorators": [
-                      {
-                        "name": "Azure.ResourceManager.@armProviderNamespace",
-                        "arguments": {}
-                      }
-                    ],
-                    "serializationOptions": {
-                      "json": {
-                        "name": "OperationDisplay"
-                      }
-                    },
-                    "isExactName": false,
-                    "properties": [
-                      {
-                        "$id": "132",
-                        "kind": "property",
-                        "name": "provider",
-                        "serializedName": "provider",
-                        "doc": "The localized friendly form of the resource provider name, e.g. \"Microsoft Monitoring Insights\" or \"Microsoft Compute\".",
-                        "type": {
-                          "$id": "133",
-                          "kind": "string",
-                          "name": "string",
-                          "crossLanguageDefinitionId": "TypeSpec.string",
-                          "decorators": []
-                        },
-                        "optional": true,
-                        "readOnly": true,
-                        "discriminator": false,
-                        "flatten": false,
-                        "decorators": [],
-                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay.provider",
-                        "serializationOptions": {
-                          "json": {
-                            "name": "provider"
-                          }
-                        },
-                        "isHttpMetadata": false,
-                        "isExactName": false
-                      },
-                      {
-                        "$id": "134",
-                        "kind": "property",
-                        "name": "resource",
-                        "serializedName": "resource",
-                        "doc": "The localized friendly name of the resource type related to this operation. E.g. \"Virtual Machines\" or \"Job Schedule Collections\".",
-                        "type": {
-                          "$id": "135",
-                          "kind": "string",
-                          "name": "string",
-                          "crossLanguageDefinitionId": "TypeSpec.string",
-                          "decorators": []
-                        },
-                        "optional": true,
-                        "readOnly": true,
-                        "discriminator": false,
-                        "flatten": false,
-                        "decorators": [],
-                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay.resource",
-                        "serializationOptions": {
-                          "json": {
-                            "name": "resource"
-                          }
-                        },
-                        "isHttpMetadata": false,
-                        "isExactName": false
-                      },
-                      {
-                        "$id": "136",
-                        "kind": "property",
-                        "name": "operation",
-                        "serializedName": "operation",
-                        "doc": "The concise, localized friendly name for the operation; suitable for dropdowns. E.g. \"Create or Update Virtual Machine\", \"Restart Virtual Machine\".",
-                        "type": {
-                          "$id": "137",
-                          "kind": "string",
-                          "name": "string",
-                          "crossLanguageDefinitionId": "TypeSpec.string",
-                          "decorators": []
-                        },
-                        "optional": true,
-                        "readOnly": true,
-                        "discriminator": false,
-                        "flatten": false,
-                        "decorators": [],
-                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay.operation",
-                        "serializationOptions": {
-                          "json": {
-                            "name": "operation"
-                          }
-                        },
-                        "isHttpMetadata": false,
-                        "isExactName": false
-                      },
-                      {
-                        "$id": "138",
-                        "kind": "property",
-                        "name": "description",
-                        "serializedName": "description",
-                        "doc": "The short, localized friendly description of the operation; suitable for tool tips and detailed views.",
-                        "type": {
-                          "$id": "139",
-                          "kind": "string",
-                          "name": "string",
-                          "crossLanguageDefinitionId": "TypeSpec.string",
-                          "decorators": []
-                        },
-                        "optional": true,
-                        "readOnly": true,
-                        "discriminator": false,
-                        "flatten": false,
-                        "decorators": [],
-                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay.description",
-                        "serializationOptions": {
-                          "json": {
-                            "name": "description"
-                          }
-                        },
-                        "isHttpMetadata": false,
-                        "isExactName": false
-                      }
-                    ]
-                  },
-                  "optional": true,
-                  "readOnly": false,
-                  "discriminator": false,
-                  "flatten": false,
-                  "decorators": [],
-                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.display",
-                  "serializationOptions": {
-                    "json": {
-                      "name": "display"
-                    }
-                  },
-                  "isHttpMetadata": false,
-                  "isExactName": false
-                },
-                {
-                  "$id": "140",
-                  "kind": "property",
-                  "name": "origin",
-                  "serializedName": "origin",
-                  "doc": "The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is \"user,system\"",
-                  "type": {
-                    "$ref": "1"
-                  },
-                  "optional": true,
-                  "readOnly": true,
-                  "discriminator": false,
-                  "flatten": false,
-                  "decorators": [],
-                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.origin",
-                  "serializationOptions": {
-                    "json": {
-                      "name": "origin"
-                    }
-                  },
-                  "isHttpMetadata": false,
-                  "isExactName": false
-                },
-                {
-                  "$id": "141",
-                  "kind": "property",
-                  "name": "actionType",
-                  "serializedName": "actionType",
-                  "doc": "Extensible enum. Indicates the action type. \"Internal\" refers to actions that are for internal only APIs.",
-                  "type": {
-                    "$ref": "6"
-                  },
-                  "optional": true,
-                  "readOnly": true,
-                  "discriminator": false,
-                  "flatten": false,
-                  "decorators": [],
-                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.actionType",
-                  "serializationOptions": {
-                    "json": {
-                      "name": "actionType"
-                    }
-                  },
-                  "isHttpMetadata": false,
-                  "isExactName": false
-                }
-              ]
-            },
-            "crossLanguageDefinitionId": "TypeSpec.Array",
-            "decorators": []
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationListResult.value",
-          "serializationOptions": {
-            "json": {
-              "name": "value"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "142",
-          "kind": "property",
-          "name": "nextLink",
-          "serializedName": "nextLink",
-          "doc": "The link to the next page of items",
-          "type": {
-            "$id": "143",
-            "kind": "url",
-            "name": "ResourceLocation",
-            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
-            "baseType": {
-              "$id": "144",
-              "kind": "url",
-              "name": "url",
-              "crossLanguageDefinitionId": "TypeSpec.url",
-              "decorators": []
-            },
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationListResult.nextLink",
-          "serializationOptions": {
-            "json": {
-              "name": "nextLink"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
-    },
-    {
-      "$ref": "125"
-    },
-    {
-      "$ref": "131"
-    },
-    {
-      "$id": "145",
-      "kind": "model",
-      "name": "ErrorResponse",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorResponse",
-      "usage": "Json,Exception",
-      "doc": "Common error response for all Azure Resource Manager APIs to return error details for failed operations.",
-      "summary": "Error response",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "ErrorResponse"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "146",
-          "kind": "property",
-          "name": "error",
-          "serializedName": "error",
-          "doc": "The error object.",
-          "type": {
-            "$id": "147",
-            "kind": "model",
-            "name": "ErrorDetail",
-            "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-            "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorDetail",
-            "usage": "Json,Exception,LroPolling",
-            "doc": "The error detail.",
-            "decorators": [
-              {
-                "name": "Azure.ResourceManager.@armProviderNamespace",
-                "arguments": {}
-              }
-            ],
-            "serializationOptions": {
-              "json": {
-                "name": "ErrorDetail"
-              }
-            },
-            "isExactName": false,
-            "properties": [
-              {
-                "$id": "148",
-                "kind": "property",
-                "name": "code",
-                "serializedName": "code",
-                "doc": "The error code.",
-                "type": {
-                  "$id": "149",
-                  "kind": "string",
-                  "name": "string",
-                  "crossLanguageDefinitionId": "TypeSpec.string",
-                  "decorators": []
-                },
-                "optional": true,
-                "readOnly": true,
-                "discriminator": false,
-                "flatten": false,
-                "decorators": [],
-                "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorDetail.code",
-                "serializationOptions": {
-                  "json": {
-                    "name": "code"
-                  }
-                },
-                "isHttpMetadata": false,
-                "isExactName": false
-              },
-              {
-                "$id": "150",
-                "kind": "property",
-                "name": "message",
-                "serializedName": "message",
-                "doc": "The error message.",
-                "type": {
-                  "$id": "151",
-                  "kind": "string",
-                  "name": "string",
-                  "crossLanguageDefinitionId": "TypeSpec.string",
-                  "decorators": []
-                },
-                "optional": true,
-                "readOnly": true,
-                "discriminator": false,
-                "flatten": false,
-                "decorators": [],
-                "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorDetail.message",
-                "serializationOptions": {
-                  "json": {
-                    "name": "message"
-                  }
-                },
-                "isHttpMetadata": false,
-                "isExactName": false
-              },
-              {
-                "$id": "152",
-                "kind": "property",
-                "name": "target",
-                "serializedName": "target",
-                "doc": "The error target.",
-                "type": {
-                  "$id": "153",
-                  "kind": "string",
-                  "name": "string",
-                  "crossLanguageDefinitionId": "TypeSpec.string",
-                  "decorators": []
-                },
-                "optional": true,
-                "readOnly": true,
-                "discriminator": false,
-                "flatten": false,
-                "decorators": [],
-                "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorDetail.target",
-                "serializationOptions": {
-                  "json": {
-                    "name": "target"
-                  }
-                },
-                "isHttpMetadata": false,
-                "isExactName": false
-              },
-              {
-                "$id": "154",
-                "kind": "property",
-                "name": "details",
-                "serializedName": "details",
-                "doc": "The error details.",
-                "type": {
-                  "$id": "155",
-                  "kind": "array",
-                  "name": "ArrayErrorDetail",
-                  "valueType": {
-                    "$ref": "147"
-                  },
-                  "crossLanguageDefinitionId": "TypeSpec.Array",
-                  "decorators": []
-                },
-                "optional": true,
-                "readOnly": true,
-                "discriminator": false,
-                "flatten": false,
-                "decorators": [],
-                "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorDetail.details",
-                "serializationOptions": {
-                  "json": {
-                    "name": "details"
-                  }
-                },
-                "isHttpMetadata": false,
-                "isExactName": false
-              },
-              {
-                "$id": "156",
-                "kind": "property",
-                "name": "additionalInfo",
-                "serializedName": "additionalInfo",
-                "doc": "The error additional info.",
-                "type": {
-                  "$id": "157",
-                  "kind": "array",
-                  "name": "ArrayErrorAdditionalInfo",
-                  "valueType": {
-                    "$id": "158",
-                    "kind": "model",
-                    "name": "ErrorAdditionalInfo",
-                    "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-                    "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorAdditionalInfo",
-                    "usage": "Json,Exception,LroPolling",
-                    "doc": "The resource management error additional info.",
-                    "decorators": [
-                      {
-                        "name": "Azure.ResourceManager.@armProviderNamespace",
-                        "arguments": {}
-                      }
-                    ],
-                    "serializationOptions": {
-                      "json": {
-                        "name": "ErrorAdditionalInfo"
-                      }
-                    },
-                    "isExactName": false,
-                    "properties": [
-                      {
-                        "$id": "159",
-                        "kind": "property",
-                        "name": "type",
-                        "serializedName": "type",
-                        "doc": "The additional info type.",
-                        "type": {
-                          "$id": "160",
-                          "kind": "string",
-                          "name": "string",
-                          "crossLanguageDefinitionId": "TypeSpec.string",
-                          "decorators": []
-                        },
-                        "optional": true,
-                        "readOnly": true,
-                        "discriminator": false,
-                        "flatten": false,
-                        "decorators": [],
-                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorAdditionalInfo.type",
-                        "serializationOptions": {
-                          "json": {
-                            "name": "type"
-                          }
-                        },
-                        "isHttpMetadata": false,
-                        "isExactName": false
-                      },
-                      {
-                        "$id": "161",
-                        "kind": "property",
-                        "name": "info",
-                        "serializedName": "info",
-                        "doc": "The additional info.",
-                        "type": {
-                          "$id": "162",
-                          "kind": "unknown",
-                          "name": "unknown",
-                          "crossLanguageDefinitionId": "",
-                          "decorators": []
-                        },
-                        "optional": true,
-                        "readOnly": true,
-                        "discriminator": false,
-                        "flatten": false,
-                        "decorators": [],
-                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorAdditionalInfo.info",
-                        "serializationOptions": {
-                          "json": {
-                            "name": "info"
-                          }
-                        },
-                        "isHttpMetadata": false,
-                        "isExactName": false
-                      }
-                    ]
-                  },
-                  "crossLanguageDefinitionId": "TypeSpec.Array",
-                  "decorators": []
-                },
-                "optional": true,
-                "readOnly": true,
-                "discriminator": false,
-                "flatten": false,
-                "decorators": [],
-                "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorDetail.additionalInfo",
-                "serializationOptions": {
-                  "json": {
-                    "name": "additionalInfo"
-                  }
-                },
-                "isHttpMetadata": false,
-                "isExactName": false
-              }
-            ]
-          },
-          "optional": true,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ErrorResponse.error",
-          "serializationOptions": {
-            "json": {
-              "name": "error"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
-    },
-    {
-      "$ref": "147"
-    },
-    {
-      "$ref": "158"
-    },
-    {
-      "$id": "163",
+      "$id": "105",
       "kind": "model",
       "name": "ConfigurationStore",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -1934,7 +1060,7 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$id": "164",
+        "$id": "106",
         "kind": "model",
         "name": "TrackedResource",
         "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -1955,7 +1081,7 @@
         },
         "isExactName": false,
         "baseModel": {
-          "$id": "165",
+          "$id": "107",
           "kind": "model",
           "name": "Resource",
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -1977,18 +1103,18 @@
           "isExactName": false,
           "properties": [
             {
-              "$id": "166",
+              "$id": "108",
               "kind": "property",
               "name": "id",
               "serializedName": "id",
               "doc": "Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}",
               "type": {
-                "$id": "167",
+                "$id": "109",
                 "kind": "string",
                 "name": "armResourceIdentifier",
                 "crossLanguageDefinitionId": "Azure.Core.armResourceIdentifier",
                 "baseType": {
-                  "$id": "168",
+                  "$id": "110",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2011,13 +1137,13 @@
               "isExactName": false
             },
             {
-              "$id": "169",
+              "$id": "111",
               "kind": "property",
               "name": "name",
               "serializedName": "name",
               "doc": "The name of the resource",
               "type": {
-                "$id": "170",
+                "$id": "112",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2038,18 +1164,18 @@
               "isExactName": false
             },
             {
-              "$id": "171",
+              "$id": "113",
               "kind": "property",
               "name": "type",
               "serializedName": "type",
               "doc": "The type of the resource. E.g. \"Microsoft.Compute/virtualMachines\" or \"Microsoft.Storage/storageAccounts\"",
               "type": {
-                "$id": "172",
+                "$id": "114",
                 "kind": "string",
                 "name": "armResourceType",
                 "crossLanguageDefinitionId": "Azure.Core.armResourceType",
                 "baseType": {
-                  "$id": "173",
+                  "$id": "115",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2072,13 +1198,13 @@
               "isExactName": false
             },
             {
-              "$id": "174",
+              "$id": "116",
               "kind": "property",
               "name": "systemData",
               "serializedName": "systemData",
               "doc": "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
               "type": {
-                "$id": "175",
+                "$id": "117",
                 "kind": "model",
                 "name": "SystemData",
                 "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -2099,13 +1225,13 @@
                 "isExactName": false,
                 "properties": [
                   {
-                    "$id": "176",
+                    "$id": "118",
                     "kind": "property",
                     "name": "createdBy",
                     "serializedName": "createdBy",
                     "doc": "The identity that created the resource.",
                     "type": {
-                      "$id": "177",
+                      "$id": "119",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2126,13 +1252,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "178",
+                    "$id": "120",
                     "kind": "property",
                     "name": "createdByType",
                     "serializedName": "createdByType",
                     "doc": "The type of identity that created the resource.",
                     "type": {
-                      "$ref": "29"
+                      "$ref": "21"
                     },
                     "optional": true,
                     "readOnly": false,
@@ -2149,18 +1275,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "179",
+                    "$id": "121",
                     "kind": "property",
                     "name": "createdAt",
                     "serializedName": "createdAt",
                     "doc": "The timestamp of resource creation (UTC).",
                     "type": {
-                      "$id": "180",
+                      "$id": "122",
                       "kind": "utcDateTime",
                       "name": "utcDateTime",
                       "encode": "rfc3339",
                       "wireType": {
-                        "$id": "181",
+                        "$id": "123",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2184,13 +1310,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "182",
+                    "$id": "124",
                     "kind": "property",
                     "name": "lastModifiedBy",
                     "serializedName": "lastModifiedBy",
                     "doc": "The identity that last modified the resource.",
                     "type": {
-                      "$id": "183",
+                      "$id": "125",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2211,13 +1337,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "184",
+                    "$id": "126",
                     "kind": "property",
                     "name": "lastModifiedByType",
                     "serializedName": "lastModifiedByType",
                     "doc": "The type of identity that last modified the resource.",
                     "type": {
-                      "$ref": "29"
+                      "$ref": "21"
                     },
                     "optional": true,
                     "readOnly": false,
@@ -2234,18 +1360,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "185",
+                    "$id": "127",
                     "kind": "property",
                     "name": "lastModifiedAt",
                     "serializedName": "lastModifiedAt",
                     "doc": "The timestamp of resource last modification (UTC)",
                     "type": {
-                      "$id": "186",
+                      "$id": "128",
                       "kind": "utcDateTime",
                       "name": "utcDateTime",
                       "encode": "rfc3339",
                       "wireType": {
-                        "$id": "187",
+                        "$id": "129",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2288,23 +1414,23 @@
         },
         "properties": [
           {
-            "$id": "188",
+            "$id": "130",
             "kind": "property",
             "name": "tags",
             "serializedName": "tags",
             "doc": "Resource tags.",
             "type": {
-              "$id": "189",
+              "$id": "131",
               "kind": "dict",
               "keyType": {
-                "$id": "190",
+                "$id": "132",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
                 "decorators": []
               },
               "valueType": {
-                "$id": "191",
+                "$id": "133",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2327,18 +1453,18 @@
             "isExactName": false
           },
           {
-            "$id": "192",
+            "$id": "134",
             "kind": "property",
             "name": "location",
             "serializedName": "location",
             "doc": "The geo-location where the resource lives",
             "type": {
-              "$id": "193",
+              "$id": "135",
               "kind": "string",
               "name": "azureLocation",
               "crossLanguageDefinitionId": "Azure.Core.azureLocation",
               "baseType": {
-                "$id": "194",
+                "$id": "136",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2364,13 +1490,13 @@
       },
       "properties": [
         {
-          "$id": "195",
+          "$id": "137",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "196",
+            "$id": "138",
             "kind": "model",
             "name": "ConfigurationStoreProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -2391,13 +1517,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "197",
+                "$id": "139",
                 "kind": "property",
                 "name": "provisioningState",
                 "serializedName": "provisioningState",
                 "doc": "The provisioning state of the configuration store.",
                 "type": {
-                  "$ref": "9"
+                  "$ref": "1"
                 },
                 "optional": true,
                 "readOnly": true,
@@ -2414,18 +1540,18 @@
                 "isExactName": false
               },
               {
-                "$id": "198",
+                "$id": "140",
                 "kind": "property",
                 "name": "creationDate",
                 "serializedName": "creationDate",
                 "doc": "The creation date of configuration store.",
                 "type": {
-                  "$id": "199",
+                  "$id": "141",
                   "kind": "utcDateTime",
                   "name": "utcDateTime",
                   "encode": "rfc3339",
                   "wireType": {
-                    "$id": "200",
+                    "$id": "142",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2449,13 +1575,13 @@
                 "isExactName": false
               },
               {
-                "$id": "201",
+                "$id": "143",
                 "kind": "property",
                 "name": "endpoint",
                 "serializedName": "endpoint",
                 "doc": "The DNS endpoint where the configuration store API will be available.",
                 "type": {
-                  "$id": "202",
+                  "$id": "144",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2476,13 +1602,13 @@
                 "isExactName": false
               },
               {
-                "$id": "203",
+                "$id": "145",
                 "kind": "property",
                 "name": "sku",
                 "serializedName": "sku",
                 "doc": "The sku of the configuration store.",
                 "type": {
-                  "$id": "204",
+                  "$id": "146",
                   "kind": "model",
                   "name": "ConfigurationStoreSku",
                   "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -2503,13 +1629,13 @@
                   "isExactName": false,
                   "properties": [
                     {
-                      "$id": "205",
+                      "$id": "147",
                       "kind": "property",
                       "name": "name",
                       "serializedName": "name",
                       "doc": "The name of the sku.",
                       "type": {
-                        "$id": "206",
+                        "$id": "148",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2546,13 +1672,13 @@
                 "isExactName": false
               },
               {
-                "$id": "207",
+                "$id": "149",
                 "kind": "property",
                 "name": "softDeleteRetentionInDays",
                 "serializedName": "softDeleteRetentionInDays",
                 "doc": "Indicates whether the configuration store need to be recovered.",
                 "type": {
-                  "$id": "208",
+                  "$id": "150",
                   "kind": "int32",
                   "name": "int32",
                   "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -2573,13 +1699,13 @@
                 "isExactName": false
               },
               {
-                "$id": "209",
+                "$id": "151",
                 "kind": "property",
                 "name": "disableLocalAuth",
                 "serializedName": "disableLocalAuth",
                 "doc": "Disables all authentication methods other than AAD authentication.",
                 "type": {
-                  "$id": "210",
+                  "$id": "152",
                   "kind": "boolean",
                   "name": "boolean",
                   "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -2600,13 +1726,13 @@
                 "isExactName": false
               },
               {
-                "$id": "211",
+                "$id": "153",
                 "kind": "property",
                 "name": "backupPolicy",
                 "serializedName": "backupPolicy",
                 "doc": "The backup policy for the configuration store.",
                 "type": {
-                  "$id": "212",
+                  "$id": "154",
                   "kind": "model",
                   "name": "BackupPolicy",
                   "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -2626,13 +1752,13 @@
                   },
                   "isExactName": false,
                   "discriminatorProperty": {
-                    "$id": "213",
+                    "$id": "155",
                     "kind": "property",
                     "name": "kind",
                     "serializedName": "kind",
                     "doc": "The backup policy kind.",
                     "type": {
-                      "$id": "214",
+                      "$id": "156",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2654,16 +1780,16 @@
                   },
                   "properties": [
                     {
-                      "$ref": "213"
+                      "$ref": "155"
                     },
                     {
-                      "$id": "215",
+                      "$id": "157",
                       "kind": "property",
                       "name": "retentionDays",
                       "serializedName": "retentionDays",
                       "doc": "The retention period in days.",
                       "type": {
-                        "$id": "216",
+                        "$id": "158",
                         "kind": "int32",
                         "name": "int32",
                         "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -2684,13 +1810,13 @@
                       "isExactName": false
                     },
                     {
-                      "$id": "217",
+                      "$id": "159",
                       "kind": "property",
                       "name": "isEnabled",
                       "serializedName": "isEnabled",
                       "doc": "Whether the backup policy is enabled.",
                       "type": {
-                        "$id": "218",
+                        "$id": "160",
                         "kind": "boolean",
                         "name": "boolean",
                         "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -2713,7 +1839,7 @@
                   ],
                   "discriminatedSubtypes": {
                     "Periodic": {
-                      "$id": "219",
+                      "$id": "161",
                       "kind": "model",
                       "name": "PeriodicBackupPolicy",
                       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -2734,17 +1860,17 @@
                       },
                       "isExactName": false,
                       "baseModel": {
-                        "$ref": "212"
+                        "$ref": "154"
                       },
                       "properties": [
                         {
-                          "$id": "220",
+                          "$id": "162",
                           "kind": "property",
                           "name": "kind",
                           "serializedName": "kind",
                           "doc": "Periodic backup kind.",
                           "type": {
-                            "$ref": "44"
+                            "$ref": "27"
                           },
                           "optional": false,
                           "readOnly": false,
@@ -2761,13 +1887,13 @@
                           "isExactName": false
                         },
                         {
-                          "$id": "221",
+                          "$id": "163",
                           "kind": "property",
                           "name": "intervalInHours",
                           "serializedName": "intervalInHours",
                           "doc": "The backup interval in hours.",
                           "type": {
-                            "$id": "222",
+                            "$id": "164",
                             "kind": "int32",
                             "name": "int32",
                             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -2790,7 +1916,7 @@
                       ]
                     },
                     "Continuous": {
-                      "$id": "223",
+                      "$id": "165",
                       "kind": "model",
                       "name": "ContinuousBackupPolicy",
                       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -2811,17 +1937,17 @@
                       },
                       "isExactName": false,
                       "baseModel": {
-                        "$ref": "212"
+                        "$ref": "154"
                       },
                       "properties": [
                         {
-                          "$id": "224",
+                          "$id": "166",
                           "kind": "property",
                           "name": "kind",
                           "serializedName": "kind",
                           "doc": "Continuous backup kind.",
                           "type": {
-                            "$ref": "46"
+                            "$ref": "29"
                           },
                           "optional": false,
                           "readOnly": false,
@@ -2838,13 +1964,13 @@
                           "isExactName": false
                         },
                         {
-                          "$id": "225",
+                          "$id": "167",
                           "kind": "property",
                           "name": "tier",
                           "serializedName": "tier",
                           "doc": "The continuous backup tier.",
                           "type": {
-                            "$id": "226",
+                            "$id": "168",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2883,13 +2009,13 @@
                 "isExactName": false
               },
               {
-                "$id": "227",
+                "$id": "169",
                 "kind": "property",
                 "name": "publicNetworkAccess",
                 "serializedName": "publicNetworkAccess",
                 "doc": "Enables or disables public network access.",
                 "type": {
-                  "$ref": "16"
+                  "$ref": "8"
                 },
                 "optional": true,
                 "readOnly": false,
@@ -2906,13 +2032,13 @@
                 "isExactName": false
               },
               {
-                "$id": "228",
+                "$id": "170",
                 "kind": "property",
                 "name": "skuTier",
                 "serializedName": "skuTier",
                 "doc": "The SKU tier of the configuration store.",
                 "type": {
-                  "$ref": "20"
+                  "$ref": "12"
                 },
                 "optional": true,
                 "readOnly": false,
@@ -2929,13 +2055,13 @@
                 "isExactName": false
               },
               {
-                "$id": "229",
+                "$id": "171",
                 "kind": "property",
                 "name": "createMode",
                 "serializedName": "createMode",
                 "doc": "The create mode for the configuration store.",
                 "type": {
-                  "$ref": "25"
+                  "$ref": "17"
                 },
                 "optional": true,
                 "readOnly": false,
@@ -2952,17 +2078,17 @@
                 "isExactName": false
               },
               {
-                "$id": "230",
+                "$id": "172",
                 "kind": "property",
                 "name": "linkedResources",
                 "serializedName": "linkedResources",
                 "doc": "The linked resources of the configuration store.",
                 "type": {
-                  "$id": "231",
+                  "$id": "173",
                   "kind": "array",
                   "name": "ArraySubResource",
                   "valueType": {
-                    "$id": "232",
+                    "$id": "174",
                     "kind": "model",
                     "name": "SubResource",
                     "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3016,13 +2142,13 @@
           "isExactName": false
         },
         {
-          "$id": "233",
+          "$id": "175",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the ConfigurationStore",
           "type": {
-            "$id": "234",
+            "$id": "176",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3050,13 +2176,13 @@
           "isExactName": false
         },
         {
-          "$id": "235",
+          "$id": "177",
           "kind": "property",
           "name": "eTag",
           "serializedName": "eTag",
           "doc": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
           "type": {
-            "$id": "236",
+            "$id": "178",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3079,341 +2205,34 @@
       ]
     },
     {
-      "$ref": "196"
+      "$ref": "138"
     },
     {
-      "$ref": "204"
+      "$ref": "146"
     },
     {
-      "$ref": "212"
+      "$ref": "154"
     },
     {
-      "$ref": "219"
-    },
-    {
-      "$ref": "223"
-    },
-    {
-      "$ref": "232"
-    },
-    {
-      "$ref": "164"
+      "$ref": "161"
     },
     {
       "$ref": "165"
     },
     {
-      "$ref": "175"
+      "$ref": "174"
     },
     {
-      "$id": "237",
-      "kind": "model",
-      "name": "ArmOperationStatusResourceProvisioningState",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus",
-      "usage": "LroPolling",
-      "doc": "Standard Azure Resource Manager operation status response, used as the response\nbody for `GetResourceOperationStatus`.",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "ArmOperationStatus"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "238",
-          "kind": "property",
-          "name": "status",
-          "serializedName": "status",
-          "doc": "The operation status",
-          "type": {
-            "$ref": "35"
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus.status",
-          "serializationOptions": {
-            "json": {
-              "name": "status"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "239",
-          "kind": "property",
-          "name": "id",
-          "serializedName": "id",
-          "doc": "The unique identifier for the operationStatus resource",
-          "type": {
-            "$id": "240",
-            "kind": "string",
-            "name": "string",
-            "crossLanguageDefinitionId": "TypeSpec.string",
-            "decorators": []
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus.id",
-          "serializationOptions": {
-            "json": {
-              "name": "id"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "241",
-          "kind": "property",
-          "name": "name",
-          "serializedName": "name",
-          "doc": "The name of the operationStatus resource",
-          "type": {
-            "$id": "242",
-            "kind": "string",
-            "name": "string",
-            "crossLanguageDefinitionId": "TypeSpec.string",
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": true,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus.name",
-          "serializationOptions": {
-            "json": {
-              "name": "name"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "243",
-          "kind": "property",
-          "name": "startTime",
-          "serializedName": "startTime",
-          "doc": "Operation start time",
-          "type": {
-            "$id": "244",
-            "kind": "utcDateTime",
-            "name": "utcDateTime",
-            "encode": "rfc3339",
-            "wireType": {
-              "$id": "245",
-              "kind": "string",
-              "name": "string",
-              "crossLanguageDefinitionId": "TypeSpec.string",
-              "decorators": []
-            },
-            "crossLanguageDefinitionId": "TypeSpec.utcDateTime",
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": true,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus.startTime",
-          "serializationOptions": {
-            "json": {
-              "name": "startTime"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "246",
-          "kind": "property",
-          "name": "endTime",
-          "serializedName": "endTime",
-          "doc": "Operation complete time",
-          "type": {
-            "$id": "247",
-            "kind": "utcDateTime",
-            "name": "utcDateTime",
-            "encode": "rfc3339",
-            "wireType": {
-              "$id": "248",
-              "kind": "string",
-              "name": "string",
-              "crossLanguageDefinitionId": "TypeSpec.string",
-              "decorators": []
-            },
-            "crossLanguageDefinitionId": "TypeSpec.utcDateTime",
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": true,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus.endTime",
-          "serializationOptions": {
-            "json": {
-              "name": "endTime"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "249",
-          "kind": "property",
-          "name": "percentComplete",
-          "serializedName": "percentComplete",
-          "doc": "The progress made toward completing the operation",
-          "type": {
-            "$id": "250",
-            "kind": "float64",
-            "name": "float64",
-            "crossLanguageDefinitionId": "TypeSpec.float64",
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": true,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus.percentComplete",
-          "serializationOptions": {
-            "json": {
-              "name": "percentComplete"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "251",
-          "kind": "property",
-          "name": "error",
-          "serializedName": "error",
-          "doc": "Errors that occurred if the operation ended with Canceled or Failed status",
-          "type": {
-            "$ref": "147"
-          },
-          "optional": true,
-          "readOnly": true,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus.error",
-          "serializationOptions": {
-            "json": {
-              "name": "error"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
+      "$ref": "106"
     },
     {
-      "$id": "252",
-      "kind": "model",
-      "name": "ConfigurationStoreListResult",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
-      "usage": "Output,Json",
-      "doc": "The response of a ConfigurationStore list operation.",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "ResourceListResult"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "253",
-          "kind": "property",
-          "name": "value",
-          "serializedName": "value",
-          "doc": "The ConfigurationStore items on this page",
-          "type": {
-            "$id": "254",
-            "kind": "array",
-            "name": "ArrayConfigurationStore",
-            "valueType": {
-              "$ref": "163"
-            },
-            "crossLanguageDefinitionId": "TypeSpec.Array",
-            "decorators": []
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
-          "serializationOptions": {
-            "json": {
-              "name": "value"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "255",
-          "kind": "property",
-          "name": "nextLink",
-          "serializedName": "nextLink",
-          "doc": "The link to the next page of items",
-          "type": {
-            "$id": "256",
-            "kind": "url",
-            "name": "ResourceLocation",
-            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
-            "baseType": {
-              "$id": "257",
-              "kind": "url",
-              "name": "url",
-              "crossLanguageDefinitionId": "TypeSpec.url",
-              "decorators": []
-            },
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
-          "serializationOptions": {
-            "json": {
-              "name": "nextLink"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
+      "$ref": "107"
     },
     {
-      "$id": "258",
+      "$ref": "117"
+    },
+    {
+      "$id": "179",
       "kind": "model",
       "name": "KeyValue",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3441,7 +2260,7 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$id": "259",
+        "$id": "180",
         "kind": "model",
         "name": "ProxyResource",
         "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3462,19 +2281,19 @@
         },
         "isExactName": false,
         "baseModel": {
-          "$ref": "165"
+          "$ref": "107"
         },
         "properties": []
       },
       "properties": [
         {
-          "$id": "260",
+          "$id": "181",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "261",
+            "$id": "182",
             "kind": "model",
             "name": "KeyValueProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3495,13 +2314,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "262",
+                "$id": "183",
                 "kind": "property",
                 "name": "value",
                 "serializedName": "value",
                 "doc": "The value of the key-value.",
                 "type": {
-                  "$id": "263",
+                  "$id": "184",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3522,13 +2341,13 @@
                 "isExactName": false
               },
               {
-                "$id": "264",
+                "$id": "185",
                 "kind": "property",
                 "name": "contentType",
                 "serializedName": "contentType",
                 "doc": "The content type of the key-value.",
                 "type": {
-                  "$id": "265",
+                  "$id": "186",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3565,13 +2384,13 @@
           "isExactName": false
         },
         {
-          "$id": "266",
+          "$id": "187",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the KeyValue",
           "type": {
-            "$id": "267",
+            "$id": "188",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3601,100 +2420,13 @@
       ]
     },
     {
-      "$ref": "261"
+      "$ref": "182"
     },
     {
-      "$ref": "259"
+      "$ref": "180"
     },
     {
-      "$id": "268",
-      "kind": "model",
-      "name": "KeyValueListResult",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
-      "usage": "Output,Json",
-      "doc": "The response of a KeyValue list operation.",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "ResourceListResult"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "269",
-          "kind": "property",
-          "name": "value",
-          "serializedName": "value",
-          "doc": "The KeyValue items on this page",
-          "type": {
-            "$id": "270",
-            "kind": "array",
-            "name": "ArrayKeyValue",
-            "valueType": {
-              "$ref": "258"
-            },
-            "crossLanguageDefinitionId": "TypeSpec.Array",
-            "decorators": []
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
-          "serializationOptions": {
-            "json": {
-              "name": "value"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "271",
-          "kind": "property",
-          "name": "nextLink",
-          "serializedName": "nextLink",
-          "doc": "The link to the next page of items",
-          "type": {
-            "$id": "272",
-            "kind": "url",
-            "name": "ResourceLocation",
-            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
-            "baseType": {
-              "$id": "273",
-              "kind": "url",
-              "name": "url",
-              "crossLanguageDefinitionId": "TypeSpec.url",
-              "decorators": []
-            },
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
-          "serializationOptions": {
-            "json": {
-              "name": "nextLink"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
-    },
-    {
-      "$id": "274",
+      "$id": "189",
       "kind": "model",
       "name": "Item",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3722,17 +2454,17 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$ref": "259"
+        "$ref": "180"
       },
       "properties": [
         {
-          "$id": "275",
+          "$id": "190",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "276",
+            "$id": "191",
             "kind": "model",
             "name": "ItemProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3753,13 +2485,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "277",
+                "$id": "192",
                 "kind": "property",
                 "name": "value",
                 "serializedName": "value",
                 "doc": "The value of the item.",
                 "type": {
-                  "$id": "278",
+                  "$id": "193",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3780,13 +2512,13 @@
                 "isExactName": false
               },
               {
-                "$id": "279",
+                "$id": "194",
                 "kind": "property",
                 "name": "contentType",
                 "serializedName": "contentType",
                 "doc": "The content type of the item.",
                 "type": {
-                  "$id": "280",
+                  "$id": "195",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3807,16 +2539,16 @@
                 "isExactName": false
               },
               {
-                "$id": "281",
+                "$id": "196",
                 "kind": "property",
                 "name": "nullableValue",
                 "serializedName": "nullableValue",
                 "doc": "Nullable value used to verify provisioning primitive wrapping.",
                 "type": {
-                  "$id": "282",
+                  "$id": "197",
                   "kind": "nullable",
                   "type": {
-                    "$id": "283",
+                    "$id": "198",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3839,13 +2571,13 @@
                 "isExactName": false
               },
               {
-                "$id": "284",
+                "$id": "199",
                 "kind": "property",
                 "name": "attributes",
                 "serializedName": "attributes",
                 "doc": "The attributes of the item.",
                 "type": {
-                  "$id": "285",
+                  "$id": "200",
                   "kind": "model",
                   "name": "ItemAttributes",
                   "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3865,7 +2597,7 @@
                   },
                   "isExactName": false,
                   "baseModel": {
-                    "$id": "286",
+                    "$id": "201",
                     "kind": "model",
                     "name": "BaseItemAttributes",
                     "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3886,13 +2618,13 @@
                     "isExactName": false,
                     "properties": [
                       {
-                        "$id": "287",
+                        "$id": "202",
                         "kind": "property",
                         "name": "enabled",
                         "serializedName": "enabled",
                         "doc": "Whether the item is enabled.",
                         "type": {
-                          "$id": "288",
+                          "$id": "203",
                           "kind": "boolean",
                           "name": "boolean",
                           "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -3913,18 +2645,18 @@
                         "isExactName": false
                       },
                       {
-                        "$id": "289",
+                        "$id": "204",
                         "kind": "property",
                         "name": "created",
                         "serializedName": "created",
                         "doc": "The creation date.",
                         "type": {
-                          "$id": "290",
+                          "$id": "205",
                           "kind": "utcDateTime",
                           "name": "utcDateTime",
                           "encode": "rfc3339",
                           "wireType": {
-                            "$id": "291",
+                            "$id": "206",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3948,18 +2680,18 @@
                         "isExactName": false
                       },
                       {
-                        "$id": "292",
+                        "$id": "207",
                         "kind": "property",
                         "name": "updated",
                         "serializedName": "updated",
                         "doc": "The last updated date.",
                         "type": {
-                          "$id": "293",
+                          "$id": "208",
                           "kind": "utcDateTime",
                           "name": "utcDateTime",
                           "encode": "rfc3339",
                           "wireType": {
-                            "$id": "294",
+                            "$id": "209",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3986,18 +2718,18 @@
                   },
                   "properties": [
                     {
-                      "$id": "295",
+                      "$id": "210",
                       "kind": "property",
                       "name": "expires",
                       "serializedName": "expires",
                       "doc": "The expiry date.",
                       "type": {
-                        "$id": "296",
+                        "$id": "211",
                         "kind": "utcDateTime",
                         "name": "utcDateTime",
                         "encode": "rfc3339",
                         "wireType": {
-                          "$id": "297",
+                          "$id": "212",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4058,13 +2790,13 @@
           "isExactName": false
         },
         {
-          "$id": "298",
+          "$id": "213",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the Item",
           "type": {
-            "$id": "299",
+            "$id": "214",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4092,13 +2824,13 @@
           "isExactName": false
         },
         {
-          "$id": "300",
+          "$id": "215",
           "kind": "property",
           "name": "tags",
           "serializedName": "tags",
           "doc": "Tags assigned to the item.",
           "type": {
-            "$ref": "189"
+            "$ref": "131"
           },
           "optional": true,
           "readOnly": true,
@@ -4117,172 +2849,16 @@
       ]
     },
     {
-      "$ref": "276"
+      "$ref": "191"
     },
     {
-      "$ref": "285"
+      "$ref": "200"
     },
     {
-      "$ref": "286"
+      "$ref": "201"
     },
     {
-      "$id": "301",
-      "kind": "model",
-      "name": "ItemCreateOrUpdateParameters",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "ProvisioningTypeSpec.ItemCreateOrUpdateParameters",
-      "usage": "Input,Json",
-      "doc": "Parameters to create or update an item.",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "ItemCreateOrUpdateParameters"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "302",
-          "kind": "property",
-          "name": "tags",
-          "serializedName": "tags",
-          "doc": "Tags assigned to the item.",
-          "type": {
-            "$ref": "189"
-          },
-          "optional": true,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "ProvisioningTypeSpec.ItemCreateOrUpdateParameters.tags",
-          "serializationOptions": {
-            "json": {
-              "name": "tags"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "303",
-          "kind": "property",
-          "name": "properties",
-          "serializedName": "properties",
-          "doc": "Properties of the item.",
-          "type": {
-            "$ref": "276"
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "ProvisioningTypeSpec.ItemCreateOrUpdateParameters.properties",
-          "serializationOptions": {
-            "json": {
-              "name": "properties"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
-    },
-    {
-      "$id": "304",
-      "kind": "model",
-      "name": "ItemListResult",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
-      "usage": "Output,Json",
-      "doc": "The response of a Item list operation.",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "ResourceListResult"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "305",
-          "kind": "property",
-          "name": "value",
-          "serializedName": "value",
-          "doc": "The Item items on this page",
-          "type": {
-            "$id": "306",
-            "kind": "array",
-            "name": "ArrayItem",
-            "valueType": {
-              "$ref": "274"
-            },
-            "crossLanguageDefinitionId": "TypeSpec.Array",
-            "decorators": []
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
-          "serializationOptions": {
-            "json": {
-              "name": "value"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "307",
-          "kind": "property",
-          "name": "nextLink",
-          "serializedName": "nextLink",
-          "doc": "The link to the next page of items",
-          "type": {
-            "$id": "308",
-            "kind": "url",
-            "name": "ResourceLocation",
-            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
-            "baseType": {
-              "$id": "309",
-              "kind": "url",
-              "name": "url",
-              "crossLanguageDefinitionId": "TypeSpec.url",
-              "decorators": []
-            },
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
-          "serializationOptions": {
-            "json": {
-              "name": "nextLink"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
-    },
-    {
-      "$id": "310",
+      "$id": "216",
       "kind": "model",
       "name": "Profile",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4310,17 +2886,17 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$ref": "259"
+        "$ref": "180"
       },
       "properties": [
         {
-          "$id": "311",
+          "$id": "217",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "312",
+            "$id": "218",
             "kind": "model",
             "name": "ProfileProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4341,13 +2917,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "313",
+                "$id": "219",
                 "kind": "property",
                 "name": "description",
                 "serializedName": "description",
                 "doc": "A scalar property that should land on the parent Profile resource\nafter flattening, and stay on `ProfileProperties` itself for the\nstandalone model.",
                 "type": {
-                  "$id": "314",
+                  "$id": "220",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4368,13 +2944,13 @@
                 "isExactName": false
               },
               {
-                "$id": "315",
+                "$id": "221",
                 "kind": "property",
                 "name": "sku",
                 "serializedName": "sku",
                 "doc": "A SKU sub-property.",
                 "type": {
-                  "$id": "316",
+                  "$id": "222",
                   "kind": "model",
                   "name": "ProfileSku",
                   "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4395,13 +2971,13 @@
                   "isExactName": false,
                   "properties": [
                     {
-                      "$id": "317",
+                      "$id": "223",
                       "kind": "property",
                       "name": "name",
                       "serializedName": "name",
                       "doc": "The SKU name.",
                       "type": {
-                        "$id": "318",
+                        "$id": "224",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4459,13 +3035,13 @@
           "isExactName": false
         },
         {
-          "$id": "319",
+          "$id": "225",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the Profile",
           "type": {
-            "$id": "320",
+            "$id": "226",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4495,100 +3071,13 @@
       ]
     },
     {
-      "$ref": "312"
+      "$ref": "218"
     },
     {
-      "$ref": "316"
+      "$ref": "222"
     },
     {
-      "$id": "321",
-      "kind": "model",
-      "name": "ProfileListResult",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
-      "usage": "Output,Json",
-      "doc": "The response of a Profile list operation.",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "ResourceListResult"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "322",
-          "kind": "property",
-          "name": "value",
-          "serializedName": "value",
-          "doc": "The Profile items on this page",
-          "type": {
-            "$id": "323",
-            "kind": "array",
-            "name": "ArrayProfile",
-            "valueType": {
-              "$ref": "310"
-            },
-            "crossLanguageDefinitionId": "TypeSpec.Array",
-            "decorators": []
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
-          "serializationOptions": {
-            "json": {
-              "name": "value"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "324",
-          "kind": "property",
-          "name": "nextLink",
-          "serializedName": "nextLink",
-          "doc": "The link to the next page of items",
-          "type": {
-            "$id": "325",
-            "kind": "url",
-            "name": "ResourceLocation",
-            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
-            "baseType": {
-              "$id": "326",
-              "kind": "url",
-              "name": "url",
-              "crossLanguageDefinitionId": "TypeSpec.url",
-              "decorators": []
-            },
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
-          "serializationOptions": {
-            "json": {
-              "name": "nextLink"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
-    },
-    {
-      "$id": "327",
+      "$id": "227",
       "kind": "model",
       "name": "ExtensionAssignment",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4612,7 +3101,7 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$id": "328",
+        "$id": "228",
         "kind": "model",
         "name": "ExtensionResource",
         "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4632,19 +3121,19 @@
         },
         "isExactName": false,
         "baseModel": {
-          "$ref": "165"
+          "$ref": "107"
         },
         "properties": []
       },
       "properties": [
         {
-          "$id": "329",
+          "$id": "229",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "330",
+            "$id": "230",
             "kind": "model",
             "name": "ExtensionAssignmentProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4665,13 +3154,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "331",
+                "$id": "231",
                 "kind": "property",
                 "name": "displayName",
                 "serializedName": "displayName",
                 "doc": "The display name of the assignment.",
                 "type": {
-                  "$id": "332",
+                  "$id": "232",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4708,13 +3197,13 @@
           "isExactName": false
         },
         {
-          "$id": "333",
+          "$id": "233",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the ExtensionAssignment",
           "type": {
-            "$id": "334",
+            "$id": "234",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4744,13 +3233,13 @@
       ]
     },
     {
-      "$ref": "330"
+      "$ref": "230"
     },
     {
-      "$ref": "328"
+      "$ref": "228"
     },
     {
-      "$id": "335",
+      "$id": "235",
       "kind": "model",
       "name": "SingletonSetting",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4784,17 +3273,17 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$ref": "259"
+        "$ref": "180"
       },
       "properties": [
         {
-          "$id": "336",
+          "$id": "236",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "337",
+            "$id": "237",
             "kind": "model",
             "name": "SingletonSettingProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4815,13 +3304,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "338",
+                "$id": "238",
                 "kind": "property",
                 "name": "enabled",
                 "serializedName": "enabled",
                 "doc": "Indicates whether the singleton setting is enabled.",
                 "type": {
-                  "$id": "339",
+                  "$id": "239",
                   "kind": "boolean",
                   "name": "boolean",
                   "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -4858,13 +3347,13 @@
           "isExactName": false
         },
         {
-          "$id": "340",
+          "$id": "240",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the SingletonSetting",
           "type": {
-            "$id": "341",
+            "$id": "241",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4894,10 +3383,10 @@
       ]
     },
     {
-      "$ref": "337"
+      "$ref": "237"
     },
     {
-      "$id": "342",
+      "$id": "242",
       "kind": "model",
       "name": "ConfigurationStorePrivateLinkResource",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4924,17 +3413,17 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$ref": "165"
+        "$ref": "107"
       },
       "properties": [
         {
-          "$id": "343",
+          "$id": "243",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "Resource properties.",
           "type": {
-            "$id": "344",
+            "$id": "244",
             "kind": "model",
             "name": "PrivateLinkResourceProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4955,13 +3444,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "345",
+                "$id": "245",
                 "kind": "property",
                 "name": "groupId",
                 "serializedName": "groupId",
                 "doc": "The private link resource group id.",
                 "type": {
-                  "$id": "346",
+                  "$id": "246",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4982,17 +3471,17 @@
                 "isExactName": false
               },
               {
-                "$id": "347",
+                "$id": "247",
                 "kind": "property",
                 "name": "requiredMembers",
                 "serializedName": "requiredMembers",
                 "doc": "The private link resource required member names.",
                 "type": {
-                  "$id": "348",
+                  "$id": "248",
                   "kind": "array",
                   "name": "Array",
                   "valueType": {
-                    "$id": "349",
+                    "$id": "249",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5016,13 +3505,13 @@
                 "isExactName": false
               },
               {
-                "$id": "350",
+                "$id": "250",
                 "kind": "property",
                 "name": "requiredZoneNames",
                 "serializedName": "requiredZoneNames",
                 "doc": "The private link resource private link DNS zone name.",
                 "type": {
-                  "$ref": "348"
+                  "$ref": "248"
                 },
                 "optional": true,
                 "readOnly": false,
@@ -5057,99 +3546,12 @@
       ]
     },
     {
-      "$ref": "344"
-    },
-    {
-      "$id": "351",
-      "kind": "model",
-      "name": "ConfigurationStorePrivateLinkResourceListResult",
-      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
-      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
-      "usage": "Output,Json",
-      "doc": "The response of a ConfigurationStorePrivateLinkResource list operation.",
-      "decorators": [
-        {
-          "name": "Azure.ResourceManager.@armProviderNamespace",
-          "arguments": {}
-        }
-      ],
-      "serializationOptions": {
-        "json": {
-          "name": "ResourceListResult"
-        }
-      },
-      "isExactName": false,
-      "properties": [
-        {
-          "$id": "352",
-          "kind": "property",
-          "name": "value",
-          "serializedName": "value",
-          "doc": "The ConfigurationStorePrivateLinkResource items on this page",
-          "type": {
-            "$id": "353",
-            "kind": "array",
-            "name": "ArrayConfigurationStorePrivateLinkResource",
-            "valueType": {
-              "$ref": "342"
-            },
-            "crossLanguageDefinitionId": "TypeSpec.Array",
-            "decorators": []
-          },
-          "optional": false,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
-          "serializationOptions": {
-            "json": {
-              "name": "value"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        },
-        {
-          "$id": "354",
-          "kind": "property",
-          "name": "nextLink",
-          "serializedName": "nextLink",
-          "doc": "The link to the next page of items",
-          "type": {
-            "$id": "355",
-            "kind": "url",
-            "name": "ResourceLocation",
-            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
-            "baseType": {
-              "$id": "356",
-              "kind": "url",
-              "name": "url",
-              "crossLanguageDefinitionId": "TypeSpec.url",
-              "decorators": []
-            },
-            "decorators": []
-          },
-          "optional": true,
-          "readOnly": false,
-          "discriminator": false,
-          "flatten": false,
-          "decorators": [],
-          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
-          "serializationOptions": {
-            "json": {
-              "name": "nextLink"
-            }
-          },
-          "isHttpMetadata": false,
-          "isExactName": false
-        }
-      ]
+      "$ref": "244"
     }
   ],
   "clients": [
     {
-      "$id": "357",
+      "$id": "251",
       "kind": "client",
       "name": "ProvisioningTypeSpecClient",
       "isExactName": false,
@@ -5157,13 +3559,13 @@
       "methods": [],
       "parameters": [
         {
-          "$id": "358",
+          "$id": "252",
           "kind": "endpoint",
           "name": "endpoint",
           "serializedName": "endpoint",
           "doc": "Service host",
           "type": {
-            "$id": "359",
+            "$id": "253",
             "kind": "url",
             "name": "endpoint",
             "crossLanguageDefinitionId": "TypeSpec.url"
@@ -5174,7 +3576,7 @@
           "isEndpoint": true,
           "defaultValue": {
             "type": {
-              "$id": "360",
+              "$id": "254",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5188,13 +3590,13 @@
           "isExactName": false
         },
         {
-          "$id": "361",
+          "$id": "255",
           "kind": "method",
           "name": "apiVersion",
           "serializedName": "apiVersion",
           "doc": "The API version to use for this operation.",
           "type": {
-            "$id": "362",
+            "$id": "256",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5204,7 +3606,7 @@
           "isApiVersion": true,
           "defaultValue": {
             "type": {
-              "$id": "363",
+              "$id": "257",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5245,72 +3647,72 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores",
                 "methods": [
                   {
-                    "$id": "364",
+                    "$id": "258",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                     "scope": {
-                      "$id": "365",
+                      "$id": "259",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "366",
+                    "$id": "260",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                     "scope": {
-                      "$id": "367",
+                      "$id": "261",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "368",
+                    "$id": "262",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.update",
                     "kind": "Update",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                     "scope": {
-                      "$id": "369",
+                      "$id": "263",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "370",
+                    "$id": "264",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.delete",
                     "kind": "Delete",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                     "scope": {
-                      "$id": "371",
+                      "$id": "265",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "372",
+                    "$id": "266",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores",
                     "scope": {
-                      "$id": "373",
+                      "$id": "267",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "374",
+                    "$id": "268",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/providers/ProvisioningTypeSpec/configurationStores",
                     "scope": {
-                      "$id": "375",
+                      "$id": "269",
                       "kind": "Subscription",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}",
                       "scopeResourceType": "Microsoft.Resources/subscriptions"
@@ -5318,7 +3720,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "376",
+                  "$id": "270",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5353,48 +3755,48 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/keyValues",
                 "methods": [
                   {
-                    "$id": "377",
+                    "$id": "271",
                     "methodId": "ProvisioningTypeSpec.KeyValues.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
                     "scope": {
-                      "$id": "378",
+                      "$id": "272",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "379",
+                    "$id": "273",
                     "methodId": "ProvisioningTypeSpec.KeyValues.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
                     "scope": {
-                      "$id": "380",
+                      "$id": "274",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "381",
+                    "$id": "275",
                     "methodId": "ProvisioningTypeSpec.KeyValues.delete",
                     "kind": "Delete",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
                     "scope": {
-                      "$id": "382",
+                      "$id": "276",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "383",
+                    "$id": "277",
                     "methodId": "ProvisioningTypeSpec.KeyValues.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues",
                     "scope": {
-                      "$id": "384",
+                      "$id": "278",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5402,7 +3804,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "385",
+                  "$id": "279",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5425,36 +3827,36 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/items",
                 "methods": [
                   {
-                    "$id": "386",
+                    "$id": "280",
                     "methodId": "ProvisioningTypeSpec.Items.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
                     "scope": {
-                      "$id": "387",
+                      "$id": "281",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "388",
+                    "$id": "282",
                     "methodId": "ProvisioningTypeSpec.Items.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
                     "scope": {
-                      "$id": "389",
+                      "$id": "283",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "390",
+                    "$id": "284",
                     "methodId": "ProvisioningTypeSpec.Items.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items",
                     "scope": {
-                      "$id": "391",
+                      "$id": "285",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5462,7 +3864,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "392",
+                  "$id": "286",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5485,48 +3887,48 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/profiles",
                 "methods": [
                   {
-                    "$id": "393",
+                    "$id": "287",
                     "methodId": "ProvisioningTypeSpec.Profiles.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
                     "scope": {
-                      "$id": "394",
+                      "$id": "288",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "395",
+                    "$id": "289",
                     "methodId": "ProvisioningTypeSpec.Profiles.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
                     "scope": {
-                      "$id": "396",
+                      "$id": "290",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "397",
+                    "$id": "291",
                     "methodId": "ProvisioningTypeSpec.Profiles.delete",
                     "kind": "Delete",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
                     "scope": {
-                      "$id": "398",
+                      "$id": "292",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "399",
+                    "$id": "293",
                     "methodId": "ProvisioningTypeSpec.Profiles.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles",
                     "scope": {
-                      "$id": "400",
+                      "$id": "294",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5534,7 +3936,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "401",
+                  "$id": "295",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5557,12 +3959,12 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/profiles/revisions",
                 "methods": [
                   {
-                    "$id": "402",
+                    "$id": "296",
                     "methodId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}/revisions/{revisionNumber}",
                     "scope": {
-                      "$id": "403",
+                      "$id": "297",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}/revisions/{revisionNumber}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5570,7 +3972,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "404",
+                  "$id": "298",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5593,30 +3995,30 @@
                 "resourceType": "ProvisioningTypeSpec/extensionAssignments",
                 "methods": [
                   {
-                    "$id": "405",
+                    "$id": "299",
                     "methodId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}",
                     "scope": {
-                      "$id": "406",
+                      "$id": "300",
                       "kind": "Extension",
                       "scopeIdPattern": "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}"
                     }
                   },
                   {
-                    "$id": "407",
+                    "$id": "301",
                     "methodId": "ProvisioningTypeSpec.ExtensionAssignments.get",
                     "kind": "Read",
                     "operationPath": "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}",
                     "scope": {
-                      "$id": "408",
+                      "$id": "302",
                       "kind": "Extension",
                       "scopeIdPattern": "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}"
                     }
                   }
                 ],
                 "scope": {
-                  "$id": "409",
+                  "$id": "303",
                   "kind": "Extension",
                   "scopeIdPattern": "/{scope}"
                 },
@@ -5635,24 +4037,24 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/settings",
                 "methods": [
                   {
-                    "$id": "410",
+                    "$id": "304",
                     "methodId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default",
                     "scope": {
-                      "$id": "411",
+                      "$id": "305",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "412",
+                    "$id": "306",
                     "methodId": "ProvisioningTypeSpec.SingletonSettings.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default",
                     "scope": {
-                      "$id": "413",
+                      "$id": "307",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5660,7 +4062,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "414",
+                  "$id": "308",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5684,24 +4086,24 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/privateLinkResources",
                 "methods": [
                   {
-                    "$id": "415",
+                    "$id": "309",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/privateLinkResources/{privateLinkResourceName}",
                     "scope": {
-                      "$id": "416",
+                      "$id": "310",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/privateLinkResources/{privateLinkResourceName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "417",
+                    "$id": "311",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/privateLinkResources",
                     "scope": {
-                      "$id": "418",
+                      "$id": "312",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5709,7 +4111,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "419",
+                  "$id": "313",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5730,11 +4132,168 @@
                 "methodId": "Azure.ResourceManager.Operations.list",
                 "operationPath": "/providers/ProvisioningTypeSpec/operations",
                 "scope": {
-                  "$id": "420",
+                  "$id": "314",
                   "kind": "Tenant",
                   "scopeIdPattern": "",
                   "scopeResourceType": "Microsoft.Resources/tenants"
                 }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Azure.ClientGenerator.Core.@provisioningProviderSchema",
+          "arguments": {
+            "resourceProjections": [
+              {
+                "resourceIdPatterns": [
+                  "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}"
+                ]
+              },
+              {
+                "resourceIdPatterns": [
+                  "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}"
+                ]
+              },
+              {
+                "resourceIdPatterns": [
+                  "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}"
+                ]
+              },
+              {
+                "resourceIdPatterns": [
+                  "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}"
+                ]
+              },
+              {
+                "resourceIdPatterns": [
+                  "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}/revisions/{revisionNumber}"
+                ]
+              },
+              {
+                "resourceIdPatterns": [
+                  "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}"
+                ]
+              },
+              {
+                "resourceIdPatterns": [
+                  "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default"
+                ]
+              },
+              {
+                "resourceIdPatterns": [
+                  "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/privateLinkResources/{privateLinkResourceName}"
+                ]
+              }
+            ],
+            "modelSettableUsage": [
+              {
+                "modelId": "ProvisioningTypeSpec.ConfigurationStore",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.KeyValue",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.Item",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.Profile",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ExtensionAssignment",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.SingletonSetting",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResource",
+                "isSettable": false
+              },
+              {
+                "modelId": "Azure.ResourceManager.CommonTypes.TrackedResource",
+                "isSettable": true
+              },
+              {
+                "modelId": "Azure.ResourceManager.CommonTypes.SystemData",
+                "isSettable": false
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ConfigurationStoreProperties",
+                "isSettable": true
+              },
+              {
+                "modelId": "Azure.ResourceManager.CommonTypes.ProxyResource",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.KeyValueProperties",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ItemProperties",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ProfileProperties",
+                "isSettable": true
+              },
+              {
+                "modelId": "Azure.ResourceManager.CommonTypes.ExtensionResource",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ExtensionAssignmentProperties",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.SingletonSettingProperties",
+                "isSettable": true
+              },
+              {
+                "modelId": "Azure.ResourceManager.CommonTypes.Resource",
+                "isSettable": true
+              },
+              {
+                "modelId": "Azure.ResourceManager.CommonTypes.PrivateLinkResourceProperties",
+                "isSettable": false
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ConfigurationStoreSku",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.BackupPolicy",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ItemAttributes",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ProfileSku",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.PeriodicBackupPolicy",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.ContinuousBackupPolicy",
+                "isSettable": true
+              },
+              {
+                "modelId": "Azure.ResourceManager.Models.SubResource",
+                "isSettable": true
+              },
+              {
+                "modelId": "ProvisioningTypeSpec.BaseItemAttributes",
+                "isSettable": true
               }
             ]
           }
@@ -5748,14 +4307,14 @@
       ],
       "children": [
         {
-          "$id": "421",
+          "$id": "315",
           "kind": "client",
           "name": "Operations",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "422",
+              "$id": "316",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -5767,7 +4326,7 @@
               ],
               "doc": "List the operations for the provider",
               "operation": {
-                "$id": "423",
+                "$id": "317",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "Operations",
@@ -5775,13 +4334,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "424",
+                    "$id": "318",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "425",
+                      "$id": "319",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5791,7 +4350,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "426",
+                        "$id": "320",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5814,18 +4373,18 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "361"
+                        "$ref": "255"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "427",
+                    "$id": "321",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "48"
+                      "$ref": "31"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -5836,12 +4395,12 @@
                     "crossLanguageDefinitionId": "Azure.ResourceManager.Operations.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "428",
+                        "$id": "322",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "48"
+                          "$ref": "31"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -5863,7 +4422,461 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "122"
+                      "$id": "323",
+                      "kind": "model",
+                      "name": "OperationListResult",
+                      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                      "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationListResult",
+                      "usage": "Output,Json",
+                      "doc": "A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get the next set of results.",
+                      "decorators": [
+                        {
+                          "name": "Azure.ResourceManager.@armProviderNamespace",
+                          "arguments": {}
+                        }
+                      ],
+                      "serializationOptions": {
+                        "json": {
+                          "name": "OperationListResult"
+                        }
+                      },
+                      "isExactName": false,
+                      "properties": [
+                        {
+                          "$id": "324",
+                          "kind": "property",
+                          "name": "value",
+                          "serializedName": "value",
+                          "doc": "The Operation items on this page",
+                          "type": {
+                            "$id": "325",
+                            "kind": "array",
+                            "name": "ArrayOperation",
+                            "valueType": {
+                              "$id": "326",
+                              "kind": "model",
+                              "name": "Operation",
+                              "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                              "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation",
+                              "usage": "Output,Json",
+                              "doc": "Details of a REST API operation, returned from the Resource Provider Operations API",
+                              "summary": "REST API Operation",
+                              "decorators": [
+                                {
+                                  "name": "Azure.ResourceManager.@armProviderNamespace",
+                                  "arguments": {}
+                                }
+                              ],
+                              "serializationOptions": {
+                                "json": {
+                                  "name": "Operation"
+                                }
+                              },
+                              "isExactName": false,
+                              "properties": [
+                                {
+                                  "$id": "327",
+                                  "kind": "property",
+                                  "name": "name",
+                                  "serializedName": "name",
+                                  "doc": "The name of the operation, as per Resource-Based Access Control (RBAC). Examples: \"Microsoft.Compute/virtualMachines/write\", \"Microsoft.Compute/virtualMachines/capture/action\"",
+                                  "type": {
+                                    "$id": "328",
+                                    "kind": "string",
+                                    "name": "string",
+                                    "crossLanguageDefinitionId": "TypeSpec.string",
+                                    "decorators": []
+                                  },
+                                  "optional": true,
+                                  "readOnly": true,
+                                  "discriminator": false,
+                                  "flatten": false,
+                                  "decorators": [],
+                                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.name",
+                                  "serializationOptions": {
+                                    "json": {
+                                      "name": "name"
+                                    }
+                                  },
+                                  "isHttpMetadata": false,
+                                  "isExactName": false
+                                },
+                                {
+                                  "$id": "329",
+                                  "kind": "property",
+                                  "name": "isDataAction",
+                                  "serializedName": "isDataAction",
+                                  "doc": "Whether the operation applies to data-plane. This is \"true\" for data-plane operations and \"false\" for Azure Resource Manager/control-plane operations.",
+                                  "type": {
+                                    "$id": "330",
+                                    "kind": "boolean",
+                                    "name": "boolean",
+                                    "crossLanguageDefinitionId": "TypeSpec.boolean",
+                                    "decorators": []
+                                  },
+                                  "optional": true,
+                                  "readOnly": true,
+                                  "discriminator": false,
+                                  "flatten": false,
+                                  "decorators": [],
+                                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.isDataAction",
+                                  "serializationOptions": {
+                                    "json": {
+                                      "name": "isDataAction"
+                                    }
+                                  },
+                                  "isHttpMetadata": false,
+                                  "isExactName": false
+                                },
+                                {
+                                  "$id": "331",
+                                  "kind": "property",
+                                  "name": "display",
+                                  "serializedName": "display",
+                                  "doc": "Localized display information for this particular operation.",
+                                  "type": {
+                                    "$id": "332",
+                                    "kind": "model",
+                                    "name": "OperationDisplay",
+                                    "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                                    "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay",
+                                    "usage": "Output,Json",
+                                    "doc": "Localized display information for an operation.",
+                                    "decorators": [
+                                      {
+                                        "name": "Azure.ResourceManager.@armProviderNamespace",
+                                        "arguments": {}
+                                      }
+                                    ],
+                                    "serializationOptions": {
+                                      "json": {
+                                        "name": "OperationDisplay"
+                                      }
+                                    },
+                                    "isExactName": false,
+                                    "properties": [
+                                      {
+                                        "$id": "333",
+                                        "kind": "property",
+                                        "name": "provider",
+                                        "serializedName": "provider",
+                                        "doc": "The localized friendly form of the resource provider name, e.g. \"Microsoft Monitoring Insights\" or \"Microsoft Compute\".",
+                                        "type": {
+                                          "$id": "334",
+                                          "kind": "string",
+                                          "name": "string",
+                                          "crossLanguageDefinitionId": "TypeSpec.string",
+                                          "decorators": []
+                                        },
+                                        "optional": true,
+                                        "readOnly": true,
+                                        "discriminator": false,
+                                        "flatten": false,
+                                        "decorators": [],
+                                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay.provider",
+                                        "serializationOptions": {
+                                          "json": {
+                                            "name": "provider"
+                                          }
+                                        },
+                                        "isHttpMetadata": false,
+                                        "isExactName": false
+                                      },
+                                      {
+                                        "$id": "335",
+                                        "kind": "property",
+                                        "name": "resource",
+                                        "serializedName": "resource",
+                                        "doc": "The localized friendly name of the resource type related to this operation. E.g. \"Virtual Machines\" or \"Job Schedule Collections\".",
+                                        "type": {
+                                          "$id": "336",
+                                          "kind": "string",
+                                          "name": "string",
+                                          "crossLanguageDefinitionId": "TypeSpec.string",
+                                          "decorators": []
+                                        },
+                                        "optional": true,
+                                        "readOnly": true,
+                                        "discriminator": false,
+                                        "flatten": false,
+                                        "decorators": [],
+                                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay.resource",
+                                        "serializationOptions": {
+                                          "json": {
+                                            "name": "resource"
+                                          }
+                                        },
+                                        "isHttpMetadata": false,
+                                        "isExactName": false
+                                      },
+                                      {
+                                        "$id": "337",
+                                        "kind": "property",
+                                        "name": "operation",
+                                        "serializedName": "operation",
+                                        "doc": "The concise, localized friendly name for the operation; suitable for dropdowns. E.g. \"Create or Update Virtual Machine\", \"Restart Virtual Machine\".",
+                                        "type": {
+                                          "$id": "338",
+                                          "kind": "string",
+                                          "name": "string",
+                                          "crossLanguageDefinitionId": "TypeSpec.string",
+                                          "decorators": []
+                                        },
+                                        "optional": true,
+                                        "readOnly": true,
+                                        "discriminator": false,
+                                        "flatten": false,
+                                        "decorators": [],
+                                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay.operation",
+                                        "serializationOptions": {
+                                          "json": {
+                                            "name": "operation"
+                                          }
+                                        },
+                                        "isHttpMetadata": false,
+                                        "isExactName": false
+                                      },
+                                      {
+                                        "$id": "339",
+                                        "kind": "property",
+                                        "name": "description",
+                                        "serializedName": "description",
+                                        "doc": "The short, localized friendly description of the operation; suitable for tool tips and detailed views.",
+                                        "type": {
+                                          "$id": "340",
+                                          "kind": "string",
+                                          "name": "string",
+                                          "crossLanguageDefinitionId": "TypeSpec.string",
+                                          "decorators": []
+                                        },
+                                        "optional": true,
+                                        "readOnly": true,
+                                        "discriminator": false,
+                                        "flatten": false,
+                                        "decorators": [],
+                                        "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationDisplay.description",
+                                        "serializationOptions": {
+                                          "json": {
+                                            "name": "description"
+                                          }
+                                        },
+                                        "isHttpMetadata": false,
+                                        "isExactName": false
+                                      }
+                                    ]
+                                  },
+                                  "optional": true,
+                                  "readOnly": false,
+                                  "discriminator": false,
+                                  "flatten": false,
+                                  "decorators": [],
+                                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.display",
+                                  "serializationOptions": {
+                                    "json": {
+                                      "name": "display"
+                                    }
+                                  },
+                                  "isHttpMetadata": false,
+                                  "isExactName": false
+                                },
+                                {
+                                  "$id": "341",
+                                  "kind": "property",
+                                  "name": "origin",
+                                  "serializedName": "origin",
+                                  "doc": "The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is \"user,system\"",
+                                  "type": {
+                                    "$id": "342",
+                                    "kind": "enum",
+                                    "name": "Origin",
+                                    "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Origin",
+                                    "valueType": {
+                                      "$id": "343",
+                                      "kind": "string",
+                                      "name": "string",
+                                      "crossLanguageDefinitionId": "TypeSpec.string",
+                                      "decorators": []
+                                    },
+                                    "values": [
+                                      {
+                                        "$id": "344",
+                                        "kind": "enumvalue",
+                                        "name": "user",
+                                        "value": "user",
+                                        "valueType": {
+                                          "$ref": "343"
+                                        },
+                                        "enumType": {
+                                          "$ref": "342"
+                                        },
+                                        "doc": "Indicates the operation is initiated by a user.",
+                                        "decorators": [],
+                                        "isExactName": false
+                                      },
+                                      {
+                                        "$id": "345",
+                                        "kind": "enumvalue",
+                                        "name": "system",
+                                        "value": "system",
+                                        "valueType": {
+                                          "$ref": "343"
+                                        },
+                                        "enumType": {
+                                          "$ref": "342"
+                                        },
+                                        "doc": "Indicates the operation is initiated by a system.",
+                                        "decorators": [],
+                                        "isExactName": false
+                                      },
+                                      {
+                                        "$id": "346",
+                                        "kind": "enumvalue",
+                                        "name": "user,system",
+                                        "value": "user,system",
+                                        "valueType": {
+                                          "$ref": "343"
+                                        },
+                                        "enumType": {
+                                          "$ref": "342"
+                                        },
+                                        "doc": "Indicates the operation is initiated by a user or system.",
+                                        "decorators": [],
+                                        "isExactName": false
+                                      }
+                                    ],
+                                    "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                                    "doc": "The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is \"user,system\"",
+                                    "isFixed": false,
+                                    "isFlags": false,
+                                    "usage": "Output,Json",
+                                    "decorators": [],
+                                    "isExactName": false
+                                  },
+                                  "optional": true,
+                                  "readOnly": true,
+                                  "discriminator": false,
+                                  "flatten": false,
+                                  "decorators": [],
+                                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.origin",
+                                  "serializationOptions": {
+                                    "json": {
+                                      "name": "origin"
+                                    }
+                                  },
+                                  "isHttpMetadata": false,
+                                  "isExactName": false
+                                },
+                                {
+                                  "$id": "347",
+                                  "kind": "property",
+                                  "name": "actionType",
+                                  "serializedName": "actionType",
+                                  "doc": "Extensible enum. Indicates the action type. \"Internal\" refers to actions that are for internal only APIs.",
+                                  "type": {
+                                    "$id": "348",
+                                    "kind": "enum",
+                                    "name": "ActionType",
+                                    "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ActionType",
+                                    "valueType": {
+                                      "$id": "349",
+                                      "kind": "string",
+                                      "name": "string",
+                                      "crossLanguageDefinitionId": "TypeSpec.string",
+                                      "decorators": []
+                                    },
+                                    "values": [
+                                      {
+                                        "$id": "350",
+                                        "kind": "enumvalue",
+                                        "name": "Internal",
+                                        "value": "Internal",
+                                        "valueType": {
+                                          "$ref": "349"
+                                        },
+                                        "enumType": {
+                                          "$ref": "348"
+                                        },
+                                        "doc": "Actions are for internal-only APIs.",
+                                        "decorators": [],
+                                        "isExactName": false
+                                      }
+                                    ],
+                                    "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                                    "doc": "Extensible enum. Indicates the action type. \"Internal\" refers to actions that are for internal only APIs.",
+                                    "isFixed": false,
+                                    "isFlags": false,
+                                    "usage": "Output,Json",
+                                    "decorators": [],
+                                    "isExactName": false
+                                  },
+                                  "optional": true,
+                                  "readOnly": true,
+                                  "discriminator": false,
+                                  "flatten": false,
+                                  "decorators": [],
+                                  "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.Operation.actionType",
+                                  "serializationOptions": {
+                                    "json": {
+                                      "name": "actionType"
+                                    }
+                                  },
+                                  "isHttpMetadata": false,
+                                  "isExactName": false
+                                }
+                              ]
+                            },
+                            "crossLanguageDefinitionId": "TypeSpec.Array",
+                            "decorators": []
+                          },
+                          "optional": false,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationListResult.value",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "value"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        },
+                        {
+                          "$id": "351",
+                          "kind": "property",
+                          "name": "nextLink",
+                          "serializedName": "nextLink",
+                          "doc": "The link to the next page of items",
+                          "type": {
+                            "$id": "352",
+                            "kind": "url",
+                            "name": "ResourceLocation",
+                            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
+                            "baseType": {
+                              "$id": "353",
+                              "kind": "url",
+                              "name": "url",
+                              "crossLanguageDefinitionId": "TypeSpec.url",
+                              "decorators": []
+                            },
+                            "decorators": []
+                          },
+                          "optional": true,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.OperationListResult.nextLink",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "nextLink"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        }
+                      ]
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -5889,12 +4902,12 @@
               },
               "parameters": [
                 {
-                  "$ref": "428"
+                  "$ref": "322"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "124"
+                  "$ref": "325"
                 },
                 "resultSegments": [
                   "value"
@@ -5920,13 +4933,13 @@
           ],
           "parameters": [
             {
-              "$id": "429",
+              "$id": "354",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "430",
+                "$id": "355",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -5937,7 +4950,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "431",
+                  "$id": "356",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5951,7 +4964,7 @@
               "isExactName": false
             },
             {
-              "$ref": "361"
+              "$ref": "255"
             }
           ],
           "initializedBy": 0,
@@ -5963,19 +4976,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "432",
+          "$id": "357",
           "kind": "client",
           "name": "ConfigurationStores",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "433",
+              "$id": "358",
               "kind": "lro",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -5987,7 +5000,7 @@
               ],
               "doc": "Create a ConfigurationStore",
               "operation": {
-                "$id": "434",
+                "$id": "359",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -5995,13 +5008,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "435",
+                    "$id": "360",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "436",
+                      "$id": "361",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6011,7 +5024,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "437",
+                        "$id": "362",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6034,13 +5047,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "438",
+                        "$id": "363",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "439",
+                          "$id": "364",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6050,7 +5063,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "440",
+                            "$id": "365",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6078,18 +5091,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "441",
+                    "$id": "366",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "442",
+                      "$id": "367",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "443",
+                        "$id": "368",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6118,18 +5131,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "444",
+                        "$id": "369",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "445",
+                          "$id": "370",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "446",
+                            "$id": "371",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6160,13 +5173,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "447",
+                    "$id": "372",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "448",
+                      "$id": "373",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6207,13 +5220,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "449",
+                        "$id": "374",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "450",
+                          "$id": "375",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6256,13 +5269,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "451",
+                    "$id": "376",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "452",
+                      "$id": "377",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6287,13 +5300,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "453",
+                        "$id": "378",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "454",
+                          "$id": "379",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6320,13 +5333,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "455",
+                    "$id": "380",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "50"
+                      "$ref": "33"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -6337,13 +5350,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "456",
+                        "$id": "381",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "50"
+                          "$ref": "33"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -6359,12 +5372,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "457",
+                    "$id": "382",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "54"
+                      "$ref": "37"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -6375,12 +5388,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "458",
+                        "$id": "383",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "56"
+                          "$ref": "39"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -6396,13 +5409,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "459",
+                    "$id": "384",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "163"
+                      "$ref": "105"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -6416,13 +5429,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "460",
+                        "$id": "385",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "163"
+                          "$ref": "105"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -6449,7 +5462,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "163"
+                      "$ref": "105"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -6467,7 +5480,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "163"
+                      "$ref": "105"
                     },
                     "headers": [
                       {
@@ -6475,7 +5488,7 @@
                         "nameInResponse": "Azure-AsyncOperation",
                         "doc": "A link to the status monitor",
                         "type": {
-                          "$id": "461",
+                          "$id": "386",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6487,7 +5500,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "462",
+                          "$id": "387",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -6526,27 +5539,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "449"
+                  "$ref": "374"
                 },
                 {
-                  "$ref": "453"
+                  "$ref": "378"
                 },
                 {
-                  "$ref": "460"
+                  "$ref": "385"
                 },
                 {
-                  "$ref": "456"
+                  "$ref": "381"
                 },
                 {
-                  "$ref": "458"
+                  "$ref": "383"
                 },
                 {
-                  "$id": "463",
+                  "$id": "388",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "442"
+                    "$ref": "367"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -6559,7 +5572,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "163"
+                  "$ref": "105"
                 }
               },
               "isOverride": false,
@@ -6573,13 +5586,13 @@
                     200
                   ],
                   "bodyType": {
-                    "$ref": "163"
+                    "$ref": "105"
                   }
                 }
               }
             },
             {
-              "$id": "464",
+              "$id": "389",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -6591,7 +5604,7 @@
               ],
               "doc": "Get a ConfigurationStore",
               "operation": {
-                "$id": "465",
+                "$id": "390",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -6599,13 +5612,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "466",
+                    "$id": "391",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "467",
+                      "$id": "392",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6615,7 +5628,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "468",
+                        "$id": "393",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6638,24 +5651,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "438"
+                        "$ref": "363"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "469",
+                    "$id": "394",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "470",
+                      "$id": "395",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "471",
+                        "$id": "396",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6684,19 +5697,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "444"
+                        "$ref": "369"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "472",
+                    "$id": "397",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "473",
+                      "$id": "398",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6737,13 +5750,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "474",
+                        "$id": "399",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "475",
+                          "$id": "400",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6786,13 +5799,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "476",
+                    "$id": "401",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "477",
+                      "$id": "402",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6817,13 +5830,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "478",
+                        "$id": "403",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "479",
+                          "$id": "404",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6850,12 +5863,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "480",
+                    "$id": "405",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "58"
+                      "$ref": "41"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -6866,12 +5879,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "481",
+                        "$id": "406",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "58"
+                          "$ref": "41"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -6893,7 +5906,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "163"
+                      "$ref": "105"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -6924,21 +5937,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "474"
+                  "$ref": "399"
                 },
                 {
-                  "$ref": "478"
+                  "$ref": "403"
                 },
                 {
-                  "$ref": "481"
+                  "$ref": "406"
                 },
                 {
-                  "$id": "482",
+                  "$id": "407",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "470"
+                    "$ref": "395"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -6951,7 +5964,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "163"
+                  "$ref": "105"
                 }
               },
               "isOverride": false,
@@ -6960,7 +5973,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get"
             },
             {
-              "$id": "483",
+              "$id": "408",
               "kind": "lro",
               "name": "update",
               "isExactName": false,
@@ -6972,7 +5985,7 @@
               ],
               "doc": "Update a ConfigurationStore",
               "operation": {
-                "$id": "484",
+                "$id": "409",
                 "name": "update",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -6980,13 +5993,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "485",
+                    "$id": "410",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "486",
+                      "$id": "411",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6996,7 +6009,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "487",
+                        "$id": "412",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -7019,24 +6032,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "438"
+                        "$ref": "363"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "488",
+                    "$id": "413",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "489",
+                      "$id": "414",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "490",
+                        "$id": "415",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7065,19 +6078,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "444"
+                        "$ref": "369"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "491",
+                    "$id": "416",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "492",
+                      "$id": "417",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7118,13 +6131,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "493",
+                        "$id": "418",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "494",
+                          "$id": "419",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7167,13 +6180,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "495",
+                    "$id": "420",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "496",
+                      "$id": "421",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7198,13 +6211,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "497",
+                        "$id": "422",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "498",
+                          "$id": "423",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7231,13 +6244,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "499",
+                    "$id": "424",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "60"
+                      "$ref": "43"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -7248,13 +6261,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "500",
+                        "$id": "425",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "60"
+                          "$ref": "43"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -7270,12 +6283,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "501",
+                    "$id": "426",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "64"
+                      "$ref": "47"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -7286,12 +6299,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "502",
+                        "$id": "427",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "66"
+                          "$ref": "49"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -7307,13 +6320,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "503",
+                    "$id": "428",
                     "kind": "body",
                     "name": "properties",
                     "serializedName": "properties",
                     "doc": "The resource properties to be updated.",
                     "type": {
-                      "$ref": "163"
+                      "$ref": "105"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -7327,13 +6340,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.properties",
                     "methodParameterSegments": [
                       {
-                        "$id": "504",
+                        "$id": "429",
                         "kind": "method",
                         "name": "properties",
                         "serializedName": "properties",
                         "doc": "The resource properties to be updated.",
                         "type": {
-                          "$ref": "163"
+                          "$ref": "105"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -7360,7 +6373,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "163"
+                      "$ref": "105"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -7383,7 +6396,7 @@
                         "nameInResponse": "Location",
                         "doc": "The Location header contains the URL where the status of the long running operation can be checked.",
                         "type": {
-                          "$id": "505",
+                          "$id": "430",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7395,7 +6408,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "506",
+                          "$id": "431",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -7427,27 +6440,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "493"
+                  "$ref": "418"
                 },
                 {
-                  "$ref": "497"
+                  "$ref": "422"
                 },
                 {
-                  "$ref": "504"
+                  "$ref": "429"
                 },
                 {
-                  "$ref": "500"
+                  "$ref": "425"
                 },
                 {
-                  "$ref": "502"
+                  "$ref": "427"
                 },
                 {
-                  "$id": "507",
+                  "$id": "432",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "489"
+                    "$ref": "414"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -7460,7 +6473,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "163"
+                  "$ref": "105"
                 }
               },
               "isOverride": false,
@@ -7474,13 +6487,13 @@
                     200
                   ],
                   "bodyType": {
-                    "$ref": "163"
+                    "$ref": "105"
                   }
                 }
               }
             },
             {
-              "$id": "508",
+              "$id": "433",
               "kind": "lro",
               "name": "delete",
               "isExactName": false,
@@ -7492,7 +6505,7 @@
               ],
               "doc": "Delete a ConfigurationStore",
               "operation": {
-                "$id": "509",
+                "$id": "434",
                 "name": "delete",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -7500,13 +6513,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "510",
+                    "$id": "435",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "511",
+                      "$id": "436",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7516,7 +6529,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "512",
+                        "$id": "437",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -7539,24 +6552,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "438"
+                        "$ref": "363"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "513",
+                    "$id": "438",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "514",
+                      "$id": "439",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "515",
+                        "$id": "440",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7585,19 +6598,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "444"
+                        "$ref": "369"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "516",
+                    "$id": "441",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "517",
+                      "$id": "442",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7638,13 +6651,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "518",
+                        "$id": "443",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "519",
+                          "$id": "444",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7687,13 +6700,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "520",
+                    "$id": "445",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "521",
+                      "$id": "446",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7718,13 +6731,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "522",
+                        "$id": "447",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "523",
+                          "$id": "448",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7762,7 +6775,7 @@
                         "nameInResponse": "Location",
                         "doc": "The Location header contains the URL where the status of the long running operation can be checked.",
                         "type": {
-                          "$id": "524",
+                          "$id": "449",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7774,7 +6787,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "525",
+                          "$id": "450",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -7811,18 +6824,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "518"
+                  "$ref": "443"
                 },
                 {
-                  "$ref": "522"
+                  "$ref": "447"
                 },
                 {
-                  "$id": "526",
+                  "$id": "451",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "514"
+                    "$ref": "439"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -7848,7 +6861,7 @@
               }
             },
             {
-              "$id": "527",
+              "$id": "452",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -7860,7 +6873,7 @@
               ],
               "doc": "List ConfigurationStore resources by resource group",
               "operation": {
-                "$id": "528",
+                "$id": "453",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -7868,13 +6881,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "529",
+                    "$id": "454",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "530",
+                      "$id": "455",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7884,7 +6897,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "531",
+                        "$id": "456",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -7907,24 +6920,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "438"
+                        "$ref": "363"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "532",
+                    "$id": "457",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "533",
+                      "$id": "458",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "534",
+                        "$id": "459",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7953,19 +6966,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "444"
+                        "$ref": "369"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "535",
+                    "$id": "460",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "536",
+                      "$id": "461",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8006,13 +7019,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "537",
+                        "$id": "462",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "538",
+                          "$id": "463",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8055,12 +7068,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "539",
+                    "$id": "464",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "68"
+                      "$ref": "51"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -8071,12 +7084,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "540",
+                        "$id": "465",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "68"
+                          "$ref": "51"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -8098,7 +7111,91 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "252"
+                      "$id": "466",
+                      "kind": "model",
+                      "name": "ConfigurationStoreListResult",
+                      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
+                      "usage": "Output,Json",
+                      "doc": "The response of a ConfigurationStore list operation.",
+                      "decorators": [
+                        {
+                          "name": "Azure.ResourceManager.@armProviderNamespace",
+                          "arguments": {}
+                        }
+                      ],
+                      "serializationOptions": {
+                        "json": {
+                          "name": "ResourceListResult"
+                        }
+                      },
+                      "isExactName": false,
+                      "properties": [
+                        {
+                          "$id": "467",
+                          "kind": "property",
+                          "name": "value",
+                          "serializedName": "value",
+                          "doc": "The ConfigurationStore items on this page",
+                          "type": {
+                            "$id": "468",
+                            "kind": "array",
+                            "name": "ArrayConfigurationStore",
+                            "valueType": {
+                              "$ref": "105"
+                            },
+                            "crossLanguageDefinitionId": "TypeSpec.Array",
+                            "decorators": []
+                          },
+                          "optional": false,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "value"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        },
+                        {
+                          "$id": "469",
+                          "kind": "property",
+                          "name": "nextLink",
+                          "serializedName": "nextLink",
+                          "doc": "The link to the next page of items",
+                          "type": {
+                            "$id": "470",
+                            "kind": "url",
+                            "name": "ResourceLocation",
+                            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
+                            "baseType": {
+                              "$id": "471",
+                              "kind": "url",
+                              "name": "url",
+                              "crossLanguageDefinitionId": "TypeSpec.url",
+                              "decorators": []
+                            },
+                            "decorators": []
+                          },
+                          "optional": true,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "nextLink"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        }
+                      ]
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -8129,18 +7226,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "537"
+                  "$ref": "462"
                 },
                 {
-                  "$ref": "540"
+                  "$ref": "465"
                 },
                 {
-                  "$id": "541",
+                  "$id": "472",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "533"
+                    "$ref": "458"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -8153,7 +7250,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "254"
+                  "$ref": "468"
                 },
                 "resultSegments": [
                   "value"
@@ -8177,7 +7274,7 @@
               }
             },
             {
-              "$id": "542",
+              "$id": "473",
               "kind": "paging",
               "name": "listBySubscription",
               "isExactName": false,
@@ -8189,7 +7286,7 @@
               ],
               "doc": "List ConfigurationStore resources by subscription ID",
               "operation": {
-                "$id": "543",
+                "$id": "474",
                 "name": "listBySubscription",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -8197,13 +7294,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "544",
+                    "$id": "475",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "545",
+                      "$id": "476",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8213,7 +7310,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "546",
+                        "$id": "477",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8236,24 +7333,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "438"
+                        "$ref": "363"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "547",
+                    "$id": "478",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "548",
+                      "$id": "479",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "549",
+                        "$id": "480",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8282,18 +7379,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "444"
+                        "$ref": "369"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "550",
+                    "$id": "481",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "70"
+                      "$ref": "53"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -8304,12 +7401,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "551",
+                        "$id": "482",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "70"
+                          "$ref": "53"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -8331,7 +7428,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "252"
+                      "$ref": "466"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -8362,15 +7459,15 @@
               },
               "parameters": [
                 {
-                  "$ref": "551"
+                  "$ref": "482"
                 },
                 {
-                  "$id": "552",
+                  "$id": "483",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "548"
+                    "$ref": "479"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -8383,7 +7480,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "254"
+                  "$ref": "468"
                 },
                 "resultSegments": [
                   "value"
@@ -8409,13 +7506,13 @@
           ],
           "parameters": [
             {
-              "$id": "553",
+              "$id": "484",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "554",
+                "$id": "485",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -8426,7 +7523,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "555",
+                  "$id": "486",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8440,7 +7537,7 @@
               "isExactName": false
             },
             {
-              "$ref": "438"
+              "$ref": "363"
             }
           ],
           "initializedBy": 0,
@@ -8457,19 +7554,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "556",
+          "$id": "487",
           "kind": "client",
           "name": "KeyValues",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "557",
+              "$id": "488",
               "kind": "basic",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -8481,7 +7578,7 @@
               ],
               "doc": "Create a KeyValue",
               "operation": {
-                "$id": "558",
+                "$id": "489",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "KeyValue",
@@ -8489,13 +7586,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "559",
+                    "$id": "490",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "560",
+                      "$id": "491",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8505,7 +7602,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "561",
+                        "$id": "492",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8528,13 +7625,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "562",
+                        "$id": "493",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "563",
+                          "$id": "494",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8544,7 +7641,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "564",
+                            "$id": "495",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8572,18 +7669,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "565",
+                    "$id": "496",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "566",
+                      "$id": "497",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "567",
+                        "$id": "498",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8612,18 +7709,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "568",
+                        "$id": "499",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "569",
+                          "$id": "500",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "570",
+                            "$id": "501",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8654,13 +7751,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "571",
+                    "$id": "502",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "572",
+                      "$id": "503",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8701,13 +7798,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "573",
+                        "$id": "504",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "574",
+                          "$id": "505",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8750,13 +7847,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "575",
+                    "$id": "506",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "576",
+                      "$id": "507",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8781,13 +7878,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "577",
+                        "$id": "508",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "578",
+                          "$id": "509",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8814,13 +7911,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "579",
+                    "$id": "510",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "580",
+                      "$id": "511",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8845,13 +7942,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "581",
+                        "$id": "512",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "582",
+                          "$id": "513",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8878,13 +7975,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "583",
+                    "$id": "514",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "72"
+                      "$ref": "55"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -8895,13 +7992,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "584",
+                        "$id": "515",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "72"
+                          "$ref": "55"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -8917,12 +8014,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "585",
+                    "$id": "516",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "74"
+                      "$ref": "57"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -8933,12 +8030,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "586",
+                        "$id": "517",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "74"
+                          "$ref": "57"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -8954,13 +8051,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "587",
+                    "$id": "518",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "258"
+                      "$ref": "179"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -8974,13 +8071,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "588",
+                        "$id": "519",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "258"
+                          "$ref": "179"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -9007,7 +8104,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "258"
+                      "$ref": "179"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -9041,30 +8138,30 @@
               },
               "parameters": [
                 {
-                  "$ref": "573"
+                  "$ref": "504"
                 },
                 {
-                  "$ref": "577"
+                  "$ref": "508"
                 },
                 {
-                  "$ref": "581"
+                  "$ref": "512"
                 },
                 {
-                  "$ref": "588"
+                  "$ref": "519"
                 },
                 {
-                  "$ref": "584"
+                  "$ref": "515"
                 },
                 {
-                  "$ref": "586"
+                  "$ref": "517"
                 },
                 {
-                  "$id": "589",
+                  "$id": "520",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "566"
+                    "$ref": "497"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9077,7 +8174,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "258"
+                  "$ref": "179"
                 }
               },
               "isOverride": false,
@@ -9086,7 +8183,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate"
             },
             {
-              "$id": "590",
+              "$id": "521",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -9098,7 +8195,7 @@
               ],
               "doc": "Get a KeyValue",
               "operation": {
-                "$id": "591",
+                "$id": "522",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "KeyValue",
@@ -9106,13 +8203,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "592",
+                    "$id": "523",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "593",
+                      "$id": "524",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9122,7 +8219,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "594",
+                        "$id": "525",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -9145,24 +8242,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "562"
+                        "$ref": "493"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "595",
+                    "$id": "526",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "596",
+                      "$id": "527",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "597",
+                        "$id": "528",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9191,19 +8288,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "568"
+                        "$ref": "499"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "598",
+                    "$id": "529",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "599",
+                      "$id": "530",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9244,13 +8341,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "600",
+                        "$id": "531",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "601",
+                          "$id": "532",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9293,13 +8390,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "602",
+                    "$id": "533",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "603",
+                      "$id": "534",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9324,13 +8421,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "604",
+                        "$id": "535",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "605",
+                          "$id": "536",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9357,13 +8454,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "606",
+                    "$id": "537",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "607",
+                      "$id": "538",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9388,13 +8485,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "608",
+                        "$id": "539",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "609",
+                          "$id": "540",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9421,12 +8518,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "610",
+                    "$id": "541",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "76"
+                      "$ref": "59"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -9437,12 +8534,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "611",
+                        "$id": "542",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "76"
+                          "$ref": "59"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -9464,7 +8561,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "258"
+                      "$ref": "179"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -9495,24 +8592,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "600"
+                  "$ref": "531"
                 },
                 {
-                  "$ref": "604"
+                  "$ref": "535"
                 },
                 {
-                  "$ref": "608"
+                  "$ref": "539"
                 },
                 {
-                  "$ref": "611"
+                  "$ref": "542"
                 },
                 {
-                  "$id": "612",
+                  "$id": "543",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "596"
+                    "$ref": "527"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9525,7 +8622,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "258"
+                  "$ref": "179"
                 }
               },
               "isOverride": false,
@@ -9534,7 +8631,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get"
             },
             {
-              "$id": "613",
+              "$id": "544",
               "kind": "basic",
               "name": "delete",
               "isExactName": false,
@@ -9546,7 +8643,7 @@
               ],
               "doc": "Delete a KeyValue",
               "operation": {
-                "$id": "614",
+                "$id": "545",
                 "name": "delete",
                 "isExactName": false,
                 "resourceName": "KeyValue",
@@ -9554,13 +8651,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "615",
+                    "$id": "546",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "616",
+                      "$id": "547",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9570,7 +8667,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "617",
+                        "$id": "548",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -9593,24 +8690,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "562"
+                        "$ref": "493"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "618",
+                    "$id": "549",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "619",
+                      "$id": "550",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "620",
+                        "$id": "551",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9639,19 +8736,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "568"
+                        "$ref": "499"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "621",
+                    "$id": "552",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "622",
+                      "$id": "553",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9692,13 +8789,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "623",
+                        "$id": "554",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "624",
+                          "$id": "555",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9741,13 +8838,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "625",
+                    "$id": "556",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "626",
+                      "$id": "557",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9772,13 +8869,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "627",
+                        "$id": "558",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "628",
+                          "$id": "559",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9805,13 +8902,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "629",
+                    "$id": "560",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "630",
+                      "$id": "561",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9836,13 +8933,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "631",
+                        "$id": "562",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "632",
+                          "$id": "563",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9904,21 +9001,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "623"
+                  "$ref": "554"
                 },
                 {
-                  "$ref": "627"
+                  "$ref": "558"
                 },
                 {
-                  "$ref": "631"
+                  "$ref": "562"
                 },
                 {
-                  "$id": "633",
+                  "$id": "564",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "619"
+                    "$ref": "550"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9936,7 +9033,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete"
             },
             {
-              "$id": "634",
+              "$id": "565",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -9948,7 +9045,7 @@
               ],
               "doc": "List KeyValue resources by ConfigurationStore",
               "operation": {
-                "$id": "635",
+                "$id": "566",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "KeyValue",
@@ -9956,13 +9053,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "636",
+                    "$id": "567",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "637",
+                      "$id": "568",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9972,7 +9069,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "638",
+                        "$id": "569",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -9995,24 +9092,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "562"
+                        "$ref": "493"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "639",
+                    "$id": "570",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "640",
+                      "$id": "571",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "641",
+                        "$id": "572",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10041,19 +9138,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "568"
+                        "$ref": "499"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "642",
+                    "$id": "573",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "643",
+                      "$id": "574",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10094,13 +9191,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "644",
+                        "$id": "575",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "645",
+                          "$id": "576",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10143,13 +9240,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "646",
+                    "$id": "577",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "647",
+                      "$id": "578",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10174,13 +9271,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "648",
+                        "$id": "579",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "649",
+                          "$id": "580",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10207,12 +9304,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "650",
+                    "$id": "581",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "78"
+                      "$ref": "61"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -10223,12 +9320,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "651",
+                        "$id": "582",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "78"
+                          "$ref": "61"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -10250,7 +9347,91 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "268"
+                      "$id": "583",
+                      "kind": "model",
+                      "name": "KeyValueListResult",
+                      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
+                      "usage": "Output,Json",
+                      "doc": "The response of a KeyValue list operation.",
+                      "decorators": [
+                        {
+                          "name": "Azure.ResourceManager.@armProviderNamespace",
+                          "arguments": {}
+                        }
+                      ],
+                      "serializationOptions": {
+                        "json": {
+                          "name": "ResourceListResult"
+                        }
+                      },
+                      "isExactName": false,
+                      "properties": [
+                        {
+                          "$id": "584",
+                          "kind": "property",
+                          "name": "value",
+                          "serializedName": "value",
+                          "doc": "The KeyValue items on this page",
+                          "type": {
+                            "$id": "585",
+                            "kind": "array",
+                            "name": "ArrayKeyValue",
+                            "valueType": {
+                              "$ref": "179"
+                            },
+                            "crossLanguageDefinitionId": "TypeSpec.Array",
+                            "decorators": []
+                          },
+                          "optional": false,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "value"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        },
+                        {
+                          "$id": "586",
+                          "kind": "property",
+                          "name": "nextLink",
+                          "serializedName": "nextLink",
+                          "doc": "The link to the next page of items",
+                          "type": {
+                            "$id": "587",
+                            "kind": "url",
+                            "name": "ResourceLocation",
+                            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
+                            "baseType": {
+                              "$id": "588",
+                              "kind": "url",
+                              "name": "url",
+                              "crossLanguageDefinitionId": "TypeSpec.url",
+                              "decorators": []
+                            },
+                            "decorators": []
+                          },
+                          "optional": true,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "nextLink"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        }
+                      ]
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -10281,21 +9462,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "644"
+                  "$ref": "575"
                 },
                 {
-                  "$ref": "648"
+                  "$ref": "579"
                 },
                 {
-                  "$ref": "651"
+                  "$ref": "582"
                 },
                 {
-                  "$id": "652",
+                  "$id": "589",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "640"
+                    "$ref": "571"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -10308,7 +9489,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "270"
+                  "$ref": "585"
                 },
                 "resultSegments": [
                   "value"
@@ -10334,13 +9515,13 @@
           ],
           "parameters": [
             {
-              "$id": "653",
+              "$id": "590",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "654",
+                "$id": "591",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -10351,7 +9532,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "655",
+                  "$id": "592",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -10365,7 +9546,7 @@
               "isExactName": false
             },
             {
-              "$ref": "562"
+              "$ref": "493"
             }
           ],
           "initializedBy": 0,
@@ -10382,19 +9563,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "656",
+          "$id": "593",
           "kind": "client",
           "name": "Items",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "657",
+              "$id": "594",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -10406,7 +9587,7 @@
               ],
               "doc": "Get a Item",
               "operation": {
-                "$id": "658",
+                "$id": "595",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "Item",
@@ -10414,13 +9595,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "659",
+                    "$id": "596",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "660",
+                      "$id": "597",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10430,7 +9611,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "661",
+                        "$id": "598",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -10453,13 +9634,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "662",
+                        "$id": "599",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "663",
+                          "$id": "600",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10469,7 +9650,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "664",
+                            "$id": "601",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -10497,18 +9678,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "665",
+                    "$id": "602",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "666",
+                      "$id": "603",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "667",
+                        "$id": "604",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10537,18 +9718,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "668",
+                        "$id": "605",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "669",
+                          "$id": "606",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "670",
+                            "$id": "607",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10579,13 +9760,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "671",
+                    "$id": "608",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "672",
+                      "$id": "609",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10626,13 +9807,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "673",
+                        "$id": "610",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "674",
+                          "$id": "611",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10675,13 +9856,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "675",
+                    "$id": "612",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "676",
+                      "$id": "613",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10706,13 +9887,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "677",
+                        "$id": "614",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "678",
+                          "$id": "615",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10739,13 +9920,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "679",
+                    "$id": "616",
                     "kind": "path",
                     "name": "itemName",
                     "serializedName": "itemName",
                     "doc": "The name of the Item",
                     "type": {
-                      "$id": "680",
+                      "$id": "617",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10770,13 +9951,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.itemName",
                     "methodParameterSegments": [
                       {
-                        "$id": "681",
+                        "$id": "618",
                         "kind": "method",
                         "name": "itemName",
                         "serializedName": "itemName",
                         "doc": "The name of the Item",
                         "type": {
-                          "$id": "682",
+                          "$id": "619",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10803,12 +9984,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "683",
+                    "$id": "620",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "80"
+                      "$ref": "63"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -10819,12 +10000,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "684",
+                        "$id": "621",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "80"
+                          "$ref": "63"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -10846,7 +10027,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "274"
+                      "$ref": "189"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -10877,24 +10058,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "673"
+                  "$ref": "610"
                 },
                 {
-                  "$ref": "677"
+                  "$ref": "614"
                 },
                 {
-                  "$ref": "681"
+                  "$ref": "618"
                 },
                 {
-                  "$ref": "684"
+                  "$ref": "621"
                 },
                 {
-                  "$id": "685",
+                  "$id": "622",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "666"
+                    "$ref": "603"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -10907,7 +10088,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "274"
+                  "$ref": "189"
                 }
               },
               "isOverride": false,
@@ -10916,7 +10097,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get"
             },
             {
-              "$id": "686",
+              "$id": "623",
               "kind": "basic",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -10927,20 +10108,20 @@
                 "2024-05-01"
               ],
               "operation": {
-                "$id": "687",
+                "$id": "624",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "Item",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "688",
+                    "$id": "625",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "689",
+                      "$id": "626",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10950,7 +10131,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "690",
+                        "$id": "627",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -10973,24 +10154,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "662"
+                        "$ref": "599"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "691",
+                    "$id": "628",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "692",
+                      "$id": "629",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "693",
+                        "$id": "630",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11019,19 +10200,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "668"
+                        "$ref": "605"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "694",
+                    "$id": "631",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "695",
+                      "$id": "632",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11072,13 +10253,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "696",
+                        "$id": "633",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "697",
+                          "$id": "634",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11121,13 +10302,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "698",
+                    "$id": "635",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "699",
+                      "$id": "636",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11152,13 +10333,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "700",
+                        "$id": "637",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "701",
+                          "$id": "638",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11185,13 +10366,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "702",
+                    "$id": "639",
                     "kind": "path",
                     "name": "itemName",
                     "serializedName": "itemName",
                     "doc": "The name of the Item",
                     "type": {
-                      "$id": "703",
+                      "$id": "640",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11216,13 +10397,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.itemName",
                     "methodParameterSegments": [
                       {
-                        "$id": "704",
+                        "$id": "641",
                         "kind": "method",
                         "name": "itemName",
                         "serializedName": "itemName",
                         "doc": "The name of the Item",
                         "type": {
-                          "$id": "705",
+                          "$id": "642",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11249,13 +10430,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "706",
+                    "$id": "643",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "82"
+                      "$ref": "65"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -11266,13 +10447,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "707",
+                        "$id": "644",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "82"
+                          "$ref": "65"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -11288,12 +10469,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "708",
+                    "$id": "645",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "84"
+                      "$ref": "67"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -11304,12 +10485,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "709",
+                        "$id": "646",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "84"
+                          "$ref": "67"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -11325,13 +10506,79 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "710",
+                    "$id": "647",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "301"
+                      "$id": "648",
+                      "kind": "model",
+                      "name": "ItemCreateOrUpdateParameters",
+                      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                      "crossLanguageDefinitionId": "ProvisioningTypeSpec.ItemCreateOrUpdateParameters",
+                      "usage": "Input,Json",
+                      "doc": "Parameters to create or update an item.",
+                      "decorators": [
+                        {
+                          "name": "Azure.ResourceManager.@armProviderNamespace",
+                          "arguments": {}
+                        }
+                      ],
+                      "serializationOptions": {
+                        "json": {
+                          "name": "ItemCreateOrUpdateParameters"
+                        }
+                      },
+                      "isExactName": false,
+                      "properties": [
+                        {
+                          "$id": "649",
+                          "kind": "property",
+                          "name": "tags",
+                          "serializedName": "tags",
+                          "doc": "Tags assigned to the item.",
+                          "type": {
+                            "$ref": "131"
+                          },
+                          "optional": true,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "ProvisioningTypeSpec.ItemCreateOrUpdateParameters.tags",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "tags"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        },
+                        {
+                          "$id": "650",
+                          "kind": "property",
+                          "name": "properties",
+                          "serializedName": "properties",
+                          "doc": "Properties of the item.",
+                          "type": {
+                            "$ref": "191"
+                          },
+                          "optional": false,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "ProvisioningTypeSpec.ItemCreateOrUpdateParameters.properties",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "properties"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        }
+                      ]
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -11345,13 +10592,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "711",
+                        "$id": "651",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "301"
+                          "$ref": "648"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -11378,7 +10625,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "274"
+                      "$ref": "189"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -11396,7 +10643,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "274"
+                      "$ref": "189"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -11430,30 +10677,30 @@
               },
               "parameters": [
                 {
-                  "$ref": "696"
+                  "$ref": "633"
                 },
                 {
-                  "$ref": "700"
+                  "$ref": "637"
                 },
                 {
-                  "$ref": "704"
+                  "$ref": "641"
                 },
                 {
-                  "$ref": "711"
+                  "$ref": "651"
                 },
                 {
-                  "$ref": "707"
+                  "$ref": "644"
                 },
                 {
-                  "$ref": "709"
+                  "$ref": "646"
                 },
                 {
-                  "$id": "712",
+                  "$id": "652",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "692"
+                    "$ref": "629"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -11466,7 +10713,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "274"
+                  "$ref": "189"
                 }
               },
               "isOverride": false,
@@ -11475,7 +10722,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate"
             },
             {
-              "$id": "713",
+              "$id": "653",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -11487,7 +10734,7 @@
               ],
               "doc": "List Item resources by ConfigurationStore",
               "operation": {
-                "$id": "714",
+                "$id": "654",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "Item",
@@ -11495,13 +10742,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "715",
+                    "$id": "655",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "716",
+                      "$id": "656",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11511,7 +10758,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "717",
+                        "$id": "657",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11534,24 +10781,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "662"
+                        "$ref": "599"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "718",
+                    "$id": "658",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "719",
+                      "$id": "659",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "720",
+                        "$id": "660",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11580,19 +10827,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "668"
+                        "$ref": "605"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "721",
+                    "$id": "661",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "722",
+                      "$id": "662",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11633,13 +10880,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "723",
+                        "$id": "663",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "724",
+                          "$id": "664",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11682,13 +10929,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "725",
+                    "$id": "665",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "726",
+                      "$id": "666",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11713,13 +10960,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "727",
+                        "$id": "667",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "728",
+                          "$id": "668",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11746,12 +10993,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "729",
+                    "$id": "669",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "86"
+                      "$ref": "69"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -11762,12 +11009,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "730",
+                        "$id": "670",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "86"
+                          "$ref": "69"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -11789,7 +11036,91 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "304"
+                      "$id": "671",
+                      "kind": "model",
+                      "name": "ItemListResult",
+                      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
+                      "usage": "Output,Json",
+                      "doc": "The response of a Item list operation.",
+                      "decorators": [
+                        {
+                          "name": "Azure.ResourceManager.@armProviderNamespace",
+                          "arguments": {}
+                        }
+                      ],
+                      "serializationOptions": {
+                        "json": {
+                          "name": "ResourceListResult"
+                        }
+                      },
+                      "isExactName": false,
+                      "properties": [
+                        {
+                          "$id": "672",
+                          "kind": "property",
+                          "name": "value",
+                          "serializedName": "value",
+                          "doc": "The Item items on this page",
+                          "type": {
+                            "$id": "673",
+                            "kind": "array",
+                            "name": "ArrayItem",
+                            "valueType": {
+                              "$ref": "189"
+                            },
+                            "crossLanguageDefinitionId": "TypeSpec.Array",
+                            "decorators": []
+                          },
+                          "optional": false,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "value"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        },
+                        {
+                          "$id": "674",
+                          "kind": "property",
+                          "name": "nextLink",
+                          "serializedName": "nextLink",
+                          "doc": "The link to the next page of items",
+                          "type": {
+                            "$id": "675",
+                            "kind": "url",
+                            "name": "ResourceLocation",
+                            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
+                            "baseType": {
+                              "$id": "676",
+                              "kind": "url",
+                              "name": "url",
+                              "crossLanguageDefinitionId": "TypeSpec.url",
+                              "decorators": []
+                            },
+                            "decorators": []
+                          },
+                          "optional": true,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "nextLink"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        }
+                      ]
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -11820,21 +11151,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "723"
+                  "$ref": "663"
                 },
                 {
-                  "$ref": "727"
+                  "$ref": "667"
                 },
                 {
-                  "$ref": "730"
+                  "$ref": "670"
                 },
                 {
-                  "$id": "731",
+                  "$id": "677",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "719"
+                    "$ref": "659"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -11847,7 +11178,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "306"
+                  "$ref": "673"
                 },
                 "resultSegments": [
                   "value"
@@ -11873,13 +11204,13 @@
           ],
           "parameters": [
             {
-              "$id": "732",
+              "$id": "678",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "733",
+                "$id": "679",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -11890,7 +11221,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "734",
+                  "$id": "680",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11904,7 +11235,7 @@
               "isExactName": false
             },
             {
-              "$ref": "662"
+              "$ref": "599"
             }
           ],
           "initializedBy": 0,
@@ -11921,19 +11252,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "735",
+          "$id": "681",
           "kind": "client",
           "name": "Profiles",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "736",
+              "$id": "682",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -11945,7 +11276,7 @@
               ],
               "doc": "Get a Profile",
               "operation": {
-                "$id": "737",
+                "$id": "683",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -11953,13 +11284,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "738",
+                    "$id": "684",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "739",
+                      "$id": "685",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11969,7 +11300,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "740",
+                        "$id": "686",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11992,13 +11323,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "741",
+                        "$id": "687",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "742",
+                          "$id": "688",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12008,7 +11339,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "743",
+                            "$id": "689",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -12036,18 +11367,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "744",
+                    "$id": "690",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "745",
+                      "$id": "691",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "746",
+                        "$id": "692",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12076,18 +11407,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "747",
+                        "$id": "693",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "748",
+                          "$id": "694",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "749",
+                            "$id": "695",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12118,13 +11449,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "750",
+                    "$id": "696",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "751",
+                      "$id": "697",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12165,13 +11496,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "752",
+                        "$id": "698",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "753",
+                          "$id": "699",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12214,13 +11545,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "754",
+                    "$id": "700",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "755",
+                      "$id": "701",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12245,13 +11576,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "756",
+                        "$id": "702",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "757",
+                          "$id": "703",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12278,13 +11609,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "758",
+                    "$id": "704",
                     "kind": "path",
                     "name": "profileName",
                     "serializedName": "profileName",
                     "doc": "The name of the Profile",
                     "type": {
-                      "$id": "759",
+                      "$id": "705",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12309,13 +11640,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.profileName",
                     "methodParameterSegments": [
                       {
-                        "$id": "760",
+                        "$id": "706",
                         "kind": "method",
                         "name": "profileName",
                         "serializedName": "profileName",
                         "doc": "The name of the Profile",
                         "type": {
-                          "$id": "761",
+                          "$id": "707",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12342,12 +11673,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "762",
+                    "$id": "708",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "88"
+                      "$ref": "71"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -12358,12 +11689,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "763",
+                        "$id": "709",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "88"
+                          "$ref": "71"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -12385,7 +11716,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "310"
+                      "$ref": "216"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -12416,24 +11747,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "752"
+                  "$ref": "698"
                 },
                 {
-                  "$ref": "756"
+                  "$ref": "702"
                 },
                 {
-                  "$ref": "760"
+                  "$ref": "706"
                 },
                 {
-                  "$ref": "763"
+                  "$ref": "709"
                 },
                 {
-                  "$id": "764",
+                  "$id": "710",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "745"
+                    "$ref": "691"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -12446,7 +11777,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "310"
+                  "$ref": "216"
                 }
               },
               "isOverride": false,
@@ -12455,7 +11786,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get"
             },
             {
-              "$id": "765",
+              "$id": "711",
               "kind": "lro",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -12467,7 +11798,7 @@
               ],
               "doc": "Create a Profile",
               "operation": {
-                "$id": "766",
+                "$id": "712",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -12475,13 +11806,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "767",
+                    "$id": "713",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "768",
+                      "$id": "714",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12491,7 +11822,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "769",
+                        "$id": "715",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -12514,24 +11845,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "741"
+                        "$ref": "687"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "770",
+                    "$id": "716",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "771",
+                      "$id": "717",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "772",
+                        "$id": "718",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12560,19 +11891,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "747"
+                        "$ref": "693"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "773",
+                    "$id": "719",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "774",
+                      "$id": "720",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12613,13 +11944,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "775",
+                        "$id": "721",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "776",
+                          "$id": "722",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12662,13 +11993,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "777",
+                    "$id": "723",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "778",
+                      "$id": "724",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12693,13 +12024,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "779",
+                        "$id": "725",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "780",
+                          "$id": "726",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12726,13 +12057,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "781",
+                    "$id": "727",
                     "kind": "path",
                     "name": "profileName",
                     "serializedName": "profileName",
                     "doc": "The name of the Profile",
                     "type": {
-                      "$id": "782",
+                      "$id": "728",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12757,13 +12088,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.profileName",
                     "methodParameterSegments": [
                       {
-                        "$id": "783",
+                        "$id": "729",
                         "kind": "method",
                         "name": "profileName",
                         "serializedName": "profileName",
                         "doc": "The name of the Profile",
                         "type": {
-                          "$id": "784",
+                          "$id": "730",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12790,13 +12121,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "785",
+                    "$id": "731",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "90"
+                      "$ref": "73"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -12807,13 +12138,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "786",
+                        "$id": "732",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "90"
+                          "$ref": "73"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -12829,12 +12160,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "787",
+                    "$id": "733",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "94"
+                      "$ref": "77"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -12845,12 +12176,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "788",
+                        "$id": "734",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "96"
+                          "$ref": "79"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -12866,13 +12197,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "789",
+                    "$id": "735",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "310"
+                      "$ref": "216"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -12886,13 +12217,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "790",
+                        "$id": "736",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "310"
+                          "$ref": "216"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -12919,7 +12250,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "310"
+                      "$ref": "216"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -12937,7 +12268,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "310"
+                      "$ref": "216"
                     },
                     "headers": [
                       {
@@ -12945,7 +12276,7 @@
                         "nameInResponse": "Azure-AsyncOperation",
                         "doc": "A link to the status monitor",
                         "type": {
-                          "$id": "791",
+                          "$id": "737",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12957,7 +12288,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "792",
+                          "$id": "738",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -12996,30 +12327,30 @@
               },
               "parameters": [
                 {
-                  "$ref": "775"
+                  "$ref": "721"
                 },
                 {
-                  "$ref": "779"
+                  "$ref": "725"
                 },
                 {
-                  "$ref": "783"
+                  "$ref": "729"
                 },
                 {
-                  "$ref": "790"
+                  "$ref": "736"
                 },
                 {
-                  "$ref": "786"
+                  "$ref": "732"
                 },
                 {
-                  "$ref": "788"
+                  "$ref": "734"
                 },
                 {
-                  "$id": "793",
+                  "$id": "739",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "771"
+                    "$ref": "717"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -13032,7 +12363,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "310"
+                  "$ref": "216"
                 }
               },
               "isOverride": false,
@@ -13046,13 +12377,13 @@
                     200
                   ],
                   "bodyType": {
-                    "$ref": "310"
+                    "$ref": "216"
                   }
                 }
               }
             },
             {
-              "$id": "794",
+              "$id": "740",
               "kind": "lro",
               "name": "delete",
               "isExactName": false,
@@ -13064,7 +12395,7 @@
               ],
               "doc": "Delete a Profile",
               "operation": {
-                "$id": "795",
+                "$id": "741",
                 "name": "delete",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -13072,13 +12403,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "796",
+                    "$id": "742",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "797",
+                      "$id": "743",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13088,7 +12419,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "798",
+                        "$id": "744",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -13111,24 +12442,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "741"
+                        "$ref": "687"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "799",
+                    "$id": "745",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "800",
+                      "$id": "746",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "801",
+                        "$id": "747",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13157,19 +12488,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.delete.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "747"
+                        "$ref": "693"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "802",
+                    "$id": "748",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "803",
+                      "$id": "749",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13210,13 +12541,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.delete.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "804",
+                        "$id": "750",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "805",
+                          "$id": "751",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13259,13 +12590,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "806",
+                    "$id": "752",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "807",
+                      "$id": "753",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13290,13 +12621,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.delete.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "808",
+                        "$id": "754",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "809",
+                          "$id": "755",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13323,13 +12654,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "810",
+                    "$id": "756",
                     "kind": "path",
                     "name": "profileName",
                     "serializedName": "profileName",
                     "doc": "The name of the Profile",
                     "type": {
-                      "$id": "811",
+                      "$id": "757",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13354,13 +12685,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.delete.profileName",
                     "methodParameterSegments": [
                       {
-                        "$id": "812",
+                        "$id": "758",
                         "kind": "method",
                         "name": "profileName",
                         "serializedName": "profileName",
                         "doc": "The name of the Profile",
                         "type": {
-                          "$id": "813",
+                          "$id": "759",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13398,7 +12729,7 @@
                         "nameInResponse": "Location",
                         "doc": "The Location header contains the URL where the status of the long running operation can be checked.",
                         "type": {
-                          "$id": "814",
+                          "$id": "760",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13410,7 +12741,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "815",
+                          "$id": "761",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -13447,21 +12778,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "804"
+                  "$ref": "750"
                 },
                 {
-                  "$ref": "808"
+                  "$ref": "754"
                 },
                 {
-                  "$ref": "812"
+                  "$ref": "758"
                 },
                 {
-                  "$id": "816",
+                  "$id": "762",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "800"
+                    "$ref": "746"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -13487,7 +12818,7 @@
               }
             },
             {
-              "$id": "817",
+              "$id": "763",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -13499,7 +12830,7 @@
               ],
               "doc": "List Profile resources by ConfigurationStore",
               "operation": {
-                "$id": "818",
+                "$id": "764",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -13507,13 +12838,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "819",
+                    "$id": "765",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "820",
+                      "$id": "766",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13523,7 +12854,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "821",
+                        "$id": "767",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -13546,24 +12877,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "741"
+                        "$ref": "687"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "822",
+                    "$id": "768",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "823",
+                      "$id": "769",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "824",
+                        "$id": "770",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13592,19 +12923,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "747"
+                        "$ref": "693"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "825",
+                    "$id": "771",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "826",
+                      "$id": "772",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13645,13 +12976,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "827",
+                        "$id": "773",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "828",
+                          "$id": "774",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13694,13 +13025,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "829",
+                    "$id": "775",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "830",
+                      "$id": "776",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13725,13 +13056,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "831",
+                        "$id": "777",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "832",
+                          "$id": "778",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13758,12 +13089,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "833",
+                    "$id": "779",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "98"
+                      "$ref": "81"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13774,12 +13105,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "834",
+                        "$id": "780",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "98"
+                          "$ref": "81"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13801,7 +13132,91 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "321"
+                      "$id": "781",
+                      "kind": "model",
+                      "name": "ProfileListResult",
+                      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
+                      "usage": "Output,Json",
+                      "doc": "The response of a Profile list operation.",
+                      "decorators": [
+                        {
+                          "name": "Azure.ResourceManager.@armProviderNamespace",
+                          "arguments": {}
+                        }
+                      ],
+                      "serializationOptions": {
+                        "json": {
+                          "name": "ResourceListResult"
+                        }
+                      },
+                      "isExactName": false,
+                      "properties": [
+                        {
+                          "$id": "782",
+                          "kind": "property",
+                          "name": "value",
+                          "serializedName": "value",
+                          "doc": "The Profile items on this page",
+                          "type": {
+                            "$id": "783",
+                            "kind": "array",
+                            "name": "ArrayProfile",
+                            "valueType": {
+                              "$ref": "216"
+                            },
+                            "crossLanguageDefinitionId": "TypeSpec.Array",
+                            "decorators": []
+                          },
+                          "optional": false,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "value"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        },
+                        {
+                          "$id": "784",
+                          "kind": "property",
+                          "name": "nextLink",
+                          "serializedName": "nextLink",
+                          "doc": "The link to the next page of items",
+                          "type": {
+                            "$id": "785",
+                            "kind": "url",
+                            "name": "ResourceLocation",
+                            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
+                            "baseType": {
+                              "$id": "786",
+                              "kind": "url",
+                              "name": "url",
+                              "crossLanguageDefinitionId": "TypeSpec.url",
+                              "decorators": []
+                            },
+                            "decorators": []
+                          },
+                          "optional": true,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "nextLink"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        }
+                      ]
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -13832,21 +13247,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "827"
+                  "$ref": "773"
                 },
                 {
-                  "$ref": "831"
+                  "$ref": "777"
                 },
                 {
-                  "$ref": "834"
+                  "$ref": "780"
                 },
                 {
-                  "$id": "835",
+                  "$id": "787",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "823"
+                    "$ref": "769"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -13859,7 +13274,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "323"
+                  "$ref": "783"
                 },
                 "resultSegments": [
                   "value"
@@ -13885,13 +13300,13 @@
           ],
           "parameters": [
             {
-              "$id": "836",
+              "$id": "788",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "837",
+                "$id": "789",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -13902,7 +13317,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "838",
+                  "$id": "790",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -13916,7 +13331,7 @@
               "isExactName": false
             },
             {
-              "$ref": "741"
+              "$ref": "687"
             }
           ],
           "initializedBy": 0,
@@ -13933,19 +13348,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "839",
+          "$id": "791",
           "kind": "client",
           "name": "ProfileRevisions",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "840",
+              "$id": "792",
               "kind": "basic",
               "name": "getByRevisionNumber",
               "isExactName": false,
@@ -13957,7 +13372,7 @@
               ],
               "doc": "Get a specific revision of a profile.",
               "operation": {
-                "$id": "841",
+                "$id": "793",
                 "name": "getByRevisionNumber",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -13965,13 +13380,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "842",
+                    "$id": "794",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "843",
+                      "$id": "795",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13981,7 +13396,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "844",
+                        "$id": "796",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14004,13 +13419,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "845",
+                        "$id": "797",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "846",
+                          "$id": "798",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14020,7 +13435,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "847",
+                            "$id": "799",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14048,18 +13463,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "848",
+                    "$id": "800",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "849",
+                      "$id": "801",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "850",
+                        "$id": "802",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14088,18 +13503,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "851",
+                        "$id": "803",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "852",
+                          "$id": "804",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "853",
+                            "$id": "805",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14130,13 +13545,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "854",
+                    "$id": "806",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "855",
+                      "$id": "807",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14177,13 +13592,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "856",
+                        "$id": "808",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "857",
+                          "$id": "809",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14226,13 +13641,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "858",
+                    "$id": "810",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The configuration store name.",
                     "type": {
-                      "$id": "859",
+                      "$id": "811",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14250,13 +13665,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "860",
+                        "$id": "812",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The configuration store name.",
                         "type": {
-                          "$id": "861",
+                          "$id": "813",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14276,13 +13691,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "862",
+                    "$id": "814",
                     "kind": "path",
                     "name": "profileName",
                     "serializedName": "profileName",
                     "doc": "The profile name.",
                     "type": {
-                      "$id": "863",
+                      "$id": "815",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14300,13 +13715,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.profileName",
                     "methodParameterSegments": [
                       {
-                        "$id": "864",
+                        "$id": "816",
                         "kind": "method",
                         "name": "profileName",
                         "serializedName": "profileName",
                         "doc": "The profile name.",
                         "type": {
-                          "$id": "865",
+                          "$id": "817",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14326,13 +13741,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "866",
+                    "$id": "818",
                     "kind": "path",
                     "name": "revisionNumber",
                     "serializedName": "revisionNumber",
                     "doc": "The revision number.",
                     "type": {
-                      "$id": "867",
+                      "$id": "819",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14350,13 +13765,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.revisionNumber",
                     "methodParameterSegments": [
                       {
-                        "$id": "868",
+                        "$id": "820",
                         "kind": "method",
                         "name": "revisionNumber",
                         "serializedName": "revisionNumber",
                         "doc": "The revision number.",
                         "type": {
-                          "$id": "869",
+                          "$id": "821",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14376,12 +13791,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "870",
+                    "$id": "822",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "100"
+                      "$ref": "83"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14392,12 +13807,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "871",
+                        "$id": "823",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "100"
+                          "$ref": "83"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14419,7 +13834,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "310"
+                      "$ref": "216"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14445,27 +13860,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "856"
+                  "$ref": "808"
                 },
                 {
-                  "$ref": "860"
+                  "$ref": "812"
                 },
                 {
-                  "$ref": "864"
+                  "$ref": "816"
                 },
                 {
-                  "$ref": "868"
+                  "$ref": "820"
                 },
                 {
-                  "$ref": "871"
+                  "$ref": "823"
                 },
                 {
-                  "$id": "872",
+                  "$id": "824",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "849"
+                    "$ref": "801"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -14478,7 +13893,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "310"
+                  "$ref": "216"
                 }
               },
               "isOverride": false,
@@ -14489,13 +13904,13 @@
           ],
           "parameters": [
             {
-              "$id": "873",
+              "$id": "825",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "874",
+                "$id": "826",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -14506,7 +13921,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "875",
+                  "$id": "827",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14520,7 +13935,7 @@
               "isExactName": false
             },
             {
-              "$ref": "845"
+              "$ref": "797"
             }
           ],
           "initializedBy": 0,
@@ -14541,19 +13956,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "876",
+          "$id": "828",
           "kind": "client",
           "name": "ExtensionAssignments",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "877",
+              "$id": "829",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -14565,7 +13980,7 @@
               ],
               "doc": "Get a ExtensionAssignment",
               "operation": {
-                "$id": "878",
+                "$id": "830",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "ExtensionAssignment",
@@ -14573,13 +13988,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "879",
+                    "$id": "831",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "880",
+                      "$id": "832",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14589,7 +14004,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "881",
+                        "$id": "833",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14612,13 +14027,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "882",
+                        "$id": "834",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "883",
+                          "$id": "835",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14628,7 +14043,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "884",
+                            "$id": "836",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14656,13 +14071,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "885",
+                    "$id": "837",
                     "kind": "path",
                     "name": "scope",
                     "serializedName": "scope",
                     "doc": "The fully qualified Azure Resource manager identifier of the resource.",
                     "type": {
-                      "$id": "886",
+                      "$id": "838",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14680,13 +14095,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.get.scope",
                     "methodParameterSegments": [
                       {
-                        "$id": "887",
+                        "$id": "839",
                         "kind": "method",
                         "name": "scope",
                         "serializedName": "scope",
                         "doc": "The fully qualified Azure Resource manager identifier of the resource.",
                         "type": {
-                          "$id": "888",
+                          "$id": "840",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14706,13 +14121,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "889",
+                    "$id": "841",
                     "kind": "path",
                     "name": "extensionAssignmentName",
                     "serializedName": "extensionAssignmentName",
                     "doc": "The name of the ExtensionAssignment",
                     "type": {
-                      "$id": "890",
+                      "$id": "842",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14737,13 +14152,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.get.extensionAssignmentName",
                     "methodParameterSegments": [
                       {
-                        "$id": "891",
+                        "$id": "843",
                         "kind": "method",
                         "name": "extensionAssignmentName",
                         "serializedName": "extensionAssignmentName",
                         "doc": "The name of the ExtensionAssignment",
                         "type": {
-                          "$id": "892",
+                          "$id": "844",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14770,12 +14185,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "893",
+                    "$id": "845",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "102"
+                      "$ref": "85"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14786,12 +14201,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "894",
+                        "$id": "846",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "102"
+                          "$ref": "85"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14813,7 +14228,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "327"
+                      "$ref": "227"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14839,18 +14254,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "887"
+                  "$ref": "839"
                 },
                 {
-                  "$ref": "891"
+                  "$ref": "843"
                 },
                 {
-                  "$ref": "894"
+                  "$ref": "846"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "327"
+                  "$ref": "227"
                 }
               },
               "isOverride": false,
@@ -14859,7 +14274,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.get"
             },
             {
-              "$id": "895",
+              "$id": "847",
               "kind": "lro",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -14871,7 +14286,7 @@
               ],
               "doc": "Create a ExtensionAssignment",
               "operation": {
-                "$id": "896",
+                "$id": "848",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "ExtensionAssignment",
@@ -14879,13 +14294,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "897",
+                    "$id": "849",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "898",
+                      "$id": "850",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14895,7 +14310,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "899",
+                        "$id": "851",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14918,19 +14333,19 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "882"
+                        "$ref": "834"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "900",
+                    "$id": "852",
                     "kind": "path",
                     "name": "scope",
                     "serializedName": "scope",
                     "doc": "The fully qualified Azure Resource manager identifier of the resource.",
                     "type": {
-                      "$id": "901",
+                      "$id": "853",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14948,13 +14363,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.scope",
                     "methodParameterSegments": [
                       {
-                        "$id": "902",
+                        "$id": "854",
                         "kind": "method",
                         "name": "scope",
                         "serializedName": "scope",
                         "doc": "The fully qualified Azure Resource manager identifier of the resource.",
                         "type": {
-                          "$id": "903",
+                          "$id": "855",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14974,13 +14389,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "904",
+                    "$id": "856",
                     "kind": "path",
                     "name": "extensionAssignmentName",
                     "serializedName": "extensionAssignmentName",
                     "doc": "The name of the ExtensionAssignment",
                     "type": {
-                      "$id": "905",
+                      "$id": "857",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15005,13 +14420,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.extensionAssignmentName",
                     "methodParameterSegments": [
                       {
-                        "$id": "906",
+                        "$id": "858",
                         "kind": "method",
                         "name": "extensionAssignmentName",
                         "serializedName": "extensionAssignmentName",
                         "doc": "The name of the ExtensionAssignment",
                         "type": {
-                          "$id": "907",
+                          "$id": "859",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15038,13 +14453,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "908",
+                    "$id": "860",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "104"
+                      "$ref": "87"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15055,13 +14470,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "909",
+                        "$id": "861",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "104"
+                          "$ref": "87"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15077,12 +14492,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "910",
+                    "$id": "862",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "108"
+                      "$ref": "91"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15093,12 +14508,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "911",
+                        "$id": "863",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "110"
+                          "$ref": "93"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15114,13 +14529,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "912",
+                    "$id": "864",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "327"
+                      "$ref": "227"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -15134,13 +14549,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "913",
+                        "$id": "865",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "327"
+                          "$ref": "227"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -15167,7 +14582,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "327"
+                      "$ref": "227"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -15185,7 +14600,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "327"
+                      "$ref": "227"
                     },
                     "headers": [
                       {
@@ -15193,7 +14608,7 @@
                         "nameInResponse": "Azure-AsyncOperation",
                         "doc": "A link to the status monitor",
                         "type": {
-                          "$id": "914",
+                          "$id": "866",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15205,7 +14620,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "915",
+                          "$id": "867",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -15239,24 +14654,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "902"
+                  "$ref": "854"
                 },
                 {
-                  "$ref": "906"
+                  "$ref": "858"
                 },
                 {
-                  "$ref": "913"
+                  "$ref": "865"
                 },
                 {
-                  "$ref": "909"
+                  "$ref": "861"
                 },
                 {
-                  "$ref": "911"
+                  "$ref": "863"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "327"
+                  "$ref": "227"
                 }
               },
               "isOverride": false,
@@ -15270,7 +14685,7 @@
                     200
                   ],
                   "bodyType": {
-                    "$ref": "327"
+                    "$ref": "227"
                   }
                 }
               }
@@ -15278,13 +14693,13 @@
           ],
           "parameters": [
             {
-              "$id": "916",
+              "$id": "868",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "917",
+                "$id": "869",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -15295,7 +14710,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "918",
+                  "$id": "870",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -15309,7 +14724,7 @@
               "isExactName": false
             },
             {
-              "$ref": "882"
+              "$ref": "834"
             }
           ],
           "initializedBy": 0,
@@ -15326,19 +14741,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "919",
+          "$id": "871",
           "kind": "client",
           "name": "SingletonSettings",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "920",
+              "$id": "872",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -15350,7 +14765,7 @@
               ],
               "doc": "Get a SingletonSetting",
               "operation": {
-                "$id": "921",
+                "$id": "873",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "SingletonSetting",
@@ -15358,13 +14773,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "922",
+                    "$id": "874",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "923",
+                      "$id": "875",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15374,7 +14789,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "924",
+                        "$id": "876",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -15397,13 +14812,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "925",
+                        "$id": "877",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "926",
+                          "$id": "878",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15413,7 +14828,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "927",
+                            "$id": "879",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -15441,18 +14856,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "928",
+                    "$id": "880",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "929",
+                      "$id": "881",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "930",
+                        "$id": "882",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15481,18 +14896,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "931",
+                        "$id": "883",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "932",
+                          "$id": "884",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "933",
+                            "$id": "885",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15523,13 +14938,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "934",
+                    "$id": "886",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "935",
+                      "$id": "887",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15570,13 +14985,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "936",
+                        "$id": "888",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "937",
+                          "$id": "889",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15619,13 +15034,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "938",
+                    "$id": "890",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "939",
+                      "$id": "891",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15650,13 +15065,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "940",
+                        "$id": "892",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "941",
+                          "$id": "893",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15683,12 +15098,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "942",
+                    "$id": "894",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "112"
+                      "$ref": "95"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15699,12 +15114,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "943",
+                        "$id": "895",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "112"
+                          "$ref": "95"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15726,7 +15141,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "335"
+                      "$ref": "235"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -15757,21 +15172,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "936"
+                  "$ref": "888"
                 },
                 {
-                  "$ref": "940"
+                  "$ref": "892"
                 },
                 {
-                  "$ref": "943"
+                  "$ref": "895"
                 },
                 {
-                  "$id": "944",
+                  "$id": "896",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "929"
+                    "$ref": "881"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -15784,7 +15199,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "335"
+                  "$ref": "235"
                 }
               },
               "isOverride": false,
@@ -15793,7 +15208,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get"
             },
             {
-              "$id": "945",
+              "$id": "897",
               "kind": "basic",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -15805,7 +15220,7 @@
               ],
               "doc": "Create a SingletonSetting",
               "operation": {
-                "$id": "946",
+                "$id": "898",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "SingletonSetting",
@@ -15813,13 +15228,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "947",
+                    "$id": "899",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "948",
+                      "$id": "900",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15829,7 +15244,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "949",
+                        "$id": "901",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -15852,24 +15267,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "925"
+                        "$ref": "877"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "950",
+                    "$id": "902",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "951",
+                      "$id": "903",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "952",
+                        "$id": "904",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15898,19 +15313,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "931"
+                        "$ref": "883"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "953",
+                    "$id": "905",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "954",
+                      "$id": "906",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15951,13 +15366,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "955",
+                        "$id": "907",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "956",
+                          "$id": "908",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16000,13 +15415,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "957",
+                    "$id": "909",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "958",
+                      "$id": "910",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16031,13 +15446,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "959",
+                        "$id": "911",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "960",
+                          "$id": "912",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16064,13 +15479,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "961",
+                    "$id": "913",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "114"
+                      "$ref": "97"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -16081,13 +15496,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "962",
+                        "$id": "914",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "114"
+                          "$ref": "97"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -16103,12 +15518,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "963",
+                    "$id": "915",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "116"
+                      "$ref": "99"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -16119,12 +15534,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "964",
+                        "$id": "916",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "116"
+                          "$ref": "99"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -16140,13 +15555,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "965",
+                    "$id": "917",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "335"
+                      "$ref": "235"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -16160,13 +15575,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "966",
+                        "$id": "918",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "335"
+                          "$ref": "235"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -16193,7 +15608,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "335"
+                      "$ref": "235"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -16211,7 +15626,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "335"
+                      "$ref": "235"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -16245,27 +15660,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "955"
+                  "$ref": "907"
                 },
                 {
-                  "$ref": "959"
+                  "$ref": "911"
                 },
                 {
-                  "$ref": "966"
+                  "$ref": "918"
                 },
                 {
-                  "$ref": "962"
+                  "$ref": "914"
                 },
                 {
-                  "$ref": "964"
+                  "$ref": "916"
                 },
                 {
-                  "$id": "967",
+                  "$id": "919",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "951"
+                    "$ref": "903"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -16278,7 +15693,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "335"
+                  "$ref": "235"
                 }
               },
               "isOverride": false,
@@ -16289,13 +15704,13 @@
           ],
           "parameters": [
             {
-              "$id": "968",
+              "$id": "920",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "969",
+                "$id": "921",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -16306,7 +15721,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "970",
+                  "$id": "922",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -16320,7 +15735,7 @@
               "isExactName": false
             },
             {
-              "$ref": "925"
+              "$ref": "877"
             }
           ],
           "initializedBy": 0,
@@ -16337,19 +15752,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "971",
+          "$id": "923",
           "kind": "client",
           "name": "ConfigurationStorePrivateLinkResources",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "972",
+              "$id": "924",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -16361,7 +15776,7 @@
               ],
               "doc": "Get a ConfigurationStore PrivateLink",
               "operation": {
-                "$id": "973",
+                "$id": "925",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "ConfigurationStorePrivateLinkResource",
@@ -16369,13 +15784,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "974",
+                    "$id": "926",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "975",
+                      "$id": "927",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16385,7 +15800,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "976",
+                        "$id": "928",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -16408,13 +15823,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "977",
+                        "$id": "929",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "978",
+                          "$id": "930",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16424,7 +15839,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "979",
+                            "$id": "931",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -16452,18 +15867,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "980",
+                    "$id": "932",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "981",
+                      "$id": "933",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "982",
+                        "$id": "934",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16492,18 +15907,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "983",
+                        "$id": "935",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "984",
+                          "$id": "936",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "985",
+                            "$id": "937",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16534,13 +15949,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "986",
+                    "$id": "938",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "987",
+                      "$id": "939",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16581,13 +15996,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "988",
+                        "$id": "940",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "989",
+                          "$id": "941",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16630,13 +16045,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "990",
+                    "$id": "942",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "991",
+                      "$id": "943",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16661,13 +16076,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "992",
+                        "$id": "944",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "993",
+                          "$id": "945",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16694,13 +16109,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "994",
+                    "$id": "946",
                     "kind": "path",
                     "name": "privateLinkResourceName",
                     "serializedName": "privateLinkResourceName",
                     "doc": "The name of the private link associated with the Azure resource.",
                     "type": {
-                      "$id": "995",
+                      "$id": "947",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16718,13 +16133,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.get.privateLinkResourceName",
                     "methodParameterSegments": [
                       {
-                        "$id": "996",
+                        "$id": "948",
                         "kind": "method",
                         "name": "privateLinkResourceName",
                         "serializedName": "privateLinkResourceName",
                         "doc": "The name of the private link associated with the Azure resource.",
                         "type": {
-                          "$id": "997",
+                          "$id": "949",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16744,12 +16159,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "998",
+                    "$id": "950",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "118"
+                      "$ref": "101"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -16760,12 +16175,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "999",
+                        "$id": "951",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "118"
+                          "$ref": "101"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -16787,7 +16202,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "342"
+                      "$ref": "242"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -16813,24 +16228,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "988"
+                  "$ref": "940"
                 },
                 {
-                  "$ref": "992"
+                  "$ref": "944"
                 },
                 {
-                  "$ref": "996"
+                  "$ref": "948"
                 },
                 {
-                  "$ref": "999"
+                  "$ref": "951"
                 },
                 {
-                  "$id": "1000",
+                  "$id": "952",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "981"
+                    "$ref": "933"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -16843,7 +16258,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "342"
+                  "$ref": "242"
                 }
               },
               "isOverride": false,
@@ -16852,7 +16267,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.get"
             },
             {
-              "$id": "1001",
+              "$id": "953",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -16864,7 +16279,7 @@
               ],
               "doc": "List ConfigurationStore PrivateLinks",
               "operation": {
-                "$id": "1002",
+                "$id": "954",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "ConfigurationStorePrivateLinkResource",
@@ -16872,13 +16287,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "1003",
+                    "$id": "955",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "1004",
+                      "$id": "956",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16888,7 +16303,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "1005",
+                        "$id": "957",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -16911,24 +16326,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "977"
+                        "$ref": "929"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "1006",
+                    "$id": "958",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "1007",
+                      "$id": "959",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "1008",
+                        "$id": "960",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -16957,19 +16372,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "983"
+                        "$ref": "935"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "1009",
+                    "$id": "961",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "1010",
+                      "$id": "962",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -17010,13 +16425,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "1011",
+                        "$id": "963",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "1012",
+                          "$id": "964",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -17059,13 +16474,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "1013",
+                    "$id": "965",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "1014",
+                      "$id": "966",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -17090,13 +16505,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "1015",
+                        "$id": "967",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "1016",
+                          "$id": "968",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -17123,12 +16538,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "1017",
+                    "$id": "969",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "120"
+                      "$ref": "103"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -17139,12 +16554,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "1018",
+                        "$id": "970",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "120"
+                          "$ref": "103"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -17166,7 +16581,91 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "351"
+                      "$id": "971",
+                      "kind": "model",
+                      "name": "ConfigurationStorePrivateLinkResourceListResult",
+                      "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
+                      "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult",
+                      "usage": "Output,Json",
+                      "doc": "The response of a ConfigurationStorePrivateLinkResource list operation.",
+                      "decorators": [
+                        {
+                          "name": "Azure.ResourceManager.@armProviderNamespace",
+                          "arguments": {}
+                        }
+                      ],
+                      "serializationOptions": {
+                        "json": {
+                          "name": "ResourceListResult"
+                        }
+                      },
+                      "isExactName": false,
+                      "properties": [
+                        {
+                          "$id": "972",
+                          "kind": "property",
+                          "name": "value",
+                          "serializedName": "value",
+                          "doc": "The ConfigurationStorePrivateLinkResource items on this page",
+                          "type": {
+                            "$id": "973",
+                            "kind": "array",
+                            "name": "ArrayConfigurationStorePrivateLinkResource",
+                            "valueType": {
+                              "$ref": "242"
+                            },
+                            "crossLanguageDefinitionId": "TypeSpec.Array",
+                            "decorators": []
+                          },
+                          "optional": false,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.value",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "value"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        },
+                        {
+                          "$id": "974",
+                          "kind": "property",
+                          "name": "nextLink",
+                          "serializedName": "nextLink",
+                          "doc": "The link to the next page of items",
+                          "type": {
+                            "$id": "975",
+                            "kind": "url",
+                            "name": "ResourceLocation",
+                            "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
+                            "baseType": {
+                              "$id": "976",
+                              "kind": "url",
+                              "name": "url",
+                              "crossLanguageDefinitionId": "TypeSpec.url",
+                              "decorators": []
+                            },
+                            "decorators": []
+                          },
+                          "optional": true,
+                          "readOnly": false,
+                          "discriminator": false,
+                          "flatten": false,
+                          "decorators": [],
+                          "crossLanguageDefinitionId": "Azure.ResourceManager.ResourceListResult.nextLink",
+                          "serializationOptions": {
+                            "json": {
+                              "name": "nextLink"
+                            }
+                          },
+                          "isHttpMetadata": false,
+                          "isExactName": false
+                        }
+                      ]
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -17192,21 +16691,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "1011"
+                  "$ref": "963"
                 },
                 {
-                  "$ref": "1015"
+                  "$ref": "967"
                 },
                 {
-                  "$ref": "1018"
+                  "$ref": "970"
                 },
                 {
-                  "$id": "1019",
+                  "$id": "977",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "1007"
+                    "$ref": "959"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -17219,7 +16718,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "353"
+                  "$ref": "973"
                 },
                 "resultSegments": [
                   "value"
@@ -17245,13 +16744,13 @@
           ],
           "parameters": [
             {
-              "$id": "1020",
+              "$id": "978",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "1021",
+                "$id": "979",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -17262,7 +16761,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "1022",
+                  "$id": "980",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -17276,7 +16775,7 @@
               "isExactName": false
             },
             {
-              "$ref": "977"
+              "$ref": "929"
             }
           ],
           "initializedBy": 0,
@@ -17293,7 +16792,7 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "357"
+            "$ref": "251"
           },
           "isMultiServiceClient": false
         }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
@@ -4146,44 +4146,248 @@
           "arguments": {
             "resourceProjections": [
               {
+                "resourceModelId": "ProvisioningTypeSpec.ConfigurationStore",
+                "resourceName": "ConfigurationStore",
+                "resourceType": "ProvisioningTypeSpec/configurationStores",
+                "nameConstraints": {
+                  "pattern": "^[a-zA-Z0-9-]{3,24}$"
+                },
                 "resourceIdPatterns": [
                   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}"
-                ]
+                ],
+                "apiVersions": [
+                  "2024-01-01-preview",
+                  "2024-04-01",
+                  "2024-05-01"
+                ],
+                "methodIds": [
+                  "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate",
+                  "ProvisioningTypeSpec.ConfigurationStores.get",
+                  "ProvisioningTypeSpec.ConfigurationStores.update",
+                  "ProvisioningTypeSpec.ConfigurationStores.delete",
+                  "ProvisioningTypeSpec.ConfigurationStores.list",
+                  "ProvisioningTypeSpec.ConfigurationStores.listBySubscription"
+                ],
+                "rbacRoles": [
+                  {
+                    "name": "ConfigStoreContributor",
+                    "value": "00000000-0000-0000-0000-000000000001"
+                  },
+                  {
+                    "name": "ConfigStoreReader",
+                    "value": "00000000-0000-0000-0000-000000000002"
+                  },
+                  {
+                    "name": "ConfigStoreDataOperator",
+                    "value": "00000000-0000-0000-0000-000000000003"
+                  }
+                ],
+                "readableScopes": [
+                  "ResourceGroup"
+                ],
+                "writableScopes": [
+                  "ResourceGroup"
+                ],
+                "isExtensionResource": false
               },
               {
+                "resourceModelId": "ProvisioningTypeSpec.KeyValue",
+                "resourceName": "KeyValue",
+                "resourceType": "ProvisioningTypeSpec/configurationStores/keyValues",
+                "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                "nameConstraints": {
+                  "pattern": "^[a-zA-Z0-9-]{3,24}$"
+                },
                 "resourceIdPatterns": [
                   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}"
-                ]
+                ],
+                "apiVersions": [
+                  "2024-01-01-preview",
+                  "2024-04-01",
+                  "2024-05-01"
+                ],
+                "methodIds": [
+                  "ProvisioningTypeSpec.KeyValues.createOrUpdate",
+                  "ProvisioningTypeSpec.KeyValues.get",
+                  "ProvisioningTypeSpec.KeyValues.delete",
+                  "ProvisioningTypeSpec.KeyValues.list"
+                ],
+                "rbacRoles": [],
+                "readableScopes": [
+                  "ResourceGroup"
+                ],
+                "writableScopes": [
+                  "ResourceGroup"
+                ],
+                "isExtensionResource": false
               },
               {
+                "resourceModelId": "ProvisioningTypeSpec.Item",
+                "resourceName": "Item",
+                "resourceType": "ProvisioningTypeSpec/configurationStores/items",
+                "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                "nameConstraints": {
+                  "pattern": "^[a-zA-Z0-9-]{3,24}$"
+                },
                 "resourceIdPatterns": [
                   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}"
-                ]
+                ],
+                "apiVersions": [
+                  "2024-01-01-preview",
+                  "2024-04-01",
+                  "2024-05-01"
+                ],
+                "methodIds": [
+                  "ProvisioningTypeSpec.Items.createOrUpdate",
+                  "ProvisioningTypeSpec.Items.get",
+                  "ProvisioningTypeSpec.Items.list"
+                ],
+                "rbacRoles": [],
+                "readableScopes": [
+                  "ResourceGroup"
+                ],
+                "writableScopes": [
+                  "ResourceGroup"
+                ],
+                "isExtensionResource": false
               },
               {
+                "resourceModelId": "ProvisioningTypeSpec.Profile",
+                "resourceName": "Profile",
+                "resourceType": "ProvisioningTypeSpec/configurationStores/profiles",
+                "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                "nameConstraints": {
+                  "pattern": "^[a-zA-Z0-9-]{3,24}$"
+                },
                 "resourceIdPatterns": [
                   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}"
-                ]
+                ],
+                "apiVersions": [
+                  "2024-01-01-preview",
+                  "2024-04-01",
+                  "2024-05-01"
+                ],
+                "methodIds": [
+                  "ProvisioningTypeSpec.Profiles.createOrUpdate",
+                  "ProvisioningTypeSpec.Profiles.get",
+                  "ProvisioningTypeSpec.Profiles.delete",
+                  "ProvisioningTypeSpec.Profiles.list"
+                ],
+                "rbacRoles": [],
+                "readableScopes": [
+                  "ResourceGroup"
+                ],
+                "writableScopes": [
+                  "ResourceGroup"
+                ],
+                "isExtensionResource": false
               },
               {
+                "resourceModelId": "ProvisioningTypeSpec.Profile",
+                "resourceName": "ProfileRevision",
+                "resourceType": "ProvisioningTypeSpec/configurationStores/profiles/revisions",
+                "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
+                "nameConstraints": {
+                  "pattern": "^[a-zA-Z0-9-]{3,24}$"
+                },
                 "resourceIdPatterns": [
                   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}/revisions/{revisionNumber}"
-                ]
+                ],
+                "apiVersions": [
+                  "2024-01-01-preview",
+                  "2024-04-01",
+                  "2024-05-01"
+                ],
+                "methodIds": [
+                  "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber"
+                ],
+                "rbacRoles": [],
+                "readableScopes": [
+                  "ResourceGroup"
+                ],
+                "writableScopes": [],
+                "isExtensionResource": false
               },
               {
+                "resourceModelId": "ProvisioningTypeSpec.ExtensionAssignment",
+                "resourceName": "ExtensionAssignment",
+                "resourceType": "ProvisioningTypeSpec/extensionAssignments",
+                "nameConstraints": {},
                 "resourceIdPatterns": [
                   "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}"
-                ]
+                ],
+                "apiVersions": [
+                  "2024-01-01-preview",
+                  "2024-04-01",
+                  "2024-05-01"
+                ],
+                "methodIds": [
+                  "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate",
+                  "ProvisioningTypeSpec.ExtensionAssignments.get"
+                ],
+                "rbacRoles": [],
+                "readableScopes": [
+                  "Extension"
+                ],
+                "writableScopes": [
+                  "Extension"
+                ],
+                "isExtensionResource": true
               },
               {
+                "resourceModelId": "ProvisioningTypeSpec.SingletonSetting",
+                "resourceName": "SingletonSetting",
+                "resourceType": "ProvisioningTypeSpec/configurationStores/settings",
+                "singletonResourceName": "default",
+                "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                "nameConstraints": {
+                  "pattern": "^[a-zA-Z0-9-]{3,24}$"
+                },
                 "resourceIdPatterns": [
                   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default"
-                ]
+                ],
+                "apiVersions": [
+                  "2024-01-01-preview",
+                  "2024-04-01",
+                  "2024-05-01"
+                ],
+                "methodIds": [
+                  "ProvisioningTypeSpec.SingletonSettings.createOrUpdate",
+                  "ProvisioningTypeSpec.SingletonSettings.get"
+                ],
+                "rbacRoles": [],
+                "readableScopes": [
+                  "ResourceGroup"
+                ],
+                "writableScopes": [
+                  "ResourceGroup"
+                ],
+                "isExtensionResource": false
               },
               {
+                "resourceModelId": "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResource",
+                "resourceName": "ConfigurationStorePrivateLinkResource",
+                "resourceType": "ProvisioningTypeSpec/configurationStores/privateLinkResources",
+                "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                "nameConstraints": {},
                 "resourceIdPatterns": [
                   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/privateLinkResources/{privateLinkResourceName}"
-                ]
+                ],
+                "apiVersions": [
+                  "2024-01-01-preview",
+                  "2024-04-01",
+                  "2024-05-01"
+                ],
+                "methodIds": [
+                  "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.get",
+                  "ProvisioningTypeSpec.ConfigurationStorePrivateLinkResources.list"
+                ],
+                "rbacRoles": [],
+                "readableScopes": [
+                  "ResourceGroup"
+                ],
+                "writableScopes": [],
+                "isExtensionResource": false
               }
             ],
             "modelSettableUsage": [

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -9,49 +9,11 @@
       "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260701.4",
-        "@azure-typespec/http-client-csharp-mgmt": "file:../http-client-csharp-mgmt",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260707.5"
-      },
-      "devDependencies": {
-        "@azure-tools/typespec-autorest": "0.69.1",
-        "@azure-tools/typespec-azure-core": "0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.69.2",
-        "@azure-tools/typespec-azure-rulesets": "0.69.2",
-        "@azure-tools/typespec-client-generator-core": "0.69.2",
-        "@azure-tools/typespec-liftr-base": "0.14.0",
-        "@eslint/js": "^10.0.1",
-        "@types/node": "~26.0.1",
-        "@typespec/compiler": "1.13.0",
-        "@typespec/events": "0.83.0",
-        "@typespec/http": "1.13.0",
-        "@typespec/openapi": "1.13.0",
-        "@typespec/rest": "0.83.0",
-        "@typespec/sse": "0.83.0",
-        "@typespec/streams": "0.83.0",
-        "@typespec/versioning": "0.83.0",
-        "@typespec/xml": "0.83.0",
-        "@vitest/coverage-v8": "^4.1.9",
-        "@vitest/ui": "^4.1.9",
-        "eslint": "^10.6.0",
-        "globals": "^17.7.0",
-        "prettier": "~3.9.1",
-        "rimraf": "~6.1.3",
-        "typescript": "~6.0.3",
-        "typescript-eslint": "^8.62.0",
-        "vitest": "^4.1.9"
-      }
-    },
-    "../http-client-csharp-mgmt": {
-      "name": "@azure-typespec/http-client-csharp-mgmt",
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
         "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260713.2",
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260719.1",
         "@typespec/http-client-csharp": "1.0.0-alpha.20260713.9"
       },
       "devDependencies": {
-        "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
         "@azure-tools/typespec-autorest": "0.69.1",
         "@azure-tools/typespec-azure-core": "0.69.0",
         "@azure-tools/typespec-azure-resource-manager": "0.69.2",
@@ -60,29 +22,21 @@
         "@azure-tools/typespec-liftr-base": "0.14.0",
         "@eslint/js": "^10.0.1",
         "@types/node": "~26.0.1",
-        "@types/pluralize": "^0.0.33",
-        "@types/prettier": "^2.7.3",
         "@typespec/compiler": "1.13.0",
         "@typespec/events": "0.83.0",
         "@typespec/http": "1.13.0",
-        "@typespec/http-specs": "0.1.0-alpha.38",
         "@typespec/openapi": "1.13.0",
         "@typespec/rest": "0.83.0",
         "@typespec/sse": "0.83.0",
         "@typespec/streams": "0.83.0",
-        "@typespec/tspd": "0.75.0",
         "@typespec/versioning": "0.83.0",
         "@typespec/xml": "0.83.0",
         "@vitest/coverage-v8": "^4.1.9",
         "@vitest/ui": "^4.1.9",
-        "c8": "^11.0.0",
         "eslint": "^10.6.0",
         "globals": "^17.7.0",
-        "pluralize": "^8.0.0",
         "prettier": "~3.9.1",
         "rimraf": "~6.1.3",
-        "typedoc": "^0.28.19",
-        "typedoc-plugin-markdown": "^4.12.0",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.62.0",
         "vitest": "^4.1.9"
@@ -199,29 +153,35 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260701.4",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260701.4.tgz",
-      "integrity": "sha1-NxF8VHoodjlIKFJFDMuKCYl1Oes=",
+      "version": "1.0.0-alpha.20260713.2",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260713.2.tgz",
+      "integrity": "sha1-XvsUA6FKupxz6SOMurUnTS3jZCA=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260701.6"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260710.4"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "resolved": "../http-client-csharp-mgmt",
-      "link": true
+      "version": "1.0.0-alpha.20260719.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260719.1.tgz",
+      "integrity": "sha1-ZVV/bPAKRNDF7fRJ5uBPGEa2Y5E=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260713.2",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260713.9"
+      }
     },
     "node_modules/@azure-typespec/http-client-csharp/node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260701.6",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260701.6.tgz",
-      "integrity": "sha1-5wLWbQuvUPFLtXDcPu9dYgYIyRs=",
+      "version": "1.0.0-alpha.20260710.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260710.4.tgz",
+      "integrity": "sha1-t0Kbf3lrkV84Yr//7RfLAC2VOgQ=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.69.1 <0.70.0 || ~0.70.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.69.2 <0.70.0 || ~0.70.0-0",
         "@typespec/compiler": "^1.13.0",
         "@typespec/http": "^1.13.0",
         "@typespec/openapi": "^1.13.0",
@@ -232,21 +192,21 @@
       }
     },
     "node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha1-k+DoKwGGLn6jtbaZWHGdPz/SyKw=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
-      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "version": "1.11.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha1-Ha7/32LRqHHSK4ZfnzFkpj6h9XU=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -254,13 +214,13 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
-      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "version": "1.11.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/core-client/-/core-client-1.11.0.tgz",
+      "integrity": "sha1-5z0JrHl33l17QVaWt+1F0/3rZ7A=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -272,13 +232,13 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
-      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "version": "1.25.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "integrity": "sha1-kupJEu27H3OV9IKaMAYxF0qoLwg=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -290,25 +250,25 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
-      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "integrity": "sha1-1lenAOJNJW0ZXmKKeV22qMxHXqs=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
-      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "version": "1.14.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha1-fOn+V5WPEy3UIlc4VuWkXHIyuwQ=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -316,13 +276,13 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/identity": {
       "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
-      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha1-vcCRZYuqWaR+6furSHpLsBhym8M=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -342,46 +302,46 @@
       }
     },
     "node_modules/@azure/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha1-PVpif+WaJ27OdIenndkq1cUIwzk=",
       "license": "MIT",
       "dependencies": {
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.13.0.tgz",
-      "integrity": "sha512-Ea23x0U8XNFY+qJ9T44zO2BbY+AHdb+WdjmYnx36OhJ/KO+PGU5pmsNHf1DCElYX+6wyVRJz1HFeCPC/cHbRug==",
+      "version": "5.17.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
+      "integrity": "sha1-EozjSq27IGyUDpnKXgzxldEsbfw=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.8.0"
+        "@azure/msal-common": "16.11.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.8.0.tgz",
-      "integrity": "sha512-5S4RHOcInL2Nu2U217tDZbWGI6StMfcWCrA7TWvWdJmXQ+cYrrIqr84AsN62fGh2MDBysiBJPt6CfWceJfloEA==",
+      "version": "16.11.2",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-common/-/msal-common-16.11.2.tgz",
+      "integrity": "sha1-bLo7L5utC9sH7o37+nLv9Lo2nDA=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.4.tgz",
-      "integrity": "sha512-rpBUg9dA8UpC2WiFt3KeDKVQmmmVrfxdRnW+F1ebgou/jX/0tAvYuonaq5RUo8OaqzOrj4x/HaI8DmY56RXZ2Q==",
+      "version": "5.4.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-node/-/msal-node-5.4.1.tgz",
+      "integrity": "sha1-PWogGDnMfAogM9lqLW7pEXYcrMs=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.8.0",
+        "@azure/msal-common": "16.11.2",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -1734,9 +1694,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260707.5",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260707.5.tgz",
-      "integrity": "sha1-HcIiOzQSw8wuXzEW1oMPN4k61cw=",
+      "version": "1.0.0-alpha.20260713.9",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260713.9.tgz",
+      "integrity": "sha1-hb7VX1Y/AHO9a6jxEsy+UPjP9sc=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"
@@ -1744,9 +1704,9 @@
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
         "@azure-tools/typespec-client-generator-core": ">=0.69.2 <0.70.0 || ~0.70.0-0",
-        "@typespec/compiler": "^1.13.0 || >=1.14.0-0 <1.14.0",
-        "@typespec/http": "^1.13.0 || >=1.14.0-0 <1.14.0",
-        "@typespec/openapi": "^1.13.0 || >=1.14.0-0 <1.14.0",
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/http": "^1.13.0",
+        "@typespec/openapi": "^1.13.0",
         "@typespec/rest": ">=0.83.0 <0.84.0 || ~0.84.0-0",
         "@typespec/sse": ">=0.83.0 <0.84.0 || ~0.84.0-0",
         "@typespec/streams": ">=0.83.0 <0.84.0 || ~0.84.0-0",
@@ -1807,9 +1767,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
-      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "version": "0.3.7",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
+      "integrity": "sha1-mrJ1NYmDu9MLyJUM9NxX5kcGcPM=",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -1817,7 +1777,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@typespec/versioning": {
@@ -2035,8 +1995,8 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2112,14 +2072,14 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "license": "BSD-3-Clause"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk=",
       "license": "MIT",
       "dependencies": {
         "run-applescript": "^7.0.0"
@@ -2260,8 +2220,8 @@
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -2276,8 +2236,8 @@
     },
     "node_modules/default-browser-id": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha1-96fMuPUQS/jg9xujscz6Xq/bIeg=",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2288,8 +2248,8 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2310,8 +2270,8 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -2808,8 +2768,8 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -2821,8 +2781,8 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -2870,8 +2830,8 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -2908,8 +2868,8 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
       "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
@@ -2950,8 +2910,8 @@
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -3037,8 +2997,8 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha1-bNV6sB6bCsB8uEfVPTybbuMfeuI=",
       "license": "MIT",
       "dependencies": {
         "jws": "^4.0.1",
@@ -3059,8 +3019,8 @@
     },
     "node_modules/jwa": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha1-v4F20a0M1y4PP1gzhZWhPhELyAQ=",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -3070,8 +3030,8 @@
     },
     "node_modules/jws": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha1-B+3Bvo+sIOZ3soPs4mFJi9OPBpA=",
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
@@ -3393,44 +3353,44 @@
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -3594,8 +3554,8 @@
     },
     "node_modules/open": {
       "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/open/-/open-10.2.0.tgz",
+      "integrity": "sha1-udhVvgB2IOgLb7BfrJgUH+Yttzw=",
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
@@ -3868,8 +3828,8 @@
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha1-Lp5UxGZOwxBsW1Yw4knT1llcSRE=",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3880,8 +3840,8 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
       "funding": [
         {
           "type": "github",
@@ -4556,8 +4516,8 @@
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha1-h4PU32cdTVA2W+LuTHGRegVXuqs=",
       "license": "MIT",
       "dependencies": {
         "is-wsl": "^3.1.0"

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260701.4",
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260707.4",
+        "@azure-typespec/http-client-csharp-mgmt": "file:../http-client-csharp-mgmt",
         "@typespec/http-client-csharp": "1.0.0-alpha.20260707.5"
       },
       "devDependencies": {
@@ -37,6 +37,52 @@
         "globals": "^17.7.0",
         "prettier": "~3.9.1",
         "rimraf": "~6.1.3",
+        "typescript": "~6.0.3",
+        "typescript-eslint": "^8.62.0",
+        "vitest": "^4.1.9"
+      }
+    },
+    "../http-client-csharp-mgmt": {
+      "name": "@azure-typespec/http-client-csharp-mgmt",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260713.2",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260713.9"
+      },
+      "devDependencies": {
+        "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
+        "@azure-tools/typespec-autorest": "0.69.1",
+        "@azure-tools/typespec-azure-core": "0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.69.2",
+        "@azure-tools/typespec-azure-rulesets": "0.69.2",
+        "@azure-tools/typespec-client-generator-core": "0.69.2",
+        "@azure-tools/typespec-liftr-base": "0.14.0",
+        "@eslint/js": "^10.0.1",
+        "@types/node": "~26.0.1",
+        "@types/pluralize": "^0.0.33",
+        "@types/prettier": "^2.7.3",
+        "@typespec/compiler": "1.13.0",
+        "@typespec/events": "0.83.0",
+        "@typespec/http": "1.13.0",
+        "@typespec/http-specs": "0.1.0-alpha.38",
+        "@typespec/openapi": "1.13.0",
+        "@typespec/rest": "0.83.0",
+        "@typespec/sse": "0.83.0",
+        "@typespec/streams": "0.83.0",
+        "@typespec/tspd": "0.75.0",
+        "@typespec/versioning": "0.83.0",
+        "@typespec/xml": "0.83.0",
+        "@vitest/coverage-v8": "^4.1.9",
+        "@vitest/ui": "^4.1.9",
+        "c8": "^11.0.0",
+        "eslint": "^10.6.0",
+        "globals": "^17.7.0",
+        "pluralize": "^8.0.0",
+        "prettier": "~3.9.1",
+        "rimraf": "~6.1.3",
+        "typedoc": "^0.28.19",
+        "typedoc-plugin-markdown": "^4.12.0",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.62.0",
         "vitest": "^4.1.9"
@@ -162,34 +208,8 @@
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260707.4",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260707.4.tgz",
-      "integrity": "sha1-5jIdNyu1TxyDkn+u74VxbgDwt/s=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260701.4",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260701.6"
-      }
-    },
-    "node_modules/@azure-typespec/http-client-csharp-mgmt/node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260701.6",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260701.6.tgz",
-      "integrity": "sha1-5wLWbQuvUPFLtXDcPu9dYgYIyRs=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/identity": "^4.13.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.69.1 <0.70.0 || ~0.70.0-0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": ">=0.83.0 <0.84.0 || ~0.84.0-0",
-        "@typespec/sse": ">=0.83.0 <0.84.0 || ~0.84.0-0",
-        "@typespec/streams": ">=0.83.0 <0.84.0 || ~0.84.0-0",
-        "@typespec/versioning": ">=0.83.0 <0.84.0 || ~0.84.0-0"
-      }
+      "resolved": "../http-client-csharp-mgmt",
+      "link": true
     },
     "node_modules/@azure-typespec/http-client-csharp/node_modules/@typespec/http-client-csharp": {
       "version": "1.0.0-alpha.20260701.6",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -36,9 +36,9 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260701.4",
-    "@azure-typespec/http-client-csharp-mgmt": "file:../http-client-csharp-mgmt",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260707.5"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260713.2",
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260719.1",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260713.9"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.69.1",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260701.4",
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260707.4",
+    "@azure-typespec/http-client-csharp-mgmt": "file:../http-client-csharp-mgmt",
     "@typespec/http-client-csharp": "1.0.0-alpha.20260707.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- expose a management emitter callback after ARM resource detection
- move provisioning resource projection, reachability, and settable analysis into the TypeScript emitter
- filter the emitted code model and pass projection metadata to the C# generator through a decorator
- simplify the provisioning input/output libraries to consume the emitter-filtered namespace
- treat only create operations as making a provisioning resource writable
- preserve scope metadata for read-only extension resources

## Validation
- management emitter build, 145 emitter tests, lint, and formatting for changed files
- provisioning build, 53 generator tests, lint, and formatting
- `RegenSdkLocal.ps1` succeeded for 19 existing provisioning libraries; Compute was excluded from the final matrix because its checked-in output is not up to date
- regenerated Batch, CostManagement, and MySql APIs were reviewed against their TypeSpec operations and confirmed to contain no create operation

## Follow-up
- replace the temporary local management emitter and generator dependencies with a published package version before merge