### PR TITLE
Enable automated SDK build repair workflow

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -25,6 +25,11 @@
       "version": "v7.0.1",
       "sha": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     },
+    "github/gh-aw-actions/setup-cli@v0.81.6": {
+      "repo": "github/gh-aw-actions/setup-cli",
+      "version": "v0.81.6",
+      "sha": "ba6380cc6e5be5d21677bebe04d52fb48e3abec7"
+    },
     "github/gh-aw-actions/setup@v0.81.6": {
       "repo": "github/gh-aw-actions/setup",
       "version": "v0.81.6",

--- a/.github/workflows/sdk-build-repair.lock.yml
+++ b/.github/workflows/sdk-build-repair.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"f8fafbab77d5b260c3ea6414935a647bdff88990ab7d7f373b71c894c112b0db","body_hash":"059d4d6411e55c56af78efc608a70c0fdfa10d7856207f98b990b32978550e23","compiler_version":"v0.81.6","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.65"}}
-# gh-aw-manifest: {"version":1,"secrets":["GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"9a946fdbd5fb07b82b2f5a4466058b876ab72bb2","version":"v5.3.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba6380cc6e5be5d21677bebe04d52fb48e3abec7","version":"v0.81.6"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11","digest":"sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11@sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11","digest":"sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11@sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11","digest":"sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11@sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.30","digest":"sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.30@sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"e5b39f44569f34e14d859a407a6da6d7fff272faaaf9336d64eee785b3add86f","body_hash":"059d4d6411e55c56af78efc608a70c0fdfa10d7856207f98b990b32978550e23","compiler_version":"v0.81.6","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.65"}}
+# gh-aw-manifest: {"version":1,"secrets":["GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"9a946fdbd5fb07b82b2f5a4466058b876ab72bb2","version":"v5.3.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba6380cc6e5be5d21677bebe04d52fb48e3abec7","version":"v0.81.6"},{"repo":"github/gh-aw-actions/setup-cli","sha":"ba6380cc6e5be5d21677bebe04d52fb48e3abec7","version":"v0.81.6"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11","digest":"sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11@sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11","digest":"sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11@sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11","digest":"sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11@sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.30","digest":"sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.30@sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
 # This file was automatically generated by gh-aw (v0.81.6). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -25,6 +25,10 @@
 #
 # Auto-repair custom-code build failures on release-planner Auto SDK PRs labeled auto-sdk-build-fix, by driving the shared azsdk customized-update engine in custom-code-only scope.
 #
+# Frontmatter env variables:
+#   - AZSDK_COPILOT_CLI_PATH: (main workflow)
+#   - AZSDK_COPILOT_GITHUB_TOKEN: (main workflow)
+#
 # Secrets used:
 #   - GH_AW_CI_TRIGGER_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
@@ -41,6 +45,7 @@
 #   - actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+#   - github/gh-aw-actions/setup-cli@ba6380cc6e5be5d21677bebe04d52fb48e3abec7 # v0.81.6
 #   - github/gh-aw-actions/setup@ba6380cc6e5be5d21677bebe04d52fb48e3abec7 # v0.81.6
 #
 # Container images used:
@@ -76,14 +81,15 @@ concurrency: sdk-build-repair-${{ github.event.pull_request.number || github.eve
 
 run-name: "SDK Build Repair"
 
+env:
+  AZSDK_COPILOT_CLI_PATH: /usr/local/bin/copilot
+  AZSDK_COPILOT_GITHUB_TOKEN: ${{ github.token }}
+
 jobs:
   activation:
     needs: pre_activation
     if: >
       needs.pre_activation.outputs.activated == 'true' && (((vars.SDK_BUILD_REPAIR_ENABLED == 'true'
-      && contains(
-      fromJSON(vars.SDK_BUILD_REPAIR_ALLOWED_PRS || '[]'),
-      github.event.pull_request.number || github.event.issue.number)
       && (github.event_name != 'pull_request'
       || (github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.base.ref == 'main'
@@ -513,6 +519,10 @@ jobs:
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '10.0.x'
+      - name: Install gh-aw extension
+        uses: github/gh-aw-actions/setup-cli@ba6380cc6e5be5d21677bebe04d52fb48e3abec7 # v0.81.6
+        with:
+          version: 'v0.81.6'
       - name: Create gh-aw temp directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh"
       - name: Configure gh CLI for GitHub Enterprise
@@ -520,10 +530,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Install azsdk CLI
-        run: |
-          $dir = Join-Path $env:RUNNER_TEMP 'azsdk-cli'
-          ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $dir
-          Add-Content -Path $env:GITHUB_PATH -Value $dir
+        run: "# gh-aw exposes tool-cache bin directories inside the agent sandbox.\n$dir = Join-Path $env:RUNNER_TOOL_CACHE 'azsdk/latest/x64/bin'\n./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $dir\nAdd-Content -Path $env:GITHUB_PATH -Value $dir\n& (Join-Path $dir 'azsdk') --version\n"
         shell: pwsh
 
       - name: Configure Git credentials
@@ -1589,9 +1596,6 @@ jobs:
   pre_activation:
     if: >
       (github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) || github.actor == 'azure-sdk' || github.actor == 'azure-sdk-automation[bot]') && (((vars.SDK_BUILD_REPAIR_ENABLED == 'true'
-      && contains(
-      fromJSON(vars.SDK_BUILD_REPAIR_ALLOWED_PRS || '[]'),
-      github.event.pull_request.number || github.event.issue.number)
       && (github.event_name != 'pull_request'
       || (github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/sdk-build-repair.md
+++ b/.github/workflows/sdk-build-repair.md
@@ -51,11 +51,9 @@ on:
   roles: [admin, maintainer, write]
   bots: ["azure-sdk", "azure-sdk-automation[bot]"]
 
-# Master kill-switch (fail-safe) + PR allowlist + eligibility gate. The workflow stays
-# dormant unless the repo Actions variable SDK_BUILD_REPAIR_ENABLED is exactly 'true' and
-# the PR number is in SDK_BUILD_REPAIR_ALLOWED_PRS (a JSON array such as `[12345]`). An
-# absent or empty allowlist permits no PRs. In addition, on the automatic (pull_request)
-# path the PR must be a genuine release-planner Auto SDK PR:
+# Master kill-switch (fail-safe) + eligibility gate. The workflow stays dormant unless
+# the repo Actions variable SDK_BUILD_REPAIR_ENABLED is exactly 'true'. In addition, on
+# the automatic (pull_request) path the PR must be a genuine release-planner Auto SDK PR:
 # same-repo (no forks), opened by the `azure-sdk` or `azure-sdk-automation[bot]` release bot,
 # targeting `main`, on an
 # `sdkauto/` branch. This gates *which PRs are eligible* (not just *who* can trigger), so a
@@ -65,9 +63,6 @@ on:
 # "Eligibility" in the prompt below.
 if: >-
   ${{ vars.SDK_BUILD_REPAIR_ENABLED == 'true'
-      && contains(
-          fromJSON(vars.SDK_BUILD_REPAIR_ALLOWED_PRS || '[]'),
-          github.event.pull_request.number || github.event.issue.number)
       && (github.event_name != 'pull_request'
           || (github.event.pull_request.head.repo.full_name == github.repository
               && github.event.pull_request.base.ref == 'main'
@@ -83,6 +78,12 @@ permissions:
   contents: read
   pull-requests: read
   copilot-requests: write
+
+# Authenticate the nested Copilot SDK used by azsdk with the workflow's Copilot CLI
+# and built-in token.
+env:
+  AZSDK_COPILOT_CLI_PATH: /usr/local/bin/copilot
+  AZSDK_COPILOT_GITHUB_TOKEN: ${{ github.token }}
 
 network:
   allowed:
@@ -102,9 +103,11 @@ steps:
   - name: Install azsdk CLI
     shell: pwsh
     run: |
-      $dir = Join-Path $env:RUNNER_TEMP 'azsdk-cli'
+      # gh-aw exposes tool-cache bin directories inside the agent sandbox.
+      $dir = Join-Path $env:RUNNER_TOOL_CACHE 'azsdk/latest/x64/bin'
       ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $dir
       Add-Content -Path $env:GITHUB_PATH -Value $dir
+      & (Join-Path $dir 'azsdk') --version
 
 tools:
   github:


### PR DESCRIPTION
## Purpose

Enable the SDK build repair agent for eligible release-planner Auto SDK PRs.

## Changes

- remove the temporary per-PR allowlist while retaining the repository kill switch
- retain same-repository, release-bot, `main`, and `sdkauto/*` eligibility gates
- authenticate nested azsdk Copilot sessions with the built-in workflow token
- reuse the workflow's installed Copilot CLI and expose azsdk through the mounted tool cache
- regenerate the gh-aw lock file

## Validation

- `gh aw compile sdk-build-repair --strict`
- end-to-end repair completed successfully on #61234 using azsdk 0.6.33: https://github.com/Azure/azure-sdk-for-net/actions/runs/30491883496

The `SDK_BUILD_REPAIR_ENABLED` repository variable remains the production kill switch and should be set to `true` when this PR is merged.