### PR TITLE
Use shallow, tagless checkout in the SDK regeneration stage

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -303,7 +303,14 @@ extends:
         jobs:
         - job: Initialize
           steps:
+          # EXPERIMENT (do not merge from this repo; belongs in Azure/azure-sdk-tools).
+          # Full history is 4.8 GB against 119 MB at depth 1, with 7345 tags and 53104
+          # remote refs. Neither regen job reads history: they npm ci, generate config
+          # files, commit and push. The push-conflict retry in git-branch-push.ps1 needs
+          # only the local commit's parent, which is the checked-out tip and exists here.
           - checkout: self
+            fetchDepth: 1
+            fetchTags: false
 
           - template: /eng/common/pipelines/templates/steps/login-to-github.yml
             parameters:
@@ -398,7 +405,12 @@ extends:
             matrixArtifactsPath: $(Pipeline.Workspace)/matrix_artifacts
             emitterNpmrcPath: $(Agent.TempDirectory)/${{ parameters.EmitterPackagePath }}/.npmrc
           steps:
+          # EXPERIMENT (do not merge from this repo; belongs in Azure/azure-sdk-tools).
+          # See the Initialize job above. This is the hot one: checkout dominates the
+          # ~6.3 min per-job setup, roughly 75.7 aggregate minutes across the matrix.
           - checkout: self
+            fetchDepth: 1
+            fetchTags: false
 
           - template: /eng/common/pipelines/templates/steps/login-to-github.yml
             parameters:


### PR DESCRIPTION
> `eng/common/**` is mirrored from Azure/azure-sdk-tools. This PR records and reviews the verified change; the final implementation must be submitted upstream and synced back rather than merged directly here.

## Change

Use shallow, tagless checkout for the `Initialize` and matrix `Generate` jobs in the TypeSpec emitter regeneration stage:

```yaml
- checkout: self
  fetchDepth: 1
  fetchTags: false
```

These jobs do not read repository history. A full regeneration also exercised concurrent push-conflict retries successfully, confirming that the commit parent required by `git-branch-push.ps1` remains available at depth 1.

## Verified result

Full mgmt regeneration, internal build 6633135:

| Metric | Baseline | Shallow/tagless | Change |
|---|---:|---:|---:|
| Initialize checkout | 4.08 min | 0.70 min | **-83%** |
| Average Generate checkout | 4.21 min | 0.66 min | **-84%** |
| Aggregate Generate checkout | 75.7 min | 11.9 min | **-63.8 agent-min** |
| Aggregate non-generation work | 115.1 min | 63.8 min | **-51.3 agent-min** |
| Slowest Generate job | 23.86 min | 21.77 min | **-2.09 min** |
| Regenerate stage | 35.66 min | 35.59 min | flat in this run |

The critical Network group provides an apples-to-apples comparison: generation was essentially unchanged (`17.58 -> 17.70 min`), while the complete job fell `23.86 -> 21.77 min` because checkout was shorter.

The optimization removed about **4.24 minutes from critical-path execution**, but Azure DevOps orchestration gaps increased by 3.99 minutes in this run:

| Orchestration gap | Baseline | Experiment | Change |
|---|---:|---:|---:|
| Initialize finish -> Generate start | 2.08 min | 4.12 min | +2.04 min |
| Last Generate finish -> Create PR start | 0.53 min | 2.48 min | +1.95 min |

These gaps contain no user tasks and occur after checkout. They are scheduler/control-plane variance, not work introduced by this change. The run therefore proves the checkout and agent-consumption improvement, though a single run does not establish a stable end-to-end wall-clock reduction.

## Motivation

The repository has approximately 4.8 GB of Git history versus 119 MB at depth 1, plus 7,345 tags and 53,104 remote refs. Checkout was the largest untouched fixed cost after generator improvements failed to move overall stage duration.

Package-level parallelism is not an alternative on the current pool: one package already consumes about 10.67 CPU cores, and `/m:4` measured only a 1.03x throughput change on the agents.
