### PR TITLE
[AzureMonitorExporter] [AzureMonitorDistro] Harden redirect handling against credential and telemetry leakage

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Hardened Azure Monitor ingestion and Live Metrics redirect handling to prevent credentials and telemetry from being forwarded to untrusted destinations.
+  ([#61244](https://github.com/Azure/azure-sdk-for-net/pull/61244))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Hardened Azure Monitor ingestion and Live Metrics redirect handling to prevent credentials and telemetry from being forwarded to untrusted destinations.
+
 ### Other Changes
 
 ## 1.5.0 (2026-04-30)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Hardened ingestion and Live Metrics redirect handling to reject untrusted destinations before replaying telemetry or caching the redirect. Redirect targets must now use HTTPS and match an approved Azure Monitor trust boundary, preventing credentials and telemetry from being forwarded to attacker-controlled endpoints.
+  ([#61244](https://github.com/Azure/azure-sdk-for-net/pull/61244))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Hardened ingestion and Live Metrics redirect handling to reject untrusted destinations before replaying telemetry or caching the redirect. Redirect targets must now use HTTPS and match an approved Azure Monitor trust boundary, preventing credentials and telemetry from being forwarded to attacker-controlled endpoints.
+
 ### Other Changes
 
 - Customer SDK stats are now on by default; opt out with `APPLICATIONINSIGHTS_SDKSTATS_DISABLED=true`. `dropCode`/`retryCode` dimension values now use the spec's SCREAMING_SNAKE_CASE (e.g. `CLIENT_EXCEPTION`).

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/IngestionRedirectPolicy.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/IngestionRedirectPolicy.cs
@@ -33,8 +33,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             if (_cache.TryRead(out Uri? redirectUri))
             {
-                // Set up for the redirect
-                request.Uri.Reset(redirectUri);
+                if (RedirectPolicyHelper.IsTrustedIngestionRedirect(request.Uri.ToUri(), redirectUri))
+                {
+                    // Set up for the redirect
+                    request.Uri.Reset(redirectUri);
+                }
             }
 
             if (async)
@@ -54,6 +57,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 if (!TryGetRedirectUri(response, out redirectUri))
                 {
                     AzureMonitorExporterEventSource.Log.RedirectHeaderParseFailed();
+                    break;
+                }
+
+                if (!RedirectPolicyHelper.IsTrustedIngestionRedirect(request.Uri.ToUri(), redirectUri))
+                {
                     break;
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/RedirectPolicyHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/RedirectPolicyHelper.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    internal static class RedirectPolicyHelper
+    {
+        private static readonly string[] s_allowedRedirectDomainSuffixes =
+        {
+            ".livediagnostics.monitor.azure.com",
+            ".monitor.azure.com",
+            ".services.visualstudio.com",
+            ".applicationinsights.azure.com",
+            ".monitor.azure.us",
+            ".applicationinsights.azure.us",
+            ".monitor.azure.cn",
+            ".applicationinsights.azure.cn",
+        };
+
+        internal static bool IsTrustedIngestionRedirect(Uri currentUri, Uri redirectUri)
+        {
+            if (!IsValidHttpsRedirect(redirectUri) || !currentUri.IsAbsoluteUri)
+            {
+                return false;
+            }
+
+            string currentHost = GetCanonicalHost(currentUri);
+            string redirectHost = GetCanonicalHost(redirectUri);
+            if (string.IsNullOrEmpty(currentHost) || string.IsNullOrEmpty(redirectHost))
+            {
+                return false;
+            }
+
+            if (string.Equals(currentHost, redirectHost, StringComparison.Ordinal))
+            {
+                return string.Equals(currentUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                    && currentUri.Port == redirectUri.Port;
+            }
+
+            if (!currentUri.IsDefaultPort || !redirectUri.IsDefaultPort)
+            {
+                return false;
+            }
+
+            foreach (string suffix in s_allowedRedirectDomainSuffixes)
+            {
+                if (currentHost.EndsWith(suffix, StringComparison.Ordinal)
+                    && redirectHost.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal static bool IsTrustedLiveMetricsRedirect(Uri redirectUri)
+        {
+            if (!IsValidHttpsRedirect(redirectUri) || !redirectUri.IsDefaultPort)
+            {
+                return false;
+            }
+
+            string redirectHost = GetCanonicalHost(redirectUri);
+            foreach (string suffix in s_allowedRedirectDomainSuffixes)
+            {
+                if (redirectHost.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsValidHttpsRedirect(Uri redirectUri) =>
+            redirectUri.IsAbsoluteUri
+            && string.Equals(redirectUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrEmpty(redirectUri.UserInfo);
+
+        private static string GetCanonicalHost(Uri uri) => uri.IdnHost.TrimEnd('.').ToLowerInvariant();
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LiveMetrics/Internals/LiveMetricsRedirectPolicy.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LiveMetrics/Internals/LiveMetricsRedirectPolicy.cs
@@ -7,13 +7,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.LiveMetrics;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 {
     internal sealed class LiveMetricsRedirectPolicy : HttpPipelinePolicy
     {
-        private string? _redirectHostValue;
+        private Uri? _redirectUri;
 
         public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
@@ -38,9 +39,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             Request request = message.Request;
 
             // If we have a cached redirect, apply it
-            if (_redirectHostValue is not null)
+            if (_redirectUri is not null)
             {
-                request.Uri.Host = _redirectHostValue;
+                ApplyRedirect(request, _redirectUri);
             }
 
             // Process the request
@@ -54,10 +55,12 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             }
 
             // Check for redirection and retry
-            if (IsRedirection(message.Response, out string? redirectionValue))
+            if (IsRedirection(message.Response, out string? redirectionValue)
+                && Uri.TryCreate(redirectionValue, UriKind.Absolute, out Uri? redirectUri)
+                && RedirectPolicyHelper.IsTrustedLiveMetricsRedirect(redirectUri!))
             {
                 Debug.WriteLine($"OnPing: Received Redirection: {redirectionValue}");
-                AzureMonitorLiveMetricsEventSource.Log.LiveMetricsRedirectReceived(redirectionValue);
+                AzureMonitorLiveMetricsEventSource.Log.LiveMetricsRedirectReceived(redirectionValue!);
 
                 message.Response.Dispose();
 
@@ -70,11 +73,10 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                 // FINAL VALUE:
                 // https://westus.livediagnostics.monitor.azure.com/QuickPulseService.svc/ping?api-version=2024-04-01-preview&ikey=00000000-0000-0000-0000-000000000000
 
-                // Extract the host value from the redirection URI
-                _redirectHostValue = new Uri(redirectionValue).Host;
+                _redirectUri = redirectUri;
 
                 // Apply redirect
-                request.Uri.Host = _redirectHostValue;
+                ApplyRedirect(request, redirectUri!);
 
                 // Issue the redirected request.
                 if (async)
@@ -89,6 +91,13 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 
             message.SetProperty("redirectionComplete", true);
             return;
+        }
+
+        private static void ApplyRedirect(Request request, Uri redirectUri)
+        {
+            request.Uri.Scheme = redirectUri.Scheme;
+            request.Uri.Host = redirectUri.Host;
+            request.Uri.Port = redirectUri.Port;
         }
 
         private static bool IsRedirection(Response response, [NotNullWhen(true)] out string? redirectValue)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/IngestionRedirectPolicyTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/IngestionRedirectPolicyTests.cs
@@ -14,13 +14,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 {
     public class IngestionRedirectPolicyTests
     {
+        private static readonly Uri s_originalUri = new Uri("https://westus-0.in.applicationinsights.azure.com/");
+        private const string TrustedRedirectUri = "https://eastus-0.in.applicationinsights.azure.com/";
+
         [Theory]
         [InlineData(307)]
         [InlineData(308)]
         [InlineData(400)]
         public void UsesLocationResponseHeaderAsNewRequestUri(int statusCode)
         {
-            var mockTransport = new MockTransport(new MockResponse(statusCode).AddHeader("Location", "http://new.host/"), new MockResponse(200));
+            var mockTransport = new MockTransport(new MockResponse(statusCode).AddHeader("Location", TrustedRedirectUri), new MockResponse(200));
 
             AzureMonitorExporterOptions options = new()
             {
@@ -28,12 +31,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
-            var message = new HttpMessage(CreateMockRequest(new Uri("http://host")), new ResponseClassifier());
+            var message = new HttpMessage(CreateMockRequest(s_originalUri), new ResponseClassifier());
             pipeline.SendAsync(message, CancellationToken.None);
 
             if (statusCode == 307 || statusCode == 308)
             {
-                Assert.Equal("http://new.host/", mockTransport.Requests[1].Uri.ToString());
+                Assert.Equal(TrustedRedirectUri, mockTransport.Requests[1].Uri.ToString());
                 Assert.Equal(2, mockTransport.Requests.Count);
             }
             else
@@ -46,7 +49,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void UsesCachedIngestionUri()
         {
-            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", "http://new.host/"),
+            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", TrustedRedirectUri),
                                 new MockResponse(200).AddHeader("Cache-Control", "public,max-age=1"),
                                 new MockResponse(200),
                                 new MockResponse(200));
@@ -59,33 +62,33 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
 
             // Default behavior, request gets redirected.
-            var message = new HttpMessage(CreateMockRequest(new Uri("http://host1")), new ResponseClassifier());
+            var message = new HttpMessage(CreateMockRequest(s_originalUri), new ResponseClassifier());
             pipeline.SendAsync(message, CancellationToken.None);
 
-            Assert.Equal("http://new.host/", mockTransport.Requests[1].Uri.ToString());
+            Assert.Equal(TrustedRedirectUri, mockTransport.Requests[1].Uri.ToString());
             Assert.Equal(2, mockTransport.Requests.Count);
 
             // Redirect is cached.
-            message = new HttpMessage(CreateMockRequest(new Uri("http://host2")), new ResponseClassifier());
+            message = new HttpMessage(CreateMockRequest(s_originalUri), new ResponseClassifier());
             pipeline.SendAsync(message, CancellationToken.None);
 
             Assert.Equal(3, mockTransport.Requests.Count);
-            Assert.Equal("http://new.host/", mockTransport.Requests[2].Uri.ToString());
+            Assert.Equal(TrustedRedirectUri, mockTransport.Requests[2].Uri.ToString());
 
             // wait for cache to expire
             Task.Delay(TimeSpan.FromSeconds(2)).Wait();
 
-            message = new HttpMessage(CreateMockRequest(new Uri("http://host3")), new ResponseClassifier());
+            message = new HttpMessage(CreateMockRequest(s_originalUri), new ResponseClassifier());
             pipeline.SendAsync(message, CancellationToken.None);
 
             Assert.Equal(4, mockTransport.Requests.Count);
-            Assert.Equal("http://host3/", mockTransport.Requests[3].Uri.ToString());
+            Assert.Equal(s_originalUri, mockTransport.Requests[3].Uri.ToUri());
         }
 
         [Fact]
         public void ReturnsOnMaxIngestionRedirects()
         {
-            var mockTransport = new MockTransport(_ => new MockResponse(307).AddHeader("Location", "http://new.host/"));
+            var mockTransport = new MockTransport(_ => new MockResponse(307).AddHeader("Location", TrustedRedirectUri));
 
             AzureMonitorExporterOptions options = new()
             {
@@ -93,16 +96,37 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
-            var message = new HttpMessage(CreateMockRequest(new Uri("http://host1")), new ResponseClassifier());
+            var message = new HttpMessage(CreateMockRequest(s_originalUri), new ResponseClassifier());
             pipeline.SendAsync(message, CancellationToken.None);
 
             Assert.Equal(10, mockTransport.Requests.Count);
         }
 
         [Fact]
-        public void VerifyAuthHeaderPreserved()
+        public void RejectsUntrustedRedirect()
         {
-            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", "http://new.host/"), new MockResponse(200));
+            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", "https://attacker.example/"), new MockResponse(200));
+
+            AzureMonitorExporterOptions options = new()
+            {
+                Transport = mockTransport,
+            };
+
+            var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
+            var request = CreateMockRequest(s_originalUri);
+            request.Headers.Add(HttpHeader.Names.Authorization, "Bearer TEST_TOKEN");
+
+            var message = new HttpMessage(request, new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            Assert.Single(mockTransport.Requests);
+            Assert.Equal(s_originalUri, mockTransport.Requests[0].Uri.ToUri());
+        }
+
+        [Fact]
+        public void VerifyAuthHeaderPreservedOnSameOriginRedirect()
+        {
+            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", s_originalUri + "newpath"), new MockResponse(200));
 
             AzureMonitorExporterOptions options = new()
             {
@@ -111,21 +135,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
             var testToken = "Bearer TEST_TOKEN";
-            var request = CreateMockRequest(new Uri("http://host1"));
+            var request = CreateMockRequest(s_originalUri);
             request.Headers.Add(HttpHeader.Names.Authorization, testToken);
 
             var message = new HttpMessage(request, new ResponseClassifier());
             pipeline.SendAsync(message, CancellationToken.None);
 
-            Assert.Equal("http://new.host/", mockTransport.Requests[1].Uri.ToString());
+            // The redirect stays within the same origin, so the Authorization header
+            // is preserved for the legitimate endpoint.
+            Assert.Equal(s_originalUri + "newpath", mockTransport.Requests[1].Uri.ToString());
             Assert.True(mockTransport.Requests[1].Headers.TryGetValue(HttpHeader.Names.Authorization, out string? token));
             Assert.Equal(testToken, token);
         }
 
         [Fact]
-        public void NullResponseDoesNotImpactPolicy()
+        public void RejectedRedirectIsNotCached()
         {
-            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", "http://new.host/"), null);
+            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", "https://attacker.example/"),
+                                new MockResponse(200));
 
             AzureMonitorExporterOptions options = new()
             {
@@ -133,12 +160,54 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
-            var message = new HttpMessage(CreateMockRequest(new Uri("http://host")), new ResponseClassifier());
+
+            var request1 = CreateMockRequest(s_originalUri);
+            var message1 = new HttpMessage(request1, new ResponseClassifier());
+            pipeline.SendAsync(message1, CancellationToken.None);
+
+            var request2 = CreateMockRequest(s_originalUri);
+            var message2 = new HttpMessage(request2, new ResponseClassifier());
+            pipeline.SendAsync(message2, CancellationToken.None);
+
+            Assert.Equal(2, mockTransport.Requests.Count);
+            Assert.All(mockTransport.Requests, request => Assert.Equal(s_originalUri, request.Uri.ToUri()));
+        }
+
+        [Theory]
+        [InlineData("http://eastus-0.in.applicationinsights.azure.com/")]
+        [InlineData("https://user@eastus-0.in.applicationinsights.azure.com/")]
+        [InlineData("https://eastus-0.in.applicationinsights.azure.com:444/")]
+        [InlineData("https://eastus-0.in.applicationinsights.azure.com.attacker.example/")]
+        [InlineData("not a uri")]
+        public void RejectsInvalidRedirectTarget(string redirectUri)
+        {
+            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", redirectUri), new MockResponse(200));
+            AzureMonitorExporterOptions options = new() { Transport = mockTransport };
+            var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
+
+            var message = new HttpMessage(CreateMockRequest(s_originalUri), new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            Assert.Single(mockTransport.Requests);
+        }
+
+        [Fact]
+        public void NullResponseDoesNotImpactPolicy()
+        {
+            var mockTransport = new MockTransport(new MockResponse(307).AddHeader("Location", TrustedRedirectUri), null);
+
+            AzureMonitorExporterOptions options = new()
+            {
+                Transport = mockTransport,
+            };
+
+            var pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
+            var message = new HttpMessage(CreateMockRequest(s_originalUri), new ResponseClassifier());
             // SendAsync does not throw on null response and fails silently.
             // It is handled on HttpMessage.Response property.
             pipeline.SendAsync(message, CancellationToken.None);
 
-            Assert.Equal("http://new.host/", mockTransport.Requests[1].Uri.ToString());
+            Assert.Equal(TrustedRedirectUri, mockTransport.Requests[1].Uri.ToString());
             Assert.Equal(2, mockTransport.Requests.Count);
             Assert.Throws<InvalidOperationException>(() => message.Response);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LiveMetricsRedirectPolicyTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LiveMetricsRedirectPolicyTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public class LiveMetricsRedirectPolicyTests
+    {
+        private const string RedirectHeaderName = "x-ms-qps-service-endpoint-redirect-v2";
+        private const string RedirectUri = "https://westus.livediagnostics.monitor.azure.com/QuickPulseService.svc";
+        private const string RedirectHost = "westus.livediagnostics.monitor.azure.com";
+        private const string OriginalUri = "https://rt.services.visualstudio.com/QuickPulseService.svc/ping";
+
+        [Fact]
+        public void RedirectUpdatesRequestHost()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(200).AddHeader(RedirectHeaderName, RedirectUri),
+                new MockResponse(200));
+
+            var pipeline = BuildPipeline(mockTransport);
+            var message = new HttpMessage(CreateMockRequest(new Uri(OriginalUri)), new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            Assert.Equal(2, mockTransport.Requests.Count);
+            Assert.Equal(RedirectHost, mockTransport.Requests[1].Uri.Host);
+        }
+
+        [Fact]
+        public void RedirectAppliesValidatedAuthority()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(200).AddHeader(RedirectHeaderName, RedirectUri),
+                new MockResponse(200));
+
+            var pipeline = BuildPipeline(mockTransport);
+            var message = new HttpMessage(CreateMockRequest(new Uri("http://rt.services.visualstudio.com:444/QuickPulseService.svc/ping")), new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            Assert.Equal(Uri.UriSchemeHttps, mockTransport.Requests[1].Uri.Scheme);
+            Assert.Equal(RedirectHost, mockTransport.Requests[1].Uri.Host);
+            Assert.Equal(443, mockTransport.Requests[1].Uri.Port);
+        }
+
+        [Fact]
+        public void VerifyAuthHeaderPreservedOnTrustedCrossHostRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(200).AddHeader(RedirectHeaderName, RedirectUri),
+                new MockResponse(200));
+
+            var pipeline = BuildPipeline(mockTransport);
+            var request = CreateMockRequest(new Uri(OriginalUri));
+            request.Headers.Add(HttpHeader.Names.Authorization, "Bearer TEST_TOKEN");
+
+            var message = new HttpMessage(request, new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            Assert.Equal(RedirectHost, mockTransport.Requests[1].Uri.Host);
+            Assert.True(mockTransport.Requests[1].Headers.TryGetValue(HttpHeader.Names.Authorization, out string? token));
+            Assert.Equal("Bearer TEST_TOKEN", token);
+        }
+
+        [Fact]
+        public void VerifyAuthHeaderPreservedOnSameHostRedirect()
+        {
+            // Redirect points to the same host the request already targets.
+            var sameHostRedirect = $"https://{RedirectHost}/QuickPulseService.svc";
+            var mockTransport = new MockTransport(
+                new MockResponse(200).AddHeader(RedirectHeaderName, sameHostRedirect),
+                new MockResponse(200));
+
+            var pipeline = BuildPipeline(mockTransport);
+            var testToken = "Bearer TEST_TOKEN";
+            var request = CreateMockRequest(new Uri($"https://{RedirectHost}/QuickPulseService.svc/ping"));
+            request.Headers.Add(HttpHeader.Names.Authorization, testToken);
+
+            var message = new HttpMessage(request, new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            // The redirect stays on the same host, so the Authorization header is preserved.
+            Assert.True(mockTransport.Requests[1].Headers.TryGetValue(HttpHeader.Names.Authorization, out string? token));
+            Assert.Equal(testToken, token);
+        }
+
+        [Fact]
+        public void VerifyAuthHeaderPreservedOnCachedTrustedRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(200).AddHeader(RedirectHeaderName, RedirectUri),
+                new MockResponse(200),
+                new MockResponse(200));
+
+            var pipeline = BuildPipeline(mockTransport);
+
+            // First request establishes the cross-host redirect in the policy cache.
+            var request1 = CreateMockRequest(new Uri(OriginalUri));
+            request1.Headers.Add(HttpHeader.Names.Authorization, "Bearer TEST_TOKEN");
+            var message1 = new HttpMessage(request1, new ResponseClassifier());
+            pipeline.SendAsync(message1, CancellationToken.None);
+
+            Assert.Equal(RedirectHost, mockTransport.Requests[1].Uri.Host);
+            Assert.True(mockTransport.Requests[1].Headers.TryGetValue(HttpHeader.Names.Authorization, out string? firstToken));
+            Assert.Equal("Bearer TEST_TOKEN", firstToken);
+
+            // Second request applies the cached trusted redirect.
+            var request2 = CreateMockRequest(new Uri(OriginalUri));
+            request2.Headers.Add(HttpHeader.Names.Authorization, "Bearer TEST_TOKEN");
+            var message2 = new HttpMessage(request2, new ResponseClassifier());
+            pipeline.SendAsync(message2, CancellationToken.None);
+
+            Assert.Equal(3, mockTransport.Requests.Count);
+            Assert.Equal(RedirectHost, mockTransport.Requests[2].Uri.Host);
+            Assert.True(mockTransport.Requests[2].Headers.TryGetValue(HttpHeader.Names.Authorization, out string? secondToken));
+            Assert.Equal("Bearer TEST_TOKEN", secondToken);
+        }
+
+        [Fact]
+        public void RejectsUntrustedRedirectWithoutCachingIt()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(200).AddHeader(RedirectHeaderName, "https://attacker.example/QuickPulseService.svc"),
+                new MockResponse(200));
+
+            var pipeline = BuildPipeline(mockTransport);
+            var firstMessage = new HttpMessage(CreateMockRequest(new Uri(OriginalUri)), new ResponseClassifier());
+            pipeline.SendAsync(firstMessage, CancellationToken.None);
+
+            var secondMessage = new HttpMessage(CreateMockRequest(new Uri(OriginalUri)), new ResponseClassifier());
+            pipeline.SendAsync(secondMessage, CancellationToken.None);
+
+            Assert.Equal(2, mockTransport.Requests.Count);
+            Assert.All(mockTransport.Requests, request => Assert.Equal(new Uri(OriginalUri).Host, request.Uri.Host));
+        }
+
+        [Theory]
+        [InlineData("http://westus.livediagnostics.monitor.azure.com/QuickPulseService.svc")]
+        [InlineData("https://user@westus.livediagnostics.monitor.azure.com/QuickPulseService.svc")]
+        [InlineData("https://westus.livediagnostics.monitor.azure.com:444/QuickPulseService.svc")]
+        [InlineData("https://westus.livediagnostics.monitor.azure.com.attacker.example/QuickPulseService.svc")]
+        [InlineData("not a uri")]
+        public void RejectsInvalidRedirectTarget(string redirectUri)
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(200).AddHeader(RedirectHeaderName, redirectUri),
+                new MockResponse(200));
+
+            var pipeline = BuildPipeline(mockTransport);
+            var message = new HttpMessage(CreateMockRequest(new Uri(OriginalUri)), new ResponseClassifier());
+            pipeline.SendAsync(message, CancellationToken.None);
+
+            Assert.Single(mockTransport.Requests);
+        }
+
+        private static HttpPipeline BuildPipeline(MockTransport mockTransport)
+        {
+            AzureMonitorExporterOptions options = new()
+            {
+                Transport = mockTransport,
+            };
+
+            return HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new LiveMetricsRedirectPolicy() });
+        }
+
+        private static MockRequest CreateMockRequest(Uri uri)
+        {
+            MockRequest mockRequest = new MockRequest();
+            mockRequest.Uri.Reset(uri);
+            mockRequest.Method = RequestMethod.Get;
+            return mockRequest;
+        }
+    }
+}


### PR DESCRIPTION
## Background

`IngestionRedirectPolicy` and `LiveMetricsRedirectPolicy` followed and cached server-provided redirect targets without validating their trust boundary. When AAD authentication was enabled, this could forward the bearer token and telemetry payload to an attacker-controlled endpoint.

The ingestion redirect could remain cached for up to 12 hours, while the Live Metrics redirect remained active for the policy lifetime.

## Changes

- Add shared validation for redirect destinations.
- Require redirect targets to:
  - be absolute HTTPS URIs;
  - contain no user information;
  - use the default HTTPS port;
  - match a trusted Azure Monitor domain policy.
- Allow ingestion redirects only when:
  - the target has the same host and port as the current endpoint; or
  - both endpoints belong to the same approved Azure Monitor domain suffix.
- Allow Live Metrics redirects only to approved Azure Monitor domains.
- Reject untrusted redirects before mutating the request, replaying telemetry, or updating redirect caches.
- Cache the complete validated Live Metrics authority instead of an unchecked host.
- Preserve support for Azure public, US Government, and China cloud endpoints.
- Preserve same-authority behavior for explicitly configured custom ingestion endpoints.

Rejected redirects are not followed or cached, preventing bearer-token disclosure, telemetry leakage, and persistent redirect cache poisoning.

## Testing

Added coverage for both redirect policies, including:

- trusted regional redirects;
- same-origin redirects;
- arbitrary cross-origin targets;
- insecure HTTP targets;
- user-info in redirect URIs;
- non-default ports;
- domain suffix-confusion targets;
- malformed redirect values;
- rejected redirect cache poisoning;
- application of the complete validated Live Metrics authority.
