### PR TITLE
Mark Machine Learning provisioning release as unreleased

### DIFF
--- a/sdk/machinelearningservices/Azure.Provisioning.MachineLearning/CHANGELOG.md
+++ b/sdk/machinelearningservices/Azure.Provisioning.MachineLearning/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (2026-07-27)
+## 1.0.0-beta.1 (Unreleased)
 
 ### Features Added
 


### PR DESCRIPTION
## Summary
- mark Azure.Provisioning.MachineLearning 1.0.0-beta.1 as unreleased
- block the release until #61453 is resolved

Fixes no issue; release is blocked by #61453.