### PR TITLE
Prepare release: System.ClientModel 1.15.0-beta.1

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 1.15.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.15.0-beta.1 (2026-07-29)
 
 ### Bugs Fixed
 
+- Fixed credential resolver caching so chain-owning resolvers are rebuilt for each resolution while resolved leaf credentials remain shared across chains.
+
 ### Other Changes
+
+- Added distributed tracing support used by generated unbranded client libraries.
 
 ## 1.14.0 (2026-06-03)
 

--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - Fixed credential resolver caching so chain-owning resolvers are rebuilt for each resolution while resolved leaf credentials remain shared across chains.
 
-### Other Changes
-
-- Added distributed tracing support used by generated unbranded client libraries.
-
 ## 1.14.0 (2026-06-03)
 
 ### Features Added


### PR DESCRIPTION
Prepares System.ClientModel 1.15.0-beta.1 for release on July 29, 2026.\n\n- Finalizes the changelog release date\n- Documents the credential resolver caching fix\n\nRelease tracking: https://dev.azure.com/azure-sdk/Release/_workitems/edit/34837/