### PR TITLE
Update Azure.Provisioning.Compute beta.2 release date

### DIFF
--- a/sdk/compute/Azure.Provisioning.Compute/CHANGELOG.md
+++ b/sdk/compute/Azure.Provisioning.Compute/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (2026-07-10)
+## 1.0.0-beta.2 (2026-07-30)
 
 ### Features Added
 


### PR DESCRIPTION
Updates the Azure.Provisioning.Compute 1.0.0-beta.2 release date to 2026-07-30 for release.