### PR TITLE
[agentserver] Use system-assigned managed identity for Entra Azure Monitor auth

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/api/Azure.AI.AgentServer.Core.net10.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/api/Azure.AI.AgentServer.Core.net10.0.cs
@@ -63,6 +63,7 @@ namespace Azure.AI.AgentServer.Core
         public static string? AgentVersion { get { throw null; } }
         public static string? AppInsightsConnectionString { get { throw null; } }
         public static bool IsAgent365TracingEnabled { get { throw null; } }
+        public static bool IsAppInsightsEntraAuth { get { throw null; } }
         public static bool IsHosted { get { throw null; } }
         public static string? OtlpEndpoint { get { throw null; } }
         public static int Port { get { throw null; } }

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/api/Azure.AI.AgentServer.Core.net8.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/api/Azure.AI.AgentServer.Core.net8.0.cs
@@ -63,6 +63,7 @@ namespace Azure.AI.AgentServer.Core
         public static string? AgentVersion { get { throw null; } }
         public static string? AppInsightsConnectionString { get { throw null; } }
         public static bool IsAgent365TracingEnabled { get { throw null; } }
+        public static bool IsAppInsightsEntraAuth { get { throw null; } }
         public static bool IsHosted { get { throw null; } }
         public static string? OtlpEndpoint { get { throw null; } }
         public static int Port { get { throw null; } }

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Platform/FoundryEnvironment.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Platform/FoundryEnvironment.cs
@@ -61,6 +61,17 @@ public static class FoundryEnvironment
     public static string? AppInsightsConnectionString { get; private set; }
 
     /// <summary>
+    /// Indicates whether Microsoft Entra (AAD) authentication is requested for
+    /// Azure Monitor export. Returns <c>true</c> when the
+    /// <c>APPLICATIONINSIGHTS_AUTH_MODE</c> environment variable is set to
+    /// <c>"Entra"</c> (case-insensitive). When enabled, the Azure Monitor
+    /// exporter is configured with a system-assigned
+    /// <see cref="Azure.Identity.ManagedIdentityCredential"/> instead of relying
+    /// on the connection string's instrumentation key alone.
+    /// </summary>
+    public static bool IsAppInsightsEntraAuth { get; private set; }
+
+    /// <summary>
     /// The SSE keep-alive comment frame interval. Sourced from the <c>SSE_KEEPALIVE_INTERVAL</c>
     /// environment variable (value in integer seconds). When absent, zero, or unparseable,
     /// returns <see cref="Timeout.InfiniteTimeSpan"/> (disabled).
@@ -139,6 +150,12 @@ public static class FoundryEnvironment
         SessionId = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_SESSION_ID");
         OtlpEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
         AppInsightsConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+
+        // Entra (AAD) auth for Azure Monitor export when APPLICATIONINSIGHTS_AUTH_MODE=Entra.
+        IsAppInsightsEntraAuth = string.Equals(
+            Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_AUTH_MODE"),
+            "Entra",
+            StringComparison.OrdinalIgnoreCase);
 
         // Port: default 8088, validate range 1-65535.
         var portEnv = Environment.GetEnvironmentVariable("PORT");

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/OpenTelemetryExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/OpenTelemetryExtensions.cs
@@ -79,10 +79,22 @@ internal static class OpenTelemetryExtensions
 
                 // When Entra-based auth is requested, export to Azure Monitor using a
                 // system-assigned managed identity (no client id) rather than relying
-                // on the connection string's instrumentation key alone.
+                // on the connection string's instrumentation key alone. If the credential
+                // cannot be created for any reason, warn and fall back to connection-string
+                // authentication rather than failing tracing setup.
                 if (FoundryEnvironment.IsAppInsightsEntraAuth)
                 {
-                    options.AzureMonitor.Credential = new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned);
+                    try
+                    {
+                        options.AzureMonitor.Credential = new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned);
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Trace.TraceWarning(
+                            "APPLICATIONINSIGHTS_AUTH_MODE=Entra requested but a managed identity " +
+                            "credential could not be created ({0}) — continuing with connection-string authentication.",
+                            ex.Message);
+                    }
                 }
             }
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/OpenTelemetryExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/OpenTelemetryExtensions.cs
@@ -76,6 +76,14 @@ internal static class OpenTelemetryExtensions
             if (!string.IsNullOrEmpty(FoundryEnvironment.AppInsightsConnectionString))
             {
                 exporters |= ExportTarget.AzureMonitor;
+
+                // When Entra-based auth is requested, export to Azure Monitor using a
+                // system-assigned managed identity (no client id) rather than relying
+                // on the connection string's instrumentation key alone.
+                if (FoundryEnvironment.IsAppInsightsEntraAuth)
+                {
+                    options.AzureMonitor.Credential = new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned);
+                }
             }
 
             if (!string.IsNullOrEmpty(FoundryEnvironment.OtlpEndpoint))

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnvironmentTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnvironmentTests.cs
@@ -20,6 +20,7 @@ public class FoundryEnvironmentTests
         Environment.SetEnvironmentVariable("PORT", null);
         Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", null);
         Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", null);
+        Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_AUTH_MODE", null);
         Environment.SetEnvironmentVariable("SSE_KEEPALIVE_INTERVAL", null);
         Environment.SetEnvironmentVariable("WS_KEEPALIVE_INTERVAL", null);
         Environment.SetEnvironmentVariable("FOUNDRY_HOSTING_ENVIRONMENT", null);
@@ -349,5 +350,40 @@ public class FoundryEnvironmentTests
         Environment.SetEnvironmentVariable("FOUNDRY_AGENT365_TRACING_ENABLED", "false");
         FoundryEnvironment.Reload();
         Assert.That(FoundryEnvironment.IsAgent365TracingEnabled, Is.False);
+    }
+
+    // ---------------------------------------------------------------
+    // IsAppInsightsEntraAuth (driven by APPLICATIONINSIGHTS_AUTH_MODE env var)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void IsAppInsightsEntraAuth_ReturnsTrue_WhenAuthModeIsEntra()
+    {
+        Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_AUTH_MODE", "Entra");
+        FoundryEnvironment.Reload();
+        Assert.That(FoundryEnvironment.IsAppInsightsEntraAuth, Is.True);
+    }
+
+    [Test]
+    public void IsAppInsightsEntraAuth_IsCaseInsensitive()
+    {
+        Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_AUTH_MODE", "entra");
+        FoundryEnvironment.Reload();
+        Assert.That(FoundryEnvironment.IsAppInsightsEntraAuth, Is.True);
+    }
+
+    [Test]
+    public void IsAppInsightsEntraAuth_ReturnsFalse_WhenNotSet()
+    {
+        FoundryEnvironment.Reload();
+        Assert.That(FoundryEnvironment.IsAppInsightsEntraAuth, Is.False);
+    }
+
+    [Test]
+    public void IsAppInsightsEntraAuth_ReturnsFalse_WhenOtherValue()
+    {
+        Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_AUTH_MODE", "ConnectionString");
+        FoundryEnvironment.Reload();
+        Assert.That(FoundryEnvironment.IsAppInsightsEntraAuth, Is.False);
     }
 }


### PR DESCRIPTION
## Summary
When `APPLICATIONINSIGHTS_CONNECTION_STRING` is set and `APPLICATIONINSIGHTS_AUTH_MODE` is `Entra`, the `Microsoft.OpenTelemetry` distro's Azure Monitor exporter is now configured with a **system-assigned** `ManagedIdentityCredential` (`ManagedIdentityId.SystemAssigned`, i.e. no client id).

This follows the [distro README](https://github.com/microsoft/opentelemetry-distro-dotnet/blob/main/README.md) guidance: `o.AzureMonitor.Credential = new DefaultAzureCredential();` for AAD/Entra auth.

Mirrors the equivalent change in the Python SDK (azure-sdk-for-python).

## Changes
- `FoundryEnvironment`: added `IsAppInsightsEntraAuth` (reads `APPLICATIONINSIGHTS_AUTH_MODE` == `Entra`, case-insensitive).
- `OpenTelemetryExtensions.AddAgentHostTelemetry`: when Azure Monitor is enabled and Entra auth is requested, sets `options.AzureMonitor.Credential = new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned)`.
- Updated public API surface (`net8.0` / `net10.0`).
- Added `FoundryEnvironmentTests` coverage for the new property.

## Testing
`dotnet test -f net8.0 --filter FoundryEnvironmentTests` — 43 passed. Core project builds clean for net8.0 and net10.0.