### PR TITLE
Update currency parsing to include British pounds

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/FieldValue.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/FieldValue.cs
@@ -260,7 +260,7 @@ namespace Azure.AI.FormRecognizer.Models
             if (!_fieldValue.ValueNumber.HasValue)
             {
                 // Workaround for receipts that was never deleted and got shipped in 3.0.0 GA so we need to maintain
-                if (float.TryParse(_fieldValue.Text.TrimStart('$'), out float parsedFloat))
+                if (float.TryParse(_fieldValue.Text.TrimStart('$', '£'), out float parsedFloat))
                 {
                     return parsedFloat;
                 }


### PR DESCRIPTION
The AsFloat method only supports stripping dollars from the currency and does not support british pounds.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
