### PR TITLE
Revert "Enforce cfs clean (#61256)"

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -41,10 +41,7 @@ extends:
     settings:
       skipBuildTagsForGitHubPullRequests: true
       # Do not add CFSClean until packages are published through ESRP instead of directly to NuGet.
-      ${{ if and(eq(variables['System.TeamProject'], 'internal'), or(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'IndividualCI'))) }}:
-        networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
-      ${{ else }}:
-        networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
+      networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -41,6 +41,8 @@ extends:
     settings:
       skipBuildTagsForGitHubPullRequests: true
       # Do not add CFSClean until packages are published through ESRP instead of directly to NuGet.
+      # Even conditional usage of CFSClean causes the pipeline to be classified as always CFSClean
+      # in the backend, which blocks publishing to NuGet.
       networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:


### PR DESCRIPTION
- This reverts commit 82a31495a85e83ea86376b5713d520c3a2bca4b3.
- Conditionally setting `CFSClean` can trigger the pipeline being classified as **always** `CFSClean` in the backend, blocking publishing to NuGet even when the pipeline is run in "publish" mode without `CFSClean`
