### PR TITLE
Fix optional overload ambiguity in management generator

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementClientGenerator.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementClientGenerator.cs
@@ -56,6 +56,8 @@ namespace Azure.Generator.Management
         /// <inheritdoc/>
         public override TypeProviderWriter GetWriter(TypeProvider provider)
         {
+            BackCompatHelper.DisambiguateOptionalOverloads(provider.Methods, provider.CustomCodeView?.Methods ?? []);
+
             if (provider is ModelFactoryProvider modelFactory)
             {
                 // Run model-factory repairs at write time, after all visitors have finalized model constructor

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableResourceProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableResourceProvider.cs
@@ -204,6 +204,7 @@ namespace Azure.Generator.Management.Providers
 
             var originalMethodList = originalMethods as IReadOnlyList<MethodProvider> ?? [.. originalMethods];
             var backCompatMethods = base.BuildMethodsForBackCompatibility(originalMethodList);
+            BackCompatHelper.DisambiguateOptionalOverloads(backCompatMethods, CustomCodeView?.Methods ?? []);
 
             return BackCompatHelper.DecorateBackwardCompatibilityMethods(backCompatMethods, originalMethodList);
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 using System.Linq;
 
@@ -42,6 +43,7 @@ namespace Azure.Generator.Management.Providers
         // Cached Get method providers
         private MethodProvider? _getAsyncMethodProvider;
         private MethodProvider? _getSyncMethodProvider;
+        private MethodProvider? _getAllAsyncMethodProvider;
         private MethodProvider? _getAllSyncMethodProvider;
 
         // Support for multiple rest clients
@@ -522,6 +524,7 @@ namespace Azure.Generator.Management.Providers
 
                 if (i == 0)
                 {
+                    _getAllAsyncMethodProvider = async;
                     _getAllSyncMethodProvider = sync;
                 }
 
@@ -540,7 +543,7 @@ namespace Azure.Generator.Management.Providers
             }
 
             const string getEnumeratormethodName = "GetEnumerator";
-            var body = Return(This.Invoke("GetAll").Invoke("GetEnumerator"));
+            var body = Return(This.Invoke("GetAll", BuildEnumeratorArguments(_getAllSyncMethodProvider!)).Invoke("GetEnumerator"));
             var getEnumeratorMethod = new MethodProvider(
                 new MethodSignature(getEnumeratormethodName, null, MethodSignatureModifiers.None, typeof(IEnumerator), null, [], ExplicitInterface: typeof(IEnumerable)),
                 body,
@@ -549,12 +552,19 @@ namespace Azure.Generator.Management.Providers
                 new MethodSignature(getEnumeratormethodName, null, MethodSignatureModifiers.None, new CSharpType(typeof(IEnumerator<>), _resource.Type), null, [], ExplicitInterface: new CSharpType(typeof(IEnumerable<>), _resource.Type)),
                 body,
                 this);
+            var cancellationToken = KnownAzureParameters.CancellationTokenWithoutDefault;
             var getEnumeratorAsyncMethod = new MethodProvider(
-                new MethodSignature("GetAsyncEnumerator", null, MethodSignatureModifiers.None, new CSharpType(typeof(IAsyncEnumerator<>), _resource.Type), null, [KnownAzureParameters.CancellationTokenWithoutDefault], ExplicitInterface: new CSharpType(typeof(IAsyncEnumerable<>), _resource.Type)),
-                Return(This.Invoke("GetAllAsync", [KnownAzureParameters.CancellationTokenWithoutDefault.PositionalReference(KnownAzureParameters.CancellationTokenWithoutDefault)]).Invoke("GetAsyncEnumerator", [KnownAzureParameters.CancellationTokenWithoutDefault])),
+                new MethodSignature("GetAsyncEnumerator", null, MethodSignatureModifiers.None, new CSharpType(typeof(IAsyncEnumerator<>), _resource.Type), null, [cancellationToken], ExplicitInterface: new CSharpType(typeof(IAsyncEnumerable<>), _resource.Type)),
+                Return(This.Invoke("GetAllAsync", BuildEnumeratorArguments(_getAllAsyncMethodProvider!, cancellationToken)).Invoke("GetAsyncEnumerator", [cancellationToken])),
                 this);
             return [getEnumeratorOfTMethod, getEnumeratorMethod, getEnumeratorAsyncMethod];
         }
+
+        private static ValueExpression[] BuildEnumeratorArguments(MethodProvider getAllMethod, ParameterProvider? cancellationToken = null)
+            => [.. getAllMethod.Signature.Parameters.Select(parameter =>
+                cancellationToken is not null && parameter.Type.Equals(typeof(CancellationToken))
+                    ? parameter.PositionalReference(cancellationToken)
+                    : parameter.DefaultValue ?? Default.CastTo(parameter.Type))];
 
         private List<MethodProvider> BuildCreateOrUpdateMethods()
         {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/BackCompatHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/BackCompatHelper.cs
@@ -85,5 +85,80 @@ namespace Azure.Generator.Management.Utilities
             var lastParameter = signature.Parameters[signature.Parameters.Count - 1];
             return lastParameter.DefaultValue is null && lastParameter.Type.Equals(typeof(CancellationToken));
         }
+
+        internal static void DisambiguateOptionalOverloads(
+            IReadOnlyList<MethodProvider> generatedMethods,
+            IReadOnlyList<MethodProvider> customMethods)
+        {
+            foreach (var generatedMethod in generatedMethods)
+            {
+                foreach (var customMethod in customMethods)
+                {
+                    var generatedParameters = generatedMethod.Signature.Parameters;
+                    var customParameters = customMethod.Signature.Parameters;
+                    int requiredParameterCount = GetRequiredParameterCount(generatedParameters);
+                    if (generatedMethod.Signature.Name != customMethod.Signature.Name ||
+                        customParameters.Count >= generatedParameters.Count ||
+                        requiredParameterCount != GetRequiredParameterCount(customParameters))
+                    {
+                        continue;
+                    }
+
+                    if (!TryGetFirstExtraParameterIndex(generatedParameters, customParameters, out int firstExtraParameterIndex))
+                    {
+                        firstExtraParameterIndex = requiredParameterCount;
+                    }
+
+                    for (int i = 0; i <= firstExtraParameterIndex; i++)
+                    {
+                        generatedParameters[i].DefaultValue = null;
+                    }
+                    for (int i = firstExtraParameterIndex + 1; i < generatedParameters.Count; i++)
+                    {
+                        if (generatedParameters[i].Type.Equals(typeof(CancellationToken)))
+                        {
+                            generatedParameters[i].DefaultValue ??= Default;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        private static int GetRequiredParameterCount(IReadOnlyList<ParameterProvider> parameters)
+        {
+            for (int i = 0; i < parameters.Count; i++)
+            {
+                if (parameters[i].DefaultValue is not null)
+                {
+                    return i;
+                }
+            }
+            return parameters.Count;
+        }
+
+        private static bool TryGetFirstExtraParameterIndex(
+            IReadOnlyList<ParameterProvider> generatedParameters,
+            IReadOnlyList<ParameterProvider> customParameters,
+            out int firstExtraParameterIndex)
+        {
+            int customIndex = 0;
+            firstExtraParameterIndex = -1;
+
+            for (int generatedIndex = 0; generatedIndex < generatedParameters.Count; generatedIndex++)
+            {
+                if (customIndex < customParameters.Count &&
+                    generatedParameters[generatedIndex].Type.Equals(customParameters[customIndex].Type))
+                {
+                    customIndex++;
+                }
+                else if (firstExtraParameterIndex < 0)
+                {
+                    firstExtraParameterIndex = generatedIndex;
+                }
+            }
+
+            return customIndex == customParameters.Count && firstExtraParameterIndex >= 0;
+        }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Generator.Management.Primitives;
+using Azure.Generator.Management.Utilities;
 using Microsoft.TypeSpec.Generator.ClientModel;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
@@ -50,6 +51,11 @@ namespace Azure.Generator.Management.Visitors
                     }
                 }
                 AddMissingLastContractModelMethods(modelFactory, updatedMethods);
+                BackCompatHelper.DisambiguateOptionalOverloads(
+                    updatedMethods,
+                    (modelFactory.CustomCodeView?.Methods ?? [])
+                        .Concat(modelFactory.LastContractView?.Methods ?? [])
+                        .ToArray());
                 modelFactory.Update(methods: updatedMethods);
                 return modelFactory;
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
@@ -813,7 +813,7 @@ namespace Azure.Generator.Management.Tests.Common
         /// Child:  .../parents/{parentName}/nestedTypes/{nestedTypeName}/children/{childName}
         /// The child has one extra path parameter (nestedTypeName) between parent and child.
         /// </summary>
-        public static (InputClient ParentClient, InputClient ChildClient, IReadOnlyList<InputModelType> InputModels) ClientWithNestedChildResource()
+        public static (InputClient ParentClient, InputClient ChildClient, IReadOnlyList<InputModelType> InputModels) ClientWithNestedChildResource(bool includeListQueryParameter = false)
         {
             const string ParentClientName = "ParentClient";
             const string ChildClientName = "ChildClient";
@@ -854,6 +854,7 @@ namespace Azure.Generator.Management.Tests.Common
             // Child operation parameters (includes nestedTypeName as extra path param)
             var nestedTypeNameOpParam = InputFactory.PathParameter("nestedTypeName", InputPrimitiveType.String, isRequired: true);
             var childNameOpParam = InputFactory.PathParameter("childName", InputPrimitiveType.String, isRequired: true);
+            var topOpParam = InputFactory.QueryParameter("top", InputPrimitiveType.Int32, serializedName: "$top");
 
             var parentIdPattern = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/parents/{parentName}";
             var childIdPattern = parentIdPattern + "/nestedTypes/{nestedTypeName}/children/{childName}";
@@ -876,7 +877,12 @@ namespace Azure.Generator.Management.Tests.Common
                     InputFactory.Property("value", InputFactory.Array(childModel)),
                     InputFactory.Property("nextLink", InputPrimitiveType.Url),
                 ]);
-            var childListOp = InputFactory.Operation(name: "listByParent", responses: [InputFactory.OperationResponse(statusCodes: [200], bodytype: childPageModel)], parameters: [subsIdOpParam, rgOpParam, parentNameOpParam, nestedTypeNameOpParam], path: childListPath);
+            List<InputParameter> childListOperationParameters = [subsIdOpParam, rgOpParam, parentNameOpParam, nestedTypeNameOpParam];
+            if (includeListQueryParameter)
+            {
+                childListOperationParameters.Add(topOpParam);
+            }
+            var childListOp = InputFactory.Operation(name: "listByParent", responses: [InputFactory.OperationResponse(statusCodes: [200], bodytype: childPageModel)], parameters: [.. childListOperationParameters], path: childListPath);
 
             // Parent method parameters
             var subscriptionIdParam = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
@@ -888,6 +894,7 @@ namespace Azure.Generator.Management.Tests.Common
             var nestedTypeNameParam = InputFactory.MethodParameter("nestedTypeName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
             var childNameParam = InputFactory.MethodParameter("childName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
             var childDataParam = InputFactory.MethodParameter("data", childModel, location: InputRequestLocation.Body, isRequired: true);
+            var topParam = InputFactory.MethodParameter("top", InputPrimitiveType.Int32, location: InputRequestLocation.Query, serializedName: "$top");
 
             // Parent service methods
             var parentGetMethod = InputFactory.BasicServiceMethod("get", parentGetOp, parameters: [parentNameParam, subscriptionIdParam, resourceGroupParam], crossLanguageDefinitionId: Guid.NewGuid().ToString());
@@ -897,7 +904,12 @@ namespace Azure.Generator.Management.Tests.Common
             var childGetMethod = InputFactory.BasicServiceMethod("get", childGetOp, parameters: [childNameParam, nestedTypeNameParam, parentNameParam, subscriptionIdParam, resourceGroupParam], crossLanguageDefinitionId: Guid.NewGuid().ToString());
             var childCreateMethod = InputFactory.BasicServiceMethod("createChild", childCreateOp, parameters: [childNameParam, nestedTypeNameParam, parentNameParam, subscriptionIdParam, resourceGroupParam, childDataParam], crossLanguageDefinitionId: Guid.NewGuid().ToString());
             var childListPagingMetadata = InputFactory.NextLinkPagingMetadata("value", "nextLink", InputResponseLocation.Body);
-            var childListMethod = InputFactory.PagingServiceMethod("listByParent", childListOp, parameters: [nestedTypeNameParam, parentNameParam, subscriptionIdParam, resourceGroupParam], pagingMetadata: childListPagingMetadata);
+            List<InputMethodParameter> childListMethodParameters = [nestedTypeNameParam, parentNameParam, subscriptionIdParam, resourceGroupParam];
+            if (includeListQueryParameter)
+            {
+                childListMethodParameters.Add(topParam);
+            }
+            var childListMethod = InputFactory.PagingServiceMethod("listByParent", childListOp, parameters: [.. childListMethodParameters], pagingMetadata: childListPagingMetadata);
 
             // Build multi-resource schema
             var armProviderDecorator = BuildArmProviderSchemaMultiResource([

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
@@ -53,6 +53,27 @@ namespace Azure.Generator.Management.Tests.Providers
         }
 
         [TestCase]
+        public void Verify_EnumeratorMethodsSpecifyOptionalGetAllArguments()
+        {
+            var (parentClient, childClient, models) = InputResourceData.ClientWithNestedChildResource(includeListQueryParameter: true);
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => models,
+                clients: () => [parentClient, childClient]);
+
+            var collection = plugin.Object.OutputLibrary.TypeProviders
+                .OfType<ResourceCollectionClientProvider>()
+                .Single(p => p.Name == "ChildTypeCollection");
+
+            var enumeratorBodies = collection.Methods
+                .Where(m => m.Signature.Name is "GetEnumerator" or "GetAsyncEnumerator")
+                .Select(m => m.BodyStatements?.ToDisplayString())
+                .ToArray();
+
+            Assert.That(enumeratorBodies, Has.Some.Contains("this.GetAll(default"));
+            Assert.That(enumeratorBodies, Has.Some.Contains("this.GetAllAsync(default"));
+        }
+
+        [TestCase]
         public void Verify_ExtensionChildCollectionValidateResourceIdUsesParentResource()
         {
             var (parentClient, childClient, models) = InputResourceData.ClientWithNestedExtensionChildResource();

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Utilities/BackCompatMethodHelperTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Utilities/BackCompatMethodHelperTests.cs
@@ -194,6 +194,92 @@ namespace Azure.Generator.Mgmt.Tests.Utilities
             Assert.That(BackCompatHelper.EndsWithRequiredCancellationToken(noParamsSignature), Is.False);
         }
 
+        [Test]
+        public void DisambiguatesGeneratedOverloadWithLeadingOptionalParameters()
+        {
+            var enclosingType = new TestTypeView("TestClient");
+            var generated = CreateMethod(
+                enclosingType,
+                [
+                    OptionalParameter("top", typeof(int?)),
+                    OptionalParameter("skipToken", typeof(string)),
+                    OptionalCancellationToken()
+                ]);
+            var custom = CreateMethod(enclosingType, [OptionalCancellationToken()]);
+
+            BackCompatHelper.DisambiguateOptionalOverloads([generated], [custom]);
+
+            Assert.That(generated.Signature.Parameters[0].DefaultValue, Is.Null);
+            Assert.That(generated.Signature.Parameters[1].DefaultValue, Is.Not.Null);
+            Assert.That(generated.Signature.Parameters[2].DefaultValue, Is.Not.Null);
+        }
+
+        [Test]
+        public void DisambiguatesGeneratedOverloadWithInsertedOptionalParameter()
+        {
+            var enclosingType = new TestTypeView("TestClient");
+            var generated = CreateMethod(
+                enclosingType,
+                [
+                    OptionalParameter("operationId", typeof(string)),
+                    OptionalParameter("resourceId", typeof(string)),
+                    OptionalParameter("fallback", typeof(object)),
+                    OptionalParameter("completedOn", typeof(DateTimeOffset?))
+                ]);
+            var custom = CreateMethod(
+                enclosingType,
+                [
+                    OptionalParameter("operationId", typeof(string)),
+                    OptionalParameter("resourceId", typeof(string)),
+                    OptionalParameter("completedOn", typeof(DateTimeOffset?))
+                ]);
+
+            BackCompatHelper.DisambiguateOptionalOverloads([generated], [custom]);
+
+            Assert.That(generated.Signature.Parameters.Take(3).All(p => p.DefaultValue is null), Is.True);
+            Assert.That(generated.Signature.Parameters[3].DefaultValue, Is.Not.Null);
+        }
+
+        [Test]
+        public void DisambiguatesGeneratedOverloadWhenParameterNamesDiffer()
+        {
+            var enclosingType = new TestTypeView("TestClient");
+            var generated = CreateMethod(
+                enclosingType,
+                [
+                    OptionalParameter("top", typeof(int?)),
+                    OptionalCancellationToken()
+                ]);
+            var custom = CreateMethod(
+                enclosingType,
+                [OptionalParameter("token", typeof(CancellationToken))]);
+
+            BackCompatHelper.DisambiguateOptionalOverloads([generated], [custom]);
+
+            Assert.That(generated.Signature.Parameters[0].DefaultValue, Is.Null);
+            Assert.That(generated.Signature.Parameters[1].DefaultValue, Is.Not.Null);
+        }
+
+        [Test]
+        public void DisambiguatesGeneratedOverloadWithoutMatchingParameterTypes()
+        {
+            var enclosingType = new TestTypeView("TestClient");
+            var generated = CreateMethod(
+                enclosingType,
+                [
+                    OptionalParameter("top", typeof(int?)),
+                    OptionalCancellationToken()
+                ]);
+            var custom = CreateMethod(
+                enclosingType,
+                [OptionalParameter("filter", typeof(bool))]);
+
+            BackCompatHelper.DisambiguateOptionalOverloads([generated], [custom]);
+
+            Assert.That(generated.Signature.Parameters[0].DefaultValue, Is.Null);
+            Assert.That(generated.Signature.Parameters[1].DefaultValue, Is.Not.Null);
+        }
+
         private static MethodProvider CreateMethod(TypeProvider enclosingType, IReadOnlyList<ParameterProvider> parameters)
         {
             var signature = new MethodSignature(
@@ -211,6 +297,9 @@ namespace Azure.Generator.Mgmt.Tests.Utilities
 
         private static ParameterProvider OptionalCancellationToken()
             => new("cancellationToken", $"The cancellation token to use.", new CSharpType(typeof(CancellationToken)), defaultValue: Default);
+
+        private static ParameterProvider OptionalParameter(string name, Type type)
+            => new(name, $"The {name}.", new CSharpType(type), defaultValue: Default);
 
         private static bool HasForwardsClientCalls(MethodProvider method)
             => method.Signature.Attributes.Any(a => a.Type.Name == ForwardsClientCallsAttributeName);

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec-MultiService/src/Generated/BarCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec-MultiService/src/Generated/BarCollection.cs
@@ -563,12 +563,12 @@ namespace Azure.Generator.MgmtTypeSpec.MultiService.Tests
 
         IEnumerator<BarResource> IEnumerable<BarResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec-MultiService/src/Generated/FooCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec-MultiService/src/Generated/FooCollection.cs
@@ -563,12 +563,12 @@ namespace Azure.Generator.MgmtTypeSpec.MultiService.Tests
 
         IEnumerator<FooResource> IEnumerable<FooResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BarCollection.cs
@@ -580,12 +580,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<BarResource> IEnumerable<BarResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BazCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BazCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<BazResource> IEnumerable<BazResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BestPracticeCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BestPracticeCollection.cs
@@ -557,12 +557,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<BestPracticeResource> IEnumerable<BestPracticeResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BestPracticeVersionCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/BestPracticeVersionCollection.cs
@@ -556,12 +556,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<BestPracticeVersionResource> IEnumerable<BestPracticeVersionResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ClusterCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ClusterCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<ClusterResource> IEnumerable<ClusterResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/DuplicatePropertyTestCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/DuplicatePropertyTestCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<DuplicatePropertyTestResource> IEnumerable<DuplicatePropertyTestResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EndpointResourceCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EndpointResourceCollection.cs
@@ -544,12 +544,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<EndpointResource> IEnumerable<EndpointResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EventGridDomainCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EventGridDomainCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<EventGridDomainResource> IEnumerable<EventGridDomainResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EventGridTopicCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/EventGridTopicCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<EventGridTopicResource> IEnumerable<EventGridTopicResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/FooCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/FooCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<FooResource> IEnumerable<FooResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/IssueTestResourceCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/IssueTestResourceCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<IssueTestResource> IEnumerable<IssueTestResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/PlaywrightQuotaCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/PlaywrightQuotaCollection.cs
@@ -534,12 +534,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<PlaywrightQuotaResource> IEnumerable<PlaywrightQuotaResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/PolicyArcAssignmentCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/PolicyArcAssignmentCollection.cs
@@ -568,12 +568,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<PolicyArcAssignmentResource> IEnumerable<PolicyArcAssignmentResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/PolicyVmAssignmentCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/PolicyVmAssignmentCollection.cs
@@ -568,12 +568,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<PolicyVmAssignmentResource> IEnumerable<PolicyVmAssignmentResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/SampleDataCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/SampleDataCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<SampleDataResource> IEnumerable<SampleDataResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ServiceGroupSiteCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ServiceGroupSiteCollection.cs
@@ -564,12 +564,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<ServiceGroupSiteResource> IEnumerable<ServiceGroupSiteResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/SharedConfigCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/SharedConfigCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<SharedConfigResource> IEnumerable<SharedConfigResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/TargetCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/TargetCollection.cs
@@ -564,18 +564,18 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<TargetResource> IEnumerable<TargetResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default, default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default, default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         IAsyncEnumerator<TargetResource> IAsyncEnumerable<TargetResource>.GetAsyncEnumerator(CancellationToken cancellationToken)
         {
-            return GetAllAsync(cancellationToken: cancellationToken).GetAsyncEnumerator(cancellationToken);
+            return GetAllAsync(default, cancellationToken: cancellationToken).GetAsyncEnumerator(cancellationToken);
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/TrafficProfileCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/TrafficProfileCollection.cs
@@ -557,12 +557,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<TrafficProfileResource> IEnumerable<TrafficProfileResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/WorkloadNetworkSegmentCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/WorkloadNetworkSegmentCollection.cs
@@ -571,12 +571,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<WorkloadNetworkSegmentResource> IEnumerable<WorkloadNetworkSegmentResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/WorkloadNetworkVmGroupCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/WorkloadNetworkVmGroupCollection.cs
@@ -571,12 +571,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<WorkloadNetworkVmGroupResource> IEnumerable<WorkloadNetworkVmGroupResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/WorkloadNetworksCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/WorkloadNetworksCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<WorkloadNetworksResource> IEnumerable<WorkloadNetworksResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZooCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/ZooCollection.cs
@@ -565,12 +565,12 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
 
         IEnumerator<ZooResource> IEnumerable<ZooResource>.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetAll().GetEnumerator();
+            return GetAll(default).GetEnumerator();
         }
 
         /// <param name="cancellationToken"> The cancellation token to use. </param>


### PR DESCRIPTION
## Description

Fixes ambiguous management SDK overloads when a shorter custom or previous-contract method keeps optional parameters and a newly generated overload adds more optional parameters.

The generator now:

- compares generated methods with custom and previous-contract overloads
- removes defaults through the first generated-only parameter so the longer overload requires an argument
- preserves legal trailing cancellation-token defaults
- emits explicit arguments when collection enumerators call the canonical `GetAll` and `GetAllAsync` overloads

This is a generic generator fix discovered while addressing #61400. The SDK API changes for that issue will follow after this fix is merged.

## Validation

- Regenerated all management generator test projects with `eng/scripts/Generate.ps1`
- Passed 274 management generator tests
- Passed 145 emitter tests
