### PR TITLE
[http-client-csharp] Add query expansion and lossy duration Spector tests

### DIFF
--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Encode/Duration/EncodeDurationTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Encode/Duration/EncodeDurationTests.cs
@@ -436,5 +436,19 @@ namespace TestProjects.Spector.Tests.Http.Encode.Duration
             var response = await new DurationClient(host, null).GetQueryClient().Int32MillisecondsArrayAsync(new[] { data1, data2 });
             Assert.AreEqual(204, response.Status);
         });
+
+        [SpectorTest]
+        public Task LossyInt32Seconds() => Test(async (host) =>
+        {
+            var response = await new DurationClient(host, null).GetLossyClient().IntSecondsAsync(TimeSpan.FromSeconds(36.25));
+            Assert.AreEqual(204, response.Status);
+        });
+
+        [SpectorTest]
+        public Task LossyInt32Milliseconds() => Test(async (host) =>
+        {
+            var response = await new DurationClient(host, null).GetLossyClient().IntMillisecondsAsync(TimeSpan.FromMilliseconds(36250.25));
+            Assert.AreEqual(204, response.Status);
+        });
     }
 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Routes/QueryTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Routes/QueryTests.cs
@@ -92,6 +92,16 @@ namespace TestProjects.Spector.Tests.Http.Routes
         });
 
         [SpectorTest]
+        public Task QueryExpansionExplodeModel() => Test(async (host) =>
+        {
+            var response = await new RoutesClient(host, null).GetQueryParametersClient()
+                .GetQueryParametersQueryExpansionClient()
+                .GetQueryParametersQueryExpansionExplodeClient()
+                .ModelAsync(new ExpandParameters("status", "active"));
+            Assert.AreEqual(204, response.Status);
+        });
+
+        [SpectorTest]
         [Ignore("https://github.com/microsoft/typespec/issues/5561")]
         public Task QueryContinuationPrimitive() => Test(async (host) =>
         {


### PR DESCRIPTION
## Summary

- add Azure emitter Spector coverage for exploded model query parameters
- add Azure emitter Spector coverage for lossy integer duration encodings

## Validation

- `Test-Spector.ps1 -filter http/routes` (18 passed, 9 skipped)
- `Test-Spector.ps1 -filter http/encode/duration` (50 passed)
- `npm run build`
- `npm run lint`
- `npm run prettier`

Related unbranded emitter coverage: microsoft/typespec#11298