### PR TITLE
Trigger package validation when its project-scoped eng files change

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -8,6 +8,7 @@ $GithubUri = "https://github.com/Azure/azure-sdk-for-net"
 $PackageRepositoryUri = "https://www.nuget.org/packages"
 
 . "$PSScriptRoot/docs/Docs-ToC.ps1"
+. "$PSScriptRoot/ProjectScopedEngFiles.ps1"
 function Get-AllPackageInfoFromRepo($serviceDirectory)
 {
   $allPackageProps = @()
@@ -94,6 +95,20 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
 {
   $additionalValidationPackages = @()
 
+  # Changes to a package's project-scoped engineering files (ApiCompat baselines,
+  # analyzer/NoWarn allow-lists, CPM overrides) live under eng/ and so are invisible to
+  # the eng/common diff-to-package detection, which only maps files under a package's
+  # sdk/<service>/<package> directory. Map those changes back to their owning package so
+  # validation rebuilds it (and re-runs ApiCompat). Without this a baseline deletion can
+  # silently ship an ApiCompat regression because the package is never rebuilt (see #60837).
+  foreach ($pkg in (Get-PackagesFromEngFileChanges -DiffObj $diffObj -AllPkgProps $AllPkgProps)) {
+    if ($LocatedPackages -notcontains $pkg -and $additionalValidationPackages -notcontains $pkg) {
+      Write-Host "Including '$($pkg.Name)' because one of its project-scoped engineering files changed."
+      $pkg.IncludedForValidation = $true
+      $additionalValidationPackages += $pkg
+    }
+  }
+
   # Use all directly changed packages for dependency calculation. This ensures that
   # when any package changes, all cross-service packages that depend on it are included
   # as indirect packages for validation testing.
@@ -129,7 +144,7 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
         continue
       }
 
-      if ($pkg -and $LocatedPackages -notcontains $pkg) {
+      if ($pkg -and $LocatedPackages -notcontains $pkg -and $additionalValidationPackages -notcontains $pkg) {
         $pkg.IncludedForValidation = $true
         $additionalValidationPackages += $pkg
       }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -103,7 +103,8 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
   # silently ship an ApiCompat regression because the package is never rebuilt (see #60837).
   foreach ($pkg in (Get-PackagesFromEngFileChanges -DiffObj $diffObj -AllPkgProps $AllPkgProps)) {
     if ($LocatedPackages -notcontains $pkg -and $additionalValidationPackages -notcontains $pkg) {
-      Write-Host "Including '$($pkg.Name)' because one of its project-scoped engineering files changed."
+      $pkgDisplayName = if ($pkg.ArtifactName) { $pkg.ArtifactName } else { $pkg.Name }
+      Write-Host "Including '$pkgDisplayName' because one of its project-scoped engineering files changed."
       $pkg.IncludedForValidation = $true
       $additionalValidationPackages += $pkg
     }

--- a/eng/scripts/ProjectScopedEngFiles.ps1
+++ b/eng/scripts/ProjectScopedEngFiles.ps1
@@ -1,0 +1,96 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+Maps changes to a package's project-scoped engineering files back to the owning package.
+
+.DESCRIPTION
+Some per-package configuration lives outside the package's sdk/<service>/<package>
+directory, under shared eng/ folders keyed by project (== package) name:
+
+    eng/apicompatbaselines/<Package>.txt                            ApiCompat baselines
+    eng/analyzerallowlist/<Package>.txt                             NoWarn / analyzer allow-list
+    eng/centralpackagemanagement/overrides/<Package>.Packages.props CPM version overrides
+
+The eng/common PR diff-to-package detection (Get-PkgPropsFromDiff) only attributes a
+changed file to a package when the file lives under that package's sdk/ directory (or a
+ci.yml TriggeringPath). A change to one of the files above therefore builds nothing, so a
+PR that (for example) deletes an ApiCompat baseline can silently ship an ApiCompat
+regression because the package is never rebuilt in CI (see #60837 / Azure.Identity).
+
+These helpers map such changes back to their package so PR validation rebuilds it and
+re-runs ApiCompat / analyzer validation.
+#>
+
+# Project-scoped eng folders where the file base name equals the project (== package) name.
+# Prefixes are forward-slash and folder-anchored; Suffix is the file extension to strip.
+$script:ProjectScopedEngFilePatterns = @(
+    @{ Prefix = "eng/apicompatbaselines/";                 Suffix = ".txt" },
+    @{ Prefix = "eng/analyzerallowlist/";                  Suffix = ".txt" },
+    @{ Prefix = "eng/centralpackagemanagement/overrides/"; Suffix = ".Packages.props" }
+)
+
+function Get-ProjectNamesFromEngFileChanges {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [string[]]$ChangedFiles
+    )
+
+    $names = @()
+    foreach ($file in $ChangedFiles) {
+        if ([string]::IsNullOrWhiteSpace($file)) {
+            continue
+        }
+
+        $normalized = $file.Replace("\", "/")
+        foreach ($pattern in $script:ProjectScopedEngFilePatterns) {
+            if (-not $normalized.StartsWith($pattern.Prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+            if (-not $normalized.EndsWith($pattern.Suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+
+            $remainder = $normalized.Substring($pattern.Prefix.Length)
+            # Only direct files in the folder map to a package; skip nested paths.
+            if ($remainder.Contains("/")) {
+                continue
+            }
+
+            $baseName = $remainder.Substring(0, $remainder.Length - $pattern.Suffix.Length)
+            if ($baseName) {
+                $names += $baseName
+            }
+        }
+    }
+
+    return @($names | Select-Object -Unique)
+}
+
+function Get-PackagesFromEngFileChanges {
+    param(
+        [Parameter(Mandatory = $true)]
+        $DiffObj,
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $AllPkgProps
+    )
+
+    $files = @()
+    if ($DiffObj.ChangedFiles) { $files += $DiffObj.ChangedFiles }
+    if ($DiffObj.DeletedFiles) { $files += $DiffObj.DeletedFiles }
+
+    $projectNames = Get-ProjectNamesFromEngFileChanges -ChangedFiles $files
+
+    $matched = @()
+    foreach ($name in $projectNames) {
+        $pkg = $AllPkgProps | Where-Object { $_.Name -eq $name -or $_.ArtifactName -eq $name } | Select-Object -First 1
+        if ($pkg) {
+            $matched += $pkg
+        }
+    }
+
+    return $matched
+}

--- a/eng/scripts/tests/ProjectScopedEngFiles.tests.ps1
+++ b/eng/scripts/tests/ProjectScopedEngFiles.tests.ps1
@@ -1,0 +1,145 @@
+#Requires -Version 7.0
+<#
+.How-To-Run
+This test file uses Pester, a testing framework for PowerShell.
+For more information about Pester, see: https://pester.dev/docs/quick-start
+
+First, ensure you have `pester` installed:
+
+`Install-Module Pester -Force`
+
+Then invoke tests with:
+
+`Invoke-Pester ./ProjectScopedEngFiles.tests.ps1`
+
+#>
+
+. (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "Helpers" PSModule-Helpers.ps1)
+Install-ModuleIfNotInstalled "Pester" "5.3.3" | Import-Module
+
+Set-StrictMode -Version 3
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot ".." "ProjectScopedEngFiles.ps1")
+
+    function New-Pkg([string]$Name) {
+        return [PSCustomObject]@{
+            Name                  = $Name
+            ArtifactName          = $Name
+            IncludedForValidation = $false
+        }
+    }
+
+    function New-Diff {
+        param([string[]]$Changed = @(), [string[]]$Deleted = @())
+        return [PSCustomObject]@{
+            ChangedFiles = $Changed
+            DeletedFiles = $Deleted
+        }
+    }
+}
+
+Describe "Get-ProjectNamesFromEngFileChanges" -Tag "UnitTest" {
+    It "maps an apicompatbaselines file to its project name" {
+        $names = Get-ProjectNamesFromEngFileChanges -ChangedFiles @("eng/apicompatbaselines/Azure.Identity.txt")
+        $names | Should -Be @("Azure.Identity")
+    }
+
+    It "maps an analyzerallowlist (NoWarn) file to its project name" {
+        $names = Get-ProjectNamesFromEngFileChanges -ChangedFiles @("eng/analyzerallowlist/Azure.Core.txt")
+        $names | Should -Be @("Azure.Core")
+    }
+
+    It "maps a centralpackagemanagement override to its project name" {
+        $names = Get-ProjectNamesFromEngFileChanges -ChangedFiles @("eng/centralpackagemanagement/overrides/Azure.ResourceManager.Network.Packages.props")
+        $names | Should -Be @("Azure.ResourceManager.Network")
+    }
+
+    It "handles backslash-separated paths" {
+        $names = Get-ProjectNamesFromEngFileChanges -ChangedFiles @("eng\apicompatbaselines\Azure.Identity.txt")
+        $names | Should -Be @("Azure.Identity")
+    }
+
+    It "ignores files that are not in a project-scoped eng folder" {
+        $names = Get-ProjectNamesFromEngFileChanges -ChangedFiles @(
+            "eng/scripts/Update-PkgVersion.ps1",
+            "sdk/core/Azure.Core/src/Azure.Core.csproj",
+            "eng/apicompatbaselines/README.md"
+        )
+        $names | Should -BeNullOrEmpty
+    }
+
+    It "ignores nested files below the project-scoped folder" {
+        $names = Get-ProjectNamesFromEngFileChanges -ChangedFiles @("eng/apicompatbaselines/subdir/Azure.Identity.txt")
+        $names | Should -BeNullOrEmpty
+    }
+
+    It "de-duplicates repeated project names" {
+        $names = Get-ProjectNamesFromEngFileChanges -ChangedFiles @(
+            "eng/apicompatbaselines/Azure.Identity.txt",
+            "eng/analyzerallowlist/Azure.Identity.txt"
+        )
+        @($names) | Should -Be @("Azure.Identity")
+    }
+
+    It "returns nothing for empty input" {
+        $names = Get-ProjectNamesFromEngFileChanges -ChangedFiles @()
+        $names | Should -BeNullOrEmpty
+    }
+}
+
+Describe "Get-PackagesFromEngFileChanges" -Tag "UnitTest" {
+    It "returns the package matching a changed baseline file" {
+        $all = @((New-Pkg "Azure.Identity"), (New-Pkg "Azure.Core"))
+        $diff = New-Diff -Changed @("eng/apicompatbaselines/Azure.Identity.txt")
+
+        $result = Get-PackagesFromEngFileChanges -DiffObj $diff -AllPkgProps $all
+
+        @($result).Count | Should -Be 1
+        $result[0].Name | Should -Be "Azure.Identity"
+    }
+
+    It "includes packages referenced only in DeletedFiles (baseline removal)" {
+        $all = @((New-Pkg "Azure.Identity"), (New-Pkg "Azure.Core"))
+        $diff = New-Diff -Deleted @("eng/apicompatbaselines/Azure.Identity.txt")
+
+        $result = Get-PackagesFromEngFileChanges -DiffObj $diff -AllPkgProps $all
+
+        @($result).Count | Should -Be 1
+        $result[0].Name | Should -Be "Azure.Identity"
+    }
+
+    It "returns every affected package from a mixed change/delete set" {
+        $all = @(
+            (New-Pkg "Azure.Identity"),
+            (New-Pkg "Azure.Core"),
+            (New-Pkg "Azure.ResourceManager.Network")
+        )
+        $diff = New-Diff `
+            -Changed @("eng/analyzerallowlist/Azure.Core.txt", "eng/centralpackagemanagement/overrides/Azure.ResourceManager.Network.Packages.props") `
+            -Deleted @("eng/apicompatbaselines/Azure.Identity.txt")
+
+        $result = Get-PackagesFromEngFileChanges -DiffObj $diff -AllPkgProps $all
+
+        ($result.Name | Sort-Object) | Should -Be @("Azure.Core", "Azure.Identity", "Azure.ResourceManager.Network")
+    }
+
+    It "returns nothing when the file base name matches no known package" {
+        $all = @((New-Pkg "Azure.Core"))
+        $diff = New-Diff -Deleted @("eng/apicompatbaselines/ApiCompatVersionOptOut.txt")
+
+        $result = Get-PackagesFromEngFileChanges -DiffObj $diff -AllPkgProps $all
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It "matches on ArtifactName when it differs from Name" {
+        $pkg = [PSCustomObject]@{ Name = "internal-name"; ArtifactName = "Azure.Special"; IncludedForValidation = $false }
+        $diff = New-Diff -Changed @("eng/apicompatbaselines/Azure.Special.txt")
+
+        $result = Get-PackagesFromEngFileChanges -DiffObj $diff -AllPkgProps @($pkg)
+
+        @($result).Count | Should -Be 1
+        $result[0].ArtifactName | Should -Be "Azure.Special"
+    }
+}


### PR DESCRIPTION
## What & why

The PR "packages changed" detection (`eng/common` `Get-PkgPropsFromDiff`) only attributes a changed file to a package when the file lives under that package's `sdk/<service>/<package>/` directory (or a ci.yml `TriggeringPath`). Per-package configuration that lives under `eng/` therefore maps to **no** package, so a PR that only touches those files rebuilds nothing.

This is how #60837 shipped an ApiCompat regression: it deleted 9 `eng/apicompatbaselines/*.txt` baselines, none of the owning packages were rebuilt in CI, and `Azure.Identity` merged green despite its ApiCompat now failing. (Reproduced: replaying #60837's exact file set through the detection selected only the `template` fallback package.)

## Fix

Map changes to a package's **project-scoped engineering files** back to the owning package via the repo-specific `Get-dotnet-AdditionalValidationPackagesFromPackageSet` hook (in `eng/scripts/Language-Settings.ps1`, not the synced `eng/common`). Covered folders, keyed by `<ProjectName>`:

- `eng/apicompatbaselines/<Package>.txt` - ApiCompat baselines
- `eng/analyzerallowlist/<Package>.txt` - NoWarn / analyzer allow-list
- `eng/centralpackagemanagement/overrides/<Package>.Packages.props` - CPM overrides

When one of these files changes (added, modified, or deleted), the owning package is included for validation so it is rebuilt and ApiCompat / analyzer validation re-runs.

## Files

- `eng/scripts/ProjectScopedEngFiles.ps1` (new) - pure helpers `Get-ProjectNamesFromEngFileChanges` / `Get-PackagesFromEngFileChanges`.
- `eng/scripts/Language-Settings.ps1` - dot-source the helper and include matched packages in the additional-validation set.
- `eng/scripts/tests/ProjectScopedEngFiles.tests.ps1` (new) - 13 Pester unit tests (tagged `UnitTest`).

## Verification

- 13/13 unit tests pass.
- End-to-end: replaying #60837's file set through the real detection now selects all 9 affected packages (including `Azure.Identity`) instead of just the template fallback.
- Negative: normal `sdk/`-only and unrelated `eng/scripts` diffs select 0 extra packages (no behavior change).
- Separately confirmed the other 8 baselines deleted in #60837 still pass ApiCompat with the baseline removed; only `Azure.Identity` was a genuine regression (restored separately).