### PR TITLE
[Core] Log only the bytes read for response content

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where response content logging could emit more bytes than were actually read when a non-buffered (streaming) response was read into a buffer larger than the response body. Previously, when the read began at offset 0, the entire caller-supplied buffer was logged — including the bytes past the response payload, which for a pooled buffer contain unrelated in-process content — and the configured `LoggedContentSizeLimit` was not applied. The logging policy now logs only the bytes that were read. ([#61399](https://github.com/Azure/azure-sdk-for-net/issues/61399))
 - Fixed an issue where `RequestFailedException` could throw a secondary `ArgumentNullException` while formatting a failed response that had a text content-type header but an empty body, masking the actual service failure. The exception now preserves the original HTTP status, reason phrase, and headers, and no longer formats empty response content.
 - Fixed `AzureCliCredential` to not pass both `--tenant` and `--subscription` flags to the Azure CLI, as the CLI rejects this combination. When a tenant is requested (for example, via challenge-based authentication) it now takes precedence and `--subscription` is omitted; `--subscription` is used only when no tenant is requested. ([#58949](https://github.com/Azure/azure-sdk-for-net/issues/58949))
 

--- a/sdk/core/Azure.Core/src/Diagnostics/AzureCoreEventSource.cs
+++ b/sdk/core/Azure.Core/src/Diagnostics/AzureCoreEventSource.cs
@@ -155,6 +155,22 @@ namespace Azure.Core.Diagnostics
             }
         }
 
+        [NonEvent]
+        public void ResponseContentBlock(string requestId, int blockNumber, byte[] content, int offset, int count, Encoding? textEncoding)
+        {
+            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            {
+                if (textEncoding is not null)
+                {
+                    ResponseContentTextBlock(requestId, blockNumber, textEncoding.GetString(content, offset, count));
+                }
+                else
+                {
+                    ResponseContentBlock(requestId, blockNumber, ToExactSizedArray(content, offset, count));
+                }
+            }
+        }
+
         [Event(ResponseContentBlockEvent, Level = EventLevel.Verbose, Message = "Response [{0}] content block {1}: {2}")]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with an array with primitive type elements.")]
         public void ResponseContentBlock(string requestId, int blockNumber, byte[] content)
@@ -228,6 +244,43 @@ namespace Azure.Core.Diagnostics
                     ErrorResponseContentBlock(requestId, blockNumber, content);
                 }
             }
+        }
+
+        [NonEvent]
+        public void ErrorResponseContentBlock(string requestId, int blockNumber, byte[] content, int offset, int count, Encoding? textEncoding)
+        {
+            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
+            {
+                if (textEncoding is not null)
+                {
+                    ErrorResponseContentTextBlock(requestId, blockNumber, textEncoding.GetString(content, offset, count));
+                }
+                else
+                {
+                    ErrorResponseContentBlock(requestId, blockNumber, ToExactSizedArray(content, offset, count));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copies the slice that was actually read into an array whose length is exactly the
+        /// payload length. The binary content events serialize the entire array they are given,
+        /// so passing the caller's buffer directly would publish its unwritten remainder - which,
+        /// for buffers rented from <see cref="System.Buffers.ArrayPool{T}"/>, is unrelated recycled
+        /// content. See https://github.com/Azure/azure-sdk-for-net/issues/61399.
+        /// </summary>
+        [NonEvent]
+        private static byte[] ToExactSizedArray(byte[] content, int offset, int count)
+        {
+            // The array is only safe to pass through when it provably holds nothing but the payload.
+            if (offset == 0 && content.Length == count)
+            {
+                return content;
+            }
+
+            byte[] bytes = new byte[count];
+            Array.Copy(content, offset, bytes, 0, count);
+            return bytes;
         }
 
         [Event(ErrorResponseContentBlockEvent, Level = EventLevel.Informational, Message = "Error response [{0}] content block {1}: {2}")]

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/LoggingPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/LoggingPolicy.cs
@@ -267,7 +267,7 @@ namespace Azure.Core.Pipeline
                 Log(requestId, eventType, bytes, textEncoding);
             }
 
-            public void Log(string requestId, bool isError, byte[] buffer, int offset, int length, Encoding? textEncoding, int? block = null)
+            public void Log(string requestId, bool isError, byte[] buffer, int offset, int length, Encoding? textEncoding, int block)
             {
                 EventType eventType = ResponseOrError(isError);
 
@@ -278,18 +278,11 @@ namespace Azure.Core.Pipeline
 
                 var logLength = Math.Min(length, _maxLength);
 
-                byte[] bytes;
-                if (length == logLength && offset == 0)
-                {
-                    bytes = buffer;
-                }
-                else
-                {
-                    bytes = new byte[logLength];
-                    Array.Copy(buffer, offset, bytes, 0, logLength);
-                }
-
-                Log(requestId, eventType, bytes, textEncoding, block);
+                // Forward the slice that was actually read rather than the caller's whole buffer.
+                // Aliasing the buffer here published its unwritten remainder, which for pooled
+                // buffers is unrelated recycled content, and also defeated _maxLength.
+                // See https://github.com/Azure/azure-sdk-for-net/issues/61399.
+                Log(requestId, eventType, buffer, offset, logLength, textEncoding, block);
             }
 
             public bool IsEnabled(bool isError)
@@ -364,6 +357,27 @@ namespace Azure.Core.Pipeline
                         break;
                     case EventType.ErrorResponse:
                         azureCoreEventSource.ErrorResponseContent(requestId, bytes, textEncoding);
+                        break;
+                }
+            }
+
+            private void Log(string requestId, EventType eventType, byte[] buffer, int offset, int count, Encoding? textEncoding, int block)
+            {
+                // We checked IsEnabled before we got here
+                Debug.Assert(_eventSource != null);
+                AzureCoreEventSource azureCoreEventSource = _eventSource!;
+
+                // ResponseOrError never yields EventType.Request, so only the response cases apply here.
+                Debug.Assert(eventType != EventType.Request);
+
+                switch (eventType)
+                {
+                    case EventType.Response:
+                        azureCoreEventSource.ResponseContentBlock(requestId, block, buffer, offset, count, textEncoding);
+                        break;
+
+                    case EventType.ErrorResponse:
+                        azureCoreEventSource.ErrorResponseContentBlock(requestId, block, buffer, offset, count, textEncoding);
                         break;
                 }
             }

--- a/sdk/core/Azure.Core/tests/EventSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/EventSourceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
@@ -546,6 +547,119 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public async Task ResponseContentBlockIsNotPaddedWhenReadAtOffsetZero()
+        {
+            Response response = await SendRequestReadingFromOffsetZero(isError: false);
+
+            EventWrittenEventArgs[] contentEvents = _listener.EventsById(ResponseContentBlockEvent).ToArray();
+
+            Assert.AreEqual(1, contentEvents.Length);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), contentEvents[0].GetProperty<byte[]>("content"));
+        }
+
+        [Test]
+        public async Task ErrorResponseContentBlockIsNotPaddedWhenReadAtOffsetZero()
+        {
+            Response response = await SendRequestReadingFromOffsetZero(isError: true);
+
+            EventWrittenEventArgs[] contentEvents = _listener.EventsById(ErrorResponseContentBlockEvent).ToArray();
+
+            Assert.AreEqual(1, contentEvents.Length);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), contentEvents[0].GetProperty<byte[]>("content"));
+        }
+
+        [Test]
+        public async Task ResponseContentTextBlockIsNotPaddedWhenReadAtOffsetZero()
+        {
+            Response response = await SendRequestReadingFromOffsetZero(
+                isError: false,
+                mockResponse => mockResponse.AddHeader(new HttpHeader("Content-Type", "text/xml"))
+            );
+
+            EventWrittenEventArgs[] contentEvents = _listener.EventsById(ResponseContentTextBlockEvent).ToArray();
+
+            Assert.AreEqual(1, contentEvents.Length);
+            Assert.AreEqual("Hello world", contentEvents[0].GetProperty<string>("content"));
+        }
+
+        [Test]
+        public async Task ErrorResponseContentTextBlockIsNotPaddedWhenReadAtOffsetZero()
+        {
+            Response response = await SendRequestReadingFromOffsetZero(
+                isError: true,
+                mockResponse => mockResponse.AddHeader(new HttpHeader("Content-Type", "text/xml"))
+            );
+
+            EventWrittenEventArgs[] contentEvents = _listener.EventsById(ErrorResponseContentTextBlockEvent).ToArray();
+
+            Assert.AreEqual(1, contentEvents.Length);
+            Assert.AreEqual("Hello world", contentEvents[0].GetProperty<string>("content"));
+        }
+
+        [Test]
+        public async Task ResponseContentTextBlockIsTruncatedWhenReadAtOffsetZero()
+        {
+            Response response = await SendRequestReadingFromOffsetZero(
+                isError: false,
+                mockResponse => mockResponse.AddHeader(new HttpHeader("Content-Type", "text/xml")),
+                maxLength: 5
+            );
+
+            EventWrittenEventArgs[] contentEvents = _listener.EventsById(ResponseContentTextBlockEvent).ToArray();
+
+            Assert.AreEqual(1, contentEvents.Length);
+            Assert.AreEqual("Hello", contentEvents[0].GetProperty<string>("content"));
+        }
+
+        [Test]
+        public async Task ResponseContentBlockIsTruncatedWhenReadAtOffsetZero()
+        {
+            Response response = await SendRequestReadingFromOffsetZero(isError: false, maxLength: 5);
+
+            EventWrittenEventArgs[] contentEvents = _listener.EventsById(ResponseContentBlockEvent).ToArray();
+
+            Assert.AreEqual(1, contentEvents.Length);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello"), contentEvents[0].GetProperty<byte[]>("content"));
+        }
+
+        [Test]
+        public async Task ErrorResponseContentIsNotPaddedWhenBufferedByRequestFailedException()
+        {
+            // Poison the pool bucket that Stream.CopyTo rents from so that any bytes leaked
+            // past the end of the response body are recognizable.
+            byte[] poison = ArrayPool<byte>.Shared.Rent(81920);
+            poison.AsSpan().Fill((byte)'Z');
+            ArrayPool<byte>.Shared.Return(poison);
+
+            var mockResponse = new MockResponse(500);
+            mockResponse.AddHeader(new HttpHeader("Content-Type", "text/xml"));
+            mockResponse.ContentStream = new NonSeekableMemoryStream(Encoding.UTF8.GetBytes("<Error/>"));
+
+            // ExpectSyncPipeline is deliberately left unset so the content stream is not wrapped in
+            // AsyncValidatingStream: RequestFailedException buffers the body from its constructor,
+            // which is necessarily a synchronous read even on the async pipeline.
+            var mockTransport = new MockTransport(mockResponse);
+            var pipeline = new HttpPipeline(mockTransport, new[] { new LoggingPolicy(logContent: true, int.MaxValue, _sanitizer, "Test-SDK") });
+
+            Response response = await SendRequestAsync(pipeline, request =>
+            {
+                request.Method = RequestMethod.Get;
+                request.Uri.Reset(new Uri("https://contoso.a.io"));
+            },
+            bufferResponse: false);
+
+            // This is the code path Azure.Core itself takes for a failed non-buffered request:
+            // the exception constructor buffers the content stream using Stream.CopyTo, which
+            // rents an 81920-byte array from the shared pool and reads into it at offset 0.
+            _ = new RequestFailedException(response);
+
+            EventWrittenEventArgs[] contentEvents = _listener.EventsById(ErrorResponseContentTextBlockEvent).ToArray();
+
+            Assert.AreEqual(1, contentEvents.Length);
+            Assert.AreEqual("<Error/>", contentEvents[0].GetProperty<string>("content"));
+        }
+
+        [Test]
         public async Task HeadersAndQueryParametersAreSanitized()
         {
             var response = new MockResponse(200);
@@ -675,6 +789,41 @@ namespace Azure.Core.Tests
                 Assert.AreEqual(5, response.ContentStream.Read(buffer, 6, 5));
                 Assert.AreEqual(0, response.ContentStream.Read(buffer, 0, 5));
             }
+
+            return mockResponse;
+        }
+
+        private async Task<Response> SendRequestReadingFromOffsetZero(
+            bool isError,
+            Action<MockResponse> setupRequest = null,
+            int maxLength = int.MaxValue)
+        {
+            var mockResponse = new MockResponse(isError ? 500 : 200);
+            mockResponse.ContentStream = new NonSeekableMemoryStream(Encoding.UTF8.GetBytes("Hello world"));
+            setupRequest?.Invoke(mockResponse);
+
+            MockTransport mockTransport = CreateMockTransport(mockResponse);
+            var pipeline = new HttpPipeline(mockTransport, new[] { new LoggingPolicy(logContent: true, maxLength, _sanitizer, "Test-SDK") });
+
+            Response response = await SendRequestAsync(pipeline, request =>
+            {
+                request.Method = RequestMethod.Get;
+                request.Uri.Reset(new Uri("https://contoso.a.io"));
+            },
+            bufferResponse: false);
+
+            // Read the whole body in a single call starting at offset 0, into a buffer that is
+            // much larger than the body and pre-filled with recognizable bytes. This mirrors what
+            // Stream.CopyTo and the base Stream.ReadAsync(Memory<byte>) overload do with buffers
+            // rented from ArrayPool, where the tail holds unrelated recycled content.
+            byte[] buffer = new byte[1024];
+            buffer.AsSpan().Fill(0xAA);
+
+            int read = IsAsync
+                ? await response.ContentStream.ReadAsync(buffer, 0, buffer.Length)
+                : response.ContentStream.Read(buffer, 0, buffer.Length);
+
+            Assert.AreEqual(11, read);
 
             return mockResponse;
         }

--- a/sdk/core/Azure.Core/tests/EventSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Buffers;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
@@ -625,12 +624,6 @@ namespace Azure.Core.Tests
         [Test]
         public async Task ErrorResponseContentIsNotPaddedWhenBufferedByRequestFailedException()
         {
-            // Poison the pool bucket that Stream.CopyTo rents from so that any bytes leaked
-            // past the end of the response body are recognizable.
-            byte[] poison = ArrayPool<byte>.Shared.Rent(81920);
-            poison.AsSpan().Fill((byte)'Z');
-            ArrayPool<byte>.Shared.Return(poison);
-
             var mockResponse = new MockResponse(500);
             mockResponse.AddHeader(new HttpHeader("Content-Type", "text/xml"));
             mockResponse.ContentStream = new NonSeekableMemoryStream(Encoding.UTF8.GetBytes("<Error/>"));
@@ -656,7 +649,13 @@ namespace Azure.Core.Tests
             EventWrittenEventArgs[] contentEvents = _listener.EventsById(ErrorResponseContentTextBlockEvent).ToArray();
 
             Assert.AreEqual(1, contentEvents.Length);
-            Assert.AreEqual("<Error/>", contentEvents[0].GetProperty<string>("content"));
+
+            // Assert on length before content: when the rented buffer is forwarded whole, the logged
+            // value is the full pool bucket (131,072 characters for a Rent(81920)), and comparing that
+            // against the expected string produces an unreadable failure message.
+            string content = contentEvents[0].GetProperty<string>("content");
+            Assert.AreEqual("<Error/>".Length, content.Length, "The logged content must not extend past the bytes actually read.");
+            Assert.AreEqual("<Error/>", content);
         }
 
         [Test]

--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where response content logging could emit more bytes than were actually read when a non-buffered (streaming) response was read into a buffer larger than the response body. Previously, when the read began at offset 0, `MessageLoggingPolicy` logged the entire caller-supplied buffer — including the bytes past the response payload, which for a pooled buffer contain unrelated in-process content — and the configured `MessageContentSizeLimit` was not applied. Only the bytes that were read are now logged. ([#61399](https://github.com/Azure/azure-sdk-for-net/issues/61399))
+
 ### Other Changes
 
 ## 1.14.0 (2026-06-03)

--- a/sdk/core/System.ClientModel/src/Internal/Logging/ClientModelEventSource.cs
+++ b/sdk/core/System.ClientModel/src/Internal/Logging/ClientModelEventSource.cs
@@ -129,6 +129,22 @@ internal sealed class ClientModelEventSource : EventSource
         }
     }
 
+    [NonEvent]
+    public void ResponseContentBlock(string requestId, int blockNumber, byte[] content, int offset, int count, Encoding? textEncoding)
+    {
+        if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+        {
+            if (textEncoding is not null)
+            {
+                ResponseContentTextBlock(requestId, blockNumber, textEncoding.GetString(content, offset, count));
+            }
+            else
+            {
+                ResponseContentBlock(requestId, blockNumber, ToExactSizedArray(content, offset, count));
+            }
+        }
+    }
+
     [Event(LoggingEventIds.ResponseContentBlockEvent, Level = EventLevel.Verbose, Message = "Response [{0}] content block {1}: {2}")]
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with an array with primitive type elements.")]
     private void ResponseContentBlock(string? requestId, int blockNumber, byte[] content)
@@ -206,6 +222,42 @@ internal sealed class ClientModelEventSource : EventSource
                 ErrorResponseContentBlock(requestId, blockNumber, content);
             }
         }
+    }
+
+    [NonEvent]
+    public void ErrorResponseContentBlock(string requestId, int blockNumber, byte[] content, int offset, int count, Encoding? textEncoding)
+    {
+        if (IsEnabled(EventLevel.Informational, EventKeywords.None))
+        {
+            if (textEncoding is not null)
+            {
+                ErrorResponseContentTextBlock(requestId, blockNumber, textEncoding.GetString(content, offset, count));
+            }
+            else
+            {
+                ErrorResponseContentBlock(requestId, blockNumber, ToExactSizedArray(content, offset, count));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Copies a slice of <paramref name="content"/> into an array whose length is exactly
+    /// <paramref name="count"/>. The binary events serialize the full length of the array they are
+    /// given, so passing the caller's buffer directly would publish the bytes past the payload —
+    /// which, for a pooled buffer, is unrelated in-process content.
+    /// See https://github.com/Azure/azure-sdk-for-net/issues/61399.
+    /// </summary>
+    [NonEvent]
+    private static byte[] ToExactSizedArray(byte[] content, int offset, int count)
+    {
+        if (offset == 0 && content.Length == count)
+        {
+            return content;
+        }
+
+        byte[] bytes = new byte[count];
+        Array.Copy(content, offset, bytes, 0, count);
+        return bytes;
     }
 
     [Event(LoggingEventIds.ErrorResponseContentBlockEvent, Level = EventLevel.Informational, Message = "Error response [{0}] content block {1}: {2}")]

--- a/sdk/core/System.ClientModel/src/Internal/Logging/PipelineMessageLogger.cs
+++ b/sdk/core/System.ClientModel/src/Internal/Logging/PipelineMessageLogger.cs
@@ -153,6 +153,28 @@ internal partial class PipelineMessageLogger
         }
     }
 
+    public void LogResponseContentBlock(string requestId, int blockNumber, byte[] content, int offset, int count, Encoding? textEncoding)
+    {
+        if (_logger is not null)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                if (textEncoding != null)
+                {
+                    ResponseContentTextBlock(_logger, requestId, blockNumber, textEncoding.GetString(content, offset, count));
+                }
+                else
+                {
+                    ResponseContentBlock(_logger, requestId, blockNumber, ToExactSizedArray(content, offset, count));
+                }
+            }
+        }
+        else
+        {
+            ClientModelEventSource.Log.ResponseContentBlock(requestId, blockNumber, content, offset, count, textEncoding);
+        }
+    }
+
     [LoggerMessage(LoggingEventIds.ResponseContentBlockEvent, LogLevel.Debug, "Response [{requestId}] content block {blockNumber}: {content}", SkipEnabledCheck = true, EventName = "ResponseContentBlock")]
     private static partial void ResponseContentBlock(ILogger logger, string requestId, int blockNumber, byte[] content);
 
@@ -229,6 +251,47 @@ internal partial class PipelineMessageLogger
         {
             ClientModelEventSource.Log.ErrorResponseContentBlock(requestId, blockNumber, content, textEncoding);
         }
+    }
+
+    public void LogErrorResponseContentBlock(string requestId, int blockNumber, byte[] content, int offset, int count, Encoding? textEncoding)
+    {
+        if (_logger is not null)
+        {
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                if (textEncoding != null)
+                {
+                    ErrorResponseContentTextBlock(_logger, requestId, blockNumber, textEncoding.GetString(content, offset, count));
+                }
+                else
+                {
+                    ErrorResponseContentBlock(_logger, requestId, blockNumber, ToExactSizedArray(content, offset, count));
+                }
+            }
+        }
+        else
+        {
+            ClientModelEventSource.Log.ErrorResponseContentBlock(requestId, blockNumber, content, offset, count, textEncoding);
+        }
+    }
+
+    /// <summary>
+    /// Copies a slice of <paramref name="content"/> into an array whose length is exactly
+    /// <paramref name="count"/>. The <c>byte[]</c> log values are rendered in full, so passing the
+    /// caller's buffer directly would publish the bytes past the payload — which, for a pooled
+    /// buffer, is unrelated in-process content.
+    /// See https://github.com/Azure/azure-sdk-for-net/issues/61399.
+    /// </summary>
+    private static byte[] ToExactSizedArray(byte[] content, int offset, int count)
+    {
+        if (offset == 0 && content.Length == count)
+        {
+            return content;
+        }
+
+        byte[] bytes = new byte[count];
+        Array.Copy(content, offset, bytes, 0, count);
+        return bytes;
     }
 
     [LoggerMessage(LoggingEventIds.ErrorResponseContentBlockEvent, LogLevel.Information, "Error response [{requestId}] content block {blockNumber}: {content}", SkipEnabledCheck = true, EventName = "ErrorResponseContentBlock")]

--- a/sdk/core/System.ClientModel/src/Pipeline/MessageLoggingPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/MessageLoggingPolicy.cs
@@ -352,24 +352,17 @@ public class MessageLoggingPolicy : PipelinePolicy
                 return;
             }
 
-            byte[] bytes;
-            if (bytesToLog == numBytesReadIntoBuffer && offset == 0)
-            {
-                bytes = buffer;
-            }
-            else
-            {
-                bytes = new byte[bytesToLog];
-                Buffer.BlockCopy(buffer, offset, bytes, 0, bytesToLog);
-            }
-
+            // The buffer is owned by the caller and is frequently larger than the payload -- often a
+            // pooled array whose remainder holds unrelated in-process content. Only the slice that
+            // was actually read may be logged.
+            // See https://github.com/Azure/azure-sdk-for-net/issues/61399.
             if (_error)
             {
-                _messageLogger.LogErrorResponseContentBlock(_requestId, _blockNumber, bytes, _textEncoding);
+                _messageLogger.LogErrorResponseContentBlock(_requestId, _blockNumber, buffer, offset, bytesToLog, _textEncoding);
             }
             else
             {
-                _messageLogger.LogResponseContentBlock(_requestId, _blockNumber, bytes, _textEncoding);
+                _messageLogger.LogResponseContentBlock(_requestId, _blockNumber, buffer, offset, bytesToLog, _textEncoding);
             }
 
             _blockNumber++;

--- a/sdk/core/System.ClientModel/tests/Pipeline/MessageLoggingPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/MessageLoggingPolicyTests.cs
@@ -532,7 +532,180 @@ public class MessageLoggingPolicyTests(bool isAsync) : SyncAsyncTestBase(isAsync
         Assert.AreEqual(Encoding.UTF8.GetBytes("Hello"), responseEvent.GetValueFromArguments<byte[]>("content"));
     }
 
+    [Test]
+    public async Task ResponseContentBlockIsNotPaddedWhenReadAtOffsetZeroEventSource()
+    {
+        using TestClientEventListener listener = new();
+        ClientLoggingOptions loggingOptions = new() { EnableMessageContentLogging = true };
+        MockPipelineResponse response = new(200, mockHeaders: _defaultHeaders);
+
+        await SendRequestReadingFromOffsetZero(response, loggingOptions);
+
+        EventWrittenEventArgs responseEvent = listener.GetAndValidateSingleEvent(ResponseContentBlockEvent, "ResponseContentBlock", EventLevel.Verbose, SystemClientModelEventSourceName);
+        Assert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), responseEvent.GetProperty<byte[]>("content"));
+    }
+
+    [Test]
+    public async Task ErrorResponseContentBlockIsNotPaddedWhenReadAtOffsetZeroEventSource()
+    {
+        using TestClientEventListener listener = new();
+        ClientLoggingOptions loggingOptions = new() { EnableMessageContentLogging = true };
+        MockPipelineResponse response = new(500, mockHeaders: _defaultHeaders);
+
+        await SendRequestReadingFromOffsetZero(response, loggingOptions);
+
+        EventWrittenEventArgs responseEvent = listener.GetAndValidateSingleEvent(ErrorResponseContentBlockEvent, "ErrorResponseContentBlock", EventLevel.Informational, SystemClientModelEventSourceName);
+        Assert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), responseEvent.GetProperty<byte[]>("content"));
+    }
+
+    [Test]
+    public async Task ResponseContentTextBlockIsNotPaddedWhenReadAtOffsetZeroEventSource()
+    {
+        using TestClientEventListener listener = new();
+        ClientLoggingOptions loggingOptions = new() { EnableMessageContentLogging = true };
+        MockPipelineResponse response = new(200, mockHeaders: _defaultTextHeaders);
+
+        await SendRequestReadingFromOffsetZero(response, loggingOptions);
+
+        EventWrittenEventArgs responseEvent = listener.GetAndValidateSingleEvent(ResponseContentTextBlockEvent, "ResponseContentTextBlock", EventLevel.Verbose, SystemClientModelEventSourceName);
+        Assert.AreEqual("Hello world", responseEvent.GetProperty<string>("content"));
+    }
+
+    [Test]
+    public async Task ErrorResponseContentTextBlockIsNotPaddedWhenReadAtOffsetZeroEventSource()
+    {
+        using TestClientEventListener listener = new();
+        ClientLoggingOptions loggingOptions = new() { EnableMessageContentLogging = true };
+        MockPipelineResponse response = new(500, mockHeaders: _defaultTextHeaders);
+
+        await SendRequestReadingFromOffsetZero(response, loggingOptions);
+
+        EventWrittenEventArgs responseEvent = listener.GetAndValidateSingleEvent(ErrorResponseContentTextBlockEvent, "ErrorResponseContentTextBlock", EventLevel.Informational, SystemClientModelEventSourceName);
+        Assert.AreEqual("Hello world", responseEvent.GetProperty<string>("content"));
+    }
+
+    [Test]
+    public async Task ResponseContentBlockIsTruncatedWhenReadAtOffsetZeroEventSource()
+    {
+        using TestClientEventListener listener = new();
+        ClientLoggingOptions loggingOptions = new() { EnableMessageContentLogging = true, MessageContentSizeLimit = 5 };
+        MockPipelineResponse response = new(200, mockHeaders: _defaultHeaders);
+
+        await SendRequestReadingFromOffsetZero(response, loggingOptions);
+
+        EventWrittenEventArgs responseEvent = listener.GetAndValidateSingleEvent(ResponseContentBlockEvent, "ResponseContentBlock", EventLevel.Verbose, SystemClientModelEventSourceName);
+        Assert.AreEqual(Encoding.UTF8.GetBytes("Hello"), responseEvent.GetProperty<byte[]>("content"));
+    }
+
+    [Test]
+    public async Task ResponseContentBlockIsNotPaddedWhenReadAtOffsetZeroILogger()
+    {
+        using TestLoggingFactory factory = new(LogLevel.Debug);
+        ClientLoggingOptions loggingOptions = new()
+        {
+            EnableMessageContentLogging = true,
+            LoggerFactory = factory
+        };
+        MockPipelineResponse response = new(200, mockHeaders: _defaultHeaders);
+
+        await SendRequestReadingFromOffsetZero(response, loggingOptions);
+
+        TestLogger logger = factory.GetLogger(LoggingPolicyCategoryName);
+        LoggerEvent responseEvent = logger.GetAndValidateSingleEvent(ResponseContentBlockEvent, "ResponseContentBlock", LogLevel.Debug);
+        Assert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), responseEvent.GetValueFromArguments<byte[]>("content"));
+    }
+
+    [Test]
+    public async Task ResponseContentTextBlockIsNotPaddedWhenReadAtOffsetZeroILogger()
+    {
+        using TestLoggingFactory factory = new(LogLevel.Debug);
+        ClientLoggingOptions loggingOptions = new()
+        {
+            EnableMessageContentLogging = true,
+            LoggerFactory = factory
+        };
+        MockPipelineResponse response = new(200, mockHeaders: _defaultTextHeaders);
+
+        await SendRequestReadingFromOffsetZero(response, loggingOptions);
+
+        TestLogger logger = factory.GetLogger(LoggingPolicyCategoryName);
+        LoggerEvent responseEvent = logger.GetAndValidateSingleEvent(ResponseContentTextBlockEvent, "ResponseContentTextBlock", LogLevel.Debug);
+        Assert.AreEqual("Hello world", responseEvent.GetValueFromArguments<string>("content"));
+    }
+
+#if !NET462
+    [Test]
+    public async Task ResponseContentBlockIsNotPaddedWhenReadIntoMemoryAtOffsetZero()
+    {
+        using TestClientEventListener listener = new();
+        ClientLoggingOptions loggingOptions = new() { EnableMessageContentLogging = true };
+        MockPipelineResponse response = new(200, mockHeaders: _defaultHeaders);
+
+        await SendRequestReadingFromOffsetZero(response, loggingOptions, useMemoryOverload: true);
+
+        EventWrittenEventArgs responseEvent = listener.GetAndValidateSingleEvent(ResponseContentBlockEvent, "ResponseContentBlock", EventLevel.Verbose, SystemClientModelEventSourceName);
+        Assert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), responseEvent.GetProperty<byte[]>("content"));
+    }
+#endif
+
     #region Helpers
+
+    /// <summary>
+    /// Sends a request whose non-buffered response is read a single time at offset 0 into a buffer
+    /// that is much larger than the response body and pre-filled with a recognizable poison value,
+    /// mimicking a recycled <see cref="System.Buffers.ArrayPool{T}"/> array.
+    /// See https://github.com/Azure/azure-sdk-for-net/issues/61399.
+    /// </summary>
+    private async Task SendRequestReadingFromOffsetZero(MockPipelineResponse response,
+                                                        ClientLoggingOptions loggingOptions,
+                                                        bool useMemoryOverload = false)
+    {
+        response.ContentStream = new NonSeekableMemoryStream(Encoding.UTF8.GetBytes("Hello world"));
+
+        ClientPipelineOptions options = new()
+        {
+            Transport = new MockPipelineTransport("Transport", i => response),
+            ClientLoggingOptions = loggingOptions,
+            RetryPolicy = new ObservablePolicy("RetryPolicy")
+        };
+
+        ClientPipeline pipeline = ClientPipeline.Create(options);
+
+        PipelineMessage message = pipeline.CreateMessage();
+        message.Request.Method = "GET";
+        message.Request.Uri = new Uri("http://example.com");
+        message.BufferResponse = false;
+
+        await pipeline.SendSyncOrAsync(message, IsAsync);
+
+        byte[] buffer = new byte[1024];
+
+        for (int index = 0; index < buffer.Length; ++index)
+        {
+            buffer[index] = 0xAA;
+        }
+
+        int read;
+
+        if (useMemoryOverload)
+        {
+#if NET462
+            read = 0;
+#else
+            read = IsAsync
+                ? await response.ContentStream!.ReadAsync(buffer.AsMemory(0, buffer.Length))
+                : response.ContentStream!.Read(buffer.AsSpan(0, buffer.Length));
+#endif
+        }
+        else
+        {
+            read = IsAsync
+                ? await response.ContentStream!.ReadAsync(buffer, 0, buffer.Length)
+                : response.ContentStream!.Read(buffer, 0, buffer.Length);
+        }
+
+        Assert.AreEqual(11, read);
+    }
 
     private class TestEventListenerWarning : TestClientEventListener
     {

--- a/sdk/core/System.ClientModel/tests/internal/Internal/Logging/PipelineMessageLoggerTests.cs
+++ b/sdk/core/System.ClientModel/tests/internal/Internal/Logging/PipelineMessageLoggerTests.cs
@@ -106,6 +106,66 @@ public class PipelineMessageLoggerTests : SyncAsyncPolicyTestBase
     }
 
     [Test]
+    public void ContentBlockSlicesAreNotPaddedWhenLoggedToILogger()
+    {
+        using TestLoggingFactory factory = new(LogLevel.Debug);
+
+        PipelineMessageLogger messageLogger = new(new PipelineMessageSanitizer([], []), factory);
+
+        byte[] buffer = CreatePoisonedBufferContaining("Hello");
+
+        messageLogger.LogResponseContentBlock("requestId", 1, buffer, 0, 5, null);
+        messageLogger.LogResponseContentBlock("requestId", 2, buffer, 0, 5, Encoding.UTF8);
+        messageLogger.LogErrorResponseContentBlock("requestId", 1, buffer, 0, 5, null);
+        messageLogger.LogErrorResponseContentBlock("requestId", 2, buffer, 0, 5, Encoding.UTF8);
+
+        TestLogger logger = factory.GetLogger(LoggingPolicyCategoryName);
+
+        Assert.AreEqual("Hello"u8.ToArray(), logger.SingleEventById(ResponseContentBlockEvent).GetValueFromArguments<byte[]>("content"));
+        Assert.AreEqual("Hello", logger.SingleEventById(ResponseContentTextBlockEvent).GetValueFromArguments<string>("content"));
+        Assert.AreEqual("Hello"u8.ToArray(), logger.SingleEventById(ErrorResponseContentBlockEvent).GetValueFromArguments<byte[]>("content"));
+        Assert.AreEqual("Hello", logger.SingleEventById(ErrorResponseContentTextBlockEvent).GetValueFromArguments<string>("content"));
+    }
+
+    [Test]
+    public void ContentBlockSlicesAreNotPaddedWhenLoggedToEventSource()
+    {
+        using TestClientEventListener listener = new();
+
+        PipelineMessageLogger messageLogger = new(new PipelineMessageSanitizer([], []), null);
+
+        byte[] buffer = CreatePoisonedBufferContaining("Hello");
+
+        messageLogger.LogResponseContentBlock("requestId", 1, buffer, 0, 5, null);
+        messageLogger.LogResponseContentBlock("requestId", 2, buffer, 0, 5, Encoding.UTF8);
+        messageLogger.LogErrorResponseContentBlock("requestId", 1, buffer, 0, 5, null);
+        messageLogger.LogErrorResponseContentBlock("requestId", 2, buffer, 0, 5, Encoding.UTF8);
+
+        Assert.AreEqual("Hello"u8.ToArray(), listener.SingleEventById(ResponseContentBlockEvent).GetProperty<byte[]>("content"));
+        Assert.AreEqual("Hello", listener.SingleEventById(ResponseContentTextBlockEvent).GetProperty<string>("content"));
+        Assert.AreEqual("Hello"u8.ToArray(), listener.SingleEventById(ErrorResponseContentBlockEvent).GetProperty<byte[]>("content"));
+        Assert.AreEqual("Hello", listener.SingleEventById(ErrorResponseContentTextBlockEvent).GetProperty<string>("content"));
+    }
+
+    /// <summary>
+    /// Produces an oversized buffer whose leading bytes are <paramref name="content"/> and whose
+    /// remainder is a recognizable poison value, mimicking a recycled pooled array.
+    /// See https://github.com/Azure/azure-sdk-for-net/issues/61399.
+    /// </summary>
+    private static byte[] CreatePoisonedBufferContaining(string content)
+    {
+        byte[] buffer = new byte[1024];
+
+        for (int index = 0; index < buffer.Length; ++index)
+        {
+            buffer[index] = 0xAA;
+        }
+
+        Encoding.UTF8.GetBytes(content, 0, content.Length, buffer, 0);
+        return buffer;
+    }
+
+    [Test]
     public void LogsAreNotWrittenToEventSourceWhenILoggerIsProvidedAndLogLevelIsWarning()
     {
         using TestClientEventListener listener = new();


### PR DESCRIPTION
## Problem

`LoggingPolicy` in `Azure.Core` and `MessageLoggingPolicy` in `System.ClientModel` substituted the caller's entire read buffer for the slice that was actually read whenever a read began at offset 0:

```csharp
if (length == logLength && offset == 0)
{
    bytes = buffer;   // publishes the whole array, not just what was read
}
```

Everything past the end of the response body was then published to the log sink as if it were response content. For buffers rented from `ArrayPool<byte>`, which `Rent` does not clear, that remainder is unrelated recycled heap content from elsewhere in the process.

Two details are worth calling out, because they differ from the original report:

- **The two conditions are not independent defects.** `DecrementLength` already  clamps the count before `Log` is called, so `length == logLength` is always  true in practice. The only condition that actually gates the bug is  `offset == 0`.

- **The configured content size limit was not enforced at all** on this path.  The substitution happened *after* `LoggedContentSizeLimit` /  `MessageContentSizeLimit` was applied, so it replaced the truncated slice with  the full array. A configured limit of 5 bytes emitted 1024.

## This does not require a caller-supplied buffer

The reported scenario suggested an unusual calling pattern was needed. It isn't.  On the error path the leak occurs entirely within `Azure.Core`:

```
BufferResponse = false
  -> IsError -> throw new RequestFailedException(response)
  -> RequestFailedException.BufferResponseIfNeeded -> Stream.CopyTo
  -> ArrayPool<byte>.Shared.Rent(81920), read at offset 0
```

In test, an **8 byte** error body produced a **131,072 character** event, with the tail filled by content from a previously returned pooled array.

## Severity

Assessed as a correctness and information-hygiene defect, **not an exploitable vulnerability**, and handled as a normal bug rather than through MSRC:

- The disclosed bytes are process-local heap memory and the destination is the application's own log sink — both inside the same trust boundary.
- There is no attacker-controlled input to the leak.
- Reaching the data requires prior compromise, or access to logs that are already treated as sensitive.

Exposure under default configuration is zero: content logging is off by default in both libraries, and the default buffered-response path does not reach this code.

## Fix

Both policies now forward the `(buffer, offset, count)` that were actually read.

- **Text path is now allocation-free** — it formats directly from the buffer segment via `Encoding.GetString(byte[], int, int)` instead of allocating an intermediate array, making it cheaper than the previously *correct* branch.

- **Binary path** copies the exact-sized slice inside the event source, after the level check, so nothing is copied when the event is disabled. The copy is skipped entirely when the array provably holds nothing but the payload.

## Testing

Existing tests never covered this because both suites read at offsets 5 and 6, never at 0 — a pure coverage gap.  Regression tests were added for the offset 0 case across the binary, text, and `ILogger` sinks, for size-limit truncation, for `Stream.ReadAsync(Memory<byte>)`,and for the `RequestFailedException` buffering path. **Each was confirmed to
fail against the unfixed code**, for example:

```
Expected string length 8 but was 131072
Expected is <System.Byte[5]>, actual is <System.Byte[1024]>
```

Results after the fix:

| Suite | Result |
| --- | --- |
| `Azure.Core` `EventSourceTests` | 78 passed / 0 failed |
| `Azure.Core` full suite (net10.0, non-Live) | 8242 passed / 2 failed* |
| `System.ClientModel` full suite (net10.0, net9.0, net8.0, net462) | 2180 / 2180 / 2180 / 2178, 0 failed |
| `dotnet format --verify-no-changes` | no violations in changed files |

\* The two failures are `Identity.BrokerCredentialTests.GetToken_ExceptionType_MatchesExpected`, which are unrelated to logging and environment-dependent.

## API impact

Only `internal` and `private` members changed. No public API surface change, so no API listing regeneration and no ApiCompat impact.
