### PR TITLE
[Identity] Remove orphaned username/password section from EnvironmentCredential docs

### DIFF
--- a/sdk/core/Azure.Core/src/Identity/Credentials/EnvironmentCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/EnvironmentCredential.cs
@@ -44,9 +44,9 @@ namespace Azure.Identity
     /// <item><term>AZURE_CLIENT_SEND_CERTIFICATE_CHAIN</term><description>(Optional) Specifies whether an authentication request will include an x5c header to support subject name / issuer based authentication. When set to `true` or `1`, authentication requests include the x5c header.</description></item>
     /// </list>
     ///
-    /// This credential ultimately uses a <see cref="ClientSecretCredential"/> or <see cref="ClientCertificateCredential"/> to
-    /// perform the authentication using these details. Please consult the
-    /// documentation of those classes for more details.
+    /// This credential uses the configuration above to create a credential for authentication (for example,
+    /// <see cref="ClientSecretCredential"/> or <see cref="ClientCertificateCredential"/>). Please consult the documentation of the selected
+    /// credential for more details.
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [UnsupportedOSPlatform("browser")]

--- a/sdk/core/Azure.Core/src/Identity/Credentials/EnvironmentCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/EnvironmentCredential.cs
@@ -44,13 +44,6 @@ namespace Azure.Identity
     /// <item><term>AZURE_CLIENT_SEND_CERTIFICATE_CHAIN</term><description>(Optional) Specifies whether an authentication request will include an x5c header to support subject name / issuer based authentication. When set to `true` or `1`, authentication requests include the x5c header.</description></item>
     /// </list>
     ///
-    /// <b>Username and password:</b>
-    /// <list type="table">
-    /// <listheader><term>Variable</term><description>Description</description></listheader>
-    /// <item><term>AZURE_TENANT_ID</term><description>The Microsoft Entra tenant (directory) ID.</description></item>
-    /// <item><term>AZURE_CLIENT_ID</term><description>The client (application) ID of an App Registration in the tenant.</description></item>
-    /// </list>
-    ///
     /// This credential ultimately uses a <see cref="ClientSecretCredential"/> or <see cref="ClientCertificateCredential"/> to
     /// perform the authentication using these details. Please consult the
     /// documentation of those classes for more details.


### PR DESCRIPTION
Fixes #61110

## Problem
The [`EnvironmentCredential` API docs](https://learn.microsoft.com/dotnet/api/azure.identity.environmentcredential) show a **`Username and password:`** section that appears duplicative — it lists only `AZURE_TENANT_ID` and `AZURE_CLIENT_ID`, the same two variables already shown in the `Service principal with secret` / `with certificate` sections, and omits the `AZURE_USERNAME` / `AZURE_PASSWORD` variables that flow actually needs.

## Root cause
PR #49889 (`[Identity] Consistency review`) intentionally de-emphasized the deprecated ROPC (`UsernamePasswordCredential`) flow. It removed the `AZURE_USERNAME` / `AZURE_PASSWORD` rows and the `UsernamePasswordCredential` reference from the summary, but left behind the now-empty `Username and password:` heading and its table. That leftover is what renders as `duplicative`.

## Fix
Remove the orphaned `Username and password:` section from the `EnvironmentCredential` class summary. This makes the docs consistent with the `Azure.Identity` README and `DefaultAzureCredential`, which no longer document the username/password flow (`UsernamePasswordCredential` is `[Obsolete]` because it doesn't support MFA).

## Notes
- Comment-only change; no public API surface impact.
- `Azure.Core` builds clean (0 warnings, 0 errors).
- The credential's runtime still reads `AZURE_USERNAME` / `AZURE_PASSWORD` (constructing the obsolete `UsernamePasswordCredential`). Whether to remove that code path entirely is a separate follow-up beyond this doc fix.