### PR TITLE
Fix sequential partitioned download finalization

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_e03c04e429"
+  "Tag": "net/storage/Azure.Storage.Blobs_d375d3a88b"
 }

--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_8a5262c858"
+  "Tag": "net/storage/Azure.Storage.Blobs_e03c04e429"
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -441,13 +441,14 @@ namespace Azure.Storage.Blobs
             foreach (Func<Task<Response<BlobDownloadStreamingResult>>> getResponse in allResponses)
             {
                 partitionChecksum.Clear();
-                await CopyToInternal(await getResponse().ConfigureAwait(false), destination, new(partitionChecksum, 0, _checksumSize), async, cancellationToken).ConfigureAwait(false);
+                long copied = await CopyToInternal(await getResponse().ConfigureAwait(false), destination, new(partitionChecksum, 0, _checksumSize), async, cancellationToken).ConfigureAwait(false);
                 if (UseMasterCrc)
                 {
                     StorageCrc64Composer.Compose(
                         (composedCrcBuf, 0L),
-                        (partitionChecksum, initialResponse.Value.Details.ContentRange.GetContentRangeLengthOrDefault()
-                            ?? initialResponse.Value.Details.ContentLength)
+                        //(partitionChecksum, initialResponse.Value.Details.ContentRange.GetContentRangeLengthOrDefault()
+                        //    ?? initialResponse.Value.Details.ContentLength)
+                        (partitionChecksum, copied)
                     ).AsSpan(0, Crc64Len).CopyTo(composedCrcBuf);
                 }
             }
@@ -492,7 +493,7 @@ namespace Azure.Storage.Blobs
             }
         }
 
-        private async Task CopyToInternal(
+        private async Task<long> CopyToInternal(
             Response<BlobDownloadStreamingResult> response,
             Stream destination,
             Memory<byte> checksumBuffer,
@@ -508,7 +509,7 @@ namespace Azure.Storage.Blobs
                 ? ChecksumCalculatingStream.GetReadStream(rawSource, hasher.AppendHash)
                 : rawSource;
 
-            await source.CopyToInternal(
+            long copied = await source.CopyToInternal(
                 destination,
                 async,
                 cancellationToken)
@@ -530,6 +531,8 @@ namespace Azure.Storage.Blobs
                     throw Errors.HashMismatchOnStreamedDownload(response.Value.Details.ContentRange);
                 }
             }
+
+            return copied;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -451,6 +451,8 @@ namespace Azure.Storage.Blobs
                     ).AsSpan(0, Crc64Len).CopyTo(composedCrcBuf);
                 }
             }
+            await FinalizeDownloadInternal(destination, composedCrcBuf?.AsMemory(0, Crc64Len) ?? default, async, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         private async Task HandleOneShotDownload(

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -446,8 +446,6 @@ namespace Azure.Storage.Blobs
                 {
                     StorageCrc64Composer.Compose(
                         (composedCrcBuf, 0L),
-                        //(partitionChecksum, initialResponse.Value.Details.ContentRange.GetContentRangeLengthOrDefault()
-                        //    ?? initialResponse.Value.Details.ContentLength)
                         (partitionChecksum, copied)
                     ).AsSpan(0, Crc64Len).CopyTo(composedCrcBuf);
                 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TransferValidationTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TransferValidationTestBase.cs
@@ -1261,7 +1261,7 @@ namespace Azure.Storage.Test.Shared
         [Test, Combinatorial]
         public virtual async Task ParallelDownloadSuccessfulHashVerification(
             [ValueSource(nameof(GetValidationAlgorithms))] StorageChecksumAlgorithm algorithm,
-            [Values(512, 2 * Constants.KB)] int chunkSize)
+            [Values(512, 2 * Constants.KB, 123)] int chunkSize)
         {
             await using IDisposingContainer<TContainerClient> disposingContainer = await GetDisposingContainerAsync();
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/assets.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.DataLake",
-  "Tag": "net/storage/Azure.Storage.Files.DataLake_972c21694c"
+  "Tag": "net/storage/Azure.Storage.Files.DataLake_bd6bbff235"
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.Files.Shares_5d4acfe2f9"
+  "Tag": "net/storage/Azure.Storage.Files.Shares_5afad97c58"
 }


### PR DESCRIPTION
Restores missing function call to end of `SequentialDownloadToInternal()`. Call is already present in `ParallelDownloadToAsync()`. This call is necessary for validating the composed CRC of the download as well as flushing the decryption stream.

Calling this API was already caught by existing tests, but those tests were live-only. CI did not catch them.