### PR TITLE
Enforce cfs clean

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,8 +40,10 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      # Do not add CFSClean until packages are published through ESRP instead of directly to NuGet.
-      networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
+      ${{ if and(eq(variables['System.TeamProject'], 'internal'), or(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'IndividualCI'))) }}:
+        networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
+      ${{ else }}:
+        networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -41,7 +41,7 @@ extends:
     settings:
       skipBuildTagsForGitHubPullRequests: true
       # Do not add CFSClean until packages are published through ESRP instead of directly to NuGet.
-      networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,6 +40,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      # Do not add CFSClean until packages are published through ESRP instead of directly to NuGet.
       ${{ if and(eq(variables['System.TeamProject'], 'internal'), or(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'IndividualCI'))) }}:
         networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
       ${{ else }}:


### PR DESCRIPTION
This pull request updates the network isolation policy configuration in the `1es-redirect.yml` pipeline template to better handle manual and non-manual builds. The main change is the conditional selection of network isolation policies based on the build reason.

Pipeline configuration improvements:

* Updated the `networkIsolationPolicy` setting to use `CFSClean2` and `CFSClean3` for manual builds, and to include `CFSClean` for all other build types by introducing an explicit conditional structure in `1es-redirect.yml`.