### PR TITLE
Forward ExcludePaths from the client archetype to the CI job template

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -94,6 +94,7 @@ extends:
             parameters:
               SDKType: ${{ parameters.SDKType }}
               ServiceDirectory: ${{ parameters.ServiceDirectory }}
+              ExcludePaths: ${{ parameters.ExcludePaths }}
               Artifacts: ${{ parameters.Artifacts }}
               ${{ if eq(parameters.ServiceDirectory, 'template') }}:
                 TestPipeline: true


### PR DESCRIPTION
## Problem

`archetype-sdk-client.yml` declares an `ExcludePaths` parameter but never forwards it to `jobs/ci.yml`, which is the template that actually consumes it — three `pr-matrix-presteps.yml` invocations (build matrix, analyze matrix, test matrix).

`pullrequest.yml` sets:

```yaml
ExcludePaths:
  - eng/packages/http-client-csharp/
```

Because the value stops at the archetype, that exclusion has silently had **no effect**: generator-only changes still select packages for PR validation.

## Fix

One line — forward the parameter:

```yaml
ExcludePaths: ${{ parameters.ExcludePaths }}
```

## Risk

The parameter defaults to `[]`, so every pipeline that does not set `ExcludePaths` is byte-identical. The only behavior change is that `pullrequest.yml`'s existing, already-intended exclusion starts working.

## Context

Found while reviewing PRs #61467 and #61501, which both carried this line incidentally. Split out here so it can be reviewed on its own merits rather than as scaffolding inside a performance change.