### PR TITLE
chore: add @meetamitbhatia to CODEOWNERS alongside @j7nw4r

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -275,17 +275,17 @@
 # ServiceOwners: @rajeshka @shankarsama
 
 # PRLabel: %Event Hubs
-/sdk/eventhub/    @axisc @hmlam @j7nw4r @jsquire @sagar0207 @sjkwak @SwayGom
+/sdk/eventhub/    @axisc @hmlam @j7nw4r @jsquire @meetamitbhatia @sagar0207 @sjkwak @SwayGom
 
 # PRLabel: %Event Hubs %Functions
-/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/    @axisc @hmlam @j7nw4r @jsquire @sagar0207 @sjkwak @SwayGom
+/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/    @axisc @hmlam @j7nw4r @jsquire @meetamitbhatia @sagar0207 @sjkwak @SwayGom
 
 # AzureSdkOwners: @jsquire
 # ServiceLabel: %Event Hubs
-# ServiceOwners: @axisc @hmlam @j7nw4r @sagar0207 @sjkwak @SwayGom
+# ServiceOwners: @axisc @hmlam @j7nw4r @meetamitbhatia @sagar0207 @sjkwak @SwayGom
 
 # PRLabel: %Functions %Service Bus
-/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/    @EldertGrootenboer @j7nw4r @jsquire @sagar0207 @skarri-microsoft @SwayGom
+/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/    @EldertGrootenboer @j7nw4r @jsquire @meetamitbhatia @sagar0207 @skarri-microsoft @SwayGom
 
 # AzureSdkOwners: @jsquire
 # ServiceLabel: %Functions
@@ -397,11 +397,11 @@
 # ServiceOwners: @efrainretana @mattgotteiner
 
 # PRLabel: %Service Bus
-/sdk/servicebus/    @EldertGrootenboer @j7nw4r @jsquire @sagar0207 @skarri-microsoft @SwayGom
+/sdk/servicebus/    @EldertGrootenboer @j7nw4r @jsquire @meetamitbhatia @sagar0207 @skarri-microsoft @SwayGom
 
 # AzureSdkOwners: @jsquire
 # ServiceLabel: %Service Bus
-# ServiceOwners: @EldertGrootenboer @j7nw4r @sagar0207 @skarri-microsoft @SwayGom
+# ServiceOwners: @EldertGrootenboer @j7nw4r @meetamitbhatia @sagar0207 @skarri-microsoft @SwayGom
 
 # PRLabel: %SignalR
 /sdk/signalr/    @chenkennt @JialinXin @vicancy @Y-Sindo


### PR DESCRIPTION
## Summary

@meetamitbhatia (Amit Bhatia) is not in the CODEOWNERS file. He works on the messaging libraries and must get review requests on the same paths as @j7nw4r.

## Motivation

@meetamitbhatia joined the messaging team. Without a CODEOWNERS entry, GitHub does not add him to pull requests that touch the messaging paths. The team then loses a reviewer, and review latency goes up.

## Changes

This change adds `@meetamitbhatia` next to `@j7nw4r` on every line that already lists `@j7nw4r`. It changes 4 owner paths and 2 `ServiceOwners` comments. It removes no owner and adds no new path.

Owner paths:

- `/sdk/eventhub/`
- `/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/`
- `/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/`
- `/sdk/servicebus/`

The owner lists in this file are in alphabetical order. The new handle keeps that order.

## Validation

@meetamitbhatia is a member of the `Azure` organization, so the CODEOWNERS linter can resolve the handle.
