### PR TITLE
Add SourceGenerated scope to analyzer allow-list suppressor

### DIFF
--- a/eng/analyzerallowlist/README.md
+++ b/eng/analyzerallowlist/README.md
@@ -33,6 +33,7 @@ nowarn:CS1591
 nowarn:AZC0034 T:Azure.Foo.Bar                       # all sites inside type Foo.Bar
 nowarn:AZC0007 M:Azure.Foo.Bar.#ctor(System.String)  # one specific member
 nowarn:CS0618 N:Azure.Foo.Models                     # everything in namespace + descendants
+nowarn:OPENAI001 SourceGenerated                     # only sites inside *.g.cs generator output
 ```
 
 ### `nowarn:CODE`
@@ -70,12 +71,41 @@ the entire assembly forever — including types that don't exist yet. A scoped
 entry keeps the analyzer live for every site except the specific symbol the
 SDK team has reviewed and approved.
 
-**Limitation:** scoped suppression only works for diagnostics whose descriptor
-declares `DiagnosticSeverity.Warning` (or lower). Diagnostics that ship as
-`DiagnosticSeverity.Error` (e.g., `AZC0034` in `azure-sdk-tools`) are skipped
-by Roslyn's `DiagnosticSuppressor` pipeline — for those, the underlying
-analyzer needs to ship the descriptor as Warning instead, with `/warnaserror+`
+### `nowarn:CODE SourceGenerated` — source-generator-output suppression
+
+A scoped entry whose target is the keyword `SourceGenerated` (case-insensitive)
+suppresses `CODE` only at sites inside **source-generator output** — files whose
+path ends with `.g.cs`. These are emitted by a source generator at build time and
+exist only in the compiler's view, so they cannot be edited or `#pragma`-annotated
+at the source (e.g. the compile-time `ModelReaderWriterContext` partial that
+references external experimental types).
+
+This scope deliberately does **not** cover checked-in generated code under a
+`Generated/` folder. That code is regenerable, so a diagnostic there should be
+fixed at its source — correct per-symbol `[Experimental]` attribution or a tight
+`#pragma` emitted by the code generator — rather than silenced by a blanket
+suppression. Example:
+
+```
+# OPENAI001 refs the source generator emits into the compile-time
+# ModelReaderWriterContext .g.cs (references to the external experimental
+# OpenAI.OpenAIContext) that we cannot annotate at the source. Hand-written and
+# checked-in generated code carry per-symbol [Experimental]/pragmas instead.
+nowarn:OPENAI001 SourceGenerated
+```
+
+**Limitation:** scoped suppression (both symbol- and `SourceGenerated`-scoped)
+only works for diagnostics whose descriptor declares `DiagnosticSeverity.Warning`
+(or lower). Roslyn's `DiagnosticSuppressor` pipeline dispatches on the
+descriptor's **default** severity, so a warning promoted to an error by
+`/warnaserror` is still suppressible; a diagnostic whose descriptor ships as
+`DiagnosticSeverity.Error` (e.g., `AZC0034` in `azure-sdk-tools`) is not. Note
+that `[Experimental("…")]` diagnostics such as `OPENAI001` have a **Warning**
+default severity (the attribute promotes them to errors), so they *can* be
+scoped-suppressed — for a genuine `Error`-descriptor diagnostic, the underlying
+analyzer must instead ship the descriptor as Warning with `/warnaserror+`
 elevating it back to Error globally.
+
 
 ## How It Works
 

--- a/sdk/tools/Azure.SdkAnalyzers/src/AllowListDiagnosticSuppressor.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/AllowListDiagnosticSuppressor.cs
@@ -36,7 +36,9 @@ namespace Azure.SdkAnalyzers
             "AZC0034",
             "AZC0035",
             "CS0618",
-            "AAIP001"
+            "AAIP001",
+            "OPENAI001",
+            "OPENAICUA001"
         };
 
         private const string SuppressionIdPrefix = "AZSDKSP";
@@ -159,6 +161,16 @@ namespace Azure.SdkAnalyzers
 
             foreach (AllowListEntry entry in candidates)
             {
+                if (entry.Scope == AllowListScopeKind.SourceGenerated)
+                {
+                    if (LocationIsGenerated(location))
+                    {
+                        return entry;
+                    }
+
+                    continue;
+                }
+
                 if (TargetMatchesLocation(entry.Target, location, compilation))
                 {
                     return entry;
@@ -166,6 +178,27 @@ namespace Azure.SdkAnalyzers
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns true when the diagnostic location originates in source-generator output
+        /// (a <c>*.g.cs</c> file, e.g. the compile-time <c>ModelReaderWriterContext</c> partial)
+        /// that exists only at build time and cannot be edited or <c>#pragma</c>-annotated at the
+        /// source. Checked-in generated code under a <c>Generated/</c> folder is deliberately NOT
+        /// covered — that code is regenerable and should carry correct per-symbol attribution or
+        /// pragmas emitted by the code generator instead of a blanket suppression.
+        /// </summary>
+        private static bool LocationIsGenerated(Location location)
+        {
+            SyntaxTree tree = location.SourceTree;
+            string filePath = tree?.FilePath;
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            // Source-generator output convention (e.g. Foo.g.cs, including compile-time context partials).
+            return filePath.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool TargetMatchesLocation(string docId, Location location, Compilation compilation)

--- a/sdk/tools/Azure.SdkAnalyzers/src/AllowListEntry.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/AllowListEntry.cs
@@ -5,26 +5,42 @@ using System;
 
 namespace Azure.SdkAnalyzers
 {
+    /// <summary>The kind of scope a parsed allow-list entry applies to.</summary>
+    internal enum AllowListScopeKind
+    {
+        /// <summary>A bare <c>nowarn:CODE</c> entry — injected into <c>$(NoWarn)</c> by MSBuild, not handled here.</summary>
+        WholeAssembly,
+
+        /// <summary>A <c>nowarn:CODE DocId</c> entry — matched at the site of the target symbol.</summary>
+        Symbol,
+
+        /// <summary>A <c>nowarn:CODE SourceGenerated</c> entry — matched at any site inside a <c>*.g.cs</c> source-generator file.</summary>
+        SourceGenerated,
+    }
+
     /// <summary>
     /// A parsed entry from a per-package allow-list file (<c>eng/analyzerallowlist/&lt;Project&gt;.txt</c>).
     /// See <c>eng/analyzerallowlist/README.md</c> for the file format.
     /// </summary>
     internal sealed class AllowListEntry
     {
-        public AllowListEntry(string code, string target, int lineNumber)
+        public AllowListEntry(string code, string target, AllowListScopeKind scope, int lineNumber)
         {
             Code = code ?? throw new ArgumentNullException(nameof(code));
             Target = target;
+            Scope = scope;
             LineNumber = lineNumber;
         }
 
         public string Code { get; }
 
-        /// <summary>DocId of the target symbol, or <c>null</c> for a whole-assembly entry.</summary>
+        /// <summary>DocId of the target symbol for <see cref="AllowListScopeKind.Symbol"/> scope; otherwise <c>null</c>.</summary>
         public string Target { get; }
+
+        public AllowListScopeKind Scope { get; }
 
         public int LineNumber { get; }
 
-        public bool IsScoped => Target != null;
+        public bool IsScoped => Scope != AllowListScopeKind.WholeAssembly;
     }
 }

--- a/sdk/tools/Azure.SdkAnalyzers/src/AllowListParser.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/AllowListParser.cs
@@ -15,6 +15,13 @@ namespace Azure.SdkAnalyzers
     {
         private const string NoWarnPrefix = "nowarn:";
 
+        /// <summary>
+        /// Scope keyword (case-insensitive) that targets source-generator output (<c>*.g.cs</c>)
+        /// instead of a symbol DocId. Used as <c>nowarn:CODE SourceGenerated</c>. Note this covers
+        /// only compile-time <c>.g.cs</c> files, not the checked-in <c>Generated/</c> folder.
+        /// </summary>
+        internal const string SourceGeneratedScopeKeyword = "SourceGenerated";
+
         public static IReadOnlyList<AllowListEntry> Parse(string text)
         {
             var results = new List<AllowListEntry>();
@@ -93,16 +100,26 @@ namespace Azure.SdkAnalyzers
                 return null;
             }
 
-            string target = NormalizeTarget(targetPart);
-            if (targetPart != null && target == null)
+            if (targetPart == null)
             {
-                // Target supplied but not a valid DocId — reject the line so the
-                // author isn't left with a silent no-op (MSBuild would also skip
+                return new AllowListEntry(code, null, AllowListScopeKind.WholeAssembly, lineNumber);
+            }
+
+            if (string.Equals(targetPart, SourceGeneratedScopeKeyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return new AllowListEntry(code, null, AllowListScopeKind.SourceGenerated, lineNumber);
+            }
+
+            string target = NormalizeTarget(targetPart);
+            if (target == null)
+            {
+                // Target supplied but not a recognized DocId or scope keyword — reject the
+                // line so the author isn't left with a silent no-op (MSBuild would also skip
                 // this line, since it still contains a space).
                 return null;
             }
 
-            return new AllowListEntry(code, target, lineNumber);
+            return new AllowListEntry(code, target, AllowListScopeKind.Symbol, lineNumber);
         }
 
         /// <summary>

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AllowListDiagnosticSuppressorTests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AllowListDiagnosticSuppressorTests.cs
@@ -266,6 +266,87 @@ namespace TestNs
             Assert.That(d.IsSuppressed, Is.False);
         }
 
+        [Test]
+        public void SupportedSuppressions_IncludeOpenAI001()
+        {
+            var suppressor = new AllowListDiagnosticSuppressor();
+            IEnumerable<string> ids = suppressor.SupportedSuppressions.Select(s => s.SuppressedDiagnosticId);
+            Assert.That(ids, Does.Contain("OPENAI001"), "OPENAI001 should be opted into scoped suppression.");
+        }
+
+        [Test]
+        public void SupportedSuppressions_IncludeOpenAICua001()
+        {
+            var suppressor = new AllowListDiagnosticSuppressor();
+            IEnumerable<string> ids = suppressor.SupportedSuppressions.Select(s => s.SuppressedDiagnosticId);
+            Assert.That(ids, Does.Contain("OPENAICUA001"), "OPENAICUA001 should be opted into scoped suppression.");
+        }
+
+        [Test]
+        public async Task SourceGeneratedScope_SuppressesInDotGCsFile()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunAsync(
+                ObsoleteConsumerSource,
+                "nowarn:CS0618 SourceGenerated",
+                sourcePath: "AzureAIExtensionsOpenAIContext.g.cs");
+
+            Diagnostic cs0618 = diagnostics.Single(d => d.Id == "CS0618");
+            Assert.That(cs0618.IsSuppressed, Is.True, "CS0618 in a .g.cs file should be suppressed by a SourceGenerated-scope entry.");
+        }
+
+        [Test]
+        public async Task SourceGeneratedScope_DoesNotSuppressInGeneratedFolder()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunAsync(
+                ObsoleteConsumerSource,
+                "nowarn:CS0618 SourceGenerated",
+                sourcePath: @"C:\sdk\ai\Azure.AI.Extensions.OpenAI\src\Generated\Models\Foo.cs");
+
+            Diagnostic cs0618 = diagnostics.Single(d => d.Id == "CS0618");
+            Assert.That(cs0618.IsSuppressed, Is.False, "CS0618 in a checked-in Generated/ folder file (not .g.cs) should NOT be suppressed by a SourceGenerated-scope entry.");
+        }
+
+        [Test]
+        public async Task SourceGeneratedScope_DoesNotSuppressInCustomFile()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunAsync(
+                ObsoleteConsumerSource,
+                "nowarn:CS0618 SourceGenerated",
+                sourcePath: @"C:\sdk\ai\Azure.AI.Extensions.OpenAI\src\Custom\Foo.cs");
+
+            Diagnostic cs0618 = diagnostics.Single(d => d.Id == "CS0618");
+            Assert.That(cs0618.IsSuppressed, Is.False, "CS0618 in hand-written custom code should NOT be suppressed by a SourceGenerated-scope entry.");
+        }
+
+        [Test]
+        public async Task SourceGeneratedScope_WithWarnAsError_StillSuppresses()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunAsync(
+                ObsoleteConsumerSource,
+                "nowarn:CS0618 SourceGenerated",
+                generalDiagnosticOption: ReportDiagnostic.Error,
+                sourcePath: "Foo.g.cs");
+
+            Diagnostic cs0618 = diagnostics.Single(d => d.Id == "CS0618");
+            Assert.That(cs0618.Severity, Is.EqualTo(DiagnosticSeverity.Error));
+            Assert.That(cs0618.IsSuppressed, Is.True, "Warning-as-error does not block SourceGenerated-scope suppression of a warning-severity diagnostic.");
+        }
+
+        private const string ObsoleteConsumerSource = @"
+namespace TestNs
+{
+    [System.Obsolete(""use the new one"")]
+    public class OldType
+    {
+        public static int Make() => 42;
+    }
+
+    public class Consumer
+    {
+        public int Use() => OldType.Make();
+    }
+}";
+
         private static Diagnostic SingleFor(IReadOnlyList<Diagnostic> diagnostics, string typeName)
         {
             return diagnostics.Single(d => d.Id == "AZC0034" && d.GetMessage().Contains("'" + typeName + "'"));
@@ -276,12 +357,13 @@ namespace TestNs
             string? allowListText,
             ReportDiagnostic generalDiagnosticOption = ReportDiagnostic.Default,
             IDictionary<string, ReportDiagnostic>? specificDiagnosticOptions = null,
-            bool useErrorSeverityDescriptor = false)
+            bool useErrorSeverityDescriptor = false,
+            string? sourcePath = null)
         {
             var refAssemblies = await AzureTestReferences.DefaultReferenceAssemblies.ResolveAsync(
                 LanguageNames.CSharp, CancellationToken.None);
 
-            SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+            SyntaxTree tree = CSharpSyntaxTree.ParseText(source, path: sourcePath ?? string.Empty);
             var compilationOptions = new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 generalDiagnosticOption: generalDiagnosticOption,

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AllowListParserTests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AllowListParserTests.cs
@@ -110,6 +110,50 @@ nowarn:AZC0102
         }
 
         [Test]
+        public void Parse_SourceGeneratedScope_Keyword()
+        {
+            var result = AllowListParser.Parse("nowarn:OPENAI001 SourceGenerated");
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Code, Is.EqualTo("OPENAI001"));
+            Assert.That(result[0].Target, Is.Null);
+            Assert.That(result[0].Scope, Is.EqualTo(AllowListScopeKind.SourceGenerated));
+            Assert.That(result[0].IsScoped, Is.True);
+        }
+
+        [Test]
+        public void Parse_SourceGeneratedScope_IsCaseInsensitive()
+        {
+            var result = AllowListParser.Parse("nowarn:OPENAI001 sourcegenerated");
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Scope, Is.EqualTo(AllowListScopeKind.SourceGenerated));
+        }
+
+        [Test]
+        public void Parse_SourceGeneratedScope_StripsTrailingInlineComment()
+        {
+            var result = AllowListParser.Parse("nowarn:OPENAICUA001 SourceGenerated # computer-use refs in generated context");
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Code, Is.EqualTo("OPENAICUA001"));
+            Assert.That(result[0].Scope, Is.EqualTo(AllowListScopeKind.SourceGenerated));
+        }
+
+        [Test]
+        public void Parse_WholeAssembly_HasWholeAssemblyScope()
+        {
+            var result = AllowListParser.Parse("nowarn:AZC0034");
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Scope, Is.EqualTo(AllowListScopeKind.WholeAssembly));
+        }
+
+        [Test]
+        public void Parse_SymbolTarget_HasSymbolScope()
+        {
+            var result = AllowListParser.Parse("nowarn:AZC0034 T:Azure.Foo.Bar");
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Scope, Is.EqualTo(AllowListScopeKind.Symbol));
+        }
+
+        [Test]
         public void Parse_MultipleEntries_Mixed()
         {
             string text = @"


### PR DESCRIPTION
## Add a `SourceGenerated` suppression scope to the analyzer allow-list

### Summary
Extends the shared `AllowListDiagnosticSuppressor` (in `Azure.SdkAnalyzers`) with a
new `SourceGenerated` scope that suppresses a diagnostic **only inside
source-generator output (`*.g.cs`)**. This gives libraries a way to silence a
diagnostic that originates in compile-time generated code they cannot annotate,
without falling back to an assembly-wide `nowarn` that also hides the diagnostic
in code they control.

### Motivation
`Azure.AI.Extensions.OpenAI` extends OpenAI SDK types marked `[Experimental("OPENAI001")]`.
The source-generated `ModelReaderWriterContext` partial (`*.g.cs`) references external
experimental types (`OpenAI.OpenAIContext`), producing `OPENAI001` at sites that exist
only in the compiler's view — they cannot be edited or `#pragma`-annotated. The prior
mitigation was a global `nowarn:OPENAI001`, which suppressed the diagnostic across the
entire assembly, including hand-written extension code that should stay analyzed.

### Changes
- **`AllowListEntry`** — new `AllowListScopeKind { WholeAssembly, Symbol, SourceGenerated }`;
  each parsed entry carries its `Scope`.
- **`AllowListParser`** — recognizes the `SourceGenerated` keyword (case-insensitive) as an
  entry target, alongside the existing `T:`/`M:`/`N:`/… DocId targets.
- **`AllowListDiagnosticSuppressor`** — registers `OPENAI001` and `OPENAICUA001` as
  suppressible IDs; matches a `SourceGenerated`-scoped entry only when the diagnostic's
  location is a `*.g.cs` file. The checked-in `Generated/` folder is intentionally **not**
  covered — regenerable code should carry correct per-symbol attribution rather than a
  blanket suppression.
- **`eng/analyzerallowlist/README.md`** — documents the `SourceGenerated` scope and
  clarifies the severity behavior: Roslyn's `DiagnosticSuppressor` dispatches on a
  descriptor's **default** severity, so a Warning promoted to an error via `/warnaserror`
  (as `[Experimental]` diagnostics are) is still suppressible; a descriptor that ships as
  `Error` is not.

### Tests
- Parser: `SourceGenerated` keyword parsing (case-insensitive, inline-comment stripping,
  scope-kind assertions).
- Suppressor: suppression in `.g.cs`; **no** suppression in a `Generated/` folder file or
  in hand-written code; suppression holds under `/warnaserror`.
- Full suite passes (44 tests) across net462/net8.0/net9.0/net10.0.

### Notes / follow-up
- The analyzer is consumed by shipping libraries as a source `ProjectReference`
  (`OutputItemType="Analyzer"`), so this change takes effect on a normal build — no
  packaging step.
- This PR contains the shared tooling only. Applying it to `Azure.AI.Extensions.OpenAI`
  (the `nowarn:OPENAI001 SourceGenerated` scoped entry, `[Experimental]` attribution of
  hand-written sites, and codegen pragmas for the checked-in `Generated/` diagnostics) is
  a separate follow-up.