### PR TITLE
Avoid parallel client plugin builds during SDK generation

### DIFF
--- a/eng/service.proj
+++ b/eng/service.proj
@@ -114,7 +114,7 @@
   <Target Name="GenerateCode" DependsOnTargets="InstallTspClient;BuildPlugin">
     <MSBuild Projects="@(ProjectReference)"
              Targets="GenerateCode"
-             Properties="SkipTspClientInstall=true"
+             Properties="SkipTspClientInstall=true;SkipBuildPlugin=true"
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="false"
              SkipNonexistentTargets="true" />


### PR DESCRIPTION
## Description

Build the client plugin once at the service traversal level and pass `SkipBuildPlugin=true` to parallel child `GenerateCode` targets.

This prevents concurrent direct builds from sharing the plugin's `bin`, `obj`, and `dist` directories. Build 6616512 failed when one of these builds could not copy `Shared/SystemClientModel/ClientDiagnostics.cs` because another parallel build was modifying the same output.

The process-isolated plugin build fix in microsoft/typespec#11224 applies to plugins built by `GeneratorHandler`; it does not cover this explicit Azure SDK prebuild.

## Related

- Azure DevOps build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6616512
- TypeSpec plugin isolation: https://github.com/microsoft/typespec/pull/11224