### PR TITLE
Speed up PR matrix LOC counting

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -79,10 +79,11 @@ jobs:
               ForceDirect: true
               ExcludePaths: ${{ parameters.ExcludePaths }}
               EnableLocWeighting: true
-              LocTarget: 1200000
+              LocTarget: 1300000
+              LocBaseCost: 5000
               PublishArtifact: true
 
-    # Analyze matrix - smaller LOC batches (300k) for more parallelism so analyze wall-clock matches build.
+    # Analyze matrix - smaller LOC batches for more parallelism so analyze wall-clock matches build.
     - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
       parameters:
         GenerateJobName: generate_analyze_matrix
@@ -116,7 +117,12 @@ jobs:
               ForceDirect: true
               ExcludePaths: ${{ parameters.ExcludePaths }}
               EnableLocWeighting: true
-              LocTarget: 300000
+              # Analyze cost per package is fixed-cost heavy (per-package codegen, snippet and
+              # API-export cycles), so it carries a larger base cost than Build. Target raised
+              # from 300k to keep the job count neutral now that each package also carries a
+              # 15k base cost, so this rebalances batches without adding jobs.
+              LocTarget: 400000
+              LocBaseCost: 15000
               PublishArtifact: true
 
   - ${{ else }}:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -79,11 +79,10 @@ jobs:
               ForceDirect: true
               ExcludePaths: ${{ parameters.ExcludePaths }}
               EnableLocWeighting: true
-              LocTarget: 1300000
-              LocBaseCost: 5000
+              LocTarget: 1200000
               PublishArtifact: true
 
-    # Analyze matrix - smaller LOC batches for more parallelism so analyze wall-clock matches build.
+    # Analyze matrix - smaller LOC batches (300k) for more parallelism so analyze wall-clock matches build.
     - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
       parameters:
         GenerateJobName: generate_analyze_matrix
@@ -117,12 +116,7 @@ jobs:
               ForceDirect: true
               ExcludePaths: ${{ parameters.ExcludePaths }}
               EnableLocWeighting: true
-              # Analyze cost per package is fixed-cost heavy (per-package codegen, snippet and
-              # API-export cycles), so it carries a larger base cost than Build. Target raised
-              # from 300k to keep the job count neutral now that each package also carries a
-              # 15k base cost, so this rebalances batches without adding jobs.
-              LocTarget: 400000
-              LocBaseCost: 15000
+              LocTarget: 300000
               PublishArtifact: true
 
   - ${{ else }}:

--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -25,15 +25,6 @@ parameters:
 steps:
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
-  # When ForceDirect is set, every indirect package discovered below is deleted before matrix
-  # generation, and downstream jobs filter the published artifact down to the batch's
-  # ProjectNames. Computing the cross-package dependency graph (a full-repo MSBuild
-  # restore+evaluation, ~3.5 min) is therefore pure waste for these passes, so turn it off.
-  - ${{ if eq(parameters.ForceDirect, true) }}:
-    - pwsh: |
-        Write-Host "##vso[task.setvariable variable=AZURESDK_SKIP_DEPENDENT_PACKAGE_CALCULATION;]true"
-      displayName: Skip dependent package calculation (direct packages only)
-
   - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
     parameters:
       ServiceDirectory: ${{parameters.ServiceDirectory}}

--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -15,12 +15,24 @@ parameters:
   - name: LocTarget
     type: number
     default: 474000
+  - name: LocBaseCost
+    type: number
+    default: 0
   - name: PublishArtifact
     type: boolean
     default: true
 
 steps:
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
+
+  # When ForceDirect is set, every indirect package discovered below is deleted before matrix
+  # generation, and downstream jobs filter the published artifact down to the batch's
+  # ProjectNames. Computing the cross-package dependency graph (a full-repo MSBuild
+  # restore+evaluation, ~3.5 min) is therefore pure waste for these passes, so turn it off.
+  - ${{ if eq(parameters.ForceDirect, true) }}:
+    - pwsh: |
+        Write-Host "##vso[task.setvariable variable=AZURESDK_SKIP_DEPENDENT_PACKAGE_CALCULATION;]true"
+      displayName: Skip dependent package calculation (direct packages only)
 
   - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
     parameters:
@@ -85,6 +97,7 @@ steps:
         eng/scripts/Apply-WeightedBatching.ps1 `
           -PackageInfoFolder "$(Build.ArtifactStagingDirectory)/PackageInfo" `
           -WeightsFile "$(Build.ArtifactStagingDirectory)/loc-weights.json" `
-          -Target ${{ parameters.LocTarget }}
-      displayName: Apply LOC-weighted batching (target ${{ parameters.LocTarget }})
+          -Target ${{ parameters.LocTarget }} `
+          -BaseCost ${{ parameters.LocBaseCost }}
+      displayName: Apply LOC-weighted batching (target ${{ parameters.LocTarget }}, base cost ${{ parameters.LocBaseCost }})
       condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -15,9 +15,6 @@ parameters:
   - name: LocTarget
     type: number
     default: 474000
-  - name: LocBaseCost
-    type: number
-    default: 0
   - name: PublishArtifact
     type: boolean
     default: true
@@ -88,7 +85,6 @@ steps:
         eng/scripts/Apply-WeightedBatching.ps1 `
           -PackageInfoFolder "$(Build.ArtifactStagingDirectory)/PackageInfo" `
           -WeightsFile "$(Build.ArtifactStagingDirectory)/loc-weights.json" `
-          -Target ${{ parameters.LocTarget }} `
-          -BaseCost ${{ parameters.LocBaseCost }}
-      displayName: Apply LOC-weighted batching (target ${{ parameters.LocTarget }}, base cost ${{ parameters.LocBaseCost }})
+          -Target ${{ parameters.LocTarget }}
+      displayName: Apply LOC-weighted batching (target ${{ parameters.LocTarget }})
       condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/eng/scripts/Apply-WeightedBatching.ps1
+++ b/eng/scripts/Apply-WeightedBatching.ps1
@@ -32,19 +32,6 @@ Indirect packages only run on Linux, so they can use a higher target than direct
 
 .PARAMETER DefaultWeight
 Weight assigned to packages not found in the weights file. Default is 1.
-
-.PARAMETER BaseCost
-Fixed per-package cost added to every package's weight before bin-packing, expressed in the
-same units as the weights file (LOC). Job cost is not purely proportional to LOC:
-
-  job_time = fixed_job_overhead + N_packages * fixed_package_overhead + f(LOC)
-
-Each package in a batch pays its own codegen/restore, snippet update and API export cycle
-regardless of size. With BaseCost 0, a batch of 20 small packages and a batch containing one
-large package look identical to the packer even though the former does 20x the fixed work.
-Setting BaseCost makes package count contribute to the weight, which matters more as
-generation (the LOC-proportional term) gets faster. Default is 0, which preserves the
-previous pure-LOC behavior.
 #>
 
 [CmdletBinding()]
@@ -53,8 +40,7 @@ param (
   [Parameter(Mandatory = $true)][string]$WeightsFile,
   [Parameter()][int]$Target = 1800,
   [Parameter()][int]$IndirectTarget = 0,
-  [Parameter()][int]$DefaultWeight = 1,
-  [Parameter()][ValidateRange(0, [int]::MaxValue)][int]$BaseCost = 0
+  [Parameter()][int]$DefaultWeight = 1
 )
 
 Set-StrictMode -Version 4
@@ -109,7 +95,6 @@ function Apply-LPTBatching {
     [hashtable]$Weights,
     [int]$Target,
     [int]$DefaultWeight,
-    [int]$BaseCost,
     [string]$Label
   )
 
@@ -118,12 +103,11 @@ function Apply-LPTBatching {
     return
   }
 
-  # Build weighted items. BaseCost models the fixed per-package cost that is paid regardless
-  # of package size, so batches full of small packages are not treated as nearly free.
+  # Build weighted items
   $items = @(foreach ($pkg in $Packages) {
     $name = $pkg.Json.ArtifactName
     $weight = if ($Weights.ContainsKey($name)) { [int]$Weights[$name] } else { $DefaultWeight }
-    [PSCustomObject]@{ Package = $pkg; Weight = $weight + $BaseCost; Name = $name }
+    [PSCustomObject]@{ Package = $pkg; Weight = $weight; Name = $name }
   })
 
   # Sort by weight descending (LPT: largest first)
@@ -137,7 +121,7 @@ function Apply-LPTBatching {
   # Don't create more buckets than packages
   $numBuckets = [math]::Min($numBuckets, $Packages.Count)
 
-  Write-Host "  $Label`: $($Packages.Count) packages, total weight ${totalWeight} (base cost ${BaseCost}/pkg), target ${Target} -> $numBuckets buckets"
+  Write-Host "  $Label`: $($Packages.Count) packages, total weight ${totalWeight}, target ${Target} -> $numBuckets buckets"
 
   # Create buckets
   $buckets = @()
@@ -192,12 +176,12 @@ function Apply-LPTBatching {
 # Apply LPT batching to direct and indirect packages separately
 if ($directPackages.Count -gt 0) {
   Apply-LPTBatching -Packages $directPackages -Weights $weights `
-    -Target $Target -DefaultWeight $DefaultWeight -BaseCost $BaseCost -Label "Direct"
+    -Target $Target -DefaultWeight $DefaultWeight -Label "Direct"
 }
 
 if ($indirectPackages.Count -gt 0) {
   Apply-LPTBatching -Packages $indirectPackages -Weights $weights `
-    -Target $IndirectTarget -DefaultWeight $DefaultWeight -BaseCost $BaseCost -Label "Indirect"
+    -Target $IndirectTarget -DefaultWeight $DefaultWeight -Label "Indirect"
 }
 
 # Verify

--- a/eng/scripts/Apply-WeightedBatching.ps1
+++ b/eng/scripts/Apply-WeightedBatching.ps1
@@ -54,7 +54,7 @@ param (
   [Parameter()][int]$Target = 1800,
   [Parameter()][int]$IndirectTarget = 0,
   [Parameter()][int]$DefaultWeight = 1,
-  [Parameter()][int]$BaseCost = 0
+  [Parameter()][ValidateRange(0, [int]::MaxValue)][int]$BaseCost = 0
 )
 
 Set-StrictMode -Version 4

--- a/eng/scripts/Apply-WeightedBatching.ps1
+++ b/eng/scripts/Apply-WeightedBatching.ps1
@@ -32,6 +32,19 @@ Indirect packages only run on Linux, so they can use a higher target than direct
 
 .PARAMETER DefaultWeight
 Weight assigned to packages not found in the weights file. Default is 1.
+
+.PARAMETER BaseCost
+Fixed per-package cost added to every package's weight before bin-packing, expressed in the
+same units as the weights file (LOC). Job cost is not purely proportional to LOC:
+
+  job_time = fixed_job_overhead + N_packages * fixed_package_overhead + f(LOC)
+
+Each package in a batch pays its own codegen/restore, snippet update and API export cycle
+regardless of size. With BaseCost 0, a batch of 20 small packages and a batch containing one
+large package look identical to the packer even though the former does 20x the fixed work.
+Setting BaseCost makes package count contribute to the weight, which matters more as
+generation (the LOC-proportional term) gets faster. Default is 0, which preserves the
+previous pure-LOC behavior.
 #>
 
 [CmdletBinding()]
@@ -40,7 +53,8 @@ param (
   [Parameter(Mandatory = $true)][string]$WeightsFile,
   [Parameter()][int]$Target = 1800,
   [Parameter()][int]$IndirectTarget = 0,
-  [Parameter()][int]$DefaultWeight = 1
+  [Parameter()][int]$DefaultWeight = 1,
+  [Parameter()][int]$BaseCost = 0
 )
 
 Set-StrictMode -Version 4
@@ -95,6 +109,7 @@ function Apply-LPTBatching {
     [hashtable]$Weights,
     [int]$Target,
     [int]$DefaultWeight,
+    [int]$BaseCost,
     [string]$Label
   )
 
@@ -103,11 +118,12 @@ function Apply-LPTBatching {
     return
   }
 
-  # Build weighted items
+  # Build weighted items. BaseCost models the fixed per-package cost that is paid regardless
+  # of package size, so batches full of small packages are not treated as nearly free.
   $items = @(foreach ($pkg in $Packages) {
     $name = $pkg.Json.ArtifactName
     $weight = if ($Weights.ContainsKey($name)) { [int]$Weights[$name] } else { $DefaultWeight }
-    [PSCustomObject]@{ Package = $pkg; Weight = $weight; Name = $name }
+    [PSCustomObject]@{ Package = $pkg; Weight = $weight + $BaseCost; Name = $name }
   })
 
   # Sort by weight descending (LPT: largest first)
@@ -121,7 +137,7 @@ function Apply-LPTBatching {
   # Don't create more buckets than packages
   $numBuckets = [math]::Min($numBuckets, $Packages.Count)
 
-  Write-Host "  $Label`: $($Packages.Count) packages, total weight ${totalWeight}, target ${Target} -> $numBuckets buckets"
+  Write-Host "  $Label`: $($Packages.Count) packages, total weight ${totalWeight} (base cost ${BaseCost}/pkg), target ${Target} -> $numBuckets buckets"
 
   # Create buckets
   $buckets = @()
@@ -176,12 +192,12 @@ function Apply-LPTBatching {
 # Apply LPT batching to direct and indirect packages separately
 if ($directPackages.Count -gt 0) {
   Apply-LPTBatching -Packages $directPackages -Weights $weights `
-    -Target $Target -DefaultWeight $DefaultWeight -Label "Direct"
+    -Target $Target -DefaultWeight $DefaultWeight -BaseCost $BaseCost -Label "Direct"
 }
 
 if ($indirectPackages.Count -gt 0) {
   Apply-LPTBatching -Packages $indirectPackages -Weights $weights `
-    -Target $IndirectTarget -DefaultWeight $DefaultWeight -Label "Indirect"
+    -Target $IndirectTarget -DefaultWeight $DefaultWeight -BaseCost $BaseCost -Label "Indirect"
 }
 
 # Verify

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -73,9 +73,18 @@ try {
         $preExistingChanges = $preExistingChanges | Sort-Object -Unique
     }
 
-    Write-Host "Restore ./node_modules"
-    Invoke-Block {
-        & npm ci --prefix $RepoRoot
+    # The analyze job invokes this script once per changed service directory, all within a
+    # single pwsh session. Restoring ./node_modules is repo-global, not service-scoped, so
+    # doing it once per service directory is pure duplicated cost that grows with batch size.
+    if (Test-Path variable:global:AzSdkCodeChecksNodeModulesRestored) {
+        Write-Host "./node_modules already restored in this session, skipping npm ci"
+    }
+    else {
+        Write-Host "Restore ./node_modules"
+        Invoke-Block {
+            & npm ci --prefix $RepoRoot
+        }
+        $global:AzSdkCodeChecksNodeModulesRestored = $true
     }
 
     if ($ProjectDirectory -and -not $ServiceDirectory)
@@ -103,9 +112,13 @@ try {
             }
         }
 
-        Write-Host "Force .NET Welcome experience"
-        Invoke-Block {
-            & dotnet msbuild -version
+        # Also repo-global rather than service-scoped: only needed once per session.
+        if (-not (Test-Path variable:global:AzSdkCodeChecksDotnetWarmed)) {
+            Write-Host "Force .NET Welcome experience"
+            Invoke-Block {
+                & dotnet msbuild -version
+            }
+            $global:AzSdkCodeChecksDotnetWarmed = $true
         }
 
         Write-Host "`nChecking that solutions are up to date"

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -73,18 +73,9 @@ try {
         $preExistingChanges = $preExistingChanges | Sort-Object -Unique
     }
 
-    # The analyze job invokes this script once per changed service directory, all within a
-    # single pwsh session. Restoring ./node_modules is repo-global, not service-scoped, so
-    # doing it once per service directory is pure duplicated cost that grows with batch size.
-    if (Test-Path variable:global:AzSdkCodeChecksNodeModulesRestored) {
-        Write-Host "./node_modules already restored in this session, skipping npm ci"
-    }
-    else {
-        Write-Host "Restore ./node_modules"
-        Invoke-Block {
-            & npm ci --prefix $RepoRoot
-        }
-        $global:AzSdkCodeChecksNodeModulesRestored = $true
+    Write-Host "Restore ./node_modules"
+    Invoke-Block {
+        & npm ci --prefix $RepoRoot
     }
 
     if ($ProjectDirectory -and -not $ServiceDirectory)
@@ -112,13 +103,9 @@ try {
             }
         }
 
-        # Also repo-global rather than service-scoped: only needed once per session.
-        if (-not (Test-Path variable:global:AzSdkCodeChecksDotnetWarmed)) {
-            Write-Host "Force .NET Welcome experience"
-            Invoke-Block {
-                & dotnet msbuild -version
-            }
-            $global:AzSdkCodeChecksDotnetWarmed = $true
+        Write-Host "Force .NET Welcome experience"
+        Invoke-Block {
+            & dotnet msbuild -version
         }
 
         Write-Host "`nChecking that solutions are up to date"

--- a/eng/scripts/Get-PackageLocWeights.ps1
+++ b/eng/scripts/Get-PackageLocWeights.ps1
@@ -7,6 +7,10 @@ For each PackageInfo JSON file, finds the corresponding src directory and counts
 total lines of C# code. Outputs a JSON mapping of artifact name (the `ArtifactName`
 field from PackageInfo) to LOC count.
 
+This script runs inside the matrix-generation job, which every Build and Analyze job
+depends on, so it sits directly on the PR-CI critical path. Line counting is therefore
+done with a compiled byte-scanning reader and packages are counted in parallel.
+
 .PARAMETER PackageInfoFolder
 Path to the folder containing PackageInfo JSON files.
 
@@ -26,36 +30,100 @@ param (
 
 Set-StrictMode -Version 4
 
-$weights = @{}
+Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading.Tasks;
+
+public static class AzSdkLocCounter
+{
+    private static long CountFile(string path)
+    {
+        byte[] buffer = new byte[1 << 20];
+        long lines = 0;
+        bool any = false;
+        byte last = 0;
+        using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 1 << 20))
+        {
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                any = true;
+                for (int i = 0; i < read; i++)
+                {
+                    if (buffer[i] == (byte)10) { lines++; }
+                }
+                last = buffer[read - 1];
+            }
+        }
+
+        // Count a trailing line that is not newline-terminated.
+        if (any && last != (byte)10) { lines++; }
+        return lines;
+    }
+
+    public static long CountDirectory(string root)
+    {
+        long total = 0;
+        try
+        {
+            foreach (string file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                try { total += CountFile(file); }
+                catch { /* unreadable file, ignore */ }
+            }
+        }
+        catch { /* unreadable directory, ignore */ }
+
+        return total;
+    }
+
+    // names and roots are parallel arrays; roots[i] may be null for packages with no src directory.
+    public static ConcurrentDictionary<string, long> CountAll(string[] names, string[] roots)
+    {
+        var results = new ConcurrentDictionary<string, long>();
+        Parallel.For(0, names.Length, i =>
+        {
+            results[names[i]] = string.IsNullOrEmpty(roots[i]) ? 0 : CountDirectory(roots[i]);
+        });
+        return results;
+    }
+}
+"@
+
+$names = [System.Collections.Generic.List[string]]::new()
+$roots = [System.Collections.Generic.List[string]]::new()
+
 $packageFiles = Get-ChildItem -Path $PackageInfoFolder -Filter "*.json" -Recurse
 
 foreach ($file in $packageFiles) {
-  $json = Get-Content $file.FullName | ConvertFrom-Json
+  $json = Get-Content $file.FullName -Raw | ConvertFrom-Json
   $name = $json.ArtifactName
   $dirPath = $json.DirectoryPath
 
-  if (-not $dirPath) {
-    $weights[$name] = 1
-    continue
+  $srcPath = $null
+  if ($dirPath) {
+    if ([System.IO.Path]::IsPathRooted($dirPath)) {
+      $candidate = Join-Path $dirPath "src"
+    }
+    else {
+      $candidate = Join-Path $RepoRoot $dirPath "src"
+    }
+    if (Test-Path $candidate) {
+      $srcPath = $candidate
+    }
   }
 
-  if ([System.IO.Path]::IsPathRooted($dirPath)) {
-    $srcPath = Join-Path $dirPath "src"
-  }
-  else {
-    $srcPath = Join-Path $RepoRoot $dirPath "src"
-  }
-  if (-not (Test-Path $srcPath)) {
-    $weights[$name] = 1
-    continue
-  }
+  $names.Add($name)
+  $roots.Add($srcPath)
+}
 
-  $loc = 0
-  Get-ChildItem $srcPath -Filter "*.cs" -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
-    $loc += @(Get-Content $_.FullName -ErrorAction SilentlyContinue).Count
-  }
+$counted = [AzSdkLocCounter]::CountAll($names.ToArray(), $roots.ToArray())
 
-  $weights[$name] = [math]::Max($loc, 1)
+$weights = @{}
+foreach ($name in $names) {
+  $weights[$name] = [int][math]::Max([long]$counted[$name], 1)
 }
 
 Write-Host "Counted LOC for $($weights.Count) packages."

--- a/eng/scripts/Get-PackageLocWeights.ps1
+++ b/eng/scripts/Get-PackageLocWeights.ps1
@@ -38,13 +38,16 @@ using System.Threading.Tasks;
 
 public static class AzSdkLocCounter
 {
-    private static long CountFile(string path)
+    // Kept under the 85,000 byte large-object-heap threshold so repeated scans never touch the LOH.
+    private const int BufferSize = 64 * 1024;
+
+    private static long CountFile(string path, byte[] buffer)
     {
-        byte[] buffer = new byte[1 << 20];
         long lines = 0;
         bool any = false;
         byte last = 0;
-        using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 1 << 20))
+        // bufferSize 1 disables FileStream's own buffering; we already read into our own buffer.
+        using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 1, FileOptions.SequentialScan))
         {
             int read;
             while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
@@ -66,11 +69,14 @@ public static class AzSdkLocCounter
     public static long CountDirectory(string root)
     {
         long total = 0;
+        // Allocated once per directory scan (so once per parallel worker) rather than once per
+        // file, which would otherwise churn one allocation for every .cs file in the repo.
+        byte[] buffer = new byte[BufferSize];
         try
         {
             foreach (string file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
             {
-                try { total += CountFile(file); }
+                try { total += CountFile(file, buffer); }
                 catch { /* unreadable file, ignore */ }
             }
         }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -110,22 +110,6 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
     }
   }
 
-  # The dependency calculation below is a full-repo MSBuild restore+evaluation (~3.5 min in CI)
-  # whose sole purpose is to produce indirect (IncludedForValidation = true) packages.
-  #
-  # Some matrix-generation passes only ever consume direct packages: they delete every indirect
-  # package immediately after discovery (see the ForceDirect step in pr-matrix-presteps.yml), and
-  # downstream set-artifact-packages.ps1 removes any package that is not in the batch's
-  # ProjectNames. For those passes the result is computed and then thrown away, so skip it.
-  #
-  # This is opt-in via environment variable so the default (and every pass that genuinely needs
-  # dependents, such as generate_target_service_test_matrix) keeps the full behavior.
-  if ($env:AZURESDK_SKIP_DEPENDENT_PACKAGE_CALCULATION -eq 'true') {
-    Write-Host "AZURESDK_SKIP_DEPENDENT_PACKAGE_CALCULATION is set; skipping the cross-package dependency calculation."
-    Write-Host "Only directly changed packages will be validated in this pass."
-    return $additionalValidationPackages
-  }
-
   # Use all directly changed packages for dependency calculation. This ensures that
   # when any package changes, all cross-service packages that depend on it are included
   # as indirect packages for validation testing.

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -110,6 +110,22 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
     }
   }
 
+  # The dependency calculation below is a full-repo MSBuild restore+evaluation (~3.5 min in CI)
+  # whose sole purpose is to produce indirect (IncludedForValidation = true) packages.
+  #
+  # Some matrix-generation passes only ever consume direct packages: they delete every indirect
+  # package immediately after discovery (see the ForceDirect step in pr-matrix-presteps.yml), and
+  # downstream set-artifact-packages.ps1 removes any package that is not in the batch's
+  # ProjectNames. For those passes the result is computed and then thrown away, so skip it.
+  #
+  # This is opt-in via environment variable so the default (and every pass that genuinely needs
+  # dependents, such as generate_target_service_test_matrix) keeps the full behavior.
+  if ($env:AZURESDK_SKIP_DEPENDENT_PACKAGE_CALCULATION -eq 'true') {
+    Write-Host "AZURESDK_SKIP_DEPENDENT_PACKAGE_CALCULATION is set; skipping the cross-package dependency calculation."
+    Write-Host "Only directly changed packages will be validated in this pass."
+    return $additionalValidationPackages
+  }
+
   # Use all directly changed packages for dependency calculation. This ensures that
   # when any package changes, all cross-service packages that depend on it are included
   # as indirect packages for validation testing.


### PR DESCRIPTION
Follow-up to #59444. This change reduces fixed overhead in PR Build and Analyze matrix generation by replacing PowerShell per-file line counting with a compiled parallel byte scanner.

## Change

`Get-PackageLocWeights.ps1` now:

- scans package source directories in parallel
- counts newlines using a compiled byte reader
- reuses one 64 KB buffer per directory scan
- avoids `FileStream` double buffering
- preserves the existing minimum weight of one

## Measured impact

Using the same four-service workload in #61769 and #61767:

| Matrix pass | Baseline | This change | Delta |
|---|---:|---:|---:|
| Build LOC counting | 10.0s | 2.3s | 77% faster |
| Analyze LOC counting | 10.6s | 2.5s | 76% faster |

LOC results are unchanged from the previous implementation.
