### PR TITLE
Enable customer SDK stats on by default in Azure Monitor exporter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Customer SDK stats are now on by default; opt out with `APPLICATIONINSIGHTS_SDKSTATS_DISABLED=true`. `dropCode`/`retryCode` dimension values now use the spec's SCREAMING_SNAKE_CASE (e.g. `CLIENT_EXCEPTION`).
+
 ## 1.8.2 (2026-06-30)
 
 ### Features Added

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsHelper.cs
@@ -38,13 +38,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
         /// <summary>
         /// Checks if customer SDK stats are enabled.
         /// </summary>
-        /// <returns>True if enabled (when APPLICATIONINSIGHTS_SDKSTATS_DISABLED=false), false otherwise</returns>
+        /// <returns>True unless explicitly disabled via APPLICATIONINSIGHTS_SDKSTATS_DISABLED=true.</returns>
         public static bool IsEnabled()
         {
             if (s_isEnabled == null)
             {
+                // On-by-default per the customer-facing SDKStats spec: emit unless the user opts out.
                 var disabledValue = DefaultPlatform.Instance.GetEnvironmentVariable(EnvironmentVariableConstants.APPLICATIONINSIGHTS_SDKSTATS_DISABLED);
-                s_isEnabled = string.Equals(disabledValue, "false", StringComparison.OrdinalIgnoreCase);
+                s_isEnabled = !string.Equals(disabledValue, "true", StringComparison.OrdinalIgnoreCase);
             }
 
             return s_isEnabled.Value;
@@ -195,7 +196,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
                 if (dropCode > 0 && dropCode < 10)
                 {
                     DropCode enumValue = (DropCode)dropCode;
-                    dropCodeString = enumValue.ToString();
+                    dropCodeString = enumValue.ToDimensionString();
                 }
 
                 dropCodeString ??= dropCode.ToString();
@@ -260,7 +261,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
                 if (retryCode > 0 && retryCode < 10)
                 {
                     DropCode enumValue = (DropCode)retryCode;
-                    retryCodeString = enumValue.ToString();
+                    retryCodeString = enumValue.ToDimensionString();
                 }
 
                 retryCodeString ??= retryCode.ToString();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/DropCodeExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/DropCodeExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
+{
+    internal static class DropCodeExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="DropCode"/> to its spec-defined dimension value
+        /// (SCREAMING_SNAKE_CASE), matching the customer-facing SDKStats specification
+        /// and the values emitted by the other language SDKs.
+        /// </summary>
+        public static string ToDimensionString(this DropCode dropCode) => dropCode switch
+        {
+            DropCode.ClientException => "CLIENT_EXCEPTION",
+            DropCode.ClientReadonly => "CLIENT_READONLY",
+            DropCode.ClientPersistenceIssue => "CLIENT_PERSISTENCE_CAPACITY",
+            DropCode.ClientStorageDisabled => "CLIENT_STORAGE_DISABLED",
+
+            // Items stored for later retry while the transmitter is backing off are a
+            // client-side retry; the spec's nearest non-timeout retry bucket is CLIENT_EXCEPTION.
+            DropCode.BackOffEnabled => "CLIENT_EXCEPTION",
+            _ => "UNKNOWN"
+        };
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -52,11 +52,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         public const string APPLICATIONINSIGHTS_STATSBEAT_DISABLED = "APPLICATIONINSIGHTS_STATSBEAT_DISABLED";
 
         /// <summary>
-        /// Available for users to enable customer SDK stats.
+        /// Available for users to opt out of customer SDK stats.
         /// </summary>
         /// <remarks>
-        /// Customer SDK stats provide insights into SDK success/failure/retry counts.
-        /// Set to "false" to enable this feature.
+        /// Customer SDK stats provide insights into SDK success/failure/retry counts and are on by default.
+        /// Set to "true" to disable this feature.
         /// </remarks>
         public const string APPLICATIONINSIGHTS_SDKSTATS_DISABLED = "APPLICATIONINSIGHTS_SDKSTATS_DISABLED";
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CustomerSdkStats/DropCodeExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CustomerSdkStats/DropCodeExtensionsTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CustomerSdkStats;
+
+public class DropCodeExtensionsTests
+{
+    [Theory]
+    [InlineData((int)DropCode.ClientException, "CLIENT_EXCEPTION")]
+    [InlineData((int)DropCode.ClientReadonly, "CLIENT_READONLY")]
+    [InlineData((int)DropCode.ClientPersistenceIssue, "CLIENT_PERSISTENCE_CAPACITY")]
+    [InlineData((int)DropCode.ClientStorageDisabled, "CLIENT_STORAGE_DISABLED")]
+    [InlineData((int)DropCode.BackOffEnabled, "CLIENT_EXCEPTION")]
+    public void ToDimensionString_ReturnsSpecCompliantValue(int dropCode, string expected)
+    {
+        Assert.Equal(expected, ((DropCode)dropCode).ToDimensionString());
+    }
+}


### PR DESCRIPTION
## Summary
Enables customer SDK stats **on by default** in the Azure Monitor OpenTelemetry exporter, so the feature is active regardless of which distro sits on top of the exporter (all distros funnel through `UseAzureMonitorExporter` -> `CustomerSdkStatsRegistration`). Also brings `dropCode`/`retryCode` dimension values into spec compliance.

## Changes
- `CustomerSdkStatsHelper.IsEnabled()`: on by default; disable only via `APPLICATIONINSIGHTS_SDKSTATS_DISABLED=true` (previously required `=false` to opt in).
- `dropCode`/`retryCode` values now use the spec's SCREAMING_SNAKE_CASE (`CLIENT_EXCEPTION`, `CLIENT_READONLY`, `CLIENT_PERSISTENCE_CAPACITY`, `CLIENT_STORAGE_DISABLED`) via new `DropCodeExtensions.ToDimensionString()`, matching the canonical Python SDK. Previously emitted PascalCase enum names.
- Updated env var doc + CHANGELOG; added `DropCodeExtensionsTests`.

## Spec
Follows `ApplicationInsights/sdkstats/customer_facing_sdk_stats.md` (on-by-default; opt-out env var).

## Testing
- Full exporter test suite: **799 passed** (net8.0).
- New `DropCodeExtensions` tests pass. No public API change (ApiCompat passed).