### PR TITLE
Emit base64 format for provisioning bytes properties

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningPropertyInfo.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningPropertyInfo.cs
@@ -15,5 +15,6 @@ namespace Azure.Generator.Provisioning.Primitives
         bool IsRequired,
         string[] BicepPath,
         string? DefaultValue = null,
-        CSharpType? TypeOverride = null);
+        CSharpType? TypeOverride = null,
+        string? Format = null);
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningModelProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningModelProvider.cs
@@ -67,7 +67,8 @@ namespace Azure.Generator.Provisioning.Providers
                 property.IsReadOnly,
                 !property.IsReadOnly && _hasSettableUsage,
                 property.IsRequired && _hasSettableUsage,
-                [serializedName]);
+                [serializedName],
+                Format: BicepTypeHelpers.GetLiteralFormat(property.Type));
         }
 
         protected override FieldProvider[] BuildFields()
@@ -183,7 +184,7 @@ namespace Azure.Generator.Provisioning.Providers
                 statements.Add(field.Assign(
                     This.Invoke(
                         methodName,
-                        BicepTypeHelpers.BuildDefinePropertyArgs(provProp.Name, provProp.BicepPath, provProp.IsOutput, provProp.IsRequired, provProp.DefaultValue),
+                        BicepTypeHelpers.BuildDefinePropertyArgs(provProp.Name, provProp.BicepPath, provProp.IsOutput, provProp.IsRequired, provProp.DefaultValue, provProp.Format),
                         typeArgs,
                         false)
                 ).Terminate());

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningPropertyProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningPropertyProvider.cs
@@ -33,6 +33,9 @@ namespace Azure.Generator.Provisioning.Providers
         /// <summary>Optional default value (e.g., for singleton resource names).</summary>
         public string? DefaultValue { get; }
 
+        /// <summary>Optional Bicep literal serialization format.</summary>
+        public string? Format { get; }
+
         private ProvisioningPropertyProvider(
             FieldProvider backingField,
             CSharpType type,
@@ -43,7 +46,8 @@ namespace Azure.Generator.Provisioning.Providers
             bool isOutput,
             bool isSettable,
             bool isRequired,
-            string? defaultValue)
+            string? defaultValue,
+            string? format)
             : base(null, MethodSignatureModifiers.Public, type, name, body, enclosingType)
         {
             BackingField = backingField;
@@ -52,6 +56,7 @@ namespace Azure.Generator.Provisioning.Providers
             IsSettable = isSettable;
             IsRequired = isRequired;
             DefaultValue = defaultValue;
+            Format = format;
         }
 
         /// <summary>
@@ -66,6 +71,7 @@ namespace Azure.Generator.Provisioning.Providers
             bool isRequired,
             string[] bicepPath,
             string? defaultValue,
+            string? format,
             TypeProvider enclosingType)
         {
             var field = new FieldProvider(
@@ -106,7 +112,7 @@ namespace Azure.Generator.Provisioning.Providers
 
             return new ProvisioningPropertyProvider(
                 field, bicepType, resolvedName, body, enclosingType,
-                bicepPath, isOutput, isSettable, isRequired, defaultValue);
+                bicepPath, isOutput, isSettable, isRequired, defaultValue, format);
         }
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -102,7 +102,8 @@ namespace Azure.Generator.Provisioning.Providers
                 propInfo.IsRequired,
                 propInfo.BicepPath,
                 propInfo.DefaultValue,
-                propInfo.TypeOverride);
+                propInfo.TypeOverride,
+                propInfo.Format);
         }
 
         /// <summary>
@@ -518,7 +519,7 @@ namespace Azure.Generator.Provisioning.Providers
                     typeOverride = new CSharpType(typeof(BicepValue<>), typeof(Azure.Core.AzureLocation));
                 }
 
-                result.Add(new ResourcePropertyInfo(prop, propertyName, bicepPath, isOutput, isSettable, isRequired, defaultValue, typeOverride));
+                result.Add(new ResourcePropertyInfo(prop, propertyName, bicepPath, isOutput, isSettable, isRequired, defaultValue, typeOverride, BicepTypeHelpers.GetLiteralFormat(prop.Type)));
             }
         }
 
@@ -581,7 +582,7 @@ namespace Azure.Generator.Provisioning.Providers
                 statements.Add(field.Assign(
                     This.Invoke(
                         methodName,
-                        BicepTypeHelpers.BuildDefinePropertyArgs(provProp.Name, provProp.BicepPath, provProp.IsOutput, provProp.IsRequired, provProp.DefaultValue),
+                        BicepTypeHelpers.BuildDefinePropertyArgs(provProp.Name, provProp.BicepPath, provProp.IsOutput, provProp.IsRequired, provProp.DefaultValue, provProp.Format),
                         typeArgs,
                         false)
                 ).Terminate());
@@ -911,7 +912,8 @@ namespace Azure.Generator.Provisioning.Providers
                     bicepPath,
                     prop.IsReadOnly,
                     !prop.IsReadOnly && _isSettableResource,
-                    prop.IsRequired));
+                    prop.IsRequired,
+                    Format: BicepTypeHelpers.GetLiteralFormat(prop.Type)));
             }
             return result;
         }
@@ -941,7 +943,8 @@ namespace Azure.Generator.Provisioning.Providers
             bool IsSettable,
             bool IsRequired,
             string? DefaultValue = null,
-            CSharpType? TypeOverride = null);
+            CSharpType? TypeOverride = null,
+            string? Format = null);
 
         // ── ResourceVersions nested class ────────────────────────────
 

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
@@ -194,7 +194,7 @@ namespace Azure.Generator.Provisioning
 
                 return ProvisioningPropertyProvider.Create(
                     resolvedName, bicepType,
-                    info.IsOutput, info.IsSettable, info.IsRequired, info.BicepPath, info.DefaultValue,
+                    info.IsOutput, info.IsSettable, info.IsRequired, info.BicepPath, info.DefaultValue, info.Format,
                     enclosingType);
             }
 

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/BicepTypeHelpers.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/BicepTypeHelpers.cs
@@ -4,6 +4,7 @@
 using Azure.Provisioning;
 using Azure.Provisioning.Primitives;
 using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using System;
 using System.Collections.Generic;
@@ -74,7 +75,7 @@ namespace Azure.Generator.Provisioning.Utilities
         /// isOutput and isRequired are independent flags and only emitted when true, using named arguments.
         /// </summary>
         public static ValueExpression[] BuildDefinePropertyArgs(
-            string propertyName, string[] bicepPath, bool isOutput, bool isRequired, string? defaultValue = null)
+            string propertyName, string[] bicepPath, bool isOutput, bool isRequired, string? defaultValue = null, string? format = null)
         {
             var args = new List<ValueExpression>
             {
@@ -93,7 +94,19 @@ namespace Azure.Generator.Provisioning.Utilities
             {
                 args.Add(new PositionalParameterReferenceExpression("defaultValue", Literal(defaultValue)));
             }
+            if (format is not null)
+            {
+                args.Add(new PositionalParameterReferenceExpression("format", Literal(format)));
+            }
             return [.. args];
         }
+
+        public static string? GetLiteralFormat(InputType type) =>
+            type switch
+            {
+                InputPrimitiveType { Kind: InputPrimitiveTypeKind.Bytes, Encode: "base64" } => "base64",
+                InputNullableType nullable => GetLiteralFormat(nullable.Type),
+                _ => null
+            };
     }
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -402,6 +402,68 @@ namespace Azure.Generator.Provisioning.Tests
         }
 
         [Test]
+        public void Base64ResourcePropertyUsesBase64Format()
+        {
+            var blobProperty = CreateProperty("Blob", type: InputPrimitiveType.Base64);
+            var metadataProperty = CreateProperty("Metadata", type: InputPrimitiveType.Any);
+            var model = CreateModel("WritableWidget", [blobProperty, metadataProperty]);
+            var writableResource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+                "Microsoft.Test/widgets",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                methods:
+                [
+                    CreateMethod(ResourceOperationKind.Read, ResourceScope.ResourceGroup),
+                    CreateMethod(ResourceOperationKind.Create, ResourceScope.ResourceGroup)
+                ]);
+            ProvisioningMockHelpers.LoadMockPlugin(inputModels: () => [model]);
+            var provider = CreateResourceProvider(writableResource);
+
+            var blobInfo = ((IProvisioningPropertyInfo)provider).GetProvisioningPropertyInfo(blobProperty);
+            var metadataInfo = ((IProvisioningPropertyInfo)provider).GetProvisioningPropertyInfo(metadataProperty);
+
+            Assert.That(blobInfo, Is.Not.Null);
+            Assert.That(blobInfo!.Format, Is.EqualTo("base64"));
+            Assert.That(metadataInfo, Is.Not.Null);
+            Assert.That(metadataInfo!.Format, Is.Null);
+        }
+
+        [Test]
+        public void Base64ModelPropertyUsesBase64Format()
+        {
+            var blobProperty = CreateProperty("Blob", type: InputPrimitiveType.Base64);
+            var metadataProperty = CreateProperty("Metadata", type: InputPrimitiveType.Any);
+            var detailsModel = CreateModel("WritableWidgetDetails", [blobProperty, metadataProperty]);
+            var detailsProperty = CreateProperty("Details", type: detailsModel);
+            var resourceModel = CreateModel("WritableWidget", [detailsProperty]);
+            var writableResource = CreateMetadata(
+                resourceModel,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+                "Microsoft.Test/widgets",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                methods:
+                [
+                    CreateMethod(ResourceOperationKind.Read, ResourceScope.ResourceGroup),
+                    CreateMethod(ResourceOperationKind.Create, ResourceScope.ResourceGroup)
+                ]);
+            ProvisioningMockHelpers.LoadMockPlugin(inputModels: () => [resourceModel, detailsModel]);
+            var resourceProvider = CreateResourceProvider(writableResource);
+            RegisterResourceProviders(resourceProvider);
+            var provider = new ProvisioningModelProvider(detailsModel);
+
+            var blobInfo = ((IProvisioningPropertyInfo)provider).GetProvisioningPropertyInfo(blobProperty);
+            var metadataInfo = ((IProvisioningPropertyInfo)provider).GetProvisioningPropertyInfo(metadataProperty);
+
+            Assert.That(blobInfo, Is.Not.Null);
+            Assert.That(blobInfo!.Format, Is.EqualTo("base64"));
+            Assert.That(metadataInfo, Is.Not.Null);
+            Assert.That(metadataInfo!.Format, Is.Null);
+        }
+
+        [Test]
         public void ReadOnlyResourceConstructorIsInternal()
         {
             var model = CreateModel("ReadOnlyWidget");

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/configurationStore.tsp
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/configurationStore.tsp
@@ -54,6 +54,12 @@ model ConfigurationStoreProperties {
 
   /** The linked resources of the configuration store. */
   linkedResources?: LinkedResource[];
+
+  /** Byte-oriented content that must be serialized as a base64 string. */
+  binaryContent?: bytes;
+
+  /** Arbitrary JSON content that should keep JSON literal semantics. */
+  jsonMetadata?: unknown;
 }
 
 /** A linked resource reference. */

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ConfigurationStoreProperties.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Models/ConfigurationStoreProperties.cs
@@ -26,6 +26,8 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         private BicepValue<ConfigurationStoreSkuTier> _skuTier;
         private BicepValue<ConfigurationStoreCreateMode> _createMode;
         private BicepList<SubResource> _linkedResources;
+        private BicepValue<BinaryData> _binaryContent;
+        private BicepValue<BinaryData> _jsonMetadata;
 
         /// <summary> Creates a new ConfigurationStoreProperties. </summary>
         public ConfigurationStoreProperties()
@@ -182,6 +184,36 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             }
         }
 
+        /// <summary> Gets or sets the BinaryContent. </summary>
+        public BicepValue<BinaryData> BinaryContent
+        {
+            get
+            {
+                Initialize();
+                return _binaryContent;
+            }
+            set
+            {
+                Initialize();
+                _binaryContent.Assign(value);
+            }
+        }
+
+        /// <summary> Gets or sets the JsonMetadata. </summary>
+        public BicepValue<BinaryData> JsonMetadata
+        {
+            get
+            {
+                Initialize();
+                return _jsonMetadata;
+            }
+            set
+            {
+                Initialize();
+                _jsonMetadata.Assign(value);
+            }
+        }
+
         /// <summary> Gets or sets the Name. </summary>
         public BicepValue<string> SkuName
         {
@@ -214,6 +246,8 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             _skuTier = DefineProperty<ConfigurationStoreSkuTier>(nameof(SkuTier), new string[] { "skuTier" });
             _createMode = DefineProperty<ConfigurationStoreCreateMode>(nameof(CreateMode), new string[] { "createMode" });
             _linkedResources = DefineListProperty<SubResource>(nameof(LinkedResources), new string[] { "linkedResources" });
+            _binaryContent = DefineProperty<BinaryData>(nameof(BinaryContent), new string[] { "binaryContent" }, format: "base64");
+            _jsonMetadata = DefineProperty<BinaryData>(nameof(JsonMetadata), new string[] { "jsonMetadata" });
             DefineAdditionalProperties();
         }
 

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
@@ -2964,6 +2964,61 @@
                 },
                 "isHttpMetadata": false,
                 "isExactName": false
+              },
+              {
+                "$id": "229",
+                "kind": "property",
+                "name": "binaryContent",
+                "serializedName": "binaryContent",
+                "doc": "Byte-oriented content that must be serialized as a base64 string.",
+                "type": {
+                  "$id": "230",
+                  "kind": "bytes",
+                  "name": "bytes",
+                  "encode": "base64",
+                  "crossLanguageDefinitionId": "TypeSpec.bytes",
+                  "decorators": []
+                },
+                "optional": true,
+                "readOnly": false,
+                "discriminator": false,
+                "flatten": false,
+                "decorators": [],
+                "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStoreProperties.binaryContent",
+                "serializationOptions": {
+                  "json": {
+                    "name": "binaryContent"
+                  }
+                },
+                "isHttpMetadata": false,
+                "isExactName": false
+              },
+              {
+                "$id": "231",
+                "kind": "property",
+                "name": "jsonMetadata",
+                "serializedName": "jsonMetadata",
+                "doc": "Arbitrary JSON content that should keep JSON literal semantics.",
+                "type": {
+                  "$id": "232",
+                  "kind": "unknown",
+                  "name": "unknown",
+                  "crossLanguageDefinitionId": "",
+                  "decorators": []
+                },
+                "optional": true,
+                "readOnly": false,
+                "discriminator": false,
+                "flatten": false,
+                "decorators": [],
+                "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStoreProperties.jsonMetadata",
+                "serializationOptions": {
+                  "json": {
+                    "name": "jsonMetadata"
+                  }
+                },
+                "isHttpMetadata": false,
+                "isExactName": false
               }
             ]
           },
@@ -2982,13 +3037,13 @@
           "isExactName": false
         },
         {
-          "$id": "229",
+          "$id": "233",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the ConfigurationStore",
           "type": {
-            "$id": "230",
+            "$id": "234",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3016,13 +3071,13 @@
           "isExactName": false
         },
         {
-          "$id": "231",
+          "$id": "235",
           "kind": "property",
           "name": "eTag",
           "serializedName": "eTag",
           "doc": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
           "type": {
-            "$id": "232",
+            "$id": "236",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3072,7 +3127,7 @@
       "$ref": "171"
     },
     {
-      "$id": "233",
+      "$id": "237",
       "kind": "model",
       "name": "ArmOperationStatusResourceProvisioningState",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3093,7 +3148,7 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "234",
+          "$id": "238",
           "kind": "property",
           "name": "status",
           "serializedName": "status",
@@ -3116,13 +3171,13 @@
           "isExactName": false
         },
         {
-          "$id": "235",
+          "$id": "239",
           "kind": "property",
           "name": "id",
           "serializedName": "id",
           "doc": "The unique identifier for the operationStatus resource",
           "type": {
-            "$id": "236",
+            "$id": "240",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3143,13 +3198,13 @@
           "isExactName": false
         },
         {
-          "$id": "237",
+          "$id": "241",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the operationStatus resource",
           "type": {
-            "$id": "238",
+            "$id": "242",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3170,18 +3225,18 @@
           "isExactName": false
         },
         {
-          "$id": "239",
+          "$id": "243",
           "kind": "property",
           "name": "startTime",
           "serializedName": "startTime",
           "doc": "Operation start time",
           "type": {
-            "$id": "240",
+            "$id": "244",
             "kind": "utcDateTime",
             "name": "utcDateTime",
             "encode": "rfc3339",
             "wireType": {
-              "$id": "241",
+              "$id": "245",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3205,18 +3260,18 @@
           "isExactName": false
         },
         {
-          "$id": "242",
+          "$id": "246",
           "kind": "property",
           "name": "endTime",
           "serializedName": "endTime",
           "doc": "Operation complete time",
           "type": {
-            "$id": "243",
+            "$id": "247",
             "kind": "utcDateTime",
             "name": "utcDateTime",
             "encode": "rfc3339",
             "wireType": {
-              "$id": "244",
+              "$id": "248",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3240,13 +3295,13 @@
           "isExactName": false
         },
         {
-          "$id": "245",
+          "$id": "249",
           "kind": "property",
           "name": "percentComplete",
           "serializedName": "percentComplete",
           "doc": "The progress made toward completing the operation",
           "type": {
-            "$id": "246",
+            "$id": "250",
             "kind": "float64",
             "name": "float64",
             "crossLanguageDefinitionId": "TypeSpec.float64",
@@ -3267,7 +3322,7 @@
           "isExactName": false
         },
         {
-          "$id": "247",
+          "$id": "251",
           "kind": "property",
           "name": "error",
           "serializedName": "error",
@@ -3292,7 +3347,7 @@
       ]
     },
     {
-      "$id": "248",
+      "$id": "252",
       "kind": "model",
       "name": "ConfigurationStoreListResult",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3313,13 +3368,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "249",
+          "$id": "253",
           "kind": "property",
           "name": "value",
           "serializedName": "value",
           "doc": "The ConfigurationStore items on this page",
           "type": {
-            "$id": "250",
+            "$id": "254",
             "kind": "array",
             "name": "ArrayConfigurationStore",
             "valueType": {
@@ -3343,18 +3398,18 @@
           "isExactName": false
         },
         {
-          "$id": "251",
+          "$id": "255",
           "kind": "property",
           "name": "nextLink",
           "serializedName": "nextLink",
           "doc": "The link to the next page of items",
           "type": {
-            "$id": "252",
+            "$id": "256",
             "kind": "url",
             "name": "ResourceLocation",
             "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
             "baseType": {
-              "$id": "253",
+              "$id": "257",
               "kind": "url",
               "name": "url",
               "crossLanguageDefinitionId": "TypeSpec.url",
@@ -3379,7 +3434,7 @@
       ]
     },
     {
-      "$id": "254",
+      "$id": "258",
       "kind": "model",
       "name": "KeyValue",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3407,7 +3462,7 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$id": "255",
+        "$id": "259",
         "kind": "model",
         "name": "ProxyResource",
         "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3434,13 +3489,13 @@
       },
       "properties": [
         {
-          "$id": "256",
+          "$id": "260",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "257",
+            "$id": "261",
             "kind": "model",
             "name": "KeyValueProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3461,13 +3516,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "258",
+                "$id": "262",
                 "kind": "property",
                 "name": "value",
                 "serializedName": "value",
                 "doc": "The value of the key-value.",
                 "type": {
-                  "$id": "259",
+                  "$id": "263",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3488,13 +3543,13 @@
                 "isExactName": false
               },
               {
-                "$id": "260",
+                "$id": "264",
                 "kind": "property",
                 "name": "contentType",
                 "serializedName": "contentType",
                 "doc": "The content type of the key-value.",
                 "type": {
-                  "$id": "261",
+                  "$id": "265",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3531,13 +3586,13 @@
           "isExactName": false
         },
         {
-          "$id": "262",
+          "$id": "266",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the KeyValue",
           "type": {
-            "$id": "263",
+            "$id": "267",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3567,13 +3622,13 @@
       ]
     },
     {
-      "$ref": "257"
+      "$ref": "261"
     },
     {
-      "$ref": "255"
+      "$ref": "259"
     },
     {
-      "$id": "264",
+      "$id": "268",
       "kind": "model",
       "name": "KeyValueListResult",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3594,17 +3649,17 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "265",
+          "$id": "269",
           "kind": "property",
           "name": "value",
           "serializedName": "value",
           "doc": "The KeyValue items on this page",
           "type": {
-            "$id": "266",
+            "$id": "270",
             "kind": "array",
             "name": "ArrayKeyValue",
             "valueType": {
-              "$ref": "254"
+              "$ref": "258"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -3624,18 +3679,18 @@
           "isExactName": false
         },
         {
-          "$id": "267",
+          "$id": "271",
           "kind": "property",
           "name": "nextLink",
           "serializedName": "nextLink",
           "doc": "The link to the next page of items",
           "type": {
-            "$id": "268",
+            "$id": "272",
             "kind": "url",
             "name": "ResourceLocation",
             "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
             "baseType": {
-              "$id": "269",
+              "$id": "273",
               "kind": "url",
               "name": "url",
               "crossLanguageDefinitionId": "TypeSpec.url",
@@ -3660,7 +3715,7 @@
       ]
     },
     {
-      "$id": "270",
+      "$id": "274",
       "kind": "model",
       "name": "Item",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3688,17 +3743,17 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$ref": "255"
+        "$ref": "259"
       },
       "properties": [
         {
-          "$id": "271",
+          "$id": "275",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "272",
+            "$id": "276",
             "kind": "model",
             "name": "ItemProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3719,13 +3774,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "273",
+                "$id": "277",
                 "kind": "property",
                 "name": "value",
                 "serializedName": "value",
                 "doc": "The value of the item.",
                 "type": {
-                  "$id": "274",
+                  "$id": "278",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3746,13 +3801,13 @@
                 "isExactName": false
               },
               {
-                "$id": "275",
+                "$id": "279",
                 "kind": "property",
                 "name": "contentType",
                 "serializedName": "contentType",
                 "doc": "The content type of the item.",
                 "type": {
-                  "$id": "276",
+                  "$id": "280",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3773,16 +3828,16 @@
                 "isExactName": false
               },
               {
-                "$id": "277",
+                "$id": "281",
                 "kind": "property",
                 "name": "nullableValue",
                 "serializedName": "nullableValue",
                 "doc": "Nullable value used to verify provisioning primitive wrapping.",
                 "type": {
-                  "$id": "278",
+                  "$id": "282",
                   "kind": "nullable",
                   "type": {
-                    "$id": "279",
+                    "$id": "283",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3805,13 +3860,13 @@
                 "isExactName": false
               },
               {
-                "$id": "280",
+                "$id": "284",
                 "kind": "property",
                 "name": "attributes",
                 "serializedName": "attributes",
                 "doc": "The attributes of the item.",
                 "type": {
-                  "$id": "281",
+                  "$id": "285",
                   "kind": "model",
                   "name": "ItemAttributes",
                   "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3831,7 +3886,7 @@
                   },
                   "isExactName": false,
                   "baseModel": {
-                    "$id": "282",
+                    "$id": "286",
                     "kind": "model",
                     "name": "BaseItemAttributes",
                     "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -3852,13 +3907,13 @@
                     "isExactName": false,
                     "properties": [
                       {
-                        "$id": "283",
+                        "$id": "287",
                         "kind": "property",
                         "name": "enabled",
                         "serializedName": "enabled",
                         "doc": "Whether the item is enabled.",
                         "type": {
-                          "$id": "284",
+                          "$id": "288",
                           "kind": "boolean",
                           "name": "boolean",
                           "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -3879,18 +3934,18 @@
                         "isExactName": false
                       },
                       {
-                        "$id": "285",
+                        "$id": "289",
                         "kind": "property",
                         "name": "created",
                         "serializedName": "created",
                         "doc": "The creation date.",
                         "type": {
-                          "$id": "286",
+                          "$id": "290",
                           "kind": "utcDateTime",
                           "name": "utcDateTime",
                           "encode": "rfc3339",
                           "wireType": {
-                            "$id": "287",
+                            "$id": "291",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3914,18 +3969,18 @@
                         "isExactName": false
                       },
                       {
-                        "$id": "288",
+                        "$id": "292",
                         "kind": "property",
                         "name": "updated",
                         "serializedName": "updated",
                         "doc": "The last updated date.",
                         "type": {
-                          "$id": "289",
+                          "$id": "293",
                           "kind": "utcDateTime",
                           "name": "utcDateTime",
                           "encode": "rfc3339",
                           "wireType": {
-                            "$id": "290",
+                            "$id": "294",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3952,18 +4007,18 @@
                   },
                   "properties": [
                     {
-                      "$id": "291",
+                      "$id": "295",
                       "kind": "property",
                       "name": "expires",
                       "serializedName": "expires",
                       "doc": "The expiry date.",
                       "type": {
-                        "$id": "292",
+                        "$id": "296",
                         "kind": "utcDateTime",
                         "name": "utcDateTime",
                         "encode": "rfc3339",
                         "wireType": {
-                          "$id": "293",
+                          "$id": "297",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4024,13 +4079,13 @@
           "isExactName": false
         },
         {
-          "$id": "294",
+          "$id": "298",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the Item",
           "type": {
-            "$id": "295",
+            "$id": "299",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4058,7 +4113,7 @@
           "isExactName": false
         },
         {
-          "$id": "296",
+          "$id": "300",
           "kind": "property",
           "name": "tags",
           "serializedName": "tags",
@@ -4083,16 +4138,16 @@
       ]
     },
     {
-      "$ref": "272"
+      "$ref": "276"
     },
     {
-      "$ref": "281"
+      "$ref": "285"
     },
     {
-      "$ref": "282"
+      "$ref": "286"
     },
     {
-      "$id": "297",
+      "$id": "301",
       "kind": "model",
       "name": "ItemCreateOrUpdateParameters",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4113,7 +4168,7 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "298",
+          "$id": "302",
           "kind": "property",
           "name": "tags",
           "serializedName": "tags",
@@ -4136,13 +4191,13 @@
           "isExactName": false
         },
         {
-          "$id": "299",
+          "$id": "303",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "Properties of the item.",
           "type": {
-            "$ref": "272"
+            "$ref": "276"
           },
           "optional": false,
           "readOnly": false,
@@ -4161,7 +4216,7 @@
       ]
     },
     {
-      "$id": "300",
+      "$id": "304",
       "kind": "model",
       "name": "ItemListResult",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4182,17 +4237,17 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "301",
+          "$id": "305",
           "kind": "property",
           "name": "value",
           "serializedName": "value",
           "doc": "The Item items on this page",
           "type": {
-            "$id": "302",
+            "$id": "306",
             "kind": "array",
             "name": "ArrayItem",
             "valueType": {
-              "$ref": "270"
+              "$ref": "274"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -4212,18 +4267,18 @@
           "isExactName": false
         },
         {
-          "$id": "303",
+          "$id": "307",
           "kind": "property",
           "name": "nextLink",
           "serializedName": "nextLink",
           "doc": "The link to the next page of items",
           "type": {
-            "$id": "304",
+            "$id": "308",
             "kind": "url",
             "name": "ResourceLocation",
             "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
             "baseType": {
-              "$id": "305",
+              "$id": "309",
               "kind": "url",
               "name": "url",
               "crossLanguageDefinitionId": "TypeSpec.url",
@@ -4248,7 +4303,7 @@
       ]
     },
     {
-      "$id": "306",
+      "$id": "310",
       "kind": "model",
       "name": "Profile",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4276,17 +4331,17 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$ref": "255"
+        "$ref": "259"
       },
       "properties": [
         {
-          "$id": "307",
+          "$id": "311",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "308",
+            "$id": "312",
             "kind": "model",
             "name": "ProfileProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4307,13 +4362,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "309",
+                "$id": "313",
                 "kind": "property",
                 "name": "description",
                 "serializedName": "description",
                 "doc": "A scalar property that should land on the parent Profile resource\nafter flattening, and stay on `ProfileProperties` itself for the\nstandalone model.",
                 "type": {
-                  "$id": "310",
+                  "$id": "314",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4334,13 +4389,13 @@
                 "isExactName": false
               },
               {
-                "$id": "311",
+                "$id": "315",
                 "kind": "property",
                 "name": "sku",
                 "serializedName": "sku",
                 "doc": "A SKU sub-property.",
                 "type": {
-                  "$id": "312",
+                  "$id": "316",
                   "kind": "model",
                   "name": "ProfileSku",
                   "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4361,13 +4416,13 @@
                   "isExactName": false,
                   "properties": [
                     {
-                      "$id": "313",
+                      "$id": "317",
                       "kind": "property",
                       "name": "name",
                       "serializedName": "name",
                       "doc": "The SKU name.",
                       "type": {
-                        "$id": "314",
+                        "$id": "318",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4425,13 +4480,13 @@
           "isExactName": false
         },
         {
-          "$id": "315",
+          "$id": "319",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the Profile",
           "type": {
-            "$id": "316",
+            "$id": "320",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4461,13 +4516,13 @@
       ]
     },
     {
-      "$ref": "308"
-    },
-    {
       "$ref": "312"
     },
     {
-      "$id": "317",
+      "$ref": "316"
+    },
+    {
+      "$id": "321",
       "kind": "model",
       "name": "ProfileListResult",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4488,17 +4543,17 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "318",
+          "$id": "322",
           "kind": "property",
           "name": "value",
           "serializedName": "value",
           "doc": "The Profile items on this page",
           "type": {
-            "$id": "319",
+            "$id": "323",
             "kind": "array",
             "name": "ArrayProfile",
             "valueType": {
-              "$ref": "306"
+              "$ref": "310"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -4518,18 +4573,18 @@
           "isExactName": false
         },
         {
-          "$id": "320",
+          "$id": "324",
           "kind": "property",
           "name": "nextLink",
           "serializedName": "nextLink",
           "doc": "The link to the next page of items",
           "type": {
-            "$id": "321",
+            "$id": "325",
             "kind": "url",
             "name": "ResourceLocation",
             "crossLanguageDefinitionId": "TypeSpec.Rest.ResourceLocation",
             "baseType": {
-              "$id": "322",
+              "$id": "326",
               "kind": "url",
               "name": "url",
               "crossLanguageDefinitionId": "TypeSpec.url",
@@ -4554,7 +4609,7 @@
       ]
     },
     {
-      "$id": "323",
+      "$id": "327",
       "kind": "model",
       "name": "ExtensionAssignment",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4578,7 +4633,7 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$id": "324",
+        "$id": "328",
         "kind": "model",
         "name": "ExtensionResource",
         "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4604,13 +4659,13 @@
       },
       "properties": [
         {
-          "$id": "325",
+          "$id": "329",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "326",
+            "$id": "330",
             "kind": "model",
             "name": "ExtensionAssignmentProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4631,13 +4686,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "327",
+                "$id": "331",
                 "kind": "property",
                 "name": "displayName",
                 "serializedName": "displayName",
                 "doc": "The display name of the assignment.",
                 "type": {
-                  "$id": "328",
+                  "$id": "332",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4674,13 +4729,13 @@
           "isExactName": false
         },
         {
-          "$id": "329",
+          "$id": "333",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the ExtensionAssignment",
           "type": {
-            "$id": "330",
+            "$id": "334",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4710,13 +4765,13 @@
       ]
     },
     {
-      "$ref": "326"
+      "$ref": "330"
     },
     {
-      "$ref": "324"
+      "$ref": "328"
     },
     {
-      "$id": "331",
+      "$id": "335",
       "kind": "model",
       "name": "SingletonSetting",
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4750,17 +4805,17 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$ref": "255"
+        "$ref": "259"
       },
       "properties": [
         {
-          "$id": "332",
+          "$id": "336",
           "kind": "property",
           "name": "properties",
           "serializedName": "properties",
           "doc": "The resource-specific properties for this resource.",
           "type": {
-            "$id": "333",
+            "$id": "337",
             "kind": "model",
             "name": "SingletonSettingProperties",
             "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
@@ -4781,13 +4836,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "334",
+                "$id": "338",
                 "kind": "property",
                 "name": "enabled",
                 "serializedName": "enabled",
                 "doc": "Indicates whether the singleton setting is enabled.",
                 "type": {
-                  "$id": "335",
+                  "$id": "339",
                   "kind": "boolean",
                   "name": "boolean",
                   "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -4824,13 +4879,13 @@
           "isExactName": false
         },
         {
-          "$id": "336",
+          "$id": "340",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "The name of the SingletonSetting",
           "type": {
-            "$id": "337",
+            "$id": "341",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4860,12 +4915,12 @@
       ]
     },
     {
-      "$ref": "333"
+      "$ref": "337"
     }
   ],
   "clients": [
     {
-      "$id": "338",
+      "$id": "342",
       "kind": "client",
       "name": "ProvisioningTypeSpecClient",
       "isExactName": false,
@@ -4873,13 +4928,13 @@
       "methods": [],
       "parameters": [
         {
-          "$id": "339",
+          "$id": "343",
           "kind": "endpoint",
           "name": "endpoint",
           "serializedName": "endpoint",
           "doc": "Service host",
           "type": {
-            "$id": "340",
+            "$id": "344",
             "kind": "url",
             "name": "endpoint",
             "crossLanguageDefinitionId": "TypeSpec.url"
@@ -4890,7 +4945,7 @@
           "isEndpoint": true,
           "defaultValue": {
             "type": {
-              "$id": "341",
+              "$id": "345",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string"
@@ -4904,13 +4959,13 @@
           "isExactName": false
         },
         {
-          "$id": "342",
+          "$id": "346",
           "kind": "method",
           "name": "apiVersion",
           "serializedName": "apiVersion",
           "doc": "The API version to use for this operation.",
           "type": {
-            "$id": "343",
+            "$id": "347",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4920,7 +4975,7 @@
           "isApiVersion": true,
           "defaultValue": {
             "type": {
-              "$id": "344",
+              "$id": "348",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string"
@@ -4961,33 +5016,9 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores",
                 "methods": [
                   {
-                    "$id": "345",
+                    "$id": "349",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate",
                     "kind": "Create",
-                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
-                    "scope": {
-                      "$id": "346",
-                      "kind": "ResourceGroup",
-                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
-                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
-                    }
-                  },
-                  {
-                    "$id": "347",
-                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.get",
-                    "kind": "Read",
-                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
-                    "scope": {
-                      "$id": "348",
-                      "kind": "ResourceGroup",
-                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
-                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
-                    }
-                  },
-                  {
-                    "$id": "349",
-                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.update",
-                    "kind": "Update",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                     "scope": {
                       "$id": "350",
@@ -4998,8 +5029,8 @@
                   },
                   {
                     "$id": "351",
-                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.delete",
-                    "kind": "Delete",
+                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.get",
+                    "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                     "scope": {
                       "$id": "352",
@@ -5010,23 +5041,47 @@
                   },
                   {
                     "$id": "353",
+                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.update",
+                    "kind": "Update",
+                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                    "scope": {
+                      "$id": "354",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
+                  },
+                  {
+                    "$id": "355",
+                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.delete",
+                    "kind": "Delete",
+                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                    "scope": {
+                      "$id": "356",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
+                  },
+                  {
+                    "$id": "357",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores",
                     "scope": {
-                      "$id": "354",
+                      "$id": "358",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "355",
+                    "$id": "359",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/providers/ProvisioningTypeSpec/configurationStores",
                     "scope": {
-                      "$id": "356",
+                      "$id": "360",
                       "kind": "Subscription",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}",
                       "scopeResourceType": "Microsoft.Resources/subscriptions"
@@ -5034,7 +5089,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "357",
+                  "$id": "361",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5069,33 +5124,9 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/keyValues",
                 "methods": [
                   {
-                    "$id": "358",
+                    "$id": "362",
                     "methodId": "ProvisioningTypeSpec.KeyValues.createOrUpdate",
                     "kind": "Create",
-                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
-                    "scope": {
-                      "$id": "359",
-                      "kind": "ResourceGroup",
-                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
-                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
-                    }
-                  },
-                  {
-                    "$id": "360",
-                    "methodId": "ProvisioningTypeSpec.KeyValues.get",
-                    "kind": "Read",
-                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
-                    "scope": {
-                      "$id": "361",
-                      "kind": "ResourceGroup",
-                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
-                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
-                    }
-                  },
-                  {
-                    "$id": "362",
-                    "methodId": "ProvisioningTypeSpec.KeyValues.delete",
-                    "kind": "Delete",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
                     "scope": {
                       "$id": "363",
@@ -5106,11 +5137,35 @@
                   },
                   {
                     "$id": "364",
+                    "methodId": "ProvisioningTypeSpec.KeyValues.get",
+                    "kind": "Read",
+                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
+                    "scope": {
+                      "$id": "365",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
+                  },
+                  {
+                    "$id": "366",
+                    "methodId": "ProvisioningTypeSpec.KeyValues.delete",
+                    "kind": "Delete",
+                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
+                    "scope": {
+                      "$id": "367",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
+                  },
+                  {
+                    "$id": "368",
                     "methodId": "ProvisioningTypeSpec.KeyValues.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues",
                     "scope": {
-                      "$id": "365",
+                      "$id": "369",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5118,7 +5173,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "366",
+                  "$id": "370",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5141,36 +5196,36 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/items",
                 "methods": [
                   {
-                    "$id": "367",
+                    "$id": "371",
                     "methodId": "ProvisioningTypeSpec.Items.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
                     "scope": {
-                      "$id": "368",
+                      "$id": "372",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "369",
+                    "$id": "373",
                     "methodId": "ProvisioningTypeSpec.Items.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
                     "scope": {
-                      "$id": "370",
+                      "$id": "374",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "371",
+                    "$id": "375",
                     "methodId": "ProvisioningTypeSpec.Items.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items",
                     "scope": {
-                      "$id": "372",
+                      "$id": "376",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5178,7 +5233,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "373",
+                  "$id": "377",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5201,33 +5256,9 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/profiles",
                 "methods": [
                   {
-                    "$id": "374",
+                    "$id": "378",
                     "methodId": "ProvisioningTypeSpec.Profiles.createOrUpdate",
                     "kind": "Create",
-                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
-                    "scope": {
-                      "$id": "375",
-                      "kind": "ResourceGroup",
-                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
-                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
-                    }
-                  },
-                  {
-                    "$id": "376",
-                    "methodId": "ProvisioningTypeSpec.Profiles.get",
-                    "kind": "Read",
-                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
-                    "scope": {
-                      "$id": "377",
-                      "kind": "ResourceGroup",
-                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
-                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
-                    }
-                  },
-                  {
-                    "$id": "378",
-                    "methodId": "ProvisioningTypeSpec.Profiles.delete",
-                    "kind": "Delete",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
                     "scope": {
                       "$id": "379",
@@ -5238,11 +5269,35 @@
                   },
                   {
                     "$id": "380",
+                    "methodId": "ProvisioningTypeSpec.Profiles.get",
+                    "kind": "Read",
+                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
+                    "scope": {
+                      "$id": "381",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
+                  },
+                  {
+                    "$id": "382",
+                    "methodId": "ProvisioningTypeSpec.Profiles.delete",
+                    "kind": "Delete",
+                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
+                    "scope": {
+                      "$id": "383",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
+                  },
+                  {
+                    "$id": "384",
                     "methodId": "ProvisioningTypeSpec.Profiles.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles",
                     "scope": {
-                      "$id": "381",
+                      "$id": "385",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5250,7 +5305,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "382",
+                  "$id": "386",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5273,12 +5328,12 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/profiles/revisions",
                 "methods": [
                   {
-                    "$id": "383",
+                    "$id": "387",
                     "methodId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}/revisions/{revisionNumber}",
                     "scope": {
-                      "$id": "384",
+                      "$id": "388",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/profiles/{profileName}/revisions/{revisionNumber}",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5286,7 +5341,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "385",
+                  "$id": "389",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5309,30 +5364,30 @@
                 "resourceType": "ProvisioningTypeSpec/extensionAssignments",
                 "methods": [
                   {
-                    "$id": "386",
+                    "$id": "390",
                     "methodId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}",
                     "scope": {
-                      "$id": "387",
+                      "$id": "391",
                       "kind": "Extension",
                       "scopeIdPattern": "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}"
                     }
                   },
                   {
-                    "$id": "388",
+                    "$id": "392",
                     "methodId": "ProvisioningTypeSpec.ExtensionAssignments.get",
                     "kind": "Read",
                     "operationPath": "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}",
                     "scope": {
-                      "$id": "389",
+                      "$id": "393",
                       "kind": "Extension",
                       "scopeIdPattern": "/{scope}/providers/ProvisioningTypeSpec/extensionAssignments/{extensionAssignmentName}"
                     }
                   }
                 ],
                 "scope": {
-                  "$id": "390",
+                  "$id": "394",
                   "kind": "Extension",
                   "scopeIdPattern": "/{scope}"
                 },
@@ -5351,24 +5406,24 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/settings",
                 "methods": [
                   {
-                    "$id": "391",
+                    "$id": "395",
                     "methodId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default",
                     "scope": {
-                      "$id": "392",
+                      "$id": "396",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
                     }
                   },
                   {
-                    "$id": "393",
+                    "$id": "397",
                     "methodId": "ProvisioningTypeSpec.SingletonSettings.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default",
                     "scope": {
-                      "$id": "394",
+                      "$id": "398",
                       "kind": "ResourceGroup",
                       "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/settings/default",
                       "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5376,7 +5431,7 @@
                   }
                 ],
                 "scope": {
-                  "$id": "395",
+                  "$id": "399",
                   "kind": "ResourceGroup",
                   "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
                   "scopeResourceType": "Microsoft.Resources/resourceGroups"
@@ -5400,7 +5455,7 @@
                 "methodId": "Azure.ResourceManager.Operations.list",
                 "operationPath": "/providers/ProvisioningTypeSpec/operations",
                 "scope": {
-                  "$id": "396",
+                  "$id": "400",
                   "kind": "Tenant",
                   "scopeIdPattern": "",
                   "scopeResourceType": "Microsoft.Resources/tenants"
@@ -5418,14 +5473,14 @@
       ],
       "children": [
         {
-          "$id": "397",
+          "$id": "401",
           "kind": "client",
           "name": "Operations",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "398",
+              "$id": "402",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -5437,7 +5492,7 @@
               ],
               "doc": "List the operations for the provider",
               "operation": {
-                "$id": "399",
+                "$id": "403",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "Operations",
@@ -5445,13 +5500,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "400",
+                    "$id": "404",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "401",
+                      "$id": "405",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5461,7 +5516,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "402",
+                        "$id": "406",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5484,13 +5539,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "342"
+                        "$ref": "346"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "403",
+                    "$id": "407",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -5506,7 +5561,7 @@
                     "crossLanguageDefinitionId": "Azure.ResourceManager.Operations.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "404",
+                        "$id": "408",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -5559,7 +5614,7 @@
               },
               "parameters": [
                 {
-                  "$ref": "404"
+                  "$ref": "408"
                 }
               ],
               "response": {
@@ -5590,13 +5645,13 @@
           ],
           "parameters": [
             {
-              "$id": "405",
+              "$id": "409",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "406",
+                "$id": "410",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -5607,7 +5662,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "407",
+                  "$id": "411",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5621,7 +5676,7 @@
               "isExactName": false
             },
             {
-              "$ref": "342"
+              "$ref": "346"
             }
           ],
           "initializedBy": 0,
@@ -5633,19 +5688,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "338"
+            "$ref": "342"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "408",
+          "$id": "412",
           "kind": "client",
           "name": "ConfigurationStores",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "409",
+              "$id": "413",
               "kind": "lro",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -5657,7 +5712,7 @@
               ],
               "doc": "Create a ConfigurationStore",
               "operation": {
-                "$id": "410",
+                "$id": "414",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -5665,13 +5720,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "411",
+                    "$id": "415",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "412",
+                      "$id": "416",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5681,7 +5736,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "413",
+                        "$id": "417",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5704,13 +5759,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "414",
+                        "$id": "418",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "415",
+                          "$id": "419",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5720,7 +5775,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "416",
+                            "$id": "420",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5748,18 +5803,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "417",
+                    "$id": "421",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "418",
+                      "$id": "422",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "419",
+                        "$id": "423",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5788,18 +5843,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "420",
+                        "$id": "424",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "421",
+                          "$id": "425",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "422",
+                            "$id": "426",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5830,13 +5885,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "423",
+                    "$id": "427",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "424",
+                      "$id": "428",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5877,13 +5932,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "425",
+                        "$id": "429",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "426",
+                          "$id": "430",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5926,13 +5981,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "427",
+                    "$id": "431",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "428",
+                      "$id": "432",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5957,13 +6012,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "429",
+                        "$id": "433",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "430",
+                          "$id": "434",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5990,7 +6045,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "431",
+                    "$id": "435",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -6007,7 +6062,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "432",
+                        "$id": "436",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -6029,7 +6084,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "433",
+                    "$id": "437",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -6045,7 +6100,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "434",
+                        "$id": "438",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -6066,7 +6121,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "435",
+                    "$id": "439",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
@@ -6086,7 +6141,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "436",
+                        "$id": "440",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
@@ -6145,7 +6200,7 @@
                         "nameInResponse": "Azure-AsyncOperation",
                         "doc": "A link to the status monitor",
                         "type": {
-                          "$id": "437",
+                          "$id": "441",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6157,7 +6212,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "438",
+                          "$id": "442",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -6196,27 +6251,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "425"
+                  "$ref": "429"
                 },
                 {
-                  "$ref": "429"
+                  "$ref": "433"
+                },
+                {
+                  "$ref": "440"
                 },
                 {
                   "$ref": "436"
                 },
                 {
-                  "$ref": "432"
+                  "$ref": "438"
                 },
                 {
-                  "$ref": "434"
-                },
-                {
-                  "$id": "439",
+                  "$id": "443",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "418"
+                    "$ref": "422"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -6249,7 +6304,7 @@
               }
             },
             {
-              "$id": "440",
+              "$id": "444",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -6261,7 +6316,7 @@
               ],
               "doc": "Get a ConfigurationStore",
               "operation": {
-                "$id": "441",
+                "$id": "445",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -6269,13 +6324,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "442",
+                    "$id": "446",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "443",
+                      "$id": "447",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6285,7 +6340,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "444",
+                        "$id": "448",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6308,24 +6363,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "414"
+                        "$ref": "418"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "445",
+                    "$id": "449",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "446",
+                      "$id": "450",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "447",
+                        "$id": "451",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6354,19 +6409,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "420"
+                        "$ref": "424"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "448",
+                    "$id": "452",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "449",
+                      "$id": "453",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6407,13 +6462,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "450",
+                        "$id": "454",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "451",
+                          "$id": "455",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6456,13 +6511,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "452",
+                    "$id": "456",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "453",
+                      "$id": "457",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6487,13 +6542,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "454",
+                        "$id": "458",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "455",
+                          "$id": "459",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6520,7 +6575,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "456",
+                    "$id": "460",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -6536,7 +6591,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "457",
+                        "$id": "461",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -6594,21 +6649,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "450"
-                },
-                {
                   "$ref": "454"
                 },
                 {
-                  "$ref": "457"
+                  "$ref": "458"
                 },
                 {
-                  "$id": "458",
+                  "$ref": "461"
+                },
+                {
+                  "$id": "462",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "446"
+                    "$ref": "450"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -6630,7 +6685,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get"
             },
             {
-              "$id": "459",
+              "$id": "463",
               "kind": "lro",
               "name": "update",
               "isExactName": false,
@@ -6642,7 +6697,7 @@
               ],
               "doc": "Update a ConfigurationStore",
               "operation": {
-                "$id": "460",
+                "$id": "464",
                 "name": "update",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -6650,13 +6705,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "461",
+                    "$id": "465",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "462",
+                      "$id": "466",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6666,7 +6721,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "463",
+                        "$id": "467",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6689,24 +6744,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "414"
+                        "$ref": "418"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "464",
+                    "$id": "468",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "465",
+                      "$id": "469",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "466",
+                        "$id": "470",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6735,19 +6790,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "420"
+                        "$ref": "424"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "467",
+                    "$id": "471",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "468",
+                      "$id": "472",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6788,13 +6843,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "469",
+                        "$id": "473",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "470",
+                          "$id": "474",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6837,13 +6892,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "471",
+                    "$id": "475",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "472",
+                      "$id": "476",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6868,13 +6923,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "473",
+                        "$id": "477",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "474",
+                          "$id": "478",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6901,7 +6956,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "475",
+                    "$id": "479",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -6918,7 +6973,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "476",
+                        "$id": "480",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -6940,7 +6995,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "477",
+                    "$id": "481",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -6956,7 +7011,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "478",
+                        "$id": "482",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -6977,7 +7032,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "479",
+                    "$id": "483",
                     "kind": "body",
                     "name": "properties",
                     "serializedName": "properties",
@@ -6997,7 +7052,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.properties",
                     "methodParameterSegments": [
                       {
-                        "$id": "480",
+                        "$id": "484",
                         "kind": "method",
                         "name": "properties",
                         "serializedName": "properties",
@@ -7053,7 +7108,7 @@
                         "nameInResponse": "Location",
                         "doc": "The Location header contains the URL where the status of the long running operation can be checked.",
                         "type": {
-                          "$id": "481",
+                          "$id": "485",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7065,7 +7120,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "482",
+                          "$id": "486",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -7097,27 +7152,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "469"
+                  "$ref": "473"
                 },
                 {
-                  "$ref": "473"
+                  "$ref": "477"
+                },
+                {
+                  "$ref": "484"
                 },
                 {
                   "$ref": "480"
                 },
                 {
-                  "$ref": "476"
+                  "$ref": "482"
                 },
                 {
-                  "$ref": "478"
-                },
-                {
-                  "$id": "483",
+                  "$id": "487",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "465"
+                    "$ref": "469"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -7150,7 +7205,7 @@
               }
             },
             {
-              "$id": "484",
+              "$id": "488",
               "kind": "lro",
               "name": "delete",
               "isExactName": false,
@@ -7162,7 +7217,7 @@
               ],
               "doc": "Delete a ConfigurationStore",
               "operation": {
-                "$id": "485",
+                "$id": "489",
                 "name": "delete",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -7170,13 +7225,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "486",
+                    "$id": "490",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "487",
+                      "$id": "491",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7186,7 +7241,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "488",
+                        "$id": "492",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -7209,24 +7264,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "414"
+                        "$ref": "418"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "489",
+                    "$id": "493",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "490",
+                      "$id": "494",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "491",
+                        "$id": "495",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7255,19 +7310,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "420"
+                        "$ref": "424"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "492",
+                    "$id": "496",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "493",
+                      "$id": "497",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7308,13 +7363,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "494",
+                        "$id": "498",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "495",
+                          "$id": "499",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7357,13 +7412,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "496",
+                    "$id": "500",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "497",
+                      "$id": "501",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7388,13 +7443,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "498",
+                        "$id": "502",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "499",
+                          "$id": "503",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7432,7 +7487,7 @@
                         "nameInResponse": "Location",
                         "doc": "The Location header contains the URL where the status of the long running operation can be checked.",
                         "type": {
-                          "$id": "500",
+                          "$id": "504",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7444,7 +7499,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "501",
+                          "$id": "505",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -7481,18 +7536,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "494"
-                },
-                {
                   "$ref": "498"
                 },
                 {
-                  "$id": "502",
+                  "$ref": "502"
+                },
+                {
+                  "$id": "506",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "490"
+                    "$ref": "494"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -7518,7 +7573,7 @@
               }
             },
             {
-              "$id": "503",
+              "$id": "507",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -7530,7 +7585,7 @@
               ],
               "doc": "List ConfigurationStore resources by resource group",
               "operation": {
-                "$id": "504",
+                "$id": "508",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -7538,13 +7593,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "505",
+                    "$id": "509",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "506",
+                      "$id": "510",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7554,7 +7609,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "507",
+                        "$id": "511",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -7577,24 +7632,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "414"
+                        "$ref": "418"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "508",
+                    "$id": "512",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "509",
+                      "$id": "513",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "510",
+                        "$id": "514",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7623,19 +7678,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "420"
+                        "$ref": "424"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "511",
+                    "$id": "515",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "512",
+                      "$id": "516",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7676,13 +7731,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "513",
+                        "$id": "517",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "514",
+                          "$id": "518",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7725,7 +7780,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "515",
+                    "$id": "519",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7741,7 +7796,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "516",
+                        "$id": "520",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -7768,7 +7823,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "248"
+                      "$ref": "252"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -7799,18 +7854,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "513"
+                  "$ref": "517"
                 },
                 {
-                  "$ref": "516"
+                  "$ref": "520"
                 },
                 {
-                  "$id": "517",
+                  "$id": "521",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "509"
+                    "$ref": "513"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -7823,7 +7878,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "250"
+                  "$ref": "254"
                 },
                 "resultSegments": [
                   "value"
@@ -7847,7 +7902,7 @@
               }
             },
             {
-              "$id": "518",
+              "$id": "522",
               "kind": "paging",
               "name": "listBySubscription",
               "isExactName": false,
@@ -7859,7 +7914,7 @@
               ],
               "doc": "List ConfigurationStore resources by subscription ID",
               "operation": {
-                "$id": "519",
+                "$id": "523",
                 "name": "listBySubscription",
                 "isExactName": false,
                 "resourceName": "ConfigurationStore",
@@ -7867,13 +7922,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "520",
+                    "$id": "524",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "521",
+                      "$id": "525",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7883,7 +7938,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "522",
+                        "$id": "526",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -7906,24 +7961,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "414"
+                        "$ref": "418"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "523",
+                    "$id": "527",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "524",
+                      "$id": "528",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "525",
+                        "$id": "529",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7952,13 +8007,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "420"
+                        "$ref": "424"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "526",
+                    "$id": "530",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7974,7 +8029,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "527",
+                        "$id": "531",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -8001,7 +8056,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "248"
+                      "$ref": "252"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -8032,15 +8087,15 @@
               },
               "parameters": [
                 {
-                  "$ref": "527"
+                  "$ref": "531"
                 },
                 {
-                  "$id": "528",
+                  "$id": "532",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "524"
+                    "$ref": "528"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -8053,7 +8108,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "250"
+                  "$ref": "254"
                 },
                 "resultSegments": [
                   "value"
@@ -8079,13 +8134,13 @@
           ],
           "parameters": [
             {
-              "$id": "529",
+              "$id": "533",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "530",
+                "$id": "534",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -8096,7 +8151,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "531",
+                  "$id": "535",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8110,7 +8165,7 @@
               "isExactName": false
             },
             {
-              "$ref": "414"
+              "$ref": "418"
             }
           ],
           "initializedBy": 0,
@@ -8127,19 +8182,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "338"
+            "$ref": "342"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "532",
+          "$id": "536",
           "kind": "client",
           "name": "KeyValues",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "533",
+              "$id": "537",
               "kind": "basic",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -8151,7 +8206,7 @@
               ],
               "doc": "Create a KeyValue",
               "operation": {
-                "$id": "534",
+                "$id": "538",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "KeyValue",
@@ -8159,13 +8214,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "535",
+                    "$id": "539",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "536",
+                      "$id": "540",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8175,7 +8230,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "537",
+                        "$id": "541",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8198,13 +8253,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "538",
+                        "$id": "542",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "539",
+                          "$id": "543",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8214,7 +8269,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "540",
+                            "$id": "544",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8242,18 +8297,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "541",
+                    "$id": "545",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "542",
+                      "$id": "546",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "543",
+                        "$id": "547",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8282,18 +8337,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "544",
+                        "$id": "548",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "545",
+                          "$id": "549",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "546",
+                            "$id": "550",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8324,13 +8379,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "547",
+                    "$id": "551",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "548",
+                      "$id": "552",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8371,13 +8426,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "549",
+                        "$id": "553",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "550",
+                          "$id": "554",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8420,13 +8475,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "551",
+                    "$id": "555",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "552",
+                      "$id": "556",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8451,13 +8506,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "553",
+                        "$id": "557",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "554",
+                          "$id": "558",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8484,13 +8539,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "555",
+                    "$id": "559",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "556",
+                      "$id": "560",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8515,13 +8570,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "557",
+                        "$id": "561",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "558",
+                          "$id": "562",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8548,7 +8603,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "559",
+                    "$id": "563",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -8565,7 +8620,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "560",
+                        "$id": "564",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -8587,7 +8642,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "561",
+                    "$id": "565",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8603,7 +8658,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "562",
+                        "$id": "566",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -8624,13 +8679,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "563",
+                    "$id": "567",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "254"
+                      "$ref": "258"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -8644,13 +8699,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "564",
+                        "$id": "568",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "254"
+                          "$ref": "258"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -8677,7 +8732,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "254"
+                      "$ref": "258"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -8711,30 +8766,30 @@
               },
               "parameters": [
                 {
-                  "$ref": "549"
-                },
-                {
                   "$ref": "553"
                 },
                 {
                   "$ref": "557"
                 },
                 {
+                  "$ref": "561"
+                },
+                {
+                  "$ref": "568"
+                },
+                {
                   "$ref": "564"
                 },
                 {
-                  "$ref": "560"
+                  "$ref": "566"
                 },
                 {
-                  "$ref": "562"
-                },
-                {
-                  "$id": "565",
+                  "$id": "569",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "542"
+                    "$ref": "546"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -8747,7 +8802,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "254"
+                  "$ref": "258"
                 }
               },
               "isOverride": false,
@@ -8756,7 +8811,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate"
             },
             {
-              "$id": "566",
+              "$id": "570",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -8768,7 +8823,7 @@
               ],
               "doc": "Get a KeyValue",
               "operation": {
-                "$id": "567",
+                "$id": "571",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "KeyValue",
@@ -8776,13 +8831,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "568",
+                    "$id": "572",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "569",
+                      "$id": "573",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8792,7 +8847,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "570",
+                        "$id": "574",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8815,24 +8870,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "538"
+                        "$ref": "542"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "571",
+                    "$id": "575",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "572",
+                      "$id": "576",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "573",
+                        "$id": "577",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8861,19 +8916,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "544"
+                        "$ref": "548"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "574",
+                    "$id": "578",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "575",
+                      "$id": "579",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8914,13 +8969,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "576",
+                        "$id": "580",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "577",
+                          "$id": "581",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8963,13 +9018,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "578",
+                    "$id": "582",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "579",
+                      "$id": "583",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8994,13 +9049,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "580",
+                        "$id": "584",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "581",
+                          "$id": "585",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9027,13 +9082,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "582",
+                    "$id": "586",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "583",
+                      "$id": "587",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9058,13 +9113,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "584",
+                        "$id": "588",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "585",
+                          "$id": "589",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9091,7 +9146,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "586",
+                    "$id": "590",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9107,7 +9162,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "587",
+                        "$id": "591",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -9134,7 +9189,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "254"
+                      "$ref": "258"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -9165,24 +9220,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "576"
-                },
-                {
                   "$ref": "580"
                 },
                 {
                   "$ref": "584"
                 },
                 {
-                  "$ref": "587"
+                  "$ref": "588"
                 },
                 {
-                  "$id": "588",
+                  "$ref": "591"
+                },
+                {
+                  "$id": "592",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "572"
+                    "$ref": "576"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9195,7 +9250,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "254"
+                  "$ref": "258"
                 }
               },
               "isOverride": false,
@@ -9204,7 +9259,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get"
             },
             {
-              "$id": "589",
+              "$id": "593",
               "kind": "basic",
               "name": "delete",
               "isExactName": false,
@@ -9216,7 +9271,7 @@
               ],
               "doc": "Delete a KeyValue",
               "operation": {
-                "$id": "590",
+                "$id": "594",
                 "name": "delete",
                 "isExactName": false,
                 "resourceName": "KeyValue",
@@ -9224,13 +9279,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "591",
+                    "$id": "595",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "592",
+                      "$id": "596",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9240,7 +9295,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "593",
+                        "$id": "597",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -9263,24 +9318,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "538"
+                        "$ref": "542"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "594",
+                    "$id": "598",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "595",
+                      "$id": "599",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "596",
+                        "$id": "600",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9309,19 +9364,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "544"
+                        "$ref": "548"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "597",
+                    "$id": "601",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "598",
+                      "$id": "602",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9362,13 +9417,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "599",
+                        "$id": "603",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "600",
+                          "$id": "604",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9411,13 +9466,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "601",
+                    "$id": "605",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "602",
+                      "$id": "606",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9442,13 +9497,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "603",
+                        "$id": "607",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "604",
+                          "$id": "608",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9475,13 +9530,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "605",
+                    "$id": "609",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "606",
+                      "$id": "610",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9506,13 +9561,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "607",
+                        "$id": "611",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "608",
+                          "$id": "612",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9574,21 +9629,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "599"
-                },
-                {
                   "$ref": "603"
                 },
                 {
                   "$ref": "607"
                 },
                 {
-                  "$id": "609",
+                  "$ref": "611"
+                },
+                {
+                  "$id": "613",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "595"
+                    "$ref": "599"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9606,7 +9661,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete"
             },
             {
-              "$id": "610",
+              "$id": "614",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -9618,7 +9673,7 @@
               ],
               "doc": "List KeyValue resources by ConfigurationStore",
               "operation": {
-                "$id": "611",
+                "$id": "615",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "KeyValue",
@@ -9626,13 +9681,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "612",
+                    "$id": "616",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "613",
+                      "$id": "617",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9642,7 +9697,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "614",
+                        "$id": "618",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -9665,24 +9720,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "538"
+                        "$ref": "542"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "615",
+                    "$id": "619",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "616",
+                      "$id": "620",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "617",
+                        "$id": "621",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9711,19 +9766,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "544"
+                        "$ref": "548"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "618",
+                    "$id": "622",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "619",
+                      "$id": "623",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9764,13 +9819,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "620",
+                        "$id": "624",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "621",
+                          "$id": "625",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9813,13 +9868,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "622",
+                    "$id": "626",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "623",
+                      "$id": "627",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9844,13 +9899,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "624",
+                        "$id": "628",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "625",
+                          "$id": "629",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9877,7 +9932,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "626",
+                    "$id": "630",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9893,7 +9948,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "627",
+                        "$id": "631",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -9920,7 +9975,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "264"
+                      "$ref": "268"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -9951,21 +10006,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "620"
-                },
-                {
                   "$ref": "624"
                 },
                 {
-                  "$ref": "627"
+                  "$ref": "628"
                 },
                 {
-                  "$id": "628",
+                  "$ref": "631"
+                },
+                {
+                  "$id": "632",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "616"
+                    "$ref": "620"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9978,7 +10033,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "266"
+                  "$ref": "270"
                 },
                 "resultSegments": [
                   "value"
@@ -10004,13 +10059,13 @@
           ],
           "parameters": [
             {
-              "$id": "629",
+              "$id": "633",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "630",
+                "$id": "634",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -10021,7 +10076,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "631",
+                  "$id": "635",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -10035,7 +10090,7 @@
               "isExactName": false
             },
             {
-              "$ref": "538"
+              "$ref": "542"
             }
           ],
           "initializedBy": 0,
@@ -10052,19 +10107,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "338"
+            "$ref": "342"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "632",
+          "$id": "636",
           "kind": "client",
           "name": "Items",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "633",
+              "$id": "637",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -10076,7 +10131,7 @@
               ],
               "doc": "Get a Item",
               "operation": {
-                "$id": "634",
+                "$id": "638",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "Item",
@@ -10084,13 +10139,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "635",
+                    "$id": "639",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "636",
+                      "$id": "640",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10100,7 +10155,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "637",
+                        "$id": "641",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -10123,13 +10178,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "638",
+                        "$id": "642",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "639",
+                          "$id": "643",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10139,7 +10194,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "640",
+                            "$id": "644",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -10167,18 +10222,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "641",
+                    "$id": "645",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "642",
+                      "$id": "646",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "643",
+                        "$id": "647",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10207,18 +10262,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "644",
+                        "$id": "648",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "645",
+                          "$id": "649",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "646",
+                            "$id": "650",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10249,13 +10304,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "647",
+                    "$id": "651",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "648",
+                      "$id": "652",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10296,13 +10351,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "649",
+                        "$id": "653",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "650",
+                          "$id": "654",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10345,13 +10400,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "651",
+                    "$id": "655",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "652",
+                      "$id": "656",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10376,13 +10431,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "653",
+                        "$id": "657",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "654",
+                          "$id": "658",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10409,13 +10464,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "655",
+                    "$id": "659",
                     "kind": "path",
                     "name": "itemName",
                     "serializedName": "itemName",
                     "doc": "The name of the Item",
                     "type": {
-                      "$id": "656",
+                      "$id": "660",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10440,13 +10495,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.itemName",
                     "methodParameterSegments": [
                       {
-                        "$id": "657",
+                        "$id": "661",
                         "kind": "method",
                         "name": "itemName",
                         "serializedName": "itemName",
                         "doc": "The name of the Item",
                         "type": {
-                          "$id": "658",
+                          "$id": "662",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10473,7 +10528,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "659",
+                    "$id": "663",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10489,7 +10544,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "660",
+                        "$id": "664",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -10516,7 +10571,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "270"
+                      "$ref": "274"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -10547,24 +10602,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "649"
-                },
-                {
                   "$ref": "653"
                 },
                 {
                   "$ref": "657"
                 },
                 {
-                  "$ref": "660"
+                  "$ref": "661"
                 },
                 {
-                  "$id": "661",
+                  "$ref": "664"
+                },
+                {
+                  "$id": "665",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "642"
+                    "$ref": "646"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -10577,7 +10632,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "270"
+                  "$ref": "274"
                 }
               },
               "isOverride": false,
@@ -10586,7 +10641,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get"
             },
             {
-              "$id": "662",
+              "$id": "666",
               "kind": "basic",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -10597,20 +10652,20 @@
                 "2024-05-01"
               ],
               "operation": {
-                "$id": "663",
+                "$id": "667",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "Item",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "664",
+                    "$id": "668",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "665",
+                      "$id": "669",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10620,7 +10675,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "666",
+                        "$id": "670",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -10643,24 +10698,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "638"
+                        "$ref": "642"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "667",
+                    "$id": "671",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "668",
+                      "$id": "672",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "669",
+                        "$id": "673",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10689,19 +10744,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "644"
+                        "$ref": "648"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "670",
+                    "$id": "674",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "671",
+                      "$id": "675",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10742,13 +10797,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "672",
+                        "$id": "676",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "673",
+                          "$id": "677",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10791,13 +10846,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "674",
+                    "$id": "678",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "675",
+                      "$id": "679",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10822,13 +10877,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "676",
+                        "$id": "680",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "677",
+                          "$id": "681",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10855,13 +10910,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "678",
+                    "$id": "682",
                     "kind": "path",
                     "name": "itemName",
                     "serializedName": "itemName",
                     "doc": "The name of the Item",
                     "type": {
-                      "$id": "679",
+                      "$id": "683",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10886,13 +10941,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.itemName",
                     "methodParameterSegments": [
                       {
-                        "$id": "680",
+                        "$id": "684",
                         "kind": "method",
                         "name": "itemName",
                         "serializedName": "itemName",
                         "doc": "The name of the Item",
                         "type": {
-                          "$id": "681",
+                          "$id": "685",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10919,7 +10974,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "682",
+                    "$id": "686",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -10936,7 +10991,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "683",
+                        "$id": "687",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -10958,7 +11013,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "684",
+                    "$id": "688",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10974,7 +11029,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "685",
+                        "$id": "689",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -10995,13 +11050,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "686",
+                    "$id": "690",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "297"
+                      "$ref": "301"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -11015,13 +11070,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "687",
+                        "$id": "691",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "297"
+                          "$ref": "301"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -11048,7 +11103,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "270"
+                      "$ref": "274"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -11066,7 +11121,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "270"
+                      "$ref": "274"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -11100,30 +11155,30 @@
               },
               "parameters": [
                 {
-                  "$ref": "672"
-                },
-                {
                   "$ref": "676"
                 },
                 {
                   "$ref": "680"
                 },
                 {
+                  "$ref": "684"
+                },
+                {
+                  "$ref": "691"
+                },
+                {
                   "$ref": "687"
                 },
                 {
-                  "$ref": "683"
+                  "$ref": "689"
                 },
                 {
-                  "$ref": "685"
-                },
-                {
-                  "$id": "688",
+                  "$id": "692",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "668"
+                    "$ref": "672"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -11136,7 +11191,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "270"
+                  "$ref": "274"
                 }
               },
               "isOverride": false,
@@ -11145,7 +11200,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate"
             },
             {
-              "$id": "689",
+              "$id": "693",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -11157,7 +11212,7 @@
               ],
               "doc": "List Item resources by ConfigurationStore",
               "operation": {
-                "$id": "690",
+                "$id": "694",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "Item",
@@ -11165,13 +11220,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "691",
+                    "$id": "695",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "692",
+                      "$id": "696",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11181,7 +11236,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "693",
+                        "$id": "697",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11204,24 +11259,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "638"
+                        "$ref": "642"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "694",
+                    "$id": "698",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "695",
+                      "$id": "699",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "696",
+                        "$id": "700",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11250,19 +11305,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "644"
+                        "$ref": "648"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "697",
+                    "$id": "701",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "698",
+                      "$id": "702",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11303,13 +11358,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "699",
+                        "$id": "703",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "700",
+                          "$id": "704",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11352,13 +11407,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "701",
+                    "$id": "705",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "702",
+                      "$id": "706",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11383,13 +11438,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "703",
+                        "$id": "707",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "704",
+                          "$id": "708",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11416,7 +11471,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "705",
+                    "$id": "709",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11432,7 +11487,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "706",
+                        "$id": "710",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -11459,7 +11514,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "300"
+                      "$ref": "304"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -11490,21 +11545,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "699"
-                },
-                {
                   "$ref": "703"
                 },
                 {
-                  "$ref": "706"
+                  "$ref": "707"
                 },
                 {
-                  "$id": "707",
+                  "$ref": "710"
+                },
+                {
+                  "$id": "711",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "695"
+                    "$ref": "699"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -11517,7 +11572,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "302"
+                  "$ref": "306"
                 },
                 "resultSegments": [
                   "value"
@@ -11543,13 +11598,13 @@
           ],
           "parameters": [
             {
-              "$id": "708",
+              "$id": "712",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "709",
+                "$id": "713",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -11560,7 +11615,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "710",
+                  "$id": "714",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11574,7 +11629,7 @@
               "isExactName": false
             },
             {
-              "$ref": "638"
+              "$ref": "642"
             }
           ],
           "initializedBy": 0,
@@ -11591,19 +11646,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "338"
+            "$ref": "342"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "711",
+          "$id": "715",
           "kind": "client",
           "name": "Profiles",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "712",
+              "$id": "716",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -11615,7 +11670,7 @@
               ],
               "doc": "Get a Profile",
               "operation": {
-                "$id": "713",
+                "$id": "717",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -11623,13 +11678,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "714",
+                    "$id": "718",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "715",
+                      "$id": "719",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11639,7 +11694,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "716",
+                        "$id": "720",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11662,13 +11717,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "717",
+                        "$id": "721",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "718",
+                          "$id": "722",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11678,7 +11733,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "719",
+                            "$id": "723",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11706,18 +11761,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "720",
+                    "$id": "724",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "721",
+                      "$id": "725",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "722",
+                        "$id": "726",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11746,18 +11801,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "723",
+                        "$id": "727",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "724",
+                          "$id": "728",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "725",
+                            "$id": "729",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11788,13 +11843,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "726",
+                    "$id": "730",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "727",
+                      "$id": "731",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11835,13 +11890,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "728",
+                        "$id": "732",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "729",
+                          "$id": "733",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11884,13 +11939,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "730",
+                    "$id": "734",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "731",
+                      "$id": "735",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11915,13 +11970,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "732",
+                        "$id": "736",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "733",
+                          "$id": "737",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11948,13 +12003,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "734",
+                    "$id": "738",
                     "kind": "path",
                     "name": "profileName",
                     "serializedName": "profileName",
                     "doc": "The name of the Profile",
                     "type": {
-                      "$id": "735",
+                      "$id": "739",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11979,13 +12034,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.profileName",
                     "methodParameterSegments": [
                       {
-                        "$id": "736",
+                        "$id": "740",
                         "kind": "method",
                         "name": "profileName",
                         "serializedName": "profileName",
                         "doc": "The name of the Profile",
                         "type": {
-                          "$id": "737",
+                          "$id": "741",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12012,7 +12067,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "738",
+                    "$id": "742",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12028,7 +12083,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "739",
+                        "$id": "743",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -12055,7 +12110,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "306"
+                      "$ref": "310"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -12086,24 +12141,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "728"
-                },
-                {
                   "$ref": "732"
                 },
                 {
                   "$ref": "736"
                 },
                 {
-                  "$ref": "739"
+                  "$ref": "740"
                 },
                 {
-                  "$id": "740",
+                  "$ref": "743"
+                },
+                {
+                  "$id": "744",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "721"
+                    "$ref": "725"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -12116,7 +12171,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "306"
+                  "$ref": "310"
                 }
               },
               "isOverride": false,
@@ -12125,7 +12180,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.get"
             },
             {
-              "$id": "741",
+              "$id": "745",
               "kind": "lro",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -12137,7 +12192,7 @@
               ],
               "doc": "Create a Profile",
               "operation": {
-                "$id": "742",
+                "$id": "746",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -12145,13 +12200,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "743",
+                    "$id": "747",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "744",
+                      "$id": "748",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12161,7 +12216,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "745",
+                        "$id": "749",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -12184,24 +12239,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "717"
+                        "$ref": "721"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "746",
+                    "$id": "750",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "747",
+                      "$id": "751",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "748",
+                        "$id": "752",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12230,19 +12285,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "723"
+                        "$ref": "727"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "749",
+                    "$id": "753",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "750",
+                      "$id": "754",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12283,13 +12338,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "751",
+                        "$id": "755",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "752",
+                          "$id": "756",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12332,13 +12387,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "753",
+                    "$id": "757",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "754",
+                      "$id": "758",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12363,13 +12418,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "755",
+                        "$id": "759",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "756",
+                          "$id": "760",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12396,13 +12451,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "757",
+                    "$id": "761",
                     "kind": "path",
                     "name": "profileName",
                     "serializedName": "profileName",
                     "doc": "The name of the Profile",
                     "type": {
-                      "$id": "758",
+                      "$id": "762",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12427,13 +12482,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.profileName",
                     "methodParameterSegments": [
                       {
-                        "$id": "759",
+                        "$id": "763",
                         "kind": "method",
                         "name": "profileName",
                         "serializedName": "profileName",
                         "doc": "The name of the Profile",
                         "type": {
-                          "$id": "760",
+                          "$id": "764",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12460,7 +12515,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "761",
+                    "$id": "765",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -12477,7 +12532,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "762",
+                        "$id": "766",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -12499,7 +12554,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "763",
+                    "$id": "767",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12515,7 +12570,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "764",
+                        "$id": "768",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -12536,13 +12591,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "765",
+                    "$id": "769",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "306"
+                      "$ref": "310"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -12556,13 +12611,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "766",
+                        "$id": "770",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "306"
+                          "$ref": "310"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -12589,7 +12644,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "306"
+                      "$ref": "310"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -12607,7 +12662,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "306"
+                      "$ref": "310"
                     },
                     "headers": [
                       {
@@ -12615,7 +12670,7 @@
                         "nameInResponse": "Azure-AsyncOperation",
                         "doc": "A link to the status monitor",
                         "type": {
-                          "$id": "767",
+                          "$id": "771",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12627,7 +12682,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "768",
+                          "$id": "772",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -12666,30 +12721,30 @@
               },
               "parameters": [
                 {
-                  "$ref": "751"
-                },
-                {
                   "$ref": "755"
                 },
                 {
                   "$ref": "759"
                 },
                 {
+                  "$ref": "763"
+                },
+                {
+                  "$ref": "770"
+                },
+                {
                   "$ref": "766"
                 },
                 {
-                  "$ref": "762"
+                  "$ref": "768"
                 },
                 {
-                  "$ref": "764"
-                },
-                {
-                  "$id": "769",
+                  "$id": "773",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "747"
+                    "$ref": "751"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -12702,7 +12757,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "306"
+                  "$ref": "310"
                 }
               },
               "isOverride": false,
@@ -12716,13 +12771,13 @@
                     200
                   ],
                   "bodyType": {
-                    "$ref": "306"
+                    "$ref": "310"
                   }
                 }
               }
             },
             {
-              "$id": "770",
+              "$id": "774",
               "kind": "lro",
               "name": "delete",
               "isExactName": false,
@@ -12734,7 +12789,7 @@
               ],
               "doc": "Delete a Profile",
               "operation": {
-                "$id": "771",
+                "$id": "775",
                 "name": "delete",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -12742,13 +12797,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "772",
+                    "$id": "776",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "773",
+                      "$id": "777",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12758,7 +12813,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "774",
+                        "$id": "778",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -12781,24 +12836,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "717"
+                        "$ref": "721"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "775",
+                    "$id": "779",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "776",
+                      "$id": "780",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "777",
+                        "$id": "781",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12827,19 +12882,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.delete.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "723"
+                        "$ref": "727"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "778",
+                    "$id": "782",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "779",
+                      "$id": "783",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12880,13 +12935,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.delete.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "780",
+                        "$id": "784",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "781",
+                          "$id": "785",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12929,13 +12984,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "782",
+                    "$id": "786",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "783",
+                      "$id": "787",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12960,13 +13015,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.delete.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "784",
+                        "$id": "788",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "785",
+                          "$id": "789",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12993,13 +13048,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "786",
+                    "$id": "790",
                     "kind": "path",
                     "name": "profileName",
                     "serializedName": "profileName",
                     "doc": "The name of the Profile",
                     "type": {
-                      "$id": "787",
+                      "$id": "791",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13024,13 +13079,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.delete.profileName",
                     "methodParameterSegments": [
                       {
-                        "$id": "788",
+                        "$id": "792",
                         "kind": "method",
                         "name": "profileName",
                         "serializedName": "profileName",
                         "doc": "The name of the Profile",
                         "type": {
-                          "$id": "789",
+                          "$id": "793",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13068,7 +13123,7 @@
                         "nameInResponse": "Location",
                         "doc": "The Location header contains the URL where the status of the long running operation can be checked.",
                         "type": {
-                          "$id": "790",
+                          "$id": "794",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13080,7 +13135,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "791",
+                          "$id": "795",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -13117,21 +13172,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "780"
-                },
-                {
                   "$ref": "784"
                 },
                 {
                   "$ref": "788"
                 },
                 {
-                  "$id": "792",
+                  "$ref": "792"
+                },
+                {
+                  "$id": "796",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "776"
+                    "$ref": "780"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -13157,7 +13212,7 @@
               }
             },
             {
-              "$id": "793",
+              "$id": "797",
               "kind": "paging",
               "name": "list",
               "isExactName": false,
@@ -13169,7 +13224,7 @@
               ],
               "doc": "List Profile resources by ConfigurationStore",
               "operation": {
-                "$id": "794",
+                "$id": "798",
                 "name": "list",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -13177,13 +13232,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "795",
+                    "$id": "799",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "796",
+                      "$id": "800",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13193,7 +13248,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "797",
+                        "$id": "801",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -13216,24 +13271,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "717"
+                        "$ref": "721"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "798",
+                    "$id": "802",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "799",
+                      "$id": "803",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "800",
+                        "$id": "804",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13262,19 +13317,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "723"
+                        "$ref": "727"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "801",
+                    "$id": "805",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "802",
+                      "$id": "806",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13315,13 +13370,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "803",
+                        "$id": "807",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "804",
+                          "$id": "808",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13364,13 +13419,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "805",
+                    "$id": "809",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "806",
+                      "$id": "810",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13395,13 +13450,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "807",
+                        "$id": "811",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "808",
+                          "$id": "812",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13428,7 +13483,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "809",
+                    "$id": "813",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -13444,7 +13499,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Profiles.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "810",
+                        "$id": "814",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -13471,7 +13526,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "317"
+                      "$ref": "321"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -13502,21 +13557,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "803"
-                },
-                {
                   "$ref": "807"
                 },
                 {
-                  "$ref": "810"
+                  "$ref": "811"
                 },
                 {
-                  "$id": "811",
+                  "$ref": "814"
+                },
+                {
+                  "$id": "815",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "799"
+                    "$ref": "803"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -13529,7 +13584,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "319"
+                  "$ref": "323"
                 },
                 "resultSegments": [
                   "value"
@@ -13555,13 +13610,13 @@
           ],
           "parameters": [
             {
-              "$id": "812",
+              "$id": "816",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "813",
+                "$id": "817",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -13572,7 +13627,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "814",
+                  "$id": "818",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -13586,7 +13641,7 @@
               "isExactName": false
             },
             {
-              "$ref": "717"
+              "$ref": "721"
             }
           ],
           "initializedBy": 0,
@@ -13603,19 +13658,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "338"
+            "$ref": "342"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "815",
+          "$id": "819",
           "kind": "client",
           "name": "ProfileRevisions",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "816",
+              "$id": "820",
               "kind": "basic",
               "name": "getByRevisionNumber",
               "isExactName": false,
@@ -13627,7 +13682,7 @@
               ],
               "doc": "Get a specific revision of a profile.",
               "operation": {
-                "$id": "817",
+                "$id": "821",
                 "name": "getByRevisionNumber",
                 "isExactName": false,
                 "resourceName": "Profile",
@@ -13635,13 +13690,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "818",
+                    "$id": "822",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "819",
+                      "$id": "823",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13651,7 +13706,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "820",
+                        "$id": "824",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -13674,13 +13729,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "821",
+                        "$id": "825",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "822",
+                          "$id": "826",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13690,7 +13745,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "823",
+                            "$id": "827",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -13718,18 +13773,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "824",
+                    "$id": "828",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "825",
+                      "$id": "829",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "826",
+                        "$id": "830",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13758,18 +13813,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "827",
+                        "$id": "831",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "828",
+                          "$id": "832",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "829",
+                            "$id": "833",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13800,13 +13855,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "830",
+                    "$id": "834",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "831",
+                      "$id": "835",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13847,13 +13902,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "832",
+                        "$id": "836",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "833",
+                          "$id": "837",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13896,13 +13951,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "834",
+                    "$id": "838",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The configuration store name.",
                     "type": {
-                      "$id": "835",
+                      "$id": "839",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13920,13 +13975,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "836",
+                        "$id": "840",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The configuration store name.",
                         "type": {
-                          "$id": "837",
+                          "$id": "841",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13946,13 +14001,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "838",
+                    "$id": "842",
                     "kind": "path",
                     "name": "profileName",
                     "serializedName": "profileName",
                     "doc": "The profile name.",
                     "type": {
-                      "$id": "839",
+                      "$id": "843",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13970,13 +14025,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.profileName",
                     "methodParameterSegments": [
                       {
-                        "$id": "840",
+                        "$id": "844",
                         "kind": "method",
                         "name": "profileName",
                         "serializedName": "profileName",
                         "doc": "The profile name.",
                         "type": {
-                          "$id": "841",
+                          "$id": "845",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -13996,13 +14051,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "842",
+                    "$id": "846",
                     "kind": "path",
                     "name": "revisionNumber",
                     "serializedName": "revisionNumber",
                     "doc": "The revision number.",
                     "type": {
-                      "$id": "843",
+                      "$id": "847",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14020,13 +14075,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.revisionNumber",
                     "methodParameterSegments": [
                       {
-                        "$id": "844",
+                        "$id": "848",
                         "kind": "method",
                         "name": "revisionNumber",
                         "serializedName": "revisionNumber",
                         "doc": "The revision number.",
                         "type": {
-                          "$id": "845",
+                          "$id": "849",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14046,7 +14101,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "846",
+                    "$id": "850",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -14062,7 +14117,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ProfileRevisions.getByRevisionNumber.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "847",
+                        "$id": "851",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -14089,7 +14144,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "306"
+                      "$ref": "310"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14115,9 +14170,6 @@
               },
               "parameters": [
                 {
-                  "$ref": "832"
-                },
-                {
                   "$ref": "836"
                 },
                 {
@@ -14127,15 +14179,18 @@
                   "$ref": "844"
                 },
                 {
-                  "$ref": "847"
+                  "$ref": "848"
                 },
                 {
-                  "$id": "848",
+                  "$ref": "851"
+                },
+                {
+                  "$id": "852",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "825"
+                    "$ref": "829"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -14148,7 +14203,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "306"
+                  "$ref": "310"
                 }
               },
               "isOverride": false,
@@ -14159,13 +14214,13 @@
           ],
           "parameters": [
             {
-              "$id": "849",
+              "$id": "853",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "850",
+                "$id": "854",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -14176,7 +14231,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "851",
+                  "$id": "855",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14190,7 +14245,7 @@
               "isExactName": false
             },
             {
-              "$ref": "821"
+              "$ref": "825"
             }
           ],
           "initializedBy": 0,
@@ -14211,19 +14266,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "338"
+            "$ref": "342"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "852",
+          "$id": "856",
           "kind": "client",
           "name": "ExtensionAssignments",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "853",
+              "$id": "857",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -14235,7 +14290,7 @@
               ],
               "doc": "Get a ExtensionAssignment",
               "operation": {
-                "$id": "854",
+                "$id": "858",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "ExtensionAssignment",
@@ -14243,13 +14298,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "855",
+                    "$id": "859",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "856",
+                      "$id": "860",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14259,7 +14314,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "857",
+                        "$id": "861",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14282,13 +14337,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "858",
+                        "$id": "862",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "859",
+                          "$id": "863",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14298,7 +14353,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "860",
+                            "$id": "864",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14326,13 +14381,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "861",
+                    "$id": "865",
                     "kind": "path",
                     "name": "scope",
                     "serializedName": "scope",
                     "doc": "The fully qualified Azure Resource manager identifier of the resource.",
                     "type": {
-                      "$id": "862",
+                      "$id": "866",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14350,13 +14405,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.get.scope",
                     "methodParameterSegments": [
                       {
-                        "$id": "863",
+                        "$id": "867",
                         "kind": "method",
                         "name": "scope",
                         "serializedName": "scope",
                         "doc": "The fully qualified Azure Resource manager identifier of the resource.",
                         "type": {
-                          "$id": "864",
+                          "$id": "868",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14376,13 +14431,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "865",
+                    "$id": "869",
                     "kind": "path",
                     "name": "extensionAssignmentName",
                     "serializedName": "extensionAssignmentName",
                     "doc": "The name of the ExtensionAssignment",
                     "type": {
-                      "$id": "866",
+                      "$id": "870",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14407,13 +14462,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.get.extensionAssignmentName",
                     "methodParameterSegments": [
                       {
-                        "$id": "867",
+                        "$id": "871",
                         "kind": "method",
                         "name": "extensionAssignmentName",
                         "serializedName": "extensionAssignmentName",
                         "doc": "The name of the ExtensionAssignment",
                         "type": {
-                          "$id": "868",
+                          "$id": "872",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14440,7 +14495,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "869",
+                    "$id": "873",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -14456,7 +14511,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "870",
+                        "$id": "874",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -14483,7 +14538,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "323"
+                      "$ref": "327"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14509,18 +14564,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "863"
-                },
-                {
                   "$ref": "867"
                 },
                 {
-                  "$ref": "870"
+                  "$ref": "871"
+                },
+                {
+                  "$ref": "874"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "323"
+                  "$ref": "327"
                 }
               },
               "isOverride": false,
@@ -14529,7 +14584,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.get"
             },
             {
-              "$id": "871",
+              "$id": "875",
               "kind": "lro",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -14541,7 +14596,7 @@
               ],
               "doc": "Create a ExtensionAssignment",
               "operation": {
-                "$id": "872",
+                "$id": "876",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "ExtensionAssignment",
@@ -14549,13 +14604,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "873",
+                    "$id": "877",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "874",
+                      "$id": "878",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14565,7 +14620,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "875",
+                        "$id": "879",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14588,19 +14643,19 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "858"
+                        "$ref": "862"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "876",
+                    "$id": "880",
                     "kind": "path",
                     "name": "scope",
                     "serializedName": "scope",
                     "doc": "The fully qualified Azure Resource manager identifier of the resource.",
                     "type": {
-                      "$id": "877",
+                      "$id": "881",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14618,13 +14673,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.scope",
                     "methodParameterSegments": [
                       {
-                        "$id": "878",
+                        "$id": "882",
                         "kind": "method",
                         "name": "scope",
                         "serializedName": "scope",
                         "doc": "The fully qualified Azure Resource manager identifier of the resource.",
                         "type": {
-                          "$id": "879",
+                          "$id": "883",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14644,13 +14699,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "880",
+                    "$id": "884",
                     "kind": "path",
                     "name": "extensionAssignmentName",
                     "serializedName": "extensionAssignmentName",
                     "doc": "The name of the ExtensionAssignment",
                     "type": {
-                      "$id": "881",
+                      "$id": "885",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14675,13 +14730,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.extensionAssignmentName",
                     "methodParameterSegments": [
                       {
-                        "$id": "882",
+                        "$id": "886",
                         "kind": "method",
                         "name": "extensionAssignmentName",
                         "serializedName": "extensionAssignmentName",
                         "doc": "The name of the ExtensionAssignment",
                         "type": {
-                          "$id": "883",
+                          "$id": "887",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14708,7 +14763,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "884",
+                    "$id": "888",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -14725,7 +14780,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "885",
+                        "$id": "889",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -14747,7 +14802,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "886",
+                    "$id": "890",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -14763,7 +14818,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "887",
+                        "$id": "891",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -14784,13 +14839,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "888",
+                    "$id": "892",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "323"
+                      "$ref": "327"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -14804,13 +14859,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ExtensionAssignments.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "889",
+                        "$id": "893",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "323"
+                          "$ref": "327"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -14837,7 +14892,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "323"
+                      "$ref": "327"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14855,7 +14910,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "323"
+                      "$ref": "327"
                     },
                     "headers": [
                       {
@@ -14863,7 +14918,7 @@
                         "nameInResponse": "Azure-AsyncOperation",
                         "doc": "A link to the status monitor",
                         "type": {
-                          "$id": "890",
+                          "$id": "894",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -14875,7 +14930,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "891",
+                          "$id": "895",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -14909,24 +14964,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "878"
+                  "$ref": "882"
                 },
                 {
-                  "$ref": "882"
+                  "$ref": "886"
+                },
+                {
+                  "$ref": "893"
                 },
                 {
                   "$ref": "889"
                 },
                 {
-                  "$ref": "885"
-                },
-                {
-                  "$ref": "887"
+                  "$ref": "891"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "323"
+                  "$ref": "327"
                 }
               },
               "isOverride": false,
@@ -14940,7 +14995,7 @@
                     200
                   ],
                   "bodyType": {
-                    "$ref": "323"
+                    "$ref": "327"
                   }
                 }
               }
@@ -14948,13 +15003,13 @@
           ],
           "parameters": [
             {
-              "$id": "892",
+              "$id": "896",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "893",
+                "$id": "897",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -14965,7 +15020,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "894",
+                  "$id": "898",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -14979,7 +15034,7 @@
               "isExactName": false
             },
             {
-              "$ref": "858"
+              "$ref": "862"
             }
           ],
           "initializedBy": 0,
@@ -14996,19 +15051,19 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "338"
+            "$ref": "342"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "895",
+          "$id": "899",
           "kind": "client",
           "name": "SingletonSettings",
           "isExactName": false,
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "896",
+              "$id": "900",
               "kind": "basic",
               "name": "get",
               "isExactName": false,
@@ -15020,7 +15075,7 @@
               ],
               "doc": "Get a SingletonSetting",
               "operation": {
-                "$id": "897",
+                "$id": "901",
                 "name": "get",
                 "isExactName": false,
                 "resourceName": "SingletonSetting",
@@ -15028,13 +15083,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "898",
+                    "$id": "902",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "899",
+                      "$id": "903",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15044,7 +15099,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "900",
+                        "$id": "904",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -15067,13 +15122,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "901",
+                        "$id": "905",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "902",
+                          "$id": "906",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15083,7 +15138,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "903",
+                            "$id": "907",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -15111,18 +15166,18 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "904",
+                    "$id": "908",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "905",
+                      "$id": "909",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "906",
+                        "$id": "910",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15151,18 +15206,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "907",
+                        "$id": "911",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "908",
+                          "$id": "912",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "909",
+                            "$id": "913",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15193,13 +15248,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "910",
+                    "$id": "914",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "911",
+                      "$id": "915",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15240,13 +15295,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "912",
+                        "$id": "916",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "913",
+                          "$id": "917",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15289,13 +15344,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "914",
+                    "$id": "918",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "915",
+                      "$id": "919",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15320,13 +15375,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "916",
+                        "$id": "920",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "917",
+                          "$id": "921",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15353,7 +15408,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "918",
+                    "$id": "922",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -15369,7 +15424,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "919",
+                        "$id": "923",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -15396,7 +15451,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "331"
+                      "$ref": "335"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -15427,21 +15482,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "912"
-                },
-                {
                   "$ref": "916"
                 },
                 {
-                  "$ref": "919"
+                  "$ref": "920"
                 },
                 {
-                  "$id": "920",
+                  "$ref": "923"
+                },
+                {
+                  "$id": "924",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "905"
+                    "$ref": "909"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -15454,7 +15509,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "331"
+                  "$ref": "335"
                 }
               },
               "isOverride": false,
@@ -15463,7 +15518,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.get"
             },
             {
-              "$id": "921",
+              "$id": "925",
               "kind": "basic",
               "name": "createOrUpdate",
               "isExactName": false,
@@ -15475,7 +15530,7 @@
               ],
               "doc": "Create a SingletonSetting",
               "operation": {
-                "$id": "922",
+                "$id": "926",
                 "name": "createOrUpdate",
                 "isExactName": false,
                 "resourceName": "SingletonSetting",
@@ -15483,13 +15538,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "923",
+                    "$id": "927",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "924",
+                      "$id": "928",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15499,7 +15554,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "925",
+                        "$id": "929",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -15522,24 +15577,24 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "901"
+                        "$ref": "905"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "926",
+                    "$id": "930",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "927",
+                      "$id": "931",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "928",
+                        "$id": "932",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15568,19 +15623,19 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "907"
+                        "$ref": "911"
                       }
                     ],
                     "isExactName": false
                   },
                   {
-                    "$id": "929",
+                    "$id": "933",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "930",
+                      "$id": "934",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15621,13 +15676,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "931",
+                        "$id": "935",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "932",
+                          "$id": "936",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15670,13 +15725,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "933",
+                    "$id": "937",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "934",
+                      "$id": "938",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15701,13 +15756,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "935",
+                        "$id": "939",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "936",
+                          "$id": "940",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15734,7 +15789,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "937",
+                    "$id": "941",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -15751,7 +15806,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "938",
+                        "$id": "942",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -15773,7 +15828,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "939",
+                    "$id": "943",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -15789,7 +15844,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "940",
+                        "$id": "944",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -15810,13 +15865,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "941",
+                    "$id": "945",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
                     "doc": "Resource create parameters.",
                     "type": {
-                      "$ref": "331"
+                      "$ref": "335"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -15830,13 +15885,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.SingletonSettings.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "942",
+                        "$id": "946",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
                         "doc": "Resource create parameters.",
                         "type": {
-                          "$ref": "331"
+                          "$ref": "335"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -15863,7 +15918,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "331"
+                      "$ref": "335"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -15881,7 +15936,7 @@
                       201
                     ],
                     "bodyType": {
-                      "$ref": "331"
+                      "$ref": "335"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -15915,27 +15970,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "931"
+                  "$ref": "935"
                 },
                 {
-                  "$ref": "935"
+                  "$ref": "939"
+                },
+                {
+                  "$ref": "946"
                 },
                 {
                   "$ref": "942"
                 },
                 {
-                  "$ref": "938"
+                  "$ref": "944"
                 },
                 {
-                  "$ref": "940"
-                },
-                {
-                  "$id": "943",
+                  "$id": "947",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "927"
+                    "$ref": "931"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -15948,7 +16003,7 @@
               ],
               "response": {
                 "type": {
-                  "$ref": "331"
+                  "$ref": "335"
                 }
               },
               "isOverride": false,
@@ -15959,13 +16014,13 @@
           ],
           "parameters": [
             {
-              "$id": "944",
+              "$id": "948",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "945",
+                "$id": "949",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -15976,7 +16031,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "946",
+                  "$id": "950",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -15990,7 +16045,7 @@
               "isExactName": false
             },
             {
-              "$ref": "901"
+              "$ref": "905"
             }
           ],
           "initializedBy": 0,
@@ -16007,7 +16062,7 @@
             "2024-05-01"
           ],
           "parent": {
-            "$ref": "338"
+            "$ref": "342"
           },
           "isMultiServiceClient": false
         }


### PR DESCRIPTION
## Summary
- Preserve TypeSpec `bytes` metadata through provisioning property generation by emitting `format: "base64"` for `InputPrimitiveTypeKind.Bytes` with `Encode == "base64"`.
- Keep `unknown`/`any` BinaryData properties unformatted so they retain JSON literal semantics in Azure.Provisioning.
- Add generator coverage on the existing `ConfigurationStoreProperties` test model with both cases: `binaryContent?: bytes` and `jsonMetadata?: unknown`.

## Validation
- `eng\packages\http-client-csharp-provisioning\eng\scripts\Generate.ps1 -filter Provisioning-TypeSpec`
- `npm run test:generator` from `eng\packages\http-client-csharp-provisioning`
- `dotnet format eng\packages\http-client-csharp-provisioning\generator\Azure.Generator.Provisioning\src\Azure.Generator.Provisioning.csproj --verbosity minimal`
- `dotnet format eng\packages\http-client-csharp-provisioning\generator\Azure.Generator.Provisioning\test\Azure.Generator.Provisioning.Tests.csproj --verbosity minimal`
- `dotnet format eng\packages\http-client-csharp-provisioning\generator\TestProjects\Local\Provisioning-TypeSpec\src\Azure.Provisioning.ProvisioningTypeSpec.csproj --verbosity minimal`

Split from #60960.