### PR TITLE
fix: use public npm ado artifact registry for tsp-client install

### DIFF
--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -1,5 +1,5 @@
 <Project>
-  
+
   <PropertyGroup>
     <TypeSpecInput Condition="Exists('$(MSBuildProjectDirectory)/../tsp-location.yaml') and $(MSBuildProjectDirectory.EndsWith('src'))">$(MSBuildProjectDirectory)/../tsp-location.yaml</TypeSpecInput>
     <_TspClientDir>$(MSBuildThisFileDirectory)common/tsp-client</_TspClientDir>
@@ -18,7 +18,7 @@
    <!-- For projects using the new TypeSpec generator, we don't include the Autorest dependency which pulls in the GenerateCode target.
    So we need to add it here. -->
   <Target Name="InstallTspClient" Condition="'$(TypeSpecInput)' != '' AND '$(SkipTspClientInstall)' != 'true'">
-    <Exec Command="npm ci --prefix $(_TspClientDir)" />
+    <Exec Command="npm ci --prefix $(_TspClientDir) --registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/" />
   </Target>
 
   <Target Name="BuildPlugin" Condition="'$(TypeSpecInput)' != '' AND '$(SkipBuildPlugin)' != 'true'">
@@ -32,14 +32,3 @@
   </Target>
 
 </Project>
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This PR fixes an issue when running the generation target on local dev machines:

```
PS C:\Users\jorgerangel\Development\AzureSdk\azure-sdk-for-net\sdk\appconfiguration\Azure.Data.AppConfiguration> dotnet build .\src\ /t:GenerateCode /p:Trace=true --verbosity diagnostic
Restore complete (1.8s)
    Determining projects to restore...
    All projects are up-to-date for restore.
  Azure.Data.AppConfiguration failed with 1 error(s) (105.0s)
    npm warn cleanup Failed to remove some directories [
    npm warn cleanup   [
    npm warn cleanup     '\\\\?\\C:\\Users\\jorgerangel\\Development\\AzureSdk\\azure-sdk-for-net\\eng\\common\\tsp-client\\node_modules\\@azure-tools',
    npm warn cleanup     [Error: EPERM: operation not permitted, rmdir 'C:\Users\jorgerangel\Development\AzureSdk\azure-sdk-for-net\eng\common\tsp-client\node_modules\@azure-tools\typespec-azure-core\dist\src\decorators'] {
    npm warn cleanup       errno: -4048,
    npm warn cleanup       code: 'EPERM',
    npm warn cleanup       syscall: 'rmdir',
    npm warn cleanup       path: 'C:\\Users\\jorgerangel\\Development\\AzureSdk\\azure-sdk-for-net\\eng\\common\\tsp-client\\node_modules\\@azure-tools\\typespec-azure-core\\dist\\src\\decorators'
    npm warn cleanup     }
    npm warn cleanup   ],
    npm warn cleanup   [
    npm warn cleanup     '\\\\?\\C:\\Users\\jorgerangel\\Development\\AzureSdk\\azure-sdk-for-net\\eng\\common\\tsp-client\\node_modules\\@typespec',
    npm warn cleanup     [Error: EPERM: operation not permitted, rmdir 'C:\Users\jorgerangel\Development\AzureSdk\azure-sdk-for-net\eng\common\tsp-client\node_modules\@typespec\compiler\dist\src\server'] {
    npm warn cleanup       errno: -4048,
    npm warn cleanup       code: 'EPERM',
    npm warn cleanup       syscall: 'rmdir',
    npm warn cleanup       path: 'C:\\Users\\jorgerangel\\Development\\AzureSdk\\azure-sdk-for-net\\eng\\common\\tsp-client\\node_modules\\@typespec\\compiler\\dist\\src\\server'
    npm warn cleanup     }
    npm warn cleanup   ],
    npm warn cleanup   [
    npm warn cleanup     '\\\\?\\C:\\Users\\jorgerangel\\Development\\AzureSdk\\azure-sdk-for-net\\eng\\common\\tsp-client\\node_modules\\@typespec\\compiler',
    npm warn cleanup     [Error: EPERM: operation not permitted, rmdir 'C:\Users\jorgerangel\Development\AzureSdk\azure-sdk-for-net\eng\common\tsp-client\node_modules\@typespec\compiler\templates\__snapshots__\library-ts\src'] {
    npm warn cleanup       errno: -4048,
    npm warn cleanup       code: 'EPERM',
    npm warn cleanup       syscall: 'rmdir',
    npm warn cleanup       path: 'C:\\Users\\jorgerangel\\Development\\AzureSdk\\azure-sdk-for-net\\eng\\common\\tsp-client\\node_modules\\@typespec\\compiler\\templates\\__snapshots__\\library-ts\\src'
    npm warn cleanup     }
    npm warn cleanup   ]
    npm warn cleanup ]
    npm error code ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE
    npm error errno ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE
    npm error request to https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz failed, reason: 8C220000:error:0A000410:SSL routines:ssl3_read_bytes:ssl/tls alert handshake failure:openssl\ssl\record\rec_layer_s3.c:918:SSL alert number 40
    npm error
    npm error A complete log of this run can be found in: C:\Users\jorgerangel\AppData\Local\npm-cache\_logs\2026-07-28T18_54_49_729Z-debug-0.log
```