### PR TITLE
Validate management TypeSpec commits in PRs

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -39,11 +39,35 @@ parameters:
   - name: LimitForPullRequest
     type: boolean
     default: false
+  - name: VerifyMgmtTypeSpecCommit
+    type: boolean
+    default: false
   - name: ExcludePaths
     type: object
     default: []
 
 jobs:
+  # Management pipelines set LimitForPullRequest because their tests run in aggregate.
+  # VerifyMgmtTypeSpecCommit covers management pipelines that intentionally run their own PR tests.
+  - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), or(eq(parameters.LimitForPullRequest, true), eq(parameters.VerifyMgmtTypeSpecCommit, true))) }}:
+    - job: VerifyMgmtTypeSpecCommit
+      displayName: Verify management TypeSpec commit
+      pool:
+        name: $(LINUXPOOL)
+        image: $(LINUXVMIMAGE)
+        os: linux
+      steps:
+        - checkout: self
+          fetchDepth: 0
+          fetchFilter: tree:0
+          fetchTags: false
+
+        - pwsh: >
+            ./eng/scripts/Verify-Mgmt-TypeSpecCommit.ps1
+            -ServiceDirectory "${{ parameters.ServiceDirectory }}"
+            -ChangedFilesOnly
+          displayName: Verify TypeSpec commit is from specs main
+
   - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
     # Build matrix - larger LOC batches (1.2M) for fewer jobs and lower per-job overhead.
     - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -48,6 +48,9 @@ parameters:
   - name: LimitForPullRequest
     type: boolean
     default: false
+  - name: VerifyMgmtTypeSpecCommit
+    type: boolean
+    default: false
   - name: oneESTemplateTag
     type: string
     default: true
@@ -99,6 +102,7 @@ extends:
                 TestPipeline: true
               ArtifactName: packages
               LimitForPullRequest: ${{ parameters.LimitForPullRequest }}
+              VerifyMgmtTypeSpecCommit: ${{ parameters.VerifyMgmtTypeSpecCommit }}
               BuildSnippets: ${{ parameters.BuildSnippets }}
               TestSetupSteps: ${{ parameters.TestSetupSteps }}
               TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}

--- a/eng/scripts/Verify-Mgmt-TypeSpecCommit.ps1
+++ b/eng/scripts/Verify-Mgmt-TypeSpecCommit.ps1
@@ -153,8 +153,10 @@ function Invoke-MgmtTypeSpecCommitVerification {
     return
   }
 
-  . (Join-Path $PSScriptRoot "../common/scripts/Helpers/PSModule-Helpers.ps1")
-  Install-ModuleIfNotInstalled "powershell-yaml" "0.4.7" | Import-Module
+  if (-not (Get-Command ConvertFrom-Yaml -ErrorAction Ignore)) {
+    . (Join-Path $PSScriptRoot "../common/scripts/Helpers/PSModule-Helpers.ps1")
+    Install-ModuleIfNotInstalled "powershell-yaml" "0.4.7" | Import-Module
+  }
 
   $temporarySpecRepo = $null
   if (-not $SpecRepoPath) {

--- a/eng/scripts/Verify-Mgmt-TypeSpecCommit.ps1
+++ b/eng/scripts/Verify-Mgmt-TypeSpecCommit.ps1
@@ -1,0 +1,221 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+Verifies that management-plane TypeSpec commits belong to azure-rest-api-specs/main.
+
+.PARAMETER ServiceDirectory
+The service directory under sdk. Use "auto" to scan all service directories.
+
+.PARAMETER RepoRoot
+The azure-sdk-for-net repository root.
+
+.PARAMETER SpecRepoPath
+An existing azure-rest-api-specs clone. Intended for local validation and tests.
+
+.PARAMETER ChangedFilesOnly
+Only validate management-plane tsp-location.yaml files changed by the pull request.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ServiceDirectory,
+  [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")),
+  [string]$SpecRepoPath,
+  [string]$SpecRepoUrl = "https://github.com/Azure/azure-rest-api-specs.git",
+  [switch]$ChangedFilesOnly,
+  [string]$SourceCommittish = $env:SYSTEM_PULLREQUEST_SOURCECOMMITID,
+  [string]$TargetCommittish = ("origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCH" -replace "refs/heads/")
+)
+
+function Get-MgmtTypeSpecLocations {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$SdkPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ServiceDirectory
+  )
+
+  $searchRoot = if ($ServiceDirectory -eq "auto") {
+    $SdkPath
+  }
+  else {
+    Join-Path $SdkPath $ServiceDirectory
+  }
+
+  if (-not (Test-Path $searchRoot -PathType Container)) {
+    throw "SDK service directory does not exist: $searchRoot"
+  }
+
+  return @(Get-ChildItem -Path $searchRoot -Filter "tsp-location.yaml" -File -Recurse |
+      Where-Object { $_.Directory.Name -like "Azure.ResourceManager.*" })
+}
+
+function Get-ChangedMgmtTypeSpecLocations {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$ServiceDirectory,
+    [Parameter(Mandatory = $true)]
+    [string]$SourceCommittish,
+    [Parameter(Mandatory = $true)]
+    [string]$TargetCommittish
+  )
+
+  git -C $RepoRoot cat-file -e "$TargetCommittish^{commit}" 2>$null
+  if ($LASTEXITCODE -ne 0 -and $TargetCommittish -match "^origin/(?<branch>.+)$") {
+    $targetBranch = $matches["branch"]
+    git -C $RepoRoot fetch --quiet --no-tags origin `
+      "+refs/heads/${targetBranch}:refs/remotes/origin/${targetBranch}"
+    if ($LASTEXITCODE -ne 0) {
+      throw "Failed to fetch pull request target branch '$targetBranch'."
+    }
+  }
+
+  $servicePath = if ($ServiceDirectory -eq "auto") { "sdk" } else { "sdk/$ServiceDirectory" }
+  $changedFiles = @(git -C $RepoRoot diff "$TargetCommittish...$SourceCommittish" `
+      --name-only --diff-filter=d -- $servicePath)
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to get changed files between '$TargetCommittish' and '$SourceCommittish'."
+  }
+
+  return @($changedFiles |
+      Where-Object {
+        $_ -match '(^|/)Azure\.ResourceManager\.[^/]+/tsp-location\.yaml$'
+      } |
+      ForEach-Object { Get-Item (Join-Path $RepoRoot $_) })
+}
+
+function Get-SpecMainRef {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepositoryPath
+  )
+
+  foreach ($ref in @("refs/remotes/origin/main", "refs/heads/main")) {
+    git -C $RepositoryPath show-ref --verify --quiet $ref
+    if ($LASTEXITCODE -eq 0) {
+      return $ref
+    }
+  }
+
+  throw "The specs repository at '$RepositoryPath' does not contain a main branch."
+}
+
+function Test-SpecCommitOnMain {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepositoryPath,
+    [Parameter(Mandatory = $true)]
+    [string]$MainRef,
+    [Parameter(Mandatory = $true)]
+    [string]$Commit
+  )
+
+  git -C $RepositoryPath cat-file -e "$Commit^{commit}" 2>$null
+  if ($LASTEXITCODE -ne 0) {
+    return $false
+  }
+
+  git -C $RepositoryPath merge-base --is-ancestor $Commit $MainRef
+  return $LASTEXITCODE -eq 0
+}
+
+function Invoke-MgmtTypeSpecCommitVerification {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ServiceDirectory,
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+    [string]$SpecRepoPath,
+    [Parameter(Mandatory = $true)]
+    [string]$SpecRepoUrl,
+    [switch]$ChangedFilesOnly,
+    [string]$SourceCommittish,
+    [string]$TargetCommittish
+  )
+
+  $tspLocations = if ($ChangedFilesOnly) {
+    Get-ChangedMgmtTypeSpecLocations `
+      -RepoRoot $RepoRoot `
+      -ServiceDirectory $ServiceDirectory `
+      -SourceCommittish $SourceCommittish `
+      -TargetCommittish $TargetCommittish
+  }
+  else {
+    Get-MgmtTypeSpecLocations `
+      -SdkPath (Join-Path $RepoRoot "sdk") `
+      -ServiceDirectory $ServiceDirectory
+  }
+
+  if ($tspLocations.Count -eq 0) {
+    Write-Host "No management-plane tsp-location.yaml files require validation for '$ServiceDirectory'."
+    return
+  }
+
+  . (Join-Path $PSScriptRoot "../common/scripts/Helpers/PSModule-Helpers.ps1")
+  Install-ModuleIfNotInstalled "powershell-yaml" "0.4.7" | Import-Module
+
+  $temporarySpecRepo = $null
+  if (-not $SpecRepoPath) {
+    $temporarySpecRepo = Join-Path ([IO.Path]::GetTempPath()) "azure-rest-api-specs-$([guid]::NewGuid())"
+    git clone --quiet --filter=tree:0 --no-checkout --single-branch --branch main $SpecRepoUrl $temporarySpecRepo
+    if ($LASTEXITCODE -ne 0) {
+      throw "Failed to clone azure-rest-api-specs/main from '$SpecRepoUrl'."
+    }
+    $SpecRepoPath = $temporarySpecRepo
+  }
+
+  try {
+    $mainRef = Get-SpecMainRef -RepositoryPath $SpecRepoPath
+    $errors = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($tspLocation in $tspLocations) {
+      $config = Get-Content -Path $tspLocation.FullName -Raw | ConvertFrom-Yaml
+      $repo = $config["repo"]
+      $commit = $config["commit"]
+
+      if ($repo -ne "Azure/azure-rest-api-specs") {
+        $errors.Add("$($tspLocation.FullName): repo must be 'Azure/azure-rest-api-specs', but is '$repo'.")
+        continue
+      }
+
+      if ($commit -eq "main") {
+        Write-Host "$($tspLocation.FullName): commit is main."
+        continue
+      }
+
+      if ($commit -notmatch "^[0-9a-fA-F]{40}$") {
+        $errors.Add("$($tspLocation.FullName): commit must be 'main' or a 40-character SHA, but is '$commit'.")
+        continue
+      }
+
+      if (-not (Test-SpecCommitOnMain -RepositoryPath $SpecRepoPath -MainRef $mainRef -Commit $commit)) {
+        $errors.Add("$($tspLocation.FullName): commit '$commit' does not belong to Azure/azure-rest-api-specs main.")
+        continue
+      }
+
+      Write-Host "$($tspLocation.FullName): commit '$commit' belongs to Azure/azure-rest-api-specs main."
+    }
+
+    if ($errors.Count -gt 0) {
+      throw ($errors -join [Environment]::NewLine)
+    }
+  }
+  finally {
+    if ($temporarySpecRepo -and (Test-Path $temporarySpecRepo)) {
+      Remove-Item -Path $temporarySpecRepo -Recurse -Force
+    }
+  }
+}
+
+if ($MyInvocation.InvocationName -ne ".") {
+  Invoke-MgmtTypeSpecCommitVerification `
+    -ServiceDirectory $ServiceDirectory `
+    -RepoRoot $RepoRoot `
+    -SpecRepoPath $SpecRepoPath `
+    -SpecRepoUrl $SpecRepoUrl `
+    -ChangedFilesOnly:$ChangedFilesOnly `
+    -SourceCommittish $SourceCommittish `
+    -TargetCommittish $TargetCommittish
+}

--- a/eng/scripts/tests/Verify-Mgmt-TypeSpecCommit.Tests.ps1
+++ b/eng/scripts/tests/Verify-Mgmt-TypeSpecCommit.Tests.ps1
@@ -1,0 +1,127 @@
+#Requires -Version 7.0
+
+. (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "Helpers" "PSModule-Helpers.ps1")
+Install-ModuleIfNotInstalled "Pester" "5.3.3" | Import-Module
+
+BeforeAll {
+  . (Join-Path $PSScriptRoot ".." "Verify-Mgmt-TypeSpecCommit.ps1") -ServiceDirectory "unused"
+
+  function Invoke-Git {
+    param([string]$RepositoryPath, [Parameter(ValueFromRemainingArguments)]$Arguments)
+
+    git -C $RepositoryPath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+      throw "git $Arguments failed."
+    }
+  }
+}
+
+Describe "Verify-Mgmt-TypeSpecCommit" -Tag "UnitTest" {
+  BeforeEach {
+    $caseRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+    $testRoot = Join-Path $caseRoot "repo"
+    $sdkRoot = Join-Path $testRoot "sdk"
+    $serviceRoot = Join-Path $sdkRoot "test"
+    $mgmtRoot = Join-Path $serviceRoot "Azure.ResourceManager.Test"
+    $provisioningRoot = Join-Path $serviceRoot "Azure.Provisioning.Test"
+    $specRoot = Join-Path $caseRoot "spec"
+
+    New-Item -Path $mgmtRoot -ItemType Directory -Force | Out-Null
+    New-Item -Path $provisioningRoot -ItemType Directory -Force | Out-Null
+    New-Item -Path $specRoot -ItemType Directory -Force | Out-Null
+
+    Invoke-Git $specRoot init --initial-branch=main --quiet
+    Invoke-Git $specRoot config user.email "test@example.com"
+    Invoke-Git $specRoot config user.name "Test"
+    Invoke-Git $specRoot commit --allow-empty --message "main" --quiet
+    $mainCommit = Invoke-Git $specRoot rev-parse HEAD
+
+    Invoke-Git $specRoot switch --create feature --quiet
+    Invoke-Git $specRoot commit --allow-empty --message "feature" --quiet
+    $featureCommit = Invoke-Git $specRoot rev-parse HEAD
+    Invoke-Git $specRoot switch main --quiet
+
+    @"
+repo: Azure/azure-rest-api-specs
+directory: specification/test/resource-manager/Test
+commit: $mainCommit
+"@ | Set-Content (Join-Path $mgmtRoot "tsp-location.yaml")
+
+    @"
+repo: Contoso/azure-rest-api-specs
+commit: $featureCommit
+"@ | Set-Content (Join-Path $provisioningRoot "tsp-location.yaml")
+  }
+
+  It "only discovers Azure.ResourceManager packages" {
+    $locations = Get-MgmtTypeSpecLocations -SdkPath $sdkRoot -ServiceDirectory "test"
+
+    $locations.Count | Should -Be 1
+    $locations[0].Directory.Name | Should -Be "Azure.ResourceManager.Test"
+  }
+
+  It "only selects changed management TypeSpec locations" {
+    Invoke-Git $testRoot init --initial-branch=main --quiet
+    Invoke-Git $testRoot config user.email "test@example.com"
+    Invoke-Git $testRoot config user.name "Test"
+    Invoke-Git $testRoot add sdk
+    Invoke-Git $testRoot commit --message "main" --quiet
+    $sdkRemote = Join-Path $caseRoot "sdk-remote.git"
+    git clone --bare --quiet $testRoot $sdkRemote
+    $LASTEXITCODE | Should -Be 0
+    Invoke-Git $testRoot remote add origin $sdkRemote
+
+    Add-Content (Join-Path $mgmtRoot "tsp-location.yaml") "cleanup: true"
+    Add-Content (Join-Path $provisioningRoot "tsp-location.yaml") "cleanup: true"
+    Invoke-Git $testRoot add sdk
+    Invoke-Git $testRoot commit --message "change locations" --quiet
+    $sourceCommit = Invoke-Git $testRoot rev-parse HEAD
+
+    $locations = Get-ChangedMgmtTypeSpecLocations `
+      -RepoRoot $testRoot `
+      -ServiceDirectory "test" `
+      -SourceCommittish $sourceCommit `
+      -TargetCommittish "origin/main"
+
+    $locations.Count | Should -Be 1
+    $locations[0].Directory.Name | Should -Be "Azure.ResourceManager.Test"
+  }
+
+  It "accepts a commit from main" {
+    {
+      Invoke-MgmtTypeSpecCommitVerification `
+        -ServiceDirectory "test" `
+        -RepoRoot $testRoot `
+        -SpecRepoPath $specRoot `
+        -SpecRepoUrl "unused"
+    } | Should -Not -Throw
+  }
+
+  It "rejects a commit that is only on a feature branch" {
+    (Get-Content (Join-Path $mgmtRoot "tsp-location.yaml") -Raw).Replace($mainCommit, $featureCommit) |
+      Set-Content (Join-Path $mgmtRoot "tsp-location.yaml")
+
+    {
+      Invoke-MgmtTypeSpecCommitVerification `
+        -ServiceDirectory "test" `
+        -RepoRoot $testRoot `
+        -SpecRepoPath $specRoot `
+        -SpecRepoUrl "unused"
+    } | Should -Throw "*does not belong*main*"
+  }
+
+  It "rejects a specs fork" {
+    (Get-Content (Join-Path $mgmtRoot "tsp-location.yaml") -Raw).Replace(
+      "Azure/azure-rest-api-specs",
+      "Contoso/azure-rest-api-specs") |
+      Set-Content (Join-Path $mgmtRoot "tsp-location.yaml")
+
+    {
+      Invoke-MgmtTypeSpecCommitVerification `
+        -ServiceDirectory "test" `
+        -RepoRoot $testRoot `
+        -SpecRepoPath $specRoot `
+        -SpecRepoUrl "unused"
+    } | Should -Throw "*repo must be 'Azure/azure-rest-api-specs'*"
+  }
+}

--- a/sdk/computerecommender/ci.mgmt.yml
+++ b/sdk/computerecommender/ci.mgmt.yml
@@ -5,6 +5,7 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: computerecommender
+    VerifyMgmtTypeSpecCommit: true
     Artifacts:
     - name: Azure.ResourceManager.Compute.Recommender
       safeName: AzureResourceManagerComputeRecommender


### PR DESCRIPTION
## Description

Adds a management-plane PR validation job for changed Azure.ResourceManager.* tsp-location.yaml files. The check requires the official Azure/azure-rest-api-specs repository and verifies that the configured commit is reachable from main using a lightweight tree-less clone.

The validation is scoped to management CI pipelines and changed configuration files so existing spec-location debt does not block unrelated PRs.

## Testing

- Added Pester coverage for management-only discovery, PR changed-file selection, main ancestry, feature-branch rejection, and fork rejection.
- Validated real management commits against a local azure-rest-api-specs clone.
- Confirmed all management TypeSpec pipelines are covered.