### PR TITLE
updated Change log to prepare for Keys 4.11.0-beta3 release

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Release History
 
-## 4.11.0-beta.2 (2026-07-15)
+## 4.11.0-beta.3 (2026-07-16)
 
 ### Features Added
 - Added the `SecureWrapKey` and `SecureUnwrapKey` methods (and their async counterparts) to `CryptographyClient` for secure wrap/unwrap operations on Managed HSM keys ([#60933](https://github.com/Azure/azure-sdk-for-net/pull/60933)).
 - Added the `SecureKeyWrapAlgorithm` type, listing the algorithms supported by the secure wrap/unwrap operations.
 - Added the `SecureWrapResult` and `SecureUnwrapResult` model classes wrapping the results of `SecureWrapKey` and `SecureUnwrapKey`, respectively.
 - Added the `SecureWrapKey` and `SecureUnwrapKey` values to `KeyOperation`.
+
+## 4.11.0-beta.2 (2026-06-10)
+
+### Features Added
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.11.0-beta.1 (2026-06-04)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Keys client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Keys client library</AssemblyTitle>
-    <Version>4.11.0-beta.2</Version>
+    <Version>4.11.0-beta.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.10.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Keys;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
A private branch(https://github.com/Azure/azure-sdk-for-net/tree/feature/identity-token-binding-keyvault) release was made releasing the 4.11.0-beta2 resulting in the changelog not being updated , manually edited changelog to add contents of beta 2 and bump up to beta3
