### PR TITLE
Preserve public resource version types in provisioning

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -120,6 +120,7 @@ namespace Azure.Generator.Provisioning.Providers
             _createBodyWritableProperties = BuildCreateBodyWritableProperties();
             _allProperties = CollectAllProperties();
             _propertyLookup = _allProperties.ToDictionary(p => p.Property);
+            ProvisioningGenerator.Instance.AddTypeToKeep(this);
         }
 
         /// <summary>
@@ -135,6 +136,7 @@ namespace Azure.Generator.Provisioning.Providers
             _createBodyWritableProperties = [];
             _allProperties = CollectAllProperties();
             _propertyLookup = _allProperties.ToDictionary(p => p.Property);
+            ProvisioningGenerator.Instance.AddTypeToKeep(this);
         }
 
         public override void Reset()

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -954,6 +954,7 @@ namespace Azure.Generator.Provisioning.Providers
             {
                 _parent = parent;
                 _apiVersions = apiVersions;
+                ProvisioningGenerator.Instance.AddTypeToKeep(this, isRoot: false);
             }
 
             protected override string BuildName() => "ResourceVersions";

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningOutputLibrary.cs
@@ -141,12 +141,7 @@ namespace Azure.Generator.Provisioning
 
             var providers = new List<TypeProvider>();
 
-            // Add resource providers and mark them to survive post-processing.
-            foreach (var resource in Resources)
-            {
-                providers.Add(resource);
-                ProvisioningGenerator.Instance.AddTypeToKeep(resource);
-            }
+            providers.AddRange(Resources);
 
             // Add BuiltInRole struct if any resources have RBAC roles defined.
             if (BuiltInRole != null)
@@ -174,12 +169,6 @@ namespace Azure.Generator.Provisioning
                 if (model is not null)
                 {
                     providers.Add(model);
-                    // CreateModel can still return a resource provider here for discriminator-derived
-                    // models whose base chain is a resource, and those providers must also be kept.
-                    if (model is ProvisioningResourceProvider resource)
-                    {
-                        ProvisioningGenerator.Instance.AddTypeToKeep(resource);
-                    }
                 }
             }
 

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
@@ -100,6 +100,9 @@ namespace Azure.Generator.Provisioning
             if (model.IsUnknownDiscriminatorModel)
                 return null;
 
+            if (model.DiscriminatorValue is null && !ProvisioningGenerator.Instance.InputLibrary.IsModelReachable(model))
+                return null;
+
             // Resource models → look up from output library's pre-created resource providers
             var outputLib = ProvisioningGenerator.Instance.OutputLibrary;
             if (outputLib.TryGetResourcesByModel(model, out var resources))

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
@@ -100,9 +100,6 @@ namespace Azure.Generator.Provisioning
             if (model.IsUnknownDiscriminatorModel)
                 return null;
 
-            if (model.DiscriminatorValue is null && !ProvisioningGenerator.Instance.InputLibrary.IsModelReachable(model))
-                return null;
-
             // Resource models → look up from output library's pre-created resource providers
             var outputLib = ProvisioningGenerator.Instance.OutputLibrary;
             if (outputLib.TryGetResourcesByModel(model, out var resources))
@@ -134,6 +131,14 @@ namespace Azure.Generator.Provisioning
                 }
                 return canonical!;
             }
+
+            // The base generator can rediscover models through references such as derived-model
+            // hierarchies after the emitter has pruned them from the reachable model set. Do not
+            // create providers for those models because provisioning settable metadata is emitted
+            // only for reachable models. Keep this after resource lookup because resource providers
+            // are pre-created from projection metadata and must be returned through that canonical path.
+            if (!ProvisioningGenerator.Instance.InputLibrary.IsModelReachable(model))
+                return null;
 
             // Derived discriminated resource types → ProvisioningResourceProvider (derived path)
             if (model.DiscriminatorValue != null && IsBaseChainResource(model))

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningResourceProjectionTests.cs
@@ -5,6 +5,7 @@ using Azure.Generator.Management.Models;
 using Azure.Generator.Provisioning.Primitives;
 using Azure.Generator.Provisioning.Providers;
 using Azure.Generator.Provisioning.Tests.TestHelpers;
+using Microsoft.TypeSpec.Generator;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
@@ -94,6 +95,29 @@ namespace Azure.Generator.Provisioning.Tests
             Assert.That(projection.ReadableScopes, Is.EqualTo(new[] { ResourceScope.ResourceGroup }));
             Assert.That(projection.WritableScopes, Is.EqualTo(new[] { ResourceScope.Extension }));
             Assert.That(projection.IsExtensionResource, Is.True);
+        }
+
+        [Test]
+        public void ResourceVersionsAreRetainedAsNonRootType()
+        {
+            var model = CreateModel("TestResourceData");
+            var resource = CreateMetadata(
+                model,
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}",
+                "Microsoft.Test/widgets",
+                ResourceScope.ResourceGroup,
+                ["2024-01-01"],
+                methods: [CreateMethod(ResourceOperationKind.Read, ResourceScope.ResourceGroup)]);
+            ProvisioningMockHelpers.LoadMockPlugin(inputModels: () => [model]);
+            var provider = CreateResourceProvider(resource);
+
+            var resourceVersions = provider.NestedTypes.Single(type => type.Name == "ResourceVersions");
+            var nonRootTypes = (HashSet<string>)typeof(CodeModelGenerator)
+                .GetProperty("NonRootTypes", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(ProvisioningGenerator.Instance)!;
+
+            Assert.That(resourceVersions.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public), Is.True);
+            Assert.That(nonRootTypes, Does.Contain(resourceVersions.Type.FullyQualifiedName));
         }
 
         [Test]

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningTypeFactoryTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningTypeFactoryTests.cs
@@ -204,10 +204,11 @@ namespace Azure.Generator.Provisioning.Tests
             Assert.That(type.BaseType, Is.EqualTo(new CSharpType(typeof(ProvisionableConstruct))));
         }
 
-        [Test]
-        public void UnreachableOrdinaryDerivedModelIsNotCreated()
+        [TestCase(null)]
+        [TestCase("derived")]
+        public void UnreachableModelIsNotCreated(string? discriminatorValue)
         {
-            var input = CreateDerivedModel("UnreachableModel", null, _regularModel);
+            var input = CreateDerivedModel("UnreachableModel", discriminatorValue, _regularModel);
 
             var provider = _factory.CreateModel(input);
 

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningTypeFactoryTests.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/test/ProvisioningTypeFactoryTests.cs
@@ -205,6 +205,16 @@ namespace Azure.Generator.Provisioning.Tests
         }
 
         [Test]
+        public void UnreachableOrdinaryDerivedModelIsNotCreated()
+        {
+            var input = CreateDerivedModel("UnreachableModel", null, _regularModel);
+
+            var provider = _factory.CreateModel(input);
+
+            Assert.That(provider, Is.Null);
+        }
+
+        [Test]
         public void DiscriminatedBaseModelDescriptionListsDerivedModels()
         {
             var discriminator = CreateProperty("kind", InputPrimitiveType.String, isDiscriminator: true);
@@ -400,7 +410,7 @@ namespace Azure.Generator.Provisioning.Tests
                 new InputSerializationOptions(),
                 false);
 
-        private static InputModelType CreateDerivedModel(string name, string discriminatorValue, InputModelType baseModel)
+        private static InputModelType CreateDerivedModel(string name, string? discriminatorValue, InputModelType baseModel)
             => new(
                 name,
                 "Sample.Models",


### PR DESCRIPTION
## Summary
- Let every provisioning resource provider register itself as a retained root type when constructed.
- Keep each nested `ResourceVersions` provider as a retained non-root type.
- Remove resource-specific retention bookkeeping from `ProvisioningOutputLibrary`.
- Skip non-resource models that the emitter excluded from provisioning reachability before constructing providers for them.

## Root causes
After the generator dependency update, retaining the root resource provider did not implicitly retain its nested `ResourceVersions` provider. Post-processing could therefore change the nested class from `public` to `internal` during fresh generation.

Separately, the base generator can rediscover models through references such as derived-model hierarchies after the provisioning emitter has pruned those models. Constructing a `ProvisioningModelProvider` for such a model calls the strict settable analysis, but the emitter intentionally emits settable metadata only for reachable models. The type factory now rejects those rediscovered non-resource models after resource lookup.

## Reproduction
`Azure.Provisioning.MachineLearning` reproduces the `ResourceVersions` regression because it is a new library without custom `ResourceVersions` declarations. `Azure.Provisioning.Redis` does not expose that visibility change because its custom public partial `ResourceVersions` classes preserve the generated visibility.

Compute, Redis, and ServiceFabric reproduced the unreachable-model failure with `VirtualMachineCaptureResult`, `RedisUpdateProperties`, and `ServiceResourceUpdateProperties`, respectively.

## Validation
- Added direct coverage that `ResourceVersions` remains public and is retained in the generator's non-root type set.
- Added coverage for both ordinary and discriminated unreachable models.
- Regenerated the `Provisioning-TypeSpec` test project with no generated fixture changes; its existing eight `ResourceVersions` baselines remain public.
- Ran all 54 provisioning generator tests.
- Regenerated Compute, Redis, ServiceFabric, and MachineLearning successfully with the local generator.