### PR TITLE
Require ApiCompat for previews of GA packages

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -25,20 +25,12 @@
     the version to be present for shipping client libraries with a prior stable release so that removal fails the build,
     including while preparing a new preview release.
 
-    A first GA (1.0.0) has no prior stable release to compare against, so ApiCompatVersion is legitimately absent there.
+    A first stable release has no prior stable release to compare against, so ApiCompatVersion is legitimately absent there.
     In the rare case the core team approves running without ApiCompat for an already-GA'd package, add the project name
     to eng/apicompatbaselines/ApiCompatVersionOptOut.txt, which is CODEOWNERS-protected and therefore requires core team review.
   -->
   <Target Name="ValidateApiCompatVersionPresent" BeforeTargets="Build"
-          Condition="'$(ValidateRunApiCompat)' == 'true' and '$(ApiCompatVersion)' == '' and '$(IsShippingClientLibrary)' == 'true' and '$(IncludeBuildOutput)' != 'false' and '$(_VersionInProject)' != '1.0.0'">
-    <PropertyGroup>
-      <_ApiCompatVersionRequired Condition="'$(HasReleaseVersion)' != 'false'">true</_ApiCompatVersionRequired>
-      <_ApiCompatChangelogPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'CHANGELOG.md'))</_ApiCompatChangelogPath>
-    </PropertyGroup>
-    <CheckApiCompatStableRelease ChangelogPath="$(_ApiCompatChangelogPath)"
-                                 Condition="'$(_ApiCompatVersionRequired)' != 'true' and Exists('$(_ApiCompatChangelogPath)')">
-      <Output TaskParameter="HasStableRelease" PropertyName="_ApiCompatHasStableRelease" />
-    </CheckApiCompatStableRelease>
+          Condition="'$(ValidateRunApiCompat)' == 'true' and '$(ApiCompatVersion)' == '' and '$(IsShippingClientLibrary)' == 'true' and '$(IncludeBuildOutput)' != 'false'">
     <ReadLinesFromFile File="$(MSBuildThisFileDirectory)apicompatbaselines\ApiCompatVersionOptOut.txt"
                        Condition="Exists('$(MSBuildThisFileDirectory)apicompatbaselines\ApiCompatVersionOptOut.txt')">
       <Output TaskParameter="Lines" ItemName="_ApiCompatVersionOptOutLine" />
@@ -48,9 +40,19 @@
                                     Condition="'%(Identity)' == '$(MSBuildProjectName)'" />
     </ItemGroup>
     <PropertyGroup>
-      <_ApiCompatVersionRequired Condition="'$(_ApiCompatHasStableRelease)' == 'true'">true</_ApiCompatVersionRequired>
+      <_ApiCompatChangelogPath>$(PackageRootDirectory)/CHANGELOG.md</_ApiCompatChangelogPath>
     </PropertyGroup>
-    <Error Condition="'$(_ApiCompatVersionRequired)' == 'true' and '@(_ApiCompatVersionOptOutMatch)' == ''"
+    <Error Condition="'@(_ApiCompatVersionOptOutMatch)' == '' and !Exists('$(_ApiCompatChangelogPath)')"
+           Text="ApiCompat validation cannot determine release history for $(MSBuildProjectName): CHANGELOG.md was not found at $(_ApiCompatChangelogPath)." />
+    <CheckApiCompatStableRelease ChangelogPath="$(_ApiCompatChangelogPath)"
+                                 CurrentVersion="$(_VersionInProject)"
+                                 Condition="'@(_ApiCompatVersionOptOutMatch)' == '' and Exists('$(_ApiCompatChangelogPath)')">
+      <Output TaskParameter="HasStableRelease" PropertyName="_ApiCompatHasStableRelease" />
+      <Output TaskParameter="ReadError" PropertyName="_ApiCompatChangelogReadError" />
+    </CheckApiCompatStableRelease>
+    <Error Condition="'@(_ApiCompatVersionOptOutMatch)' == '' and '$(_ApiCompatChangelogReadError)' != ''"
+           Text="ApiCompat validation could not read $(_ApiCompatChangelogPath): $(_ApiCompatChangelogReadError)" />
+    <Error Condition="'@(_ApiCompatVersionOptOutMatch)' == '' and '$(_ApiCompatHasStableRelease)' == 'true'"
            Text="ApiCompatVersion is missing from $(MSBuildProjectName). It is required for libraries with a prior stable release and is managed automatically by eng/scripts/Update-PkgVersion.ps1 - do not delete it. If the core team has approved shipping this package without ApiCompat, add '$(MSBuildProjectName)' to eng/apicompatbaselines/ApiCompatVersionOptOut.txt (CODEOWNERS-protected)." />
   </Target>
 
@@ -60,17 +62,31 @@
     AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <ChangelogPath ParameterType="System.String" Required="true" />
+      <CurrentVersion ParameterType="System.String" Required="true" />
       <HasStableRelease ParameterType="System.Boolean" Output="true" />
+      <ReadError ParameterType="System.String" Output="true" />
     </ParameterGroup>
     <Task>
       <Code Type="Fragment" Language="cs"><![CDATA[
-        foreach (string line in System.IO.File.ReadLines(ChangelogPath))
+        try
         {
-          if (System.Text.RegularExpressions.Regex.IsMatch(line, @"^##\s+\d+\.\d+\.\d+\s+\("))
+          var releaseHeading = new System.Text.RegularExpressions.Regex(
+              @"^#+\s+(?<version>\d+\.\d+\.\d+)\s+\(\d{4}-\d{2}-\d{2}\)",
+              System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+
+          foreach (string line in System.IO.File.ReadLines(ChangelogPath))
           {
-            HasStableRelease = true;
-            break;
+            System.Text.RegularExpressions.Match match = releaseHeading.Match(line);
+            if (match.Success && match.Groups["version"].Value != CurrentVersion)
+            {
+              HasStableRelease = true;
+              break;
+            }
           }
+        }
+        catch (System.Exception ex)
+        {
+          ReadError = ex.Message;
         }
       ]]></Code>
     </Task>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -35,31 +35,46 @@
       <_ApiCompatVersionRequired Condition="'$(HasReleaseVersion)' != 'false'">true</_ApiCompatVersionRequired>
       <_ApiCompatChangelogPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'CHANGELOG.md'))</_ApiCompatChangelogPath>
     </PropertyGroup>
-    <ReadLinesFromFile File="$(_ApiCompatChangelogPath)"
-                       Condition="'$(_ApiCompatVersionRequired)' != 'true' and Exists('$(_ApiCompatChangelogPath)')">
-      <Output TaskParameter="Lines" ItemName="_ApiCompatChangelogLine" />
-    </ReadLinesFromFile>
+    <CheckApiCompatStableRelease ChangelogPath="$(_ApiCompatChangelogPath)"
+                                 Condition="'$(_ApiCompatVersionRequired)' != 'true' and Exists('$(_ApiCompatChangelogPath)')">
+      <Output TaskParameter="HasStableRelease" PropertyName="_ApiCompatHasStableRelease" />
+    </CheckApiCompatStableRelease>
     <ReadLinesFromFile File="$(MSBuildThisFileDirectory)apicompatbaselines\ApiCompatVersionOptOut.txt"
                        Condition="Exists('$(MSBuildThisFileDirectory)apicompatbaselines\ApiCompatVersionOptOut.txt')">
       <Output TaskParameter="Lines" ItemName="_ApiCompatVersionOptOutLine" />
     </ReadLinesFromFile>
     <ItemGroup>
-      <_ApiCompatVersionHeading Include="@(_ApiCompatChangelogLine)"
-                                Condition="$([System.String]::new('%(_ApiCompatChangelogLine.Identity)').StartsWith('## '))" />
-      <_ApiCompatStableReleaseLine Include="@(_ApiCompatVersionHeading)" />
-      <_ApiCompatStableReleaseLine Remove="@(_ApiCompatStableReleaseLine)"
-                                   Condition="$([System.String]::new('%(_ApiCompatStableReleaseLine.Identity)').Contains('-beta'))" />
-      <_ApiCompatStableReleaseLine Remove="@(_ApiCompatStableReleaseLine)"
-                                   Condition="$([System.String]::new('%(_ApiCompatStableReleaseLine.Identity)').Contains('-preview'))" />
       <_ApiCompatVersionOptOutMatch Include="@(_ApiCompatVersionOptOutLine)"
                                     Condition="'%(Identity)' == '$(MSBuildProjectName)'" />
     </ItemGroup>
     <PropertyGroup>
-      <_ApiCompatVersionRequired Condition="'@(_ApiCompatStableReleaseLine)' != ''">true</_ApiCompatVersionRequired>
+      <_ApiCompatVersionRequired Condition="'$(_ApiCompatHasStableRelease)' == 'true'">true</_ApiCompatVersionRequired>
     </PropertyGroup>
     <Error Condition="'$(_ApiCompatVersionRequired)' == 'true' and '@(_ApiCompatVersionOptOutMatch)' == ''"
            Text="ApiCompatVersion is missing from $(MSBuildProjectName). It is required for libraries with a prior stable release and is managed automatically by eng/scripts/Update-PkgVersion.ps1 - do not delete it. If the core team has approved shipping this package without ApiCompat, add '$(MSBuildProjectName)' to eng/apicompatbaselines/ApiCompatVersionOptOut.txt (CODEOWNERS-protected)." />
   </Target>
+
+  <UsingTask
+    TaskName="CheckApiCompatStableRelease"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <ChangelogPath ParameterType="System.String" Required="true" />
+      <HasStableRelease ParameterType="System.Boolean" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        foreach (string line in System.IO.File.ReadLines(ChangelogPath))
+        {
+          if (System.Text.RegularExpressions.Regex.IsMatch(line, @"^##\s+\d+\.\d+\.\d+\s+\("))
+          {
+            HasStableRelease = true;
+            break;
+          }
+        }
+      ]]></Code>
+    </Task>
+  </UsingTask>
 
   <PropertyGroup>
     <PackageRootDirectory>$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory)/../).TrimEnd("/").TrimEnd("\\"))</PackageRootDirectory>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -94,6 +94,7 @@
 
   <PropertyGroup>
     <PackageRootDirectory>$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory)/../).TrimEnd("/").TrimEnd("\\"))</PackageRootDirectory>
+    <PackageRootDirectory Condition="!Exists('$(PackageRootDirectory)/CHANGELOG.md') and Exists('$(MSBuildProjectDirectory)/CHANGELOG.md')">$(MSBuildProjectDirectory)</PackageRootDirectory>
 
     <!--
         For API compat checks, libraries that don't release often are likely to not have newer targets,

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -22,24 +22,43 @@
     ApiCompat is entirely gated on a non-empty ApiCompatVersion (see the '$(ApiCompatVersion)' != '' conditions below),
     so simply deleting the auto-managed <ApiCompatVersion> element from a project's .csproj would silently disable all
     ApiCompat enforcement without touching the CODEOWNERS-protected eng/apicompatbaselines files. This target requires
-    the version to be present for GA (non-preview) shipping client libraries so that removal fails the build.
+    the version to be present for shipping client libraries with a prior stable release so that removal fails the build,
+    including while preparing a new preview release.
 
     A first GA (1.0.0) has no prior stable release to compare against, so ApiCompatVersion is legitimately absent there.
     In the rare case the core team approves running without ApiCompat for an already-GA'd package, add the project name
     to eng/apicompatbaselines/ApiCompatVersionOptOut.txt, which is CODEOWNERS-protected and therefore requires core team review.
   -->
   <Target Name="ValidateApiCompatVersionPresent" BeforeTargets="Build"
-          Condition="'$(ValidateRunApiCompat)' == 'true' and '$(ApiCompatVersion)' == '' and '$(IsShippingClientLibrary)' == 'true' and '$(HasReleaseVersion)' != 'false' and '$(IncludeBuildOutput)' != 'false' and '$(_VersionInProject)' != '1.0.0'">
+          Condition="'$(ValidateRunApiCompat)' == 'true' and '$(ApiCompatVersion)' == '' and '$(IsShippingClientLibrary)' == 'true' and '$(IncludeBuildOutput)' != 'false' and '$(_VersionInProject)' != '1.0.0'">
+    <PropertyGroup>
+      <_ApiCompatVersionRequired Condition="'$(HasReleaseVersion)' != 'false'">true</_ApiCompatVersionRequired>
+      <_ApiCompatChangelogPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'CHANGELOG.md'))</_ApiCompatChangelogPath>
+    </PropertyGroup>
+    <ReadLinesFromFile File="$(_ApiCompatChangelogPath)"
+                       Condition="'$(_ApiCompatVersionRequired)' != 'true' and Exists('$(_ApiCompatChangelogPath)')">
+      <Output TaskParameter="Lines" ItemName="_ApiCompatChangelogLine" />
+    </ReadLinesFromFile>
     <ReadLinesFromFile File="$(MSBuildThisFileDirectory)apicompatbaselines\ApiCompatVersionOptOut.txt"
                        Condition="Exists('$(MSBuildThisFileDirectory)apicompatbaselines\ApiCompatVersionOptOut.txt')">
       <Output TaskParameter="Lines" ItemName="_ApiCompatVersionOptOutLine" />
     </ReadLinesFromFile>
     <ItemGroup>
+      <_ApiCompatVersionHeading Include="@(_ApiCompatChangelogLine)"
+                                Condition="$([System.String]::new('%(_ApiCompatChangelogLine.Identity)').StartsWith('## '))" />
+      <_ApiCompatStableReleaseLine Include="@(_ApiCompatVersionHeading)" />
+      <_ApiCompatStableReleaseLine Remove="@(_ApiCompatStableReleaseLine)"
+                                   Condition="$([System.String]::new('%(_ApiCompatStableReleaseLine.Identity)').Contains('-beta'))" />
+      <_ApiCompatStableReleaseLine Remove="@(_ApiCompatStableReleaseLine)"
+                                   Condition="$([System.String]::new('%(_ApiCompatStableReleaseLine.Identity)').Contains('-preview'))" />
       <_ApiCompatVersionOptOutMatch Include="@(_ApiCompatVersionOptOutLine)"
                                     Condition="'%(Identity)' == '$(MSBuildProjectName)'" />
     </ItemGroup>
-    <Error Condition="'@(_ApiCompatVersionOptOutMatch)' == ''"
-           Text="ApiCompatVersion is missing from $(MSBuildProjectName). It is required for GA (non-preview) libraries and is managed automatically by eng/scripts/Update-PkgVersion.ps1 - do not delete it. If the core team has approved shipping this package without ApiCompat, add '$(MSBuildProjectName)' to eng/apicompatbaselines/ApiCompatVersionOptOut.txt (CODEOWNERS-protected)." />
+    <PropertyGroup>
+      <_ApiCompatVersionRequired Condition="'@(_ApiCompatStableReleaseLine)' != ''">true</_ApiCompatVersionRequired>
+    </PropertyGroup>
+    <Error Condition="'$(_ApiCompatVersionRequired)' == 'true' and '@(_ApiCompatVersionOptOutMatch)' == ''"
+           Text="ApiCompatVersion is missing from $(MSBuildProjectName). It is required for libraries with a prior stable release and is managed automatically by eng/scripts/Update-PkgVersion.ps1 - do not delete it. If the core team has approved shipping this package without ApiCompat, add '$(MSBuildProjectName)' to eng/apicompatbaselines/ApiCompatVersionOptOut.txt (CODEOWNERS-protected)." />
   </Target>
 
   <PropertyGroup>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -41,6 +41,7 @@
     </ItemGroup>
     <PropertyGroup>
       <_ApiCompatChangelogPath>$(PackageRootDirectory)/CHANGELOG.md</_ApiCompatChangelogPath>
+      <_ApiCompatChangelogPath Condition="!$(MSBuildProjectDirectory.EndsWith('\src')) and !$(MSBuildProjectDirectory.EndsWith('/src'))">$(MSBuildProjectDirectory)/CHANGELOG.md</_ApiCompatChangelogPath>
     </PropertyGroup>
     <Error Condition="'@(_ApiCompatVersionOptOutMatch)' == '' and !Exists('$(_ApiCompatChangelogPath)')"
            Text="ApiCompat validation cannot determine release history for $(MSBuildProjectName): CHANGELOG.md was not found at $(_ApiCompatChangelogPath)." />
@@ -94,7 +95,6 @@
 
   <PropertyGroup>
     <PackageRootDirectory>$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory)/../).TrimEnd("/").TrimEnd("\\"))</PackageRootDirectory>
-    <PackageRootDirectory Condition="!Exists('$(PackageRootDirectory)/CHANGELOG.md') and Exists('$(MSBuildProjectDirectory)/CHANGELOG.md')">$(MSBuildProjectDirectory)</PackageRootDirectory>
 
     <!--
         For API compat checks, libraries that don't release often are likely to not have newer targets,

--- a/eng/apicompatbaselines/ApiCompatVersionOptOut.txt
+++ b/eng/apicompatbaselines/ApiCompatVersionOptOut.txt
@@ -3,7 +3,8 @@
 # ApiCompat enforcement is gated on a non-empty <ApiCompatVersion> in each shipping library's .csproj.
 # To prevent a partner from silently disabling ApiCompat by deleting that auto-managed element, the
 # ValidateApiCompatVersionPresent target in eng/Directory.Build.Common.targets fails the build when a
-# GA (non-preview) shipping client library is missing ApiCompatVersion.
+# shipping client library with a prior stable release is missing ApiCompatVersion, including while
+# preparing a preview release.
 #
 # In the rare case the core team approves shipping an already-GA'd package without ApiCompat, add the
 # project name (MSBuildProjectName, e.g. Azure.Storage.Blobs) on its own line below. Because this file

--- a/sdk/cloudmachine/Azure.Projects.AI.Foundry/CHANGELOG.md
+++ b/sdk/cloudmachine/Azure.Projects.AI.Foundry/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Release History
+
+## 1.0.0 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes

--- a/sdk/cloudmachine/Azure.Projects.Tsp/CHANGELOG.md
+++ b/sdk/cloudmachine/Azure.Projects.Tsp/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Release History
+
+## 1.0.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes


### PR DESCRIPTION
## Summary
- require `ApiCompatVersion` during preview cycles for packages that have a prior stable release
- infer prior stable releases from package changelog version headings
- preserve first-preview, first-GA, and CODEOWNERS-protected opt-out behavior

## Validation
- already-GA preview package with an empty `ApiCompatVersion` fails the full build
- stable package with an empty `ApiCompatVersion` fails
- first-preview packages without a stable release remain exempt
- explicit `ApiCompatVersionOptOut.txt` entries remain supported
- representative already-GA preview and first-preview packages build normally

Fixes #61497