### PR TITLE
Regenerate OperationalInsights provisioning code

### DIFF
--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/ClusterProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/ClusterProperties.cs
@@ -186,8 +186,8 @@ namespace Azure.Provisioning.OperationalInsights
             _isAvailabilityZonesEnabled = DefineProperty<bool>(nameof(IsAvailabilityZonesEnabled), new string[] { "isAvailabilityZonesEnabled" });
             _billingType = DefineProperty<OperationalInsightsBillingType>(nameof(BillingType), new string[] { "billingType" });
             _keyVaultProperties = DefineModelProperty<OperationalInsightsKeyVaultProperties>(nameof(KeyVaultProperties), new string[] { "keyVaultProperties" });
-            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, isOutput: true);
-            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, isOutput: true);
+            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, isOutput: true, format: "O");
+            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, isOutput: true, format: "O");
             _associatedWorkspaces = DefineListProperty<OperationalInsightsClusterAssociatedWorkspace>(nameof(AssociatedWorkspaces), new string[] { "associatedWorkspaces" });
             _capacityReservationProperties = DefineModelProperty<OperationalInsightsCapacityReservationProperties>(nameof(CapacityReservationProperties), new string[] { "capacityReservationProperties" });
             _replication = DefineModelProperty<OperationalInsightsClusterReplicationProperties>(nameof(Replication), new string[] { "replication" });

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/DataExportProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/DataExportProperties.cs
@@ -172,8 +172,8 @@ namespace Azure.Provisioning.OperationalInsights
             _tableNames = DefineListProperty<string>(nameof(TableNames), new string[] { "tableNames" }, isRequired: true);
             _destination = DefineModelProperty<Destination>(nameof(Destination), new string[] { "destination" });
             _isEnabled = DefineProperty<bool>(nameof(IsEnabled), new string[] { "enable" });
-            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" });
-            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" });
+            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, format: "O");
+            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, format: "O");
             DefineAdditionalProperties();
         }
 

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/LogAnalyticsQueryPackProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/LogAnalyticsQueryPackProperties.cs
@@ -69,8 +69,8 @@ namespace Azure.Provisioning.OperationalInsights
         {
             base.DefineProvisionableProperties();
             _queryPackId = DefineProperty<Guid>(nameof(QueryPackId), new string[] { "queryPackId" }, isOutput: true);
-            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "timeCreated" }, isOutput: true);
-            _modifiedOn = DefineProperty<DateTimeOffset>(nameof(ModifiedOn), new string[] { "timeModified" }, isOutput: true);
+            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "timeCreated" }, isOutput: true, format: "O");
+            _modifiedOn = DefineProperty<DateTimeOffset>(nameof(ModifiedOn), new string[] { "timeModified" }, isOutput: true, format: "O");
             _provisioningState = DefineProperty<string>(nameof(ProvisioningState), new string[] { "provisioningState" }, isOutput: true);
             DefineAdditionalProperties();
         }

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/LogAnalyticsQueryPackQueryProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/LogAnalyticsQueryPackQueryProperties.cs
@@ -166,8 +166,8 @@ namespace Azure.Provisioning.OperationalInsights
             base.DefineProvisionableProperties();
             _applicationId = DefineProperty<Guid>(nameof(ApplicationId), new string[] { "id" }, isOutput: true);
             _displayName = DefineProperty<string>(nameof(DisplayName), new string[] { "displayName" }, isRequired: true);
-            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "timeCreated" }, isOutput: true);
-            _modifiedOn = DefineProperty<DateTimeOffset>(nameof(ModifiedOn), new string[] { "timeModified" }, isOutput: true);
+            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "timeCreated" }, isOutput: true, format: "O");
+            _modifiedOn = DefineProperty<DateTimeOffset>(nameof(ModifiedOn), new string[] { "timeModified" }, isOutput: true, format: "O");
             _author = DefineProperty<string>(nameof(Author), new string[] { "author" }, isOutput: true);
             _description = DefineProperty<string>(nameof(Description), new string[] { "description" });
             _body = DefineProperty<string>(nameof(Body), new string[] { "body" }, isRequired: true);

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsCapacityReservationProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsCapacityReservationProperties.cs
@@ -46,7 +46,7 @@ namespace Azure.Provisioning.OperationalInsights
         protected override void DefineProvisionableProperties()
         {
             base.DefineProvisionableProperties();
-            _lastSkuUpdatedOn = DefineProperty<DateTimeOffset>(nameof(LastSkuUpdatedOn), new string[] { "lastSkuUpdate" }, isOutput: true);
+            _lastSkuUpdatedOn = DefineProperty<DateTimeOffset>(nameof(LastSkuUpdatedOn), new string[] { "lastSkuUpdate" }, isOutput: true, format: "O");
             _minCapacity = DefineProperty<long>(nameof(MinCapacity), new string[] { "minCapacity" }, isOutput: true);
             DefineAdditionalProperties();
         }

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsClusterAssociatedWorkspace.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsClusterAssociatedWorkspace.cs
@@ -72,7 +72,7 @@ namespace Azure.Provisioning.OperationalInsights
             _workspaceId = DefineProperty<Guid>(nameof(WorkspaceId), new string[] { "workspaceId" }, isOutput: true);
             _workspaceName = DefineProperty<string>(nameof(WorkspaceName), new string[] { "workspaceName" }, isOutput: true);
             _resourceId = DefineProperty<ResourceIdentifier>(nameof(ResourceId), new string[] { "resourceId" }, isOutput: true);
-            _associatedOn = DefineProperty<DateTimeOffset>(nameof(AssociatedOn), new string[] { "associateDate" }, isOutput: true);
+            _associatedOn = DefineProperty<DateTimeOffset>(nameof(AssociatedOn), new string[] { "associateDate" }, isOutput: true, format: "O");
             DefineAdditionalProperties();
         }
 

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsClusterReplicationProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsClusterReplicationProperties.cs
@@ -110,8 +110,8 @@ namespace Azure.Provisioning.OperationalInsights
             _isReplicationEnabled = DefineProperty<bool>(nameof(IsReplicationEnabled), new string[] { "enabled" });
             _isAvailabilityZonesEnabled = DefineProperty<bool>(nameof(IsAvailabilityZonesEnabled), new string[] { "isAvailabilityZonesEnabled" });
             _provisioningState = DefineProperty<OperationalInsightsClusterReplicationState>(nameof(ProvisioningState), new string[] { "provisioningState" }, isOutput: true);
-            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, isOutput: true);
-            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, isOutput: true);
+            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, isOutput: true, format: "O");
+            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, isOutput: true, format: "O");
             DefineAdditionalProperties();
         }
 

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsSummaryRule.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsSummaryRule.cs
@@ -123,7 +123,7 @@ namespace Azure.Provisioning.OperationalInsights
             _query = DefineProperty<string>(nameof(Query), new string[] { "query" });
             _binSize = DefineProperty<int>(nameof(BinSize), new string[] { "binSize" });
             _binDelay = DefineProperty<int>(nameof(BinDelay), new string[] { "binDelay" });
-            _binStartOn = DefineProperty<DateTimeOffset>(nameof(BinStartOn), new string[] { "binStartTime" });
+            _binStartOn = DefineProperty<DateTimeOffset>(nameof(BinStartOn), new string[] { "binStartTime" }, format: "O");
             _timeSelector = DefineProperty<OperationalInsightsSummaryTimeSelector>(nameof(TimeSelector), new string[] { "timeSelector" });
             _destinationTable = DefineProperty<string>(nameof(DestinationTable), new string[] { "destinationTable" });
             DefineAdditionalProperties();

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsTableRestoredLogs.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsTableRestoredLogs.cs
@@ -83,8 +83,8 @@ namespace Azure.Provisioning.OperationalInsights
         protected override void DefineProvisionableProperties()
         {
             base.DefineProvisionableProperties();
-            _startRestoreOn = DefineProperty<DateTimeOffset>(nameof(StartRestoreOn), new string[] { "startRestoreTime" });
-            _endRestoreOn = DefineProperty<DateTimeOffset>(nameof(EndRestoreOn), new string[] { "endRestoreTime" });
+            _startRestoreOn = DefineProperty<DateTimeOffset>(nameof(StartRestoreOn), new string[] { "startRestoreTime" }, format: "O");
+            _endRestoreOn = DefineProperty<DateTimeOffset>(nameof(EndRestoreOn), new string[] { "endRestoreTime" }, format: "O");
             _sourceTable = DefineProperty<string>(nameof(SourceTable), new string[] { "sourceTable" });
             _azureAsyncOperationId = DefineProperty<Guid>(nameof(AzureAsyncOperationId), new string[] { "azureAsyncOperationId" }, isOutput: true);
             DefineAdditionalProperties();

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsTableSearchResults.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsTableSearchResults.cs
@@ -129,8 +129,8 @@ namespace Azure.Provisioning.OperationalInsights
             _query = DefineProperty<string>(nameof(Query), new string[] { "query" });
             _description = DefineProperty<string>(nameof(Description), new string[] { "description" });
             _limit = DefineProperty<int>(nameof(Limit), new string[] { "limit" });
-            _startSearchOn = DefineProperty<DateTimeOffset>(nameof(StartSearchOn), new string[] { "startSearchTime" });
-            _endSearchOn = DefineProperty<DateTimeOffset>(nameof(EndSearchOn), new string[] { "endSearchTime" });
+            _startSearchOn = DefineProperty<DateTimeOffset>(nameof(StartSearchOn), new string[] { "startSearchTime" }, format: "O");
+            _endSearchOn = DefineProperty<DateTimeOffset>(nameof(EndSearchOn), new string[] { "endSearchTime" }, format: "O");
             _sourceTable = DefineProperty<string>(nameof(SourceTable), new string[] { "sourceTable" }, isOutput: true);
             _azureAsyncOperationId = DefineProperty<Guid>(nameof(AzureAsyncOperationId), new string[] { "azureAsyncOperationId" }, isOutput: true);
             DefineAdditionalProperties();

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsWorkspaceFailoverProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsWorkspaceFailoverProperties.cs
@@ -47,7 +47,7 @@ namespace Azure.Provisioning.OperationalInsights
         {
             base.DefineProvisionableProperties();
             _state = DefineProperty<OperationalInsightsWorkspaceFailoverState>(nameof(State), new string[] { "state" }, isOutput: true);
-            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, isOutput: true);
+            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, isOutput: true, format: "O");
             DefineAdditionalProperties();
         }
 

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsWorkspaceReplicationProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsWorkspaceReplicationProperties.cs
@@ -93,8 +93,8 @@ namespace Azure.Provisioning.OperationalInsights
             _location = DefineProperty<AzureLocation>(nameof(Location), new string[] { "location" });
             _isReplicationEnabled = DefineProperty<bool>(nameof(IsReplicationEnabled), new string[] { "enabled" });
             _provisioningState = DefineProperty<OperationalInsightsWorkspaceReplicationState>(nameof(ProvisioningState), new string[] { "provisioningState" }, isOutput: true);
-            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, isOutput: true);
-            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, isOutput: true);
+            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, isOutput: true, format: "O");
+            _lastModifiedOn = DefineProperty<DateTimeOffset>(nameof(LastModifiedOn), new string[] { "lastModifiedDate" }, isOutput: true, format: "O");
             DefineAdditionalProperties();
         }
 

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsWorkspaceSku.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/OperationalInsightsWorkspaceSku.cs
@@ -69,7 +69,7 @@ namespace Azure.Provisioning.OperationalInsights
             base.DefineProvisionableProperties();
             _name = DefineProperty<OperationalInsightsWorkspaceSkuName>(nameof(Name), new string[] { "name" }, isRequired: true);
             _capacityReservationLevel = DefineProperty<OperationalInsightsWorkspaceCapacityReservationLevel>(nameof(CapacityReservationLevel), new string[] { "capacityReservationLevel" });
-            _lastSkuUpdatedOn = DefineProperty<DateTimeOffset>(nameof(LastSkuUpdatedOn), new string[] { "lastSkuUpdate" }, isOutput: true);
+            _lastSkuUpdatedOn = DefineProperty<DateTimeOffset>(nameof(LastSkuUpdatedOn), new string[] { "lastSkuUpdate" }, isOutput: true, format: "O");
             DefineAdditionalProperties();
         }
 

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/WorkspaceProperties.cs
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/src/Generated/Models/WorkspaceProperties.cs
@@ -245,8 +245,8 @@ namespace Azure.Provisioning.OperationalInsights
             _sku = DefineModelProperty<OperationalInsightsWorkspaceSku>(nameof(Sku), new string[] { "sku" });
             _retentionInDays = DefineProperty<int>(nameof(RetentionInDays), new string[] { "retentionInDays" });
             _workspaceCapping = DefineModelProperty<OperationalInsightsWorkspaceCapping>(nameof(WorkspaceCapping), new string[] { "workspaceCapping" });
-            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, isOutput: true);
-            _modifiedOn = DefineProperty<DateTimeOffset>(nameof(ModifiedOn), new string[] { "modifiedDate" }, isOutput: true);
+            _createdOn = DefineProperty<DateTimeOffset>(nameof(CreatedOn), new string[] { "createdDate" }, isOutput: true, format: "O");
+            _modifiedOn = DefineProperty<DateTimeOffset>(nameof(ModifiedOn), new string[] { "modifiedDate" }, isOutput: true, format: "O");
             _publicNetworkAccessForIngestion = DefineProperty<OperationalInsightsPublicNetworkAccessType>(nameof(PublicNetworkAccessForIngestion), new string[] { "publicNetworkAccessForIngestion" });
             _publicNetworkAccessForQuery = DefineProperty<OperationalInsightsPublicNetworkAccessType>(nameof(PublicNetworkAccessForQuery), new string[] { "publicNetworkAccessForQuery" });
             _forceCmkForQuery = DefineProperty<bool>(nameof(ForceCmkForQuery), new string[] { "forceCmkForQuery" });


### PR DESCRIPTION
## Summary
- regenerate `Azure.Provisioning.OperationalInsights` with `@azure-typespec/http-client-csharp-provisioning` `1.0.0-alpha.20260729.5`
- preserve TypeSpec date-time formats by registering affected `DateTimeOffset` properties with round-trip (`O`) formatting

## Validation
- `dotnet format` passed
- TypeSpec regeneration completed with no warnings or errors
- API export completed with no API changes
- non-live tests and ApiCompat passed across all target frameworks