### PR TITLE
PR CI: install the .NET 8/9 SDKs only on jobs that test those frameworks

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -39,5 +39,6 @@ extends:
     ${{ else }}:
       ServiceDirectory: ${{ parameters.Service }}
     BuildSnippets: true
+    EnableTestRuntimeTrimming: true
     ExcludePaths:
       - eng/packages/http-client-csharp/

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -26,6 +26,9 @@ parameters:
     default: ''
   - name: OSName
     type: string
+  - name: EnableTestRuntimeTrimming
+    type: boolean
+    default: false
 
 jobs:
   - job:
@@ -131,6 +134,7 @@ jobs:
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
         parameters:
           NuGetCacheKey: Test
+          SkipUnusedTestRuntimes: ${{ parameters.EnableTestRuntimeTrimming }}
 
       # this section is only included when invoking with a dynamic set of packages (EG net - pullrequest)
       - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
@@ -203,6 +207,12 @@ jobs:
       - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@5
         condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))
         displayName: Generate Code Coverage Reports
+        # The task shells out to 'dotnet <task>/tools/net8.0/ReportGenerator.dll'. The
+        # coverage leg runs on a net10.0 agent, so once the 8.0 SDK install is skipped
+        # this only starts because the agent image happens to preinstall the 8.0
+        # runtime. Roll forward explicitly rather than depend on that.
+        env:
+          DOTNET_ROLL_FORWARD: Major
         inputs:
           reports: $(CodeCoverageFilePattern)
           targetdir: $(Build.ArtifactStagingDirectory)/coverage

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -42,6 +42,9 @@ parameters:
   - name: ExcludePaths
     type: object
     default: []
+  - name: EnableTestRuntimeTrimming
+    type: boolean
+    default: false
 
 jobs:
   - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
@@ -235,6 +238,8 @@ jobs:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           TestSetupSteps: ${{ parameters.TestSetupSteps }}
           TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+          ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+            EnableTestRuntimeTrimming: ${{ parameters.EnableTestRuntimeTrimming }}
 
   - ${{ if ne(parameters.TestDependsOnDependency, 'not-specified') }}:
     - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -54,6 +54,9 @@ parameters:
   - name: ExcludePaths
     type: object
     default: []
+  - name: EnableTestRuntimeTrimming
+    type: boolean
+    default: false
   - name: PublicFeed
     type: string
     default: 'Nuget.org'
@@ -102,6 +105,7 @@ extends:
               BuildSnippets: ${{ parameters.BuildSnippets }}
               TestSetupSteps: ${{ parameters.TestSetupSteps }}
               TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+              EnableTestRuntimeTrimming: ${{ parameters.EnableTestRuntimeTrimming }}
               MatrixConfigs:
                 - ${{ each config in parameters.MatrixConfigs }}:
                     - ${{ config }}

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -2,6 +2,10 @@ parameters:
   EnableNuGetCache: true
   NuGetCacheKey: 'Build'
   Container: false
+  # When true, the .NET 8 and .NET 9 SDKs are installed only for jobs that actually
+  # run tests on those frameworks. Jobs leave $(TestTargetFramework) unset unless they
+  # come from the test matrix, and those keep installing everything.
+  SkipUnusedTestRuntimes: false
 
 steps:
   # Need to authenticate so our pipeline can update packages in the feed.
@@ -17,6 +21,8 @@ steps:
   - task: UseDotNet@2 # We need .NET 9 for the .NET 9 tests
     displayName: 'Use .NET 9.0 SDK'
     retryCountOnTaskFailure: 3
+    ${{ if parameters.SkipUnusedTestRuntimes }}:
+      condition: and(succeeded(), or(eq(variables['TestTargetFramework'], ''), eq(variables['TestTargetFramework'], 'net9.0')))
     inputs:
       # AspNetCore runtime pack can't be installed outside of SDK and we need it for integration tests
       packageType: sdk
@@ -25,6 +31,8 @@ steps:
   - task: UseDotNet@2 # We need .NET 8 for the .NET 8 tests
     displayName: 'Use .NET 8.0 SDK'
     retryCountOnTaskFailure: 3
+    ${{ if parameters.SkipUnusedTestRuntimes }}:
+      condition: and(succeeded(), or(eq(variables['TestTargetFramework'], ''), eq(variables['TestTargetFramework'], 'net8.0')))
     inputs:
       # AspNetCore runtime pack can't be installed outside of SDK and we need it for integration tests
       packageType: sdk

--- a/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
@@ -77,6 +77,12 @@ namespace Azure.Core.TestFramework
                 RedirectStandardError = true,
                 EnvironmentVariables =
                 {
+                    // The proxy ships as a framework-dependent net8.0 application. The
+                    // default 'Minor' roll-forward policy will not run it on a host that
+                    // only has a newer major runtime, which happens whenever a test leg
+                    // does not itself target net8.0. eng/common/testproxy/test-proxy-tool.yml
+                    // sets the same variable when the pipeline starts this binary.
+                    ["DOTNET_ROLL_FORWARD"] = "Major",
                     ["ASPNETCORE_URLS"] = $"http://{IpAddress}:0;https://{IpAddress}:0",
                     ["Logging__LogLevel__Azure.Sdk.Tools.TestProxy"] = s_enableDebugProxyLogging ? "Debug" : "Error",
                     ["Logging__LogLevel__Default"] = "Error",

--- a/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestProxyProcess.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestProxyProcess.cs
@@ -107,6 +107,13 @@ public class TestProxyProcess
         testProxyProcessInfo.RedirectStandardError = true;
 
         // Set environment variables
+        // The proxy ships as a framework-dependent net8.0 application, both as the tool
+        // pinned in .config/dotnet-tools.json and as any TEST_PROXY_EXE_PATH override.
+        // The default 'Minor' roll-forward policy will not run it on a host that only has
+        // a newer major runtime, which happens whenever a test leg does not itself target
+        // net8.0. eng/common/testproxy/test-proxy-tool.yml sets the same variable when the
+        // pipeline starts this binary.
+        testProxyProcessInfo.EnvironmentVariables["DOTNET_ROLL_FORWARD"] = "Major";
         testProxyProcessInfo.EnvironmentVariables["ASPNETCORE_URLS"] = $"http://{IpAddress}:0;https://{IpAddress}:0";
         testProxyProcessInfo.EnvironmentVariables["Logging__LogLevel__Azure.Sdk.Tools.TestProxy"] = TestEnvironment.EnableTestProxyDebugLogs ? "Debug" : "Error";
         testProxyProcessInfo.EnvironmentVariables["Logging__LogLevel__Default"] = "Error";

--- a/sdk/openai/tools/TestFramework/src/Recording/Proxy/ProxyService.cs
+++ b/sdk/openai/tools/TestFramework/src/Recording/Proxy/ProxyService.cs
@@ -50,6 +50,13 @@ public class ProxyService : IDisposable
             UseShellExecute = false,
             EnvironmentVariables =
             {
+                // The proxy ships as a framework-dependent net8.0 application (see the
+                // TestProxyPath metadata in OpenAI.TestFramework.csproj). The default
+                // 'Minor' roll-forward policy will not run it on a host that only has a
+                // newer major runtime, which happens whenever a test leg does not itself
+                // target net8.0. eng/common/testproxy/test-proxy-tool.yml sets the same
+                // variable when the pipeline starts this binary.
+                ["DOTNET_ROLL_FORWARD"] = "Major",
                 ["ASPNETCORE_URLS"] = $"http://127.0.0.1:{options.HttpPort};https://127.0.0.1:{options.HttpsPort}",
                 ["Logging__LogLevel__Azure.Sdk.Tools.TestProxy"] = "Error",
                 ["Logging__LogLevel__Default"] = "Error",


### PR DESCRIPTION
Split out of #61501 (Lever 2 of that PR). **Draft** — needs a full-matrix validation run with coverage enabled before review.

## What

`install-dotnet.yml` installs global.json + `9.0.x` + `8.0.x` on **every** job, but the latter two exist only to supply runtimes for the net8/net9 test legs. `net10.0` and `net462` jobs pay for two installs they never use.

Gated on `$(TestTargetFramework)` behind a new `SkipUnusedTestRuntimes` parameter, which treats an unset value as "install everything", so non-test callers are unchanged.

## Measured

From the #61501 A/B (treatment `6632010` vs baseline `6631799`, 28 paired jobs):

| | baseline | treatment | delta |
|---|---|---|---|
| Use .NET 9.0 SDK | 21.8s, 28/28 ran | 4.9s, **21/28 skipped** | −7.9 agent-min |
| Use .NET 8.0 SDK | 22.8s, 28/28 ran | 7.4s, **21/28 skipped** | −7.2 agent-min |

~15 agent-min/run, mean 23.2s/job. That is roughly **10% of the combined win** of the original PR — the checkout narrowing carried the other 90%, which is why this half was worth separating rather than blocking on.

## Why this is split out

Removing a runtime that was previously *always* present affects any framework-dependent **net8.0** tool the legs invoke. Review found four across successive rounds, all of which silently relied on the unconditional 8.0 install:

| launcher | how it starts the net8.0 binary |
|---|---|
| `Azure.Core.TestFramework/TestProxy.cs` | `dotnet <TestProxyPath>` → `tools/net8.0/…TestProxy.dll` |
| `OpenAI.TestFramework` `ProxyService.cs` | same binary, via `OpenAI.TestFramework.csproj:36` |
| `Microsoft.ClientModel.TestFramework` `TestProxyProcess.cs` | falls through to `dotnet tool run test-proxy` (net8.0 tool pinned in `.config/dotnet-tools.json`) |
| `reportgenerator@5` task | `dotnet <task>/tools/net8.0/ReportGenerator.dll` |

All four now set **`DOTNET_ROLL_FORWARD=Major`**, scoped to the individual process rather than the job. A job-wide variable would let a net8.0 leg silently run on net10 if its SDK install failed, defeating the purpose of that leg.

The coverage case is the sharpest: `platform-matrix.json` pins the `Coverage_Record` include to a **`Windows2022_NET10.0`** agent, so on the one leg where `CollectCoverage` is true, both installs are skipped.

## Validation status

Empirically this already worked before the roll-forward hardening — in treatment build `6632010`, job `Test Windows2022_NET100_Coverage_Record_PackageRef_b1`:

```
Use .NET 9.0 SDK                  skipped
Use .NET 8.0 SDK                  skipped
Generate Code Coverage Reports    succeeded
```

with the log confirming `[command]…dotnet.exe …\5.5.11\tools\net8.0\ReportGenerator.dll`, and proxy legs on Windows *and* macOS logging a running proxy. macOS has no multi-level lookup, so the explanation is simply that the agent images preinstall the .NET 8 runtime.

That is a dependency on an undocumented property of the agent image, not a guarantee — hence the explicit roll-forward. **Remaining work before this leaves draft:** a full-matrix run with coverage enabled, on a package set that includes at least one `Microsoft.ClientModel.TestFramework` and one `OpenAI.TestFramework` consumer. The original A/B used a synthetic 40-package fixture that contained none of them, so its green result was evidence about the packages measured, not about the change in general.

## Series

#61442 matrix generation cost · #61501 test checkout narrowing (the other 90%) · #61521 `ExcludePaths` forwarding · this PR runtime install trimming
