### PR TITLE
build: use ADO feed for autorest dependencies during analyze step

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -105,6 +105,7 @@ steps:
     env:
       EnableSourceLink: false
       NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/analyze-job/.npmrc
+      autorest_registry: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
 
   - pwsh: |
       $failed = $false


### PR DESCRIPTION
Autorest dependencies should be installed from the public ADO feed, not public npm.

sample run: [link](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6634542&view=logs&j=4c429d73-76a3-5ab2-1f4b-e4f874ab1c9b&t=d0d6daad-ada7-5b4e-df80-067e309b6da6&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c)