### PR TITLE
Fix mgmt generator launch profile

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1
+++ b/eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1
@@ -53,7 +53,7 @@ if ($null -eq $filter) {
     foreach ($project in $testProjects) {
         $specPath = "TestProjects/Local/$($project.Folder)"
         $mgmtLaunchSettings["profiles"].Add($project.FilterName, @{
-            "commandLineArgs" = "`$(SolutionDir)/../dist/generator/Microsoft.TypeSpec.Generator.dll `$(SolutionDir)/$specPath -g MgmtClientGenerator"
+            "commandLineArgs" = "`$(SolutionDir)/../dist/generator/Microsoft.TypeSpec.Generator.dll `$(SolutionDir)/$specPath -g ManagementClientGenerator"
             "commandName" = "Executable"
             "executablePath" = "dotnet"
         })

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Properties/launchSettings.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Properties/launchSettings.json
@@ -1,12 +1,12 @@
 {
   "profiles": {
     "Mgmt-TypeSpec": {
-      "commandLineArgs": "$(SolutionDir)/../dist/generator/Microsoft.TypeSpec.Generator.dll $(SolutionDir)/TestProjects/Local/Mgmt-TypeSpec -g MgmtClientGenerator",
+      "commandLineArgs": "$(SolutionDir)/../dist/generator/Microsoft.TypeSpec.Generator.dll $(SolutionDir)/TestProjects/Local/Mgmt-TypeSpec -g ManagementClientGenerator",
       "commandName": "Executable",
       "executablePath": "dotnet"
     },
     "Mgmt-TypeSpec-MultiService": {
-      "commandLineArgs": "$(SolutionDir)/../dist/generator/Microsoft.TypeSpec.Generator.dll $(SolutionDir)/TestProjects/Local/Mgmt-TypeSpec-MultiService -g MgmtClientGenerator",
+      "commandLineArgs": "$(SolutionDir)/../dist/generator/Microsoft.TypeSpec.Generator.dll $(SolutionDir)/TestProjects/Local/Mgmt-TypeSpec-MultiService -g ManagementClientGenerator",
       "commandName": "Executable",
       "executablePath": "dotnet"
     }


### PR DESCRIPTION
## Description

Fix the Visual Studio launch profiles for the management generator local test projects to use the registered generator name `ManagementClientGenerator` instead of the stale `MgmtClientGenerator`.

Also update `Generate.ps1` so regenerated launch settings keep the corrected generator name.

## Validation

Ran the launch command with existing built artifacts and confirmed it reaches code generation instead of failing with `Generator MgmtClientGenerator not found`.
