### PR TITLE
Expose management code model transformation API

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/emitter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/emitter.ts
@@ -25,8 +25,18 @@ import type {
   CodeModelMutator,
   CSharpEmitterContext
 } from "./code-model-types.js";
+import { ArmProviderSchema } from "./resource-metadata.js";
 
-export async function $onEmit(context: EmitContext<AzureMgmtEmitterOptions>) {
+export type ManagementCodeModelTransformer = (
+  codeModel: CodeModel,
+  sdkContext: CSharpEmitterContext,
+  armProviderSchema: ArmProviderSchema
+) => CodeModel;
+
+export async function emitManagementCodeModel(
+  context: EmitContext<AzureMgmtEmitterOptions>,
+  transform?: ManagementCodeModelTransformer
+) {
   context.options["generator-name"] ??= "ManagementClientGenerator";
   context.options["emitter-extension-path"] ??= import.meta.url;
   context.options["sdk-context-options"] ??= azureSDKContextOptions;
@@ -52,11 +62,19 @@ export async function $onEmit(context: EmitContext<AzureMgmtEmitterOptions>) {
     // inherit from parents. In mgmt SDK we flatten the hierarchy, so we infer from methods instead.
     fixClientApiVersions(codeModel, sdkContext);
 
-    updateClients(codeModel, sdkContext, context.options);
+    const armProviderSchema = updateClients(
+      codeModel,
+      sdkContext,
+      context.options
+    );
     setFlattenProperty(codeModel, sdkContext);
     setHasClientNameOverride(codeModel, sdkContext);
-    return codeModel;
+    return transform?.(codeModel, sdkContext, armProviderSchema) ?? codeModel;
   }
+}
+
+export async function $onEmit(context: EmitContext<AzureMgmtEmitterOptions>) {
+  return emitManagementCodeModel(context);
 }
 
 function setFlattenProperty(

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/index.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/index.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 export { $lib } from "./lib/lib.js";
-export { $onEmit } from "./emitter.js";
+export {
+  $onEmit,
+  emitManagementCodeModel,
+  ManagementCodeModelTransformer
+} from "./emitter.js";
 export {
   AzureMgmtEmitterOptions,
   AzureMgmtEmitterOptionsSchema

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -62,11 +62,11 @@ import { AzureMgmtEmitterOptions } from "./options.js";
 import { getAllSdkClients, traverseClient } from "./sdk-client-utils.js";
 import { $lib } from "./lib/lib.js";
 
-export async function updateClients(
+export function updateClients(
   codeModel: CodeModel,
   sdkContext: CSharpEmitterContext,
   options: AzureMgmtEmitterOptions
-) {
+): ArmProviderSchema {
   let armProviderSchema: ArmProviderSchema;
 
   if (options?.["use-legacy-resource-detection"] === false) {
@@ -76,6 +76,7 @@ export async function updateClients(
   }
 
   applyArmProviderSchemaDecorator(codeModel, armProviderSchema);
+  return armProviderSchema;
 }
 
 /**
@@ -526,11 +527,11 @@ function assignRemainingOperations(
       const scope = buildScopeInfoFromPath(operationPath);
       const isCollectionAction = isResourceCollectionAction(sdkMethod);
       const target = isCollectionAction
-        ? (findCollectionActionTargetResource(
+        ? findCollectionActionTargetResource(
             resources,
             operationPath,
             actionTarget
-          ) ?? actionTarget)
+          ) ?? actionTarget
         : actionTarget;
       target.metadata.methods.push({
         methodId,


### PR DESCRIPTION
## Summary
- expose `emitManagementCodeModel` so downstream emitters can reuse the complete management emission pipeline and transform the resulting code model
- provide the downstream transformer with the `CodeModel`, `CSharpEmitterContext`, and detected `ArmProviderSchema`
- preserve the existing `$onEmit` behavior for management SDK generation

## Validation
- management emitter lint and formatting for changed files
- 145 management emitter tests
- management emitter build
- regenerated and built the management TypeSpec test projects with no tracked generated changes

## Follow-up
- update the provisioning emitter to consume this API after a management generator package containing it is released