### PR TITLE
Prepare AgentServer Core beta.27 release notes

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Release History
 
-## 1.0.0-beta.27 (Unreleased)
+## 1.0.0-beta.27 (2026-07-29)
 
 ### Features Added
 - Added a durable key-value **state store** client under `Azure.AI.AgentServer.Core.Storage`. `FoundryStateStore.GetOrCreateAsync` binds (creating if needed) a named, Foundry-backed store; instances expose async `GetAsync`/`UpdateAsync`/`DeleteAsync` for the store and `CreateItemAsync`/`SetItemAsync`/`GetItemAsync`/`DeleteItemAsync`/`ListKeysAsync` for its items, with optimistic concurrency (`If-Match`/`ETag`), optional per-user isolation, and store-level item TTL. The .NET analogue of the Python SDK's `FoundryStateStore`.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added support for Microsoft Entra authentication when exporting telemetry to Azure Monitor. When `APPLICATIONINSIGHTS_AUTH_MODE` is set to `Entra`, the Azure Monitor exporter uses a system-assigned managed identity credential.
 
 ## 1.0.0-beta.26 (2026-06-28)
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Added a durable key-value **state store** client under `Azure.AI.AgentServer.Core.Storage`. `FoundryStateStore.GetOrCreateAsync` binds (creating if needed) a named, Foundry-backed store; instances expose async `GetAsync`/`UpdateAsync`/`DeleteAsync` for the store and `CreateItemAsync`/`SetItemAsync`/`GetItemAsync`/`DeleteItemAsync`/`ListKeysAsync` for its items, with optimistic concurrency (`If-Match`/`ETag`), optional per-user isolation, and store-level item TTL. The .NET analogue of the Python SDK's `FoundryStateStore`.
-- Added support for Microsoft Entra authentication when exporting telemetry to Azure Monitor. When `APPLICATIONINSIGHTS_AUTH_MODE` is set to `Entra`, the Azure Monitor exporter uses a system-assigned managed identity credential.
+- Added support for Microsoft Entra authentication when exporting telemetry to Azure Monitor. When `APPLICATIONINSIGHTS_AUTH_MODE` is set to `Entra`, the Azure Monitor exporter attempts to use a system-assigned managed identity credential (falling back to connection-string authentication if the credential cannot be created).
 
 ## 1.0.0-beta.26 (2026-06-28)
 


### PR DESCRIPTION
## Summary
- Date the Azure.AI.AgentServer.Core 1.0.0-beta.27 changelog entry
- Add the missing Azure Monitor Entra authentication release note

## Validation
- Ran Prepare-Release.ps1 for Azure.AI.AgentServer.Core