### PR TITLE
Use 'none' environment for auto-release publish

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -130,7 +130,11 @@ stages:
               - deployment: PublishPackage
                 displayName: Publish package to ${{ parameters.PublicFeed }} and Dev Feed
                 condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-                environment: ${{ parameters.PublicPublishEnvironment }}
+                # Auto-release is fully automated, so use an environment with no approval checks.
+                ${{ if and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['System.TeamProject'], 'internal')) }}:
+                  environment: none
+                ${{ else }}:
+                  environment: ${{ parameters.PublicPublishEnvironment }}
                 dependsOn: TagRepository
 
                 pool:


### PR DESCRIPTION
## What

The package publish deployment now targets the `none` environment for auto-release runs.

## Why

Auto-release is the fully automated post-merge CI flow on `main`; a manual approval gate would block publishing after a merged PR with the `auto-release` label.

## Impact

Manual releases and all non-auto-release runs are unaffected and continue using the existing approval-gated `PublicPublishEnvironment` value.

`none` must be, or will be auto-created as, an Azure DevOps environment with no approvals/checks.