### PR TITLE
Document shared provisioning model settability semantics

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/docs/design.md
+++ b/eng/packages/http-client-csharp-provisioning/docs/design.md
@@ -209,9 +209,9 @@ Element types for `BicepList<T>` and `BicepDictionary<T>` are resolved without `
 Generates `ProvisionableResource` subclasses from input model types + resource metadata:
 - **Property collection**: walks the model's inheritance chain and collects all properties, flattening only those with the `@flattenProperty` decorator
 - **Field-property linking**: each property gets a nullable backing field. Properties and fields are co-created through the TypeFactory property creation pipeline, ensuring names go through the mgmt visitor pipeline. These linked pairs are lazily initialized on first access.
-- **System properties**: `name`, `location` (required input), `id`, `systemData` (output-only), `tags` (input), `type` (skipped)
+- **System properties**: `name` (always settable/required — resources without a writable scope are still addressed by `bicepIdentifier`/`Name` for `FromExisting()`), `id` / `systemData` (always output-only), `type` (skipped). `location` and `tags` are **not** special-cased: like any other resource body property, they are settable/required only when the resource's settable-usage decision (§9) is `true` for that resource — a read-only (`FromExisting`-only) resource generates them as getter-only and non-required.
 - **Parent resources**: child resources get a typed `Parent` property for parent-child relationship
-- **Constructor**: `(string bicepIdentifier, string? resourceVersion)` with default API version
+- **Constructor**: `(string bicepIdentifier, string? resourceVersion)` with default API version; visibility follows the same settable-usage decision (§9) — `public` for resources with a writable (create) scope, `internal` for read-only resources, which are obtained via `FromExisting()` instead
 - **`FromExisting()`**: static factory method
 - **`ResourceVersions`**: nested class with GA API version constants
 
@@ -219,7 +219,7 @@ Generates `ProvisionableResource` subclasses from input model types + resource m
 
 Generates `ProvisionableConstruct` subclasses:
 - Same field-property co-creation pattern as resources — properties go through the TypeFactory pipeline for visitor-based name resolution
-- Getter/setter patterns: models use `AssignOrReplace`, BicepValue types use `.Assign()`, read-only properties are getter-only
+- Getter/setter patterns: models use `AssignOrReplace`, BicepValue types use `.Assign()`. A property is getter-only when *either* it is itself read-only *or* the enclosing model type has no settable usage anywhere in the TypeSpec graph (see §9) — `IsReadOnly` on the property is not the sole determinant.
 - `DefineProvisionableProperties()` maps each property to its bicep path
 
 ### Enum Provider

--- a/eng/packages/http-client-csharp-provisioning/docs/design.md
+++ b/eng/packages/http-client-csharp-provisioning/docs/design.md
@@ -265,3 +265,46 @@ eng/packages/http-client-csharp-provisioning/             ← New generator (emi
 - This migration should not introduce any breaking change comparing with the library's latest stable release.
 - Existing `partial class` customizations in non-generated code must continue to compile.
 - Existing tests must pass without modification (except for API version updates in expected Bicep strings — which should be pinned).
+
+---
+
+## 9. Shared Model Semantics & Settability
+
+### Schema Sharing Is Preserved, Not Cloned
+
+TypeSpec lets a single model (or resource body) type be referenced from many properties, resources, or operations. The generator honors that sharing instead of cloning a schema per occurrence: every `InputModelType` maps to exactly one generated CLR type (a `ProvisionableConstruct` or `ProvisionableResource` subclass), no matter how many places reference it. There is one `FooModel` class, and every property or nested reference to `Foo` anywhere in the TypeSpec graph resolves to that same type. Keeping a single shared CLR type per TypeSpec model avoids duplicate types for the same shape and keeps the generated surface aligned with what the TypeSpec author declared.
+
+### `isOutput` Is Occurrence-Level Metadata
+
+`isOutput` (passed to `DefineProperty` / `DefineModelProperty` / `DefineListProperty` / `DefineDictionaryProperty`) describes a single property **occurrence** — the read-only state of one property slot on one enclosing model or resource. Both `ProvisioningResourceProvider` and `ProvisioningModelProvider` compute it per property from that property's own `IsReadOnly` flag at its declaration site. It does **not** cascade: marking `Parent.Child` as output only affects the `Child` slot on `Parent`. `Child`'s own properties compute their own `isOutput` independently, from their own read-only state within `Child`'s definition — not from how `Child` happened to be reached.
+
+An output occurrence has two concrete effects:
+- **Generated API**: the property is emitted getter-only — `ProvisioningPropertyProvider.Create` omits the setter branch entirely when `isSettable` is `false`.
+- **Runtime guard**: `BicepValue<T>.Assign()` (and the list/dictionary equivalents) throw `InvalidOperationException` when the target's `_isOutput` flag is set, so direct assignment to an output-marked occurrence is disallowed both at compile time (no setter) and at runtime (guarded `Assign`).
+
+Neither effect reaches into the members *inside* the referenced type. If that type is also used elsewhere in a writable context, its own members can remain settable — see below.
+
+### Setter Availability Is a Separate, Type-Wide Decision
+
+Whether a shared model or resource *type* exposes setters at all is decided once for the whole TypeSpec graph, not per occurrence, by a settable-usage propagation ("dye") algorithm (`collectReachableTypes` in `provisioning-code-model.ts`, surfaced to the C# generator via `ProvisioningInputLibrary.IsModelSettable`):
+
+1. Seed a BFS from every resource projection: `isSettable = true` for resources with a deployable (PUT) writable scope, `false` for read-only/`FromExisting`-only resources.
+2. Walk every reachable type — resource body models, nested model properties (read-only properties do not propagate the settable flag further), base/derived models, array/dictionary elements, unions, and additional-properties bags.
+3. Once a model is reached with `isSettable = true` from any path, its recorded usage becomes (and stays) `true` — the flag only ever turns on, never off.
+4. The resulting per-model boolean is baked into the code model (`modelSettableUsage`) and read back via `IsModelSettable(model)`; `ProvisioningModelProvider` (`_hasSettableUsage`) and `ProvisioningResourceProvider` (`_isSettableResource`) use it to decide, for every property that is not itself an output occurrence, whether to generate a setter.
+
+Because there is exactly one CLR type per TypeSpec model, this is necessarily an all-or-nothing decision for that type: if a model is ever used where it must be settable, the single generated class exposes the needed setters everywhere it appears — including when reached through an occurrence whose *enclosing* property is itself marked `isOutput`.
+
+### Why Full Per-Occurrence Nested Read-Only Accuracy Is Impossible Here
+
+"One shared CLR type per model" and "occurrence-accurate read-only nested members" cannot both hold at once. If a model is writable when reached from one resource's create body but purely server-populated when reached from another resource's read-only output, a single shared class cannot expose setters for the first case while being fully getter-only for the second — the property definitions live on the type, not on the reference site. Bicep itself can route around this by emitting distinct input and output schemas (or wrapper types) for what is conceptually the same shape, trading schema sharing for per-usage read-only accuracy. Doing the same in generated C# would mean generating multiple CLR types (or wrappers) per shared TypeSpec model depending on usage, which directly conflicts with the goal of honoring TypeSpec's model sharing with a single generated type per model.
+
+The generator intentionally preserves shared schema identity over per-occurrence nested read-only strictness. `isOutput` still correctly gates the specific occurrence where it is declared (its own getter-only API and runtime guard); it just cannot also force every nested member of a shared type to become read-only, because that type may be legitimately writable elsewhere.
+
+### This Applies Equally to Models and Resources
+
+Both `ProvisionableConstruct` (model) and `ProvisionableResource` (resource) generation follow the same rules: `isOutput` is computed per property occurrence, and both consult the same `modelSettableUsage` result to decide setter emission. A nested property remaining settable when reached through an output-marked resource property (e.g., a shared model referenced by both a writable resource body and a read-only resource's output) is expected behavior, not a resource-property regression. When reviewing generated diffs, check:
+- Whether the occurrence itself (the specific property slot) is correctly marked `isOutput` and getter-only.
+- Whether the referenced type is ever used in a settable context anywhere in the spec — if so, its own setters are expected to remain, regardless of the occurrence under review.
+
+`isOutput` describes the read-only state of one property slot; it is not a signal that everything reachable from that slot must also be read-only.


### PR DESCRIPTION
## Summary

Documents a design invariant of the TypeSpec-based provisioning generator (ng/packages/http-client-csharp-provisioning) that was previously implemented but not written down: how shared model/schema identity interacts with property-level output metadata and setter generation.

Specifically, the new design.md section (`## 9. Shared Model Semantics & Settability`) captures:

- The emitter preserves TypeSpec model/schema sharing — one generated CLR type per TypeSpec model, never cloned per occurrence.
- isOutput is occurrence-level metadata (set per property slot based on that property's own read-only state); it does not cascade into the properties of a referenced nested model or resource.
- Direct assignment to an output-marked occurrence is disallowed both by the generated getter-only API and by a runtime guard (BicepValue.Assign throws when _isOutput is set).
- Setter availability for a shared type is a separate, type-wide decision computed once for the whole graph by the settable-usage propagation (collectReachableTypes / modelSettableUsage) algorithm — if a type is ever used in a settable context anywhere, its single generated class exposes setters everywhere it appears.
- As a consequence, fully accurate per-occurrence nested read-only behavior is not achievable while preserving shared CLR schema identity (Bicep can do this only by emitting distinct input/output schemas, which the generator intentionally does not do).
- These semantics apply equally to models and resources; a nested setter surfacing through an output-marked occurrence is expected behavior, not a regression.

## Why document this now

This distinction (occurrence-level isOutput vs. type-wide setter availability) is easy to misread as a bug during PR review of generated code — e.g. seeing a settable nested property reached through a read-only resource output and assuming it's a regression. Writing it into the design doc gives reviewers and contributors a clear reference for why that's expected.

## Testing

Documentation-only change (design.md). No build, test, or generation changes were made.