### PR TITLE
Install tsp-client once per regen job instead of once per package

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/ci.yml
+++ b/eng/packages/http-client-csharp-mgmt/ci.yml
@@ -85,18 +85,12 @@ extends:
         PublishDependsOnTest: false
         PublishPublic: ${{ and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
         HasNugetPackages: true
-      # Keep regen groups small enough to avoid the public release pipeline's
-      # 1-hour timeout. Each job carries a fixed setup cost of roughly 7 minutes
-      # that is dominated by the repo checkout, so more jobs cost more agent
-      # minutes, but generation is sequential within a job so fewer jobs cost
-      # wall clock time. Measured at 9 jobs the stage took 54.4 minutes versus
-      # 35.7 minutes at 18, so wall clock wins out at this scale.
-      #
-      # 17 rather than 18: New-RegenerateMatrix.ps1 splits 230 packages across
-      # 18 jobs into groups that only sum to 218, silently dropping the last 12
-      # packages. Fixed in Azure/azure-sdk-tools#16621; until that mirrors into
-      # eng/common here, 17 is the largest count that covers every package.
-      RegenerationJobCount: 17
+      # Workaround: keep regen groups small enough to avoid the public release
+      # pipeline's 1-hour timeout. Azure.ResourceManager.Network takes much
+      # longer than most packages and should be optimized eventually; the shared
+      # matrix generator only supports count-based batching, not per-package
+      # isolation.
+      RegenerationJobCount: 18
       MinimumPerJob: 10
       OnlyGenerateTypespec: true
       DirectoryFilterPattern: 'Azure.ResourceManager*,Azure.Provisioning*'

--- a/eng/packages/http-client-csharp-mgmt/ci.yml
+++ b/eng/packages/http-client-csharp-mgmt/ci.yml
@@ -85,12 +85,14 @@ extends:
         PublishDependsOnTest: false
         PublishPublic: ${{ and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
         HasNugetPackages: true
-      # Workaround: keep regen groups small enough to avoid the public release
-      # pipeline's 1-hour timeout. Azure.ResourceManager.Network takes much
-      # longer than most packages and should be optimized eventually; the shared
-      # matrix generator only supports count-based batching, not per-package
-      # isolation.
-      RegenerationJobCount: 18
+      # Keep regen groups small enough to avoid the public release pipeline's
+      # 1-hour timeout. Each job now regenerates its packages concurrently (see
+      # SDK_GENERATION_PARALLELISM in eng/scripts/Language-Settings.ps1), so a
+      # job absorbs more packages without a proportional increase in wall clock
+      # time and we need fewer agents than the previous count of 18. Every extra
+      # job also repays a ~6 minute fixed setup cost (repo checkout dominates),
+      # so fewer, fuller jobs are cheaper in total agent minutes as well.
+      RegenerationJobCount: 9
       MinimumPerJob: 10
       OnlyGenerateTypespec: true
       DirectoryFilterPattern: 'Azure.ResourceManager*,Azure.Provisioning*'

--- a/eng/packages/http-client-csharp-mgmt/ci.yml
+++ b/eng/packages/http-client-csharp-mgmt/ci.yml
@@ -86,13 +86,17 @@ extends:
         PublishPublic: ${{ and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
         HasNugetPackages: true
       # Keep regen groups small enough to avoid the public release pipeline's
-      # 1-hour timeout. Each job now regenerates its packages concurrently (see
-      # SDK_GENERATION_PARALLELISM in eng/scripts/Language-Settings.ps1), so a
-      # job absorbs more packages without a proportional increase in wall clock
-      # time and we need fewer agents than the previous count of 18. Every extra
-      # job also repays a ~6 minute fixed setup cost (repo checkout dominates),
-      # so fewer, fuller jobs are cheaper in total agent minutes as well.
-      RegenerationJobCount: 9
+      # 1-hour timeout. Each job carries a fixed setup cost of roughly 7 minutes
+      # that is dominated by the repo checkout, so more jobs cost more agent
+      # minutes, but generation is sequential within a job so fewer jobs cost
+      # wall clock time. Measured at 9 jobs the stage took 54.4 minutes versus
+      # 35.7 minutes at 18, so wall clock wins out at this scale.
+      #
+      # 17 rather than 18: New-RegenerateMatrix.ps1 splits 230 packages across
+      # 18 jobs into groups that only sum to 218, silently dropping the last 12
+      # packages. Fixed in Azure/azure-sdk-tools#16621; until that mirrors into
+      # eng/common here, 17 is the largest count that covers every package.
+      RegenerationJobCount: 17
       MinimumPerJob: 10
       OnlyGenerateTypespec: true
       DirectoryFilterPattern: 'Azure.ResourceManager*,Azure.Provisioning*'

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -580,20 +580,15 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    # Opt-in knob for generating packages concurrently. Both /m and BuildInParallel are
-    # required; the MSBuild task in eng/service.proj stays sequential if either is missing.
-    #
-    # Defaults to 1 (sequential) because it does not currently pay off on the CI agents.
-    # Measured on the mgmt regeneration pipeline: 230 packages at /m:4 took 0.858 min per
-    # package versus 0.882 min per package sequentially, a 1.03x speedup. The agents are
-    # small and each package already saturates them via the spec clone, the per-package
-    # npm install and the tsp compile, so adding concurrency mostly adds contention.
-    # Reducing the per-package cost is the useful lever, not overlapping packages.
-    $parallelism = if ($env:SDK_GENERATION_PARALLELISM) { [int]$env:SDK_GENERATION_PARALLELISM } else { 1 }
-    $parallelArgs = $parallelism -gt 1 ? "/m:$parallelism /p:BuildInParallel=true" : ""
-    Write-Host "Generating with parallelism $parallelism (override with SDK_GENERATION_PARALLELISM)"
-
-    Invoke-LoggedCommand "dotnet msbuild /restore $parallelArgs /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
+    # Packages are generated one at a time on purpose; do not add /m and BuildInParallel here.
+    # A single package already consumes about 10.7 CPU cores on average (26.9s wall versus
+    # 286.6s CPU for Azure.ResourceManager.DataBox), so the generator saturates a CI agent by
+    # itself and overlapping packages only splits the same cores. Measured on the mgmt
+    # regeneration pipeline, 230 packages at /m:4 took 0.858 min per package versus 0.882 min
+    # sequentially, a 1.03x speedup that is within noise. Concurrency would only pay off on a
+    # much larger agent (roughly 32+ cores); until then the useful lever is reducing the
+    # per-package cost, not overlapping packages.
+    Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }
   finally {
     Pop-Location

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -580,13 +580,16 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    # Generate packages concurrently, mirroring the -Parallel switch in
-    # eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1. Each package spends
-    # most of its time in a network-bound spec sync and a single-threaded tsp compile, so
-    # those phases overlap well. Both /m and BuildInParallel are required: the MSBuild task
-    # in eng/service.proj stays sequential if either one is missing. Set
-    # SDK_GENERATION_PARALLELISM=1 to fall back to the previous sequential behavior.
-    $parallelism = if ($env:SDK_GENERATION_PARALLELISM) { [int]$env:SDK_GENERATION_PARALLELISM } else { 4 }
+    # Opt-in knob for generating packages concurrently. Both /m and BuildInParallel are
+    # required; the MSBuild task in eng/service.proj stays sequential if either is missing.
+    #
+    # Defaults to 1 (sequential) because it does not currently pay off on the CI agents.
+    # Measured on the mgmt regeneration pipeline: 230 packages at /m:4 took 0.858 min per
+    # package versus 0.882 min per package sequentially, a 1.03x speedup. The agents are
+    # small and each package already saturates them via the spec clone, the per-package
+    # npm install and the tsp compile, so adding concurrency mostly adds contention.
+    # Reducing the per-package cost is the useful lever, not overlapping packages.
+    $parallelism = if ($env:SDK_GENERATION_PARALLELISM) { [int]$env:SDK_GENERATION_PARALLELISM } else { 1 }
     $parallelArgs = $parallelism -gt 1 ? "/m:$parallelism /p:BuildInParallel=true" : ""
     Write-Host "Generating with parallelism $parallelism (override with SDK_GENERATION_PARALLELISM)"
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -580,7 +580,17 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
+    # Generate packages concurrently, mirroring the -Parallel switch in
+    # eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1. Each package spends
+    # most of its time in a network-bound spec sync and a single-threaded tsp compile, so
+    # those phases overlap well. Both /m and BuildInParallel are required: the MSBuild task
+    # in eng/service.proj stays sequential if either one is missing. Set
+    # SDK_GENERATION_PARALLELISM=1 to fall back to the previous sequential behavior.
+    $parallelism = if ($env:SDK_GENERATION_PARALLELISM) { [int]$env:SDK_GENERATION_PARALLELISM } else { 4 }
+    $parallelArgs = $parallelism -gt 1 ? "/m:$parallelism /p:BuildInParallel=true" : ""
+    Write-Host "Generating with parallelism $parallelism (override with SDK_GENERATION_PARALLELISM)"
+
+    Invoke-LoggedCommand "dotnet msbuild /restore $parallelArgs /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }
   finally {
     Pop-Location

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -105,7 +105,7 @@
   <Target Name="InstallTspClient" Condition="'$(SkipTspClientInstall)' != 'true'">
     <ItemGroup>
       <_TypeSpecProjectReference Include="@(ProjectReference)"
-                                 Condition="$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\/').EndsWith('src')) and Exists('%(RootDir)%(Directory)../tsp-location.yaml')" />
+                                 Condition="$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('/').TrimEnd('\').EndsWith('src')) and Exists('%(RootDir)%(Directory)../tsp-location.yaml')" />
     </ItemGroup>
     <Exec Command="npm ci --prefix $(MSBuildThisFileDirectory)common/tsp-client"
           Condition="'@(_TypeSpecProjectReference)' != ''" />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -99,15 +99,19 @@
   </Target>
 
 
-  <Target Name="InstallTspClient">
-    <MSBuild Projects="@(ProjectReference)"
-             Targets="InstallTspClient"
-             BuildInParallel="false"
-             SkipNonexistentProjects="false"
-             SkipNonexistentTargets="true" />
+  <!-- Every project's InstallTspClient target runs "npm ci" against the same shared
+       eng/common/tsp-client folder, so looping over the projects reinstalls it once per
+       project. Detect whether the batch contains any TypeSpec project and install once. -->
+  <Target Name="InstallTspClient" Condition="'$(SkipTspClientInstall)' != 'true'">
+    <ItemGroup>
+      <_TypeSpecProjectReference Include="@(ProjectReference)"
+                                 Condition="$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\/').EndsWith('src')) and Exists('%(RootDir)%(Directory)../tsp-location.yaml')" />
+    </ItemGroup>
+    <Exec Command="npm ci --prefix $(MSBuildThisFileDirectory)common/tsp-client"
+          Condition="'@(_TypeSpecProjectReference)' != ''" />
   </Target>
 
-  <Target Name="BuildPlugin">
+  <Target Name="BuildPlugin" Condition="'$(SkipBuildPlugin)' != 'true'">
     <Exec Command="dotnet build $(MSBuildThisFileDirectory)packages\plugins\client\Client.Plugin\" />
   </Target>
 


### PR DESCRIPTION
## What this does

`eng/service.proj`'s `InstallTspClient` looped an MSBuild task over every project in the batch, and each project's `InstallTspClient` target in `eng/CodeGeneration.targets` runs `npm ci --prefix eng/common/tsp-client` — the *same shared folder* every time. So a regen job with 13 packages wiped and reinstalled one folder 13 times. (`GenerateCode` already passes `SkipTspClientInstall=true` down, so this was the only round, not a double.)

Now it detects whether the batch contains any TypeSpec project and installs once.

`Language-Settings.ps1` is a comment only — no behavior change.

## Honest sizing: this is ~1%, not a speedup

`npm ci` on that folder is **~2.0s** warm (1 direct dep, 53 MB, 6,517 files; npm hardlinks from cache). Removing 12 redundant installs per job:

| | |
|---|---|
| per job | ~24s |
| stage wall clock | **~0.4 min of 35.7 (≈1%)** |
| aggregate agent time | ~7 min across 18 jobs |

Worth doing as cleanup. Not worth expecting a difference in the pipeline.

## Why there is no bigger win here

This started as an investigation into why generator improvements (`Azure.ResourceManager.Network`: >30 min → <7 min) did not move the `Regenerate` stage. Measuring a real internal run (35.7 min):

| | |
|---|---|
| `Initialize` | 7.6 min (4.1 of it repo checkout) |
| Stage gap | 2.1 min |
| Slowest `Generate` job | 23.9 min (6.3 setup + 17.6 generating) |
| `Create PR` | 1.3 min |

- **~49% of the stage is fixed overhead** no generator work can touch. Across 18 jobs only 63% of job time is generating; `Checkout azure-sdk-for-net` alone costs 75.7 aggregate minutes.
- **Network is no longer alone on the critical path** — the next-slowest jobs plateau at 20.6–20.7 min, so further Network-only wins yield ~3 min and stop.
- **Grouping cannot help.** All 18 jobs started within 0.1 min of each other on distinct agents, so the pool granted P=18 with no queuing. Makespan is `Overhead + Work/N` while `P >= N`, but `(N*Overhead + Work)/P` once `P < N`, which is increasing in N. The optimum is N = P, because **the overhead is per-job, not per-group**.

### Intra-job concurrency was tried and does not work

An earlier revision overlapped packages within a job at `/m:4` (as `RegenSdkLocal.ps1` does locally). A full pipeline run measured it:

| | baseline (18 jobs, sequential) | run (9 jobs, `/m:4`) |
|---|---|---|
| packages generated | 218 | 230 |
| slowest job | 23.9 min | 34.3 min |
| **stage** | **35.7 min** | **54.4 min** |

Normalising for package count: **0.882 → 0.858 min/package, a 1.03x speedup** — noise.

**Root cause: the generator is already parallel.** For one package (`Azure.ResourceManager.DataBox`): wall 26.9s, user CPU 282.9s, sys 3.6s → **10.67 cores average**. A single package already saturates an agent, so the ceiling on job-level concurrency is `agent_cores / 10.67`:

| machine | cores | predicted | measured |
|---|---|---|---|
| dev container | 32 | 3.00x | **3.1x** |
| azsdk-pool agent | ~11 implied | 1.03x | **1.03x** |

That is why `RegenSdkLocal.ps1 -Parallel` is fast on a workstation and does nothing in CI. No job count or grouping changes this, so the parallelism knob was removed and the finding left as a comment.

**The real lever is per-package cost, not concurrency.** A single package installs ~256 MB / 10,745 files of `node_modules` into `TempTypeSpecFiles`; over 230 packages that is ~2.4M file writes per regeneration. `RegenSdkLocal.ps1` avoids this by symlinking a shared `node_modules` and using a `--depth 1 --sparse` spec clone. That direction needs changes in `tsp-client`, not here. Failing that, a larger agent SKU would make concurrency pay off immediately.

## Related

Azure/azure-sdk-tools#16621 fixes `New-RegenerateMatrix.ps1` silently dropping packages: at 230 packages across 18 jobs the groups sum to only 218, so 12 packages including `Azure.ResourceManager.AppService` are **never regenerated**. That is a correctness bug and the more important finding from this investigation. `RegenerationJobCount` is deliberately left at 18 here to wait for that fix to mirror into `eng/common`, rather than working around it.
