### PR TITLE
Retain raw request URI builder internal helpers

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureClientGenerator.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureClientGenerator.cs
@@ -31,7 +31,9 @@ public class AzureClientGenerator : ScmCodeModelGenerator
     /// <inheritdoc/>
     public override AzureOutputLibrary OutputLibrary => _azureOutputLibrary ??= new();
 
-    internal RawRequestUriBuilderExtensionsDefinition RawRequestUriBuilderExtensionsDefinition { get; } = new();
+    private RawRequestUriBuilderExtensionsDefinition? _rawRequestUriBuilderExtensionsDefinition;
+    internal RawRequestUriBuilderExtensionsDefinition RawRequestUriBuilderExtensionsDefinition =>
+        _rawRequestUriBuilderExtensionsDefinition ??= new();
 
     internal RequestHeaderExtensionsDefinition RequestHeaderExtensionsDefinition { get; } = new();
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/RawRequestUriBuilderExtensionsDefinition.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/RawRequestUriBuilderExtensionsDefinition.cs
@@ -15,14 +15,11 @@ using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Providers
 {
-    internal class RawRequestUriBuilderExtensionsDefinition : TypeProvider
+    internal class RawRequestUriBuilderExtensionsDefinition : InternalHelperProvider
     {
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Internal", $"{Name}.cs");
 
         protected override string BuildName() => "RawRequestUriBuilderExtensions";
-
-        protected override TypeSignatureModifiers BuildDeclarationModifiers() =>
-            TypeSignatureModifiers.Internal | TypeSignatureModifiers.Static | TypeSignatureModifiers.Class;
 
         protected override MethodProvider[] BuildMethods()
         {

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/RawRequestUriBuilderExtensionsTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/RawRequestUriBuilderExtensionsTests.cs
@@ -19,6 +19,7 @@ namespace Azure.Generator.Tests.Providers
             MockHelpers.LoadMockGenerator();
             var uriBuilderDefinition = new RawRequestUriBuilderExtensionsDefinition();
 
+            Assert.AreEqual("InternalHelperProvider", uriBuilderDefinition.GetType().BaseType?.Name);
             var writer = new TypeProviderWriter(uriBuilderDefinition);
             var file = writer.Write();
             Assert.AreEqual(Helpers.GetExpectedFromFile(), file.Content);

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/RawRequestUriBuilderExtensionsTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/RawRequestUriBuilderExtensionsTests.cs
@@ -7,6 +7,7 @@ using Azure.Generator.Tests.Common;
 using Azure.Generator.Tests.TestHelpers;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
 using NUnit.Framework;
 
 namespace Azure.Generator.Tests.Providers
@@ -19,7 +20,7 @@ namespace Azure.Generator.Tests.Providers
             MockHelpers.LoadMockGenerator();
             var uriBuilderDefinition = new RawRequestUriBuilderExtensionsDefinition();
 
-            Assert.AreEqual("InternalHelperProvider", uriBuilderDefinition.GetType().BaseType?.Name);
+            Assert.AreEqual(nameof(InternalHelperProvider), uriBuilderDefinition.GetType().BaseType?.Name);
         }
 
         [Test]

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/RawRequestUriBuilderExtensionsTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/RawRequestUriBuilderExtensionsTests.cs
@@ -14,12 +14,20 @@ namespace Azure.Generator.Tests.Providers
     public class RawRequestUriBuilderExtensionsTests
     {
         [Test]
-        public void AddsAppendExtensionMethods()
+        public void IsInternalHelperProvider()
         {
             MockHelpers.LoadMockGenerator();
             var uriBuilderDefinition = new RawRequestUriBuilderExtensionsDefinition();
 
             Assert.AreEqual("InternalHelperProvider", uriBuilderDefinition.GetType().BaseType?.Name);
+        }
+
+        [Test]
+        public void AddsAppendExtensionMethods()
+        {
+            MockHelpers.LoadMockGenerator();
+            var uriBuilderDefinition = new RawRequestUriBuilderExtensionsDefinition();
+
             var writer = new TypeProviderWriter(uriBuilderDefinition);
             var file = writer.Write();
             Assert.AreEqual(Helpers.GetExpectedFromFile(), file.Content);


### PR DESCRIPTION
## Summary

- retain `RawRequestUriBuilderExtensions` as an internal helper even when generated code does not reference it
- lazily initialize the provider after `CodeModelGenerator.Instance` is available
- add regression coverage for the helper-provider inheritance

This keeps the helper consistently available to package customizations.

Fixes #61316.

## Tests

- `RawRequestUriBuilderExtensionsTests`
- `eng/packages/http-client-csharp/eng/scripts/Generate.ps1`