### PR TITLE
[Maintenance] Revert 1.2.0-beta.11 release date to Unreleased

### DIFF
--- a/sdk/maintenance/Azure.ResourceManager.Maintenance/CHANGELOG.md
+++ b/sdk/maintenance/Azure.ResourceManager.Maintenance/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0-beta.11 (2026-06-26)
+## 1.2.0-beta.11 (Unreleased)
 
 ### Features Added
 


### PR DESCRIPTION
Change the release date of Azure.ResourceManager.Maintenance 1.2.0-beta.11 back to Unreleased.
Service is not ready for 2025-10-01-preview