### PR TITLE
Peel Synapse.Artifacts/EventGrid(.SystemEvents)/TextAnalytics/Provisioning.Deployment/SignalRService off NoWarn skip list

### DIFF
--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -26,10 +26,8 @@ Azure.Monitor.OpenTelemetry.AspNetCore
 Azure.Projects
 Azure.Projects.Provisioning
 Azure.Provisioning
-Azure.Provisioning.Deployment
 Azure.ResourceManager.InformaticaDataManagement
 Microsoft.Azure.WebJobs.Extensions.EventHubs
 Microsoft.Azure.WebJobs.Extensions.ServiceBus
-Microsoft.Azure.WebJobs.Extensions.SignalRService
 Microsoft.Azure.WebJobs.Extensions.Tables
 Microsoft.ClientModel.TestFramework

--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -20,11 +20,7 @@ Azure.AI.Inference
 Azure.AI.Language.QuestionAnswering.Inference
 Azure.AI.OpenAI
 Azure.AI.OpenAI.Assistants
-Azure.AI.TextAnalytics
 Azure.AI.VoiceLive.Snippets
-Azure.Analytics.Synapse.Artifacts
-Azure.Messaging.EventGrid
-Azure.Messaging.EventGrid.SystemEvents
 Azure.Messaging.ServiceBus
 Azure.Monitor.OpenTelemetry.AspNetCore
 Azure.Projects

--- a/eng/analyzerallowlist/Azure.AI.TextAnalytics.txt
+++ b/eng/analyzerallowlist/Azure.AI.TextAnalytics.txt
@@ -1,0 +1,9 @@
+# Azure.AI.TextAnalytics approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# These are GA'd public type names. The collisions are with unrelated libraries
+# (Azure.Search.Documents, Azure.AI.FormRecognizer) that are never referenced
+# together with Azure.AI.TextAnalytics, and renaming them would be a breaking
+# change, so AZC0034 is suppressed for these specific types.
+nowarn:AZC0034 T:Azure.AI.TextAnalytics.EntityCategory
+nowarn:AZC0034 T:Azure.AI.TextAnalytics.ClassifyDocumentOperation

--- a/sdk/eventgrid/Azure.Messaging.EventGrid.SystemEvents/src/Azure.Messaging.EventGrid.SystemEvents.csproj
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid.SystemEvents/src/Azure.Messaging.EventGrid.SystemEvents.csproj
@@ -9,10 +9,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
-    <NoWarn>
-      $(NoWarn);
-      AZC0034; <!-- Cannot reuse type names; expected due to system event type forwarding. -->
-    </NoWarn>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>
 

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
@@ -9,10 +9,6 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <NoWarn>
-      $(NoWarn);
-      AZC0034; <!-- Cannot reuse type names; expected due to system event type forwarding. -->
-    </NoWarn>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>
 

--- a/sdk/provisioning/Azure.Provisioning.Deployment/src/Azure.Provisioning.Deployment.csproj
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/src/Azure.Provisioning.Deployment.csproj
@@ -9,8 +9,6 @@
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
     <!-- Disable warning AZC0012: Single word class names -->
-    <!-- Disable warning IDE0130: Namespace does not match folder structure-->
-    <NoWarn>CS1591;AZC0012;IDE0130;$(NoWarn)</NoWarn>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>
 

--- a/sdk/provisioning/Azure.Provisioning.Deployment/src/Azure.Provisioning.Deployment.csproj
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/src/Azure.Provisioning.Deployment.csproj
@@ -7,8 +7,6 @@
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
 
-    <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->
-    <!-- Disable warning AZC0012: Single word class names -->
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>
 

--- a/sdk/provisioning/Azure.Provisioning.Deployment/src/BicepErrorMessage.cs
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/src/BicepErrorMessage.cs
@@ -35,6 +35,11 @@ public partial class BicepErrorMessage
     /// If this is not provided then defer to the <see cref="RawText"/>.
     /// </summary>
     public int? ColumnNumber { get; private set; }
+    /// <summary>
+    /// Indicates whether this message represents an error (<see langword="true"/>) or a
+    /// warning (<see langword="false"/>). If this is not provided then defer to the
+    /// <see cref="RawText"/>.
+    /// </summary>
     public bool? IsError { get; private set; }
 
     /// <summary>

--- a/sdk/provisioning/Azure.Provisioning.Deployment/src/ProvisioningPlan.Deploy.cs
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/src/ProvisioningPlan.Deploy.cs
@@ -22,6 +22,10 @@ namespace Azure.Provisioning;
 // groups to help feel out whether we want to offer this experience, but we'd
 // also want to expand to subscriptions, management groups, tenants, etc.
 
+/// <summary>
+/// Provides extension methods for deploying and validating a <see cref="ProvisioningPlan"/>
+/// against Azure resource groups.
+/// </summary>
 public static class ProvisioningPlanExtensions
 {
     private static Lazy<ExternalBicepTool> BicepTool { get; } = new(ExternalBicepTool.FindBestTool);
@@ -51,6 +55,15 @@ public static class ProvisioningPlanExtensions
     // TODO: Take an optional Bicep path
     // TODO: Take an ARM template directly
 
+    /// <summary>
+    /// Compiles the plan to an ARM template, creates a new resource group, and deploys the template into it.
+    /// </summary>
+    /// <param name="plan">The provisioning plan to deploy.</param>
+    /// <param name="resourceGroupName">The name of the resource group to create.</param>
+    /// <param name="location">The location in which to create the resource group.</param>
+    /// <param name="options">Optional deployment options.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+    /// <returns>The completed <see cref="ProvisioningDeployment"/>.</returns>
     public static ProvisioningDeployment DeployToNewResourceGroup(
         this ProvisioningPlan plan,
         string resourceGroupName,
@@ -66,6 +79,15 @@ public static class ProvisioningPlanExtensions
                 cancellationToken)
             .EnsureCompleted();
 
+    /// <summary>
+    /// Compiles the plan to an ARM template, creates a new resource group, and deploys the template into it.
+    /// </summary>
+    /// <param name="plan">The provisioning plan to deploy.</param>
+    /// <param name="resourceGroupName">The name of the resource group to create.</param>
+    /// <param name="location">The location in which to create the resource group.</param>
+    /// <param name="options">Optional deployment options.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+    /// <returns>The completed <see cref="ProvisioningDeployment"/>.</returns>
     public static async Task<ProvisioningDeployment> DeployToNewResourceGroupAsync(
         this ProvisioningPlan plan,
         string resourceGroupName,
@@ -113,6 +135,14 @@ public static class ProvisioningPlanExtensions
         return ProcessDeploymentInternal(plan, options, deployment);
     }
 
+    /// <summary>
+    /// Compiles the plan to an ARM template and deploys it into an existing resource group.
+    /// </summary>
+    /// <param name="plan">The provisioning plan to deploy.</param>
+    /// <param name="resourceGroupName">The name of the existing resource group to deploy into.</param>
+    /// <param name="options">Optional deployment options.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+    /// <returns>The completed <see cref="ProvisioningDeployment"/>.</returns>
     public static ProvisioningDeployment DeployToResourceGroup(
         this ProvisioningPlan plan,
         string resourceGroupName,
@@ -126,6 +156,14 @@ public static class ProvisioningPlanExtensions
                 cancellationToken)
             .EnsureCompleted();
 
+    /// <summary>
+    /// Compiles the plan to an ARM template and deploys it into an existing resource group.
+    /// </summary>
+    /// <param name="plan">The provisioning plan to deploy.</param>
+    /// <param name="resourceGroupName">The name of the existing resource group to deploy into.</param>
+    /// <param name="options">Optional deployment options.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+    /// <returns>The completed <see cref="ProvisioningDeployment"/>.</returns>
     public static async Task<ProvisioningDeployment> DeployToResourceGroupAsync(
         this ProvisioningPlan plan,
         string resourceGroupName,
@@ -234,6 +272,14 @@ public static class ProvisioningPlanExtensions
         return new ProvisioningDeployment(plan, options, deployment, outputs);
     }
 
+    /// <summary>
+    /// Compiles the plan to an ARM template and validates it against an existing resource group without deploying.
+    /// </summary>
+    /// <param name="plan">The provisioning plan to validate.</param>
+    /// <param name="resourceGroupName">The name of the existing resource group to validate against.</param>
+    /// <param name="options">Optional deployment options.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+    /// <returns>The <see cref="ArmDeploymentValidateResult"/> describing the validation outcome.</returns>
     public static ArmDeploymentValidateResult ValidateInResourceGroup(
         this ProvisioningPlan plan,
         string resourceGroupName,
@@ -247,6 +293,14 @@ public static class ProvisioningPlanExtensions
                 cancellationToken)
             .EnsureCompleted();
 
+    /// <summary>
+    /// Compiles the plan to an ARM template and validates it against an existing resource group without deploying.
+    /// </summary>
+    /// <param name="plan">The provisioning plan to validate.</param>
+    /// <param name="resourceGroupName">The name of the existing resource group to validate against.</param>
+    /// <param name="options">Optional deployment options.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+    /// <returns>The <see cref="ArmDeploymentValidateResult"/> describing the validation outcome.</returns>
     public static async Task<ArmDeploymentValidateResult> ValidateInResourceGroupAsync(
         this ProvisioningPlan plan,
         string resourceGroupName,

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/SecurityTokenStatus.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/SecurityTokenStatus.cs
@@ -3,10 +3,16 @@
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
+    /// <summary>
+    /// Represents the result of validating a security token supplied to a SignalR trigger.
+    /// </summary>
     public enum SecurityTokenStatus
     {
+        /// <summary>The token is present and valid.</summary>
         Valid,
+        /// <summary>The token is present but failed validation.</summary>
         Error,
+        /// <summary>No token was supplied.</summary>
         Empty
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRAsyncCollector.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRAsyncCollector.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             _converter = new();
         }
 
+        /// <summary>
+        /// Adds a SignalR message or group action to be sent to the SignalR Service.
+        /// </summary>
+        /// <param name="item">The SignalR message or group action to send.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
         public async Task AddAsync(T item, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (item == null)
@@ -102,6 +107,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             }
         }
 
+        /// <summary>
+        /// Flushes the collector. Items are sent as they are added, so this is a no-op.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
         public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.CompletedTask;

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Exceptions/SignalRTriggerException.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Exceptions/SignalRTriggerException.cs
@@ -5,16 +5,32 @@ using System;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
+    /// <summary>
+    /// The exception thrown when a SignalR trigger fails to process an invocation.
+    /// </summary>
     public class SignalRTriggerException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignalRTriggerException"/> class.
+        /// </summary>
         public SignalRTriggerException() : base()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignalRTriggerException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public SignalRTriggerException(string message) : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignalRTriggerException"/> class with a specified error message
+        /// and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public SignalRTriggerException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -8,7 +8,6 @@
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <SignAssembly>true</SignAssembly>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
-    <NoWarn>$(NoWarn);CS1591;AZC0107;</NoWarn>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SecurityTokenValidationAttribute.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SecurityTokenValidationAttribute.cs
@@ -6,6 +6,9 @@ using Microsoft.Azure.WebJobs.Description;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
+    /// <summary>
+    /// Binds the validation status of the incoming security token to a function return value or parameter.
+    /// </summary>
     [AttributeUsage(AttributeTargets.ReturnValue | AttributeTargets.Parameter)]
     [Binding]
     public class SecurityTokenValidationAttribute : Attribute

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRWebJobsStartup.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalRWebJobsStartup.cs
@@ -8,8 +8,15 @@ using Microsoft.Azure.WebJobs.Hosting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
+    /// <summary>
+    /// Registers the SignalR Service extension with the WebJobs host at startup.
+    /// </summary>
     public class SignalRWebJobsStartup : IWebJobsStartup
     {
+        /// <summary>
+        /// Configures the WebJobs host to use the SignalR Service extension.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebJobsBuilder"/> used to configure the host.</param>
         public void Configure(IWebJobsBuilder builder)
         {
             builder.AddSignalR();

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/ServerlessHub.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/ServerlessHub.cs
@@ -152,6 +152,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             return JwtSecurityTokenHandler.Value.ReadJwtToken(jwt).Claims.ToList();
         }
 
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="ServerlessHub"/> and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/ServerlessHub.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/ServerlessHub.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         }
 
         /// <summary>
-        /// Releases the unmanaged resources used by the <see cref="ServerlessHub"/> and optionally releases the managed resources.
+        /// Releases the resources used by the <see cref="ServerlessHub"/>.
         /// </summary>
         /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/ServerlessHubOfT.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/ServerlessHubOfT.cs
@@ -13,6 +13,10 @@ using Microsoft.Azure.SignalR.Management;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
+    /// <summary>
+    /// A base class for a strongly typed serverless SignalR hub.
+    /// </summary>
+    /// <typeparam name="T">The interface describing the client methods that can be invoked on this hub.</typeparam>
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "https://github.com/Azure/azure-sdk-for-net/issues/17164")]
     public abstract class ServerlessHub<T> where T : class
     {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRFilterAttribute.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRFilterAttribute.cs
@@ -9,10 +9,19 @@ using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
+    /// <summary>
+    /// A base attribute for filters that run before a SignalR trigger function is invoked.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
 #pragma warning disable CS0618 // Type or member is obsolete
     public abstract class SignalRFilterAttribute : FunctionInvocationFilterAttribute
     {
+        /// <summary>
+        /// Executed before the target function is invoked; extracts the <see cref="InvocationContext"/> from the
+        /// executing arguments and dispatches to <see cref="FilterAsync"/>.
+        /// </summary>
+        /// <param name="executingContext">The context for the function that is about to be executed.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
         public override Task OnExecutingAsync(FunctionExecutingContext executingContext,
             CancellationToken cancellationToken)
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Azure.Analytics.Synapse.Artifacts.csproj
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Azure.Analytics.Synapse.Artifacts.csproj
@@ -6,14 +6,6 @@
     <PackageTags>Microsoft Azure Synapse Artifacts;$(PackageCommonTags)</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-
-    <NoWarn>
-      $(NoWarn);
-      SA1649;
-      CA1812;
-      <!-- Missing XML comment for publicly visible type or member  -->
-      CS1591;
-    </NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <IncludeAutorestDependency>true</IncludeAutorestDependency>
   </PropertyGroup>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
@@ -7,8 +7,6 @@
     <ApiCompatVersion>5.3.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Text Analytics</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <!-- AZC0012 - Single word class names are too generic for Entity.cs class  -->
-    <NoWarn>$(NoWarn);3021;AZC0012;AZC0034</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <IncludeAutorestDependency>true</IncludeAutorestDependency>
     <AotCompatOptOut>true</AotCompatOptOut>


### PR DESCRIPTION
Continues draining `eng/NoWarnSkipValidation.txt` by peeling six packages off the temporary skip list (22 → 16). Each package removes its unreviewed `<NoWarn>` codes by fixing the underlying warning, confirming the code is already dead, or recording a reviewed per-symbol allow-list entry.

## Packages peeled

**Dead-code removals** (the suppressed codes no longer fire — verified by building with the suppression removed):
- **Azure.Analytics.Synapse.Artifacts** — SA1649, CA1812, CS1591
- **Azure.Messaging.EventGrid** — AZC0034
- **Azure.Messaging.EventGrid.SystemEvents** — AZC0034

**Allow-list (breaking to fix)**:
- **Azure.AI.TextAnalytics** — 3021 and AZC0012 are dead and removed; the two live AZC0034 sites (`EntityCategory`, `ClassifyDocumentOperation`) are GA'd public type names that collide with unrelated libraries (`Azure.Search.Documents`, `Azure.AI.FormRecognizer`) which are never referenced together. Renaming would be breaking, so they move to a per-type allow-list following the existing `Azure.AI.Language.Text` precedent.

**Documentation added** (fixed CS1591 by documenting the public API; dead AZC0012/IDE0130/AZC0107 also removed):
- **Azure.Provisioning.Deployment** — documented the `ProvisioningPlanExtensions` deploy/validate methods and `BicepErrorMessage.IsError`.
- **Microsoft.Azure.WebJobs.Extensions.SignalRService** — documented the serverless hub, async collector, filter attribute, trigger exception, security-token types, and startup class.

## Not included (need dedicated review)
- **Azure.Messaging.ServiceBus** — AZC0007 is live on `ServiceBusClient` constructors (suppressed per azure-sdk-tools#127); left on the skip list pending a decision on that issue.

Each peeled package was rebuilt with `-p:ValidateRunApiCompat` / NoWarn validation enforced and builds clean with no AZSDK0002.
