### PR TITLE
Update Azure.ResourceManager.ComputeFleet 1.1.0-beta.3 changelog

### DIFF
--- a/sdk/computefleet/Azure.ResourceManager.ComputeFleet/CHANGELOG.md
+++ b/sdk/computefleet/Azure.ResourceManager.ComputeFleet/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.0-beta.3 (Unreleased)
+## 1.1.0-beta.3 (2026-08-01)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added `VmSize`, `Zone`, and `Priority` properties to `ComputeFleetVirtualMachine`.
 
 ## 1.1.0-beta.2 (2026-06-18)
 


### PR DESCRIPTION
Sets the release date (2026-08-01) and content for the 1.1.0-beta.3 changelog entry (API version 2026-06-01-preview), fixing the release pipeline error about missing release date and empty sections, to unblock release readiness for release plan 35313.