### PR TITLE
Added New Key Type Support for AKP Keys

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 4.11.0-beta.4 (Unreleased)
 
 ### Features Added
+- Added support for Algorithm Key Pair (AKP) keys, such as ML-DSA post-quantum keys:
+  - Added the `KeyType.Akp` and `KeyType.AkpHsm` key types.
+  - Added the `AkpAlgorithm` type listing the supported AKP algorithms.
+  - Added the `CreateAkpKeyOptions` model and the new `CreateAkpKey` and `CreateAkpKeyAsync` methods in `KeyClient`.
+  - Added the `Algorithm` and `Pub` properties to `JsonWebKey`.
 
 ### Breaking Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/AkpAlgorithm.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/AkpAlgorithm.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+namespace Azure.Security.KeyVault.Keys
+{
+    /// <summary>
+    /// The algorithm identifier for an Algorithm Key Pair (AKP) key, such as ML-DSA.
+    /// This value is required when the <see cref="KeyType"/> is <see cref="KeyType.Akp"/> or <see cref="KeyType.AkpHsm"/>.
+    /// </summary>
+    public readonly struct AkpAlgorithm : IEquatable<AkpAlgorithm>
+    {
+        internal const string MLDsa44Value = "ML-DSA-44";
+        internal const string MLDsa65Value = "ML-DSA-65";
+        internal const string MLDsa87Value = "ML-DSA-87";
+
+        private readonly string _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AkpAlgorithm"/> structure.
+        /// </summary>
+        /// <param name="value">The string value of the instance.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        public AkpAlgorithm(string value)
+        {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Gets the ML-DSA-44 algorithm, as defined by FIPS 204.
+        /// </summary>
+        public static AkpAlgorithm MLDsa44 { get; } = new AkpAlgorithm(MLDsa44Value);
+
+        /// <summary>
+        /// Gets the ML-DSA-65 algorithm, as defined by FIPS 204.
+        /// </summary>
+        public static AkpAlgorithm MLDsa65 { get; } = new AkpAlgorithm(MLDsa65Value);
+
+        /// <summary>
+        /// Gets the ML-DSA-87 algorithm, as defined by FIPS 204.
+        /// </summary>
+        public static AkpAlgorithm MLDsa87 { get; } = new AkpAlgorithm(MLDsa87Value);
+
+        /// <summary>
+        /// Determines if two <see cref="AkpAlgorithm"/> values are the same.
+        /// </summary>
+        /// <param name="left">The first <see cref="AkpAlgorithm"/> to compare.</param>
+        /// <param name="right">The second <see cref="AkpAlgorithm"/> to compare.</param>
+        /// <returns>True if <paramref name="left"/> and <paramref name="right"/> are the same; otherwise, false.</returns>
+        public static bool operator ==(AkpAlgorithm left, AkpAlgorithm right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines if two <see cref="AkpAlgorithm"/> values are different.
+        /// </summary>
+        /// <param name="left">The first <see cref="AkpAlgorithm"/> to compare.</param>
+        /// <param name="right">The second <see cref="AkpAlgorithm"/> to compare.</param>
+        /// <returns>True if <paramref name="left"/> and <paramref name="right"/> are different; otherwise, false.</returns>
+        public static bool operator !=(AkpAlgorithm left, AkpAlgorithm right) => !left.Equals(right);
+
+        /// <summary>
+        /// Converts a string to a <see cref="AkpAlgorithm"/>.
+        /// </summary>
+        /// <param name="value">The string value to convert.</param>
+        public static implicit operator AkpAlgorithm(string value) => new AkpAlgorithm(value);
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => obj is AkpAlgorithm other && Equals(other);
+
+        /// <inheritdoc/>
+        public bool Equals(AkpAlgorithm other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+
+        /// <inheritdoc/>
+        public override string ToString() => _value;
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/CreateAkpKeyOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/CreateAkpKeyOptions.cs
@@ -39,10 +39,11 @@ namespace Azure.Security.KeyVault.Keys
         /// <param name="algorithm">The algorithm identifier for the Algorithm Key Pair (AKP) key. See <see cref="AkpAlgorithm"/> for possible values.</param>
         /// <param name="hardwareProtected">True to create a hardware-protected key in a hardware security module (HSM). The default is false to create a software key.</param>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null, or <paramref name="algorithm"/> is not set.</exception>
         public CreateAkpKeyOptions(string name, AkpAlgorithm algorithm, bool hardwareProtected = false)
         {
             Argument.AssertNotNullOrEmpty(name, nameof(name));
+            Argument.AssertNotNull(algorithm.ToString(), nameof(algorithm));
 
             Name = name;
             Algorithm = algorithm;

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/CreateAkpKeyOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/CreateAkpKeyOptions.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+
+namespace Azure.Security.KeyVault.Keys
+{
+    /// <summary>
+    /// The properties needed to create an Algorithm Key Pair (AKP) key, such as ML-DSA, using the <see cref="KeyClient"/>.
+    /// </summary>
+    public class CreateAkpKeyOptions : CreateKeyOptions
+    {
+        /// <summary>
+        /// Gets the name of the key to create.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the key type of the <see cref="JsonWebKey"/> to create, including <see cref="KeyType.Akp"/> and <see cref="KeyType.AkpHsm"/>.
+        /// </summary>
+        public KeyType KeyType { get; }
+
+        /// <summary>
+        /// Gets the algorithm identifier for the Algorithm Key Pair (AKP) key. See <see cref="AkpAlgorithm"/> for possible values.
+        /// </summary>
+        public AkpAlgorithm Algorithm { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether to create a hardware-protected key in a hardware security module (HSM).
+        /// </summary>
+        /// <value><c>true</c> to create a hardware-protected key; otherwise, <c>false</c> to create a software key.</value>
+        public bool HardwareProtected { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateAkpKeyOptions"/> class.
+        /// </summary>
+        /// <param name="name">The name of the key to create.</param>
+        /// <param name="algorithm">The algorithm identifier for the Algorithm Key Pair (AKP) key. See <see cref="AkpAlgorithm"/> for possible values.</param>
+        /// <param name="hardwareProtected">True to create a hardware-protected key in a hardware security module (HSM). The default is false to create a software key.</param>
+        /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+        public CreateAkpKeyOptions(string name, AkpAlgorithm algorithm, bool hardwareProtected = false)
+        {
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
+
+            Name = name;
+            Algorithm = algorithm;
+            HardwareProtected = hardwareProtected;
+            if (hardwareProtected)
+            {
+                KeyType = KeyType.AkpHsm;
+            }
+            else
+            {
+                KeyType = KeyType.Akp;
+            }
+        }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
@@ -1110,6 +1110,148 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         }
 
         /// <summary>
+        /// Signs a message using a post-quantum ML-DSA (AKP) key.
+        /// </summary>
+        /// <param name="options">The <see cref="MLDsaSignOptions"/> describing the message or external mu to sign and any optional context.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+        /// <returns>
+        /// The result of the sign operation. The returned <see cref="SignResult"/> contains the signature
+        /// along with all other information needed to verify it. This information should be stored with the signature.
+        /// </returns>
+        /// <remarks>
+        /// The algorithm is inferred from the key and is not specified by the caller. This operation is always performed by the vault and is not supported by local-only clients.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client was constructed with a local key and cannot perform this operation.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual async Task<SignResult> SignAsync(MLDsaSignOptions options, CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotNull(options, nameof(options));
+
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(CryptographyClient)}.{nameof(Sign)}");
+            scope.AddAttribute(OTelKeyIdKey, _keyId);
+            scope.Start();
+
+            try
+            {
+                ThrowIfLocalOnly(nameof(Sign));
+
+                return await _remoteProvider.SignAsync(options, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Signs a message using a post-quantum ML-DSA (AKP) key.
+        /// </summary>
+        /// <param name="options">The <see cref="MLDsaSignOptions"/> describing the message or external mu to sign and any optional context.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+        /// <returns>
+        /// The result of the sign operation. The returned <see cref="SignResult"/> contains the signature
+        /// along with all other information needed to verify it. This information should be stored with the signature.
+        /// </returns>
+        /// <remarks>
+        /// The algorithm is inferred from the key and is not specified by the caller. This operation is always performed by the vault and is not supported by local-only clients.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client was constructed with a local key and cannot perform this operation.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual SignResult Sign(MLDsaSignOptions options, CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotNull(options, nameof(options));
+
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(CryptographyClient)}.{nameof(Sign)}");
+            scope.AddAttribute(OTelKeyIdKey, _keyId);
+            scope.Start();
+
+            try
+            {
+                ThrowIfLocalOnly(nameof(Sign));
+
+                return _remoteProvider.Sign(options, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Verifies a signature using a post-quantum ML-DSA (AKP) key.
+        /// </summary>
+        /// <param name="options">The <see cref="MLDsaVerifyOptions"/> describing the signature to verify, the message or external mu, and any optional context.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+        /// <returns>
+        /// The result of the verify operation. If the signature is valid the <see cref="VerifyResult.IsValid"/> property of the returned <see cref="VerifyResult"/> will be set to true.
+        /// </returns>
+        /// <remarks>
+        /// The algorithm is inferred from the key and is not specified by the caller. This operation is always performed by the vault and is not supported by local-only clients.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client was constructed with a local key and cannot perform this operation.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual async Task<VerifyResult> VerifyAsync(MLDsaVerifyOptions options, CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotNull(options, nameof(options));
+
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(CryptographyClient)}.{nameof(Verify)}");
+            scope.AddAttribute(OTelKeyIdKey, _keyId);
+            scope.Start();
+
+            try
+            {
+                ThrowIfLocalOnly(nameof(Verify));
+
+                return await _remoteProvider.VerifyAsync(options, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Verifies a signature using a post-quantum ML-DSA (AKP) key.
+        /// </summary>
+        /// <param name="options">The <see cref="MLDsaVerifyOptions"/> describing the signature to verify, the message or external mu, and any optional context.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+        /// <returns>
+        /// The result of the verify operation. If the signature is valid the <see cref="VerifyResult.IsValid"/> property of the returned <see cref="VerifyResult"/> will be set to true.
+        /// </returns>
+        /// <remarks>
+        /// The algorithm is inferred from the key and is not specified by the caller. This operation is always performed by the vault and is not supported by local-only clients.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The client was constructed with a local key and cannot perform this operation.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual VerifyResult Verify(MLDsaVerifyOptions options, CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotNull(options, nameof(options));
+
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(CryptographyClient)}.{nameof(Verify)}");
+            scope.AddAttribute(OTelKeyIdKey, _keyId);
+            scope.Start();
+
+            try
+            {
+                ThrowIfLocalOnly(nameof(Verify));
+
+                return _remoteProvider.Verify(options, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Signs the specified data.
         /// </summary>
         /// <param name="algorithm">The <see cref="SignatureAlgorithm"/> to use.</param>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_01_01_Preview;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_05_01_Preview;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client
@@ -69,6 +69,12 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             /// The Key Vault API version 2026-01-01-preview.
             /// </summary>
             V2026_01_01_Preview = 8,
+
+            /// <summary>
+            /// The Key Vault API version 2026-05-01-preview.
+            /// </summary>
+            V2026_05_01_Preview = 9,
+
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -112,6 +118,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
                 ServiceVersion.V7_6 => "7.6",
                 ServiceVersion.V2025_07_01 => "2025-07-01",
                 ServiceVersion.V2026_01_01_Preview => "2026-01-01-preview",
+                ServiceVersion.V2026_05_01_Preview => "2026-05-01-preview",
                 _ => throw new ArgumentException(Version.ToString()),
             };
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeySignParameters.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeySignParameters.cs
@@ -10,10 +10,16 @@ namespace Azure.Security.KeyVault.Keys
     {
         private static readonly JsonEncodedText s_algorithmPropertyNameBytes = JsonEncodedText.Encode("alg");
         private static readonly JsonEncodedText s_digestPropertyNameBytes = JsonEncodedText.Encode("value");
+        private static readonly JsonEncodedText s_externalMuPropertyNameBytes = JsonEncodedText.Encode("external_mu");
+        private static readonly JsonEncodedText s_contextPropertyNameBytes = JsonEncodedText.Encode("context");
 
         public string Algorithm { get; set; }
 
         public byte[] Digest { get; set; }
+
+        public byte[] ExternalMu { get; set; }
+
+        public byte[] Context { get; set; }
 
         void IJsonSerializable.WriteProperties(Utf8JsonWriter json)
         {
@@ -24,6 +30,14 @@ namespace Azure.Security.KeyVault.Keys
             if (Digest != null)
             {
                 json.WriteString(s_digestPropertyNameBytes, Base64Url.Encode(Digest));
+            }
+            if (ExternalMu != null)
+            {
+                json.WriteString(s_externalMuPropertyNameBytes, Base64Url.Encode(ExternalMu));
+            }
+            if (Context != null)
+            {
+                json.WriteString(s_contextPropertyNameBytes, Base64Url.Encode(Context));
             }
         }
     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyVerifyParameters.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyVerifyParameters.cs
@@ -11,12 +11,18 @@ namespace Azure.Security.KeyVault.Keys
         private static readonly JsonEncodedText s_algorithmPropertyNameBytes = JsonEncodedText.Encode("alg");
         private static readonly JsonEncodedText s_digestPropertyNameBytes = JsonEncodedText.Encode("digest");
         private static readonly JsonEncodedText s_signaturePropertyNameBytes = JsonEncodedText.Encode("value");
+        private static readonly JsonEncodedText s_externalMuPropertyNameBytes = JsonEncodedText.Encode("external_mu");
+        private static readonly JsonEncodedText s_contextPropertyNameBytes = JsonEncodedText.Encode("context");
 
         public string Algorithm { get; set; }
 
         public byte[] Digest { get; set; }
 
         public byte[] Signature { get; set; }
+
+        public byte[] ExternalMu { get; set; }
+
+        public byte[] Context { get; set; }
 
         void IJsonSerializable.WriteProperties(Utf8JsonWriter json)
         {
@@ -31,6 +37,14 @@ namespace Azure.Security.KeyVault.Keys
             if (Signature != null)
             {
                 json.WriteString(s_signaturePropertyNameBytes, Base64Url.Encode(Signature));
+            }
+            if (ExternalMu != null)
+            {
+                json.WriteString(s_externalMuPropertyNameBytes, Base64Url.Encode(ExternalMu));
+            }
+            if (Context != null)
+            {
+                json.WriteString(s_contextPropertyNameBytes, Base64Url.Encode(Context));
             }
         }
     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/MLDsaSignOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/MLDsaSignOptions.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+
+namespace Azure.Security.KeyVault.Keys.Cryptography
+{
+    /// <summary>
+    /// Options for signing with a post-quantum ML-DSA (AKP) key using
+    /// <see cref="CryptographyClient.Sign(MLDsaSignOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    /// <remarks>
+    /// Exactly one of <see cref="Message"/> or <see cref="ExternalMu"/> must be set.
+    /// When <see cref="ExternalMu"/> is specified, <see cref="Context"/> must not be set.
+    /// The algorithm is inferred from the key and is not specified by the caller.
+    /// </remarks>
+    public class MLDsaSignOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MLDsaSignOptions"/> class.
+        /// </summary>
+        public MLDsaSignOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MLDsaSignOptions"/> class for signing a message.
+        /// </summary>
+        /// <param name="message">The message to sign.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+        public MLDsaSignOptions(byte[] message)
+        {
+            Argument.AssertNotNull(message, nameof(message));
+
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets or sets the message to sign. Mutually exclusive with <see cref="ExternalMu"/>.
+        /// </summary>
+        public byte[] Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pre-computed 64-byte mu value to sign. Mutually exclusive with
+        /// <see cref="Message"/> and cannot be combined with <see cref="Context"/>.
+        /// </summary>
+        public byte[] ExternalMu { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional context of up to 255 bytes. Cannot be used with <see cref="ExternalMu"/>.
+        /// </summary>
+        public byte[] Context { get; set; }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/MLDsaVerifyOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/MLDsaVerifyOptions.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+
+namespace Azure.Security.KeyVault.Keys.Cryptography
+{
+    /// <summary>
+    /// Options for verifying a signature with a post-quantum ML-DSA (AKP) key using
+    /// <see cref="CryptographyClient.Verify(MLDsaVerifyOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Signature"/> is always required. Exactly one of <see cref="Message"/> or
+    /// <see cref="ExternalMu"/> must be set. When <see cref="ExternalMu"/> is specified,
+    /// <see cref="Context"/> must not be set. The algorithm is inferred from the key and is not
+    /// specified by the caller.
+    /// </remarks>
+    public class MLDsaVerifyOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MLDsaVerifyOptions"/> class.
+        /// </summary>
+        public MLDsaVerifyOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MLDsaVerifyOptions"/> class for verifying a message signature.
+        /// </summary>
+        /// <param name="message">The message corresponding to the <paramref name="signature"/>.</param>
+        /// <param name="signature">The signature to verify.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> or <paramref name="signature"/> is null.</exception>
+        public MLDsaVerifyOptions(byte[] message, byte[] signature)
+        {
+            Argument.AssertNotNull(message, nameof(message));
+            Argument.AssertNotNull(signature, nameof(signature));
+
+            Message = message;
+            Signature = signature;
+        }
+
+        /// <summary>
+        /// Gets or sets the message corresponding to the <see cref="Signature"/>. Mutually exclusive with <see cref="ExternalMu"/>.
+        /// </summary>
+        public byte[] Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the signature to verify. This value is required.
+        /// </summary>
+        public byte[] Signature { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pre-computed 64-byte mu value corresponding to the <see cref="Signature"/>.
+        /// Mutually exclusive with <see cref="Message"/> and cannot be combined with <see cref="Context"/>.
+        /// </summary>
+        public byte[] ExternalMu { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional context of up to 255 bytes. Cannot be used with <see cref="ExternalMu"/>.
+        /// </summary>
+        public byte[] Context { get; set; }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RemoteCryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RemoteCryptographyClient.cs
@@ -398,6 +398,104 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             }
         }
 
+        public virtual async Task<Response<SignResult>> SignAsync(MLDsaSignOptions options, CancellationToken cancellationToken = default)
+        {
+            var parameters = new KeySignParameters
+            {
+                Digest = options.Message,
+                ExternalMu = options.ExternalMu,
+                Context = options.Context,
+            };
+
+            using DiagnosticScope scope = Pipeline.CreateScope($"{nameof(RemoteCryptographyClient)}.{nameof(Sign)}");
+            scope.AddAttribute(OTelKeyIdKey, _keyIdStr);
+            scope.Start();
+
+            try
+            {
+                return await Pipeline.SendRequestAsync(RequestMethod.Post, parameters, () => new SignResult(), cancellationToken, "/sign").ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        public virtual Response<SignResult> Sign(MLDsaSignOptions options, CancellationToken cancellationToken = default)
+        {
+            var parameters = new KeySignParameters
+            {
+                Digest = options.Message,
+                ExternalMu = options.ExternalMu,
+                Context = options.Context,
+            };
+
+            using DiagnosticScope scope = Pipeline.CreateScope($"{nameof(RemoteCryptographyClient)}.{nameof(Sign)}");
+            scope.AddAttribute(OTelKeyIdKey, _keyIdStr);
+            scope.Start();
+
+            try
+            {
+                return Pipeline.SendRequest(RequestMethod.Post, parameters, () => new SignResult(), cancellationToken, "/sign");
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        public virtual async Task<Response<VerifyResult>> VerifyAsync(MLDsaVerifyOptions options, CancellationToken cancellationToken = default)
+        {
+            var parameters = new KeyVerifyParameters
+            {
+                Digest = options.Message,
+                Signature = options.Signature,
+                ExternalMu = options.ExternalMu,
+                Context = options.Context,
+            };
+
+            using DiagnosticScope scope = Pipeline.CreateScope($"{nameof(RemoteCryptographyClient)}.{nameof(Verify)}");
+            scope.AddAttribute(OTelKeyIdKey, _keyIdStr);
+            scope.Start();
+
+            try
+            {
+                return await Pipeline.SendRequestAsync(RequestMethod.Post, parameters, () => new VerifyResult { KeyId = _keyId.AbsoluteUri }, cancellationToken, "/verify").ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        public virtual Response<VerifyResult> Verify(MLDsaVerifyOptions options, CancellationToken cancellationToken = default)
+        {
+            var parameters = new KeyVerifyParameters
+            {
+                Digest = options.Message,
+                Signature = options.Signature,
+                ExternalMu = options.ExternalMu,
+                Context = options.Context,
+            };
+
+            using DiagnosticScope scope = Pipeline.CreateScope($"{nameof(RemoteCryptographyClient)}.{nameof(Verify)}");
+            scope.AddAttribute(OTelKeyIdKey, _keyIdStr);
+            scope.Start();
+
+            try
+            {
+                return Pipeline.SendRequest(RequestMethod.Post, parameters, () => new VerifyResult { KeyId = _keyId.AbsoluteUri }, cancellationToken, "/verify");
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
         internal virtual async Task<Response<KeyVaultKey>> GetKeyAsync(CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = Pipeline.CreateScope($"{nameof(RemoteCryptographyClient)}.{nameof(GetKey)}");

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/JsonWebKey.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/JsonWebKey.cs
@@ -37,6 +37,8 @@ namespace Azure.Security.KeyVault.Keys
         private const string DPropertyName = "d";
         private const string KPropertyName = "k";
         private const string TPropertyName = "key_hsm";
+        private const string AlgorithmPropertyName = "alg";
+        private const string PubPropertyName = "pub";
 
         private static readonly JsonEncodedText s_keyIdPropertyNameBytes = JsonEncodedText.Encode(KeyIdPropertyName);
         private static readonly JsonEncodedText s_keyTypePropertyNameBytes = JsonEncodedText.Encode(KeyTypePropertyName);
@@ -54,6 +56,8 @@ namespace Azure.Security.KeyVault.Keys
         private static readonly JsonEncodedText s_dPropertyNameBytes = JsonEncodedText.Encode(DPropertyName);
         private static readonly JsonEncodedText s_kPropertyNameBytes = JsonEncodedText.Encode(KPropertyName);
         private static readonly JsonEncodedText s_tPropertyNameBytes = JsonEncodedText.Encode(TPropertyName);
+        private static readonly JsonEncodedText s_algorithmPropertyNameBytes = JsonEncodedText.Encode(AlgorithmPropertyName);
+        private static readonly JsonEncodedText s_pubPropertyNameBytes = JsonEncodedText.Encode(PubPropertyName);
 
         private static readonly KeyOperation[] s_aesKeyOperation = { KeyOperation.Encrypt, KeyOperation.Decrypt, KeyOperation.WrapKey, KeyOperation.UnwrapKey };
         private static readonly KeyOperation[] s_rSAPublicKeyOperation = { KeyOperation.Encrypt, KeyOperation.Verify, KeyOperation.WrapKey };
@@ -253,6 +257,21 @@ namespace Azure.Security.KeyVault.Keys
         /// </summary>
         public byte[] T { get; set; }
 
+        #region AKP Key Parameters
+
+        /// <summary>
+        /// Gets or sets the algorithm identifier for an Algorithm Key Pair (AKP) key, such as ML-DSA.
+        /// This value is set when the <see cref="KeyType"/> is <see cref="KeyType.Akp"/> or <see cref="KeyType.AkpHsm"/>.
+        /// </summary>
+        public AkpAlgorithm? Algorithm { get; set; }
+
+        /// <summary>
+        /// Gets or sets the public key for an Algorithm Key Pair (AKP) key, such as ML-DSA.
+        /// </summary>
+        public byte[] Pub { get; set; }
+
+        #endregion
+
         internal bool HasPrivateKey
         {
             get
@@ -427,6 +446,12 @@ namespace Azure.Security.KeyVault.Keys
                     case TPropertyName:
                         T = Base64Url.Decode(prop.Value.GetString());
                         break;
+                    case AlgorithmPropertyName:
+                        Algorithm = prop.Value.GetString();
+                        break;
+                    case PubPropertyName:
+                        Pub = Base64Url.Decode(prop.Value.GetString());
+                        break;
                 }
             }
         }
@@ -501,6 +526,14 @@ namespace Azure.Security.KeyVault.Keys
             if (T != null)
             {
                 json.WriteString(s_tPropertyNameBytes, Base64Url.Encode(T));
+            }
+            if (Algorithm.HasValue)
+            {
+                json.WriteString(s_algorithmPropertyNameBytes, Algorithm.Value.ToString());
+            }
+            if (Pub != null)
+            {
+                json.WriteString(s_pubPropertyNameBytes, Base64Url.Encode(Pub));
             }
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -330,6 +330,68 @@ namespace Azure.Security.KeyVault.Keys
         }
 
         /// <summary>
+        /// Creates and stores a new Algorithm Key Pair (AKP) key. If the named key already exists,
+        /// a new version of the key is created. This operation requires the keys/create permission.
+        /// Only available with service version <see cref="KeyClientOptions.ServiceVersion.V2026_05_01_Preview"/> and newer.
+        /// </summary>
+        /// <param name="akpKeyOptions">The key options object containing information about the Algorithm Key Pair (AKP) key being created.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="akpKeyOptions"/> is null.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        [CallerShouldAudit(CallerShouldAuditReason)]
+        public virtual Response<KeyVaultKey> CreateAkpKey(CreateAkpKeyOptions akpKeyOptions, CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotNull(akpKeyOptions, nameof(akpKeyOptions));
+
+            var parameters = new KeyRequestParameters(akpKeyOptions);
+
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(KeyClient)}.{nameof(CreateAkpKey)}");
+            scope.AddAttribute(OTelKeyNameKey, akpKeyOptions.Name);
+            scope.Start();
+
+            try
+            {
+                return _pipeline.SendRequest(RequestMethod.Post, parameters, () => new KeyVaultKey(akpKeyOptions.Name), cancellationToken, KeysPath, akpKeyOptions.Name, "/create");
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Creates and stores a new Algorithm Key Pair (AKP) key. If the named key already exists,
+        /// a new version of the key is created. This operation requires the keys/create permission.
+        /// Only available with service version <see cref="KeyClientOptions.ServiceVersion.V2026_05_01_Preview"/> and newer.
+        /// </summary>
+        /// <param name="akpKeyOptions">The key options object containing information about the Algorithm Key Pair (AKP) key being created.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="akpKeyOptions"/> is null.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        [CallerShouldAudit(CallerShouldAuditReason)]
+        public virtual async Task<Response<KeyVaultKey>> CreateAkpKeyAsync(CreateAkpKeyOptions akpKeyOptions, CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotNull(akpKeyOptions, nameof(akpKeyOptions));
+
+            var parameters = new KeyRequestParameters(akpKeyOptions);
+
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(KeyClient)}.{nameof(CreateAkpKey)}");
+            scope.AddAttribute(OTelKeyNameKey, akpKeyOptions.Name);
+            scope.Start();
+
+            try
+            {
+                return await _pipeline.SendRequestAsync(RequestMethod.Post, parameters, () => new KeyVaultKey(akpKeyOptions.Name), cancellationToken, KeysPath, akpKeyOptions.Name, "/create").ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Registers a Managed HSM key that points at material managed by an external HSM.
         /// This operation requires the keys/create permission. Only available with service version
         /// <see cref="KeyClientOptions.ServiceVersion.V2026_01_01_Preview"/> and newer, and only supported on Managed HSM.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Keys
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_01_01_Preview;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_05_01_Preview;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client
@@ -69,6 +69,11 @@ namespace Azure.Security.KeyVault.Keys
             /// The Key Vault API version 2026-01-01-preview.
             /// </summary>
             V2026_01_01_Preview = 8,
+
+            /// <summary>
+            /// The Key Vault API version 2026-05-01-preview.
+            /// </summary>
+            V2026_05_01_Preview = 9,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -112,6 +117,7 @@ namespace Azure.Security.KeyVault.Keys
                 ServiceVersion.V7_6 => "7.6",
                 ServiceVersion.V2025_07_01 => "2025-07-01",
                 ServiceVersion.V2026_01_01_Preview => "2026-01-01-preview",
+                ServiceVersion.V2026_05_01_Preview => "2026-05-01-preview",
                 _ => throw new ArgumentException(Version.ToString()),
             };
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyOperation.cs
@@ -35,12 +35,12 @@ namespace Azure.Security.KeyVault.Keys
         public static KeyOperation Decrypt { get; } = new KeyOperation("decrypt");
 
         /// <summary>
-        /// Gets a value that indicates the key can be used to sign with the <see cref="CryptographyClient.SignAsync"/> or <see cref="CryptographyClient.Sign"/> methods.
+        /// Gets a value that indicates the key can be used to sign with the <see cref="CryptographyClient.SignAsync(SignatureAlgorithm, byte[], System.Threading.CancellationToken)">SignAsync</see> or <see cref="CryptographyClient.Sign(SignatureAlgorithm, byte[], System.Threading.CancellationToken)">Sign</see> methods.
         /// </summary>
         public static KeyOperation Sign { get; } = new KeyOperation("sign");
 
         /// <summary>
-        /// Gets a value that indicates the key can be used to verify with the <see cref="CryptographyClient.VerifyAsync"/> or <see cref="CryptographyClient.Verify"/> methods.
+        /// Gets a value that indicates the key can be used to verify with the <see cref="CryptographyClient.VerifyAsync(SignatureAlgorithm, byte[], byte[], System.Threading.CancellationToken)">VerifyAsync</see> or <see cref="CryptographyClient.Verify(SignatureAlgorithm, byte[], byte[], System.Threading.CancellationToken)">Verify</see> methods.
         /// </summary>
         public static KeyOperation Verify { get; } = new KeyOperation("verify");
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyRequestParameters.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyRequestParameters.cs
@@ -17,6 +17,7 @@ namespace Azure.Security.KeyVault.Keys
         private const string TagsPropertyName = "tags";
         private const string PublicExponentPropertyName = "public_exponent";
         private const string ReleasePolicyPropertyName = "release_policy";
+        private const string AlgorithmPropertyName = "alg";
 
         private static readonly JsonEncodedText s_keyTypePropertyNameBytes = JsonEncodedText.Encode(KeyTypePropertyName);
         private static readonly JsonEncodedText s_keySizePropertyNameBytes = JsonEncodedText.Encode(KeySizePropertyName);
@@ -26,6 +27,7 @@ namespace Azure.Security.KeyVault.Keys
         private static readonly JsonEncodedText s_tagsPropertyNameBytes = JsonEncodedText.Encode(TagsPropertyName);
         private static readonly JsonEncodedText s_publicExponentPropertyNameBytes = JsonEncodedText.Encode(PublicExponentPropertyName);
         private static readonly JsonEncodedText s_releasePolicyPropertyNameBytes = JsonEncodedText.Encode(ReleasePolicyPropertyName);
+        private static readonly JsonEncodedText s_algorithmPropertyNameBytes = JsonEncodedText.Encode(AlgorithmPropertyName);
 
         private KeyAttributes _attributes;
 
@@ -41,6 +43,7 @@ namespace Azure.Security.KeyVault.Keys
         public KeyCurveName? Curve { get; set; }
         public int? PublicExponent { get; set; }
         public KeyReleasePolicy ReleasePolicy { get; set; }
+        public AkpAlgorithm? Algorithm { get; set; }
 
         internal KeyRequestParameters(KeyProperties key, IEnumerable<KeyOperation> operations)
         {
@@ -132,6 +135,12 @@ namespace Azure.Security.KeyVault.Keys
             }
         }
 
+        internal KeyRequestParameters(CreateAkpKeyOptions akpKey)
+            : this(akpKey.KeyType, akpKey)
+        {
+            Algorithm = akpKey.Algorithm;
+        }
+
         internal KeyRequestParameters(CreateExternalKeyOptions externalKeyOptions)
         {
             _attributes.ExternalKey = externalKeyOptions.ExternalKey;
@@ -171,6 +180,11 @@ namespace Azure.Security.KeyVault.Keys
             if (Curve.HasValue)
             {
                 json.WriteString(s_curveNamePropertyNameBytes, Curve.Value.ToString());
+            }
+
+            if (Algorithm.HasValue)
+            {
+                json.WriteString(s_algorithmPropertyNameBytes, Algorithm.Value.ToString());
             }
 
             if (_attributes.ShouldSerialize)

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyType.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyType.cs
@@ -17,6 +17,8 @@ namespace Azure.Security.KeyVault.Keys
         internal const string RsaHsmValue = "RSA-HSM";
         internal const string OctValue = "oct";
         internal const string OctHsmValue = "oct-HSM";
+        internal const string AkpValue = "AKP";
+        internal const string AkpHsmValue = "AKP-HSM";
 
         private readonly string _value;
 
@@ -58,6 +60,16 @@ namespace Azure.Security.KeyVault.Keys
         /// An AES cryptographic algorithm backed by a Hardware Security Module (HSM).
         /// </summary>
         public static KeyType OctHsm { get; } = new KeyType(OctHsmValue);
+
+        /// <summary>
+        /// An Algorithm Key Pair (AKP) key. The specific algorithm is determined by the associated <see cref="AkpAlgorithm"/>.
+        /// </summary>
+        public static KeyType Akp { get; } = new KeyType(AkpValue);
+
+        /// <summary>
+        /// An Algorithm Key Pair (AKP) key backed by a Hardware Security Module (HSM). The specific algorithm is determined by the associated <see cref="AkpAlgorithm"/>.
+        /// </summary>
+        public static KeyType AkpHsm { get; } = new KeyType(AkpHsmValue);
 
         /// <summary>
         /// Determines if two <see cref="KeyType"/> values are the same.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/AkpAlgorithmTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/AkpAlgorithmTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.Security.KeyVault.Keys.Tests
+{
+    public class AkpAlgorithmTests
+    {
+        [Test]
+        public void Equality()
+        {
+            AkpAlgorithm left = AkpAlgorithm.MLDsa65;
+            AkpAlgorithm right = new AkpAlgorithm("ML-DSA-65");
+
+            Assert.IsTrue(left == right);
+            Assert.IsFalse(left != right);
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(left.Equals((object)right));
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+        }
+
+        [Test]
+        public void Inequality()
+        {
+            AkpAlgorithm left = AkpAlgorithm.MLDsa44;
+            AkpAlgorithm right = AkpAlgorithm.MLDsa87;
+
+            Assert.IsFalse(left == right);
+            Assert.IsTrue(left != right);
+            Assert.IsFalse(left.Equals(right));
+            Assert.IsFalse(left.Equals("not an AkpAlgorithm"));
+        }
+
+        [Test]
+        public void NullValueThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AkpAlgorithm(null));
+        }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CreateAkpKeyOptionsTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CreateAkpKeyOptionsTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Azure.Security.KeyVault.Keys.Tests
+{
+    public class CreateAkpKeyOptionsTests
+    {
+        [Test]
+        public void NullNameThrows()
+        {
+            ArgumentException ex = Assert.Throws<ArgumentNullException>(
+                () => new CreateAkpKeyOptions(null, AkpAlgorithm.MLDsa65));
+            Assert.AreEqual("name", ex.ParamName);
+        }
+
+        [Test]
+        public void EmptyNameThrows()
+        {
+            ArgumentException ex = Assert.Throws<ArgumentException>(
+                () => new CreateAkpKeyOptions(string.Empty, AkpAlgorithm.MLDsa65));
+            Assert.AreEqual("name", ex.ParamName);
+        }
+
+        [Test]
+        public void UnsetAlgorithmThrows()
+        {
+            ArgumentException ex = Assert.Throws<ArgumentNullException>(
+                () => new CreateAkpKeyOptions("test", default(AkpAlgorithm)));
+            Assert.AreEqual("algorithm", ex.ParamName);
+        }
+
+        [Test]
+        public void UsesAkpKeyType()
+        {
+            CreateAkpKeyOptions options = new CreateAkpKeyOptions("test", AkpAlgorithm.MLDsa65);
+
+            Assert.AreEqual("test", options.Name);
+            Assert.AreEqual(AkpAlgorithm.MLDsa65, options.Algorithm);
+            Assert.IsFalse(options.HardwareProtected);
+            Assert.AreEqual(KeyType.Akp, options.KeyType);
+        }
+
+        [Test]
+        public void HardwareProtectedKeyUsesAkpHsmKeyType()
+        {
+            CreateAkpKeyOptions options = new CreateAkpKeyOptions("test", AkpAlgorithm.MLDsa87, hardwareProtected: true);
+
+            Assert.IsTrue(options.HardwareProtected);
+            Assert.AreEqual(KeyType.AkpHsm, options.KeyType);
+            Assert.AreEqual(AkpAlgorithm.MLDsa87, options.Algorithm);
+        }
+
+        [TestCase(false, "AKP", "ML-DSA-44")]
+        [TestCase(true, "AKP-HSM", "ML-DSA-87")]
+        public void SerializesKeyTypeAndAlgorithm(bool hardwareProtected, string expectedKeyType, string algorithm)
+        {
+            CreateAkpKeyOptions options = new CreateAkpKeyOptions("test", algorithm, hardwareProtected);
+            KeyRequestParameters parameters = new KeyRequestParameters(options);
+
+            using JsonDocument json = JsonDocument.Parse(parameters.Serialize());
+            JsonElement root = json.RootElement;
+
+            Assert.AreEqual(expectedKeyType, root.GetProperty("kty").GetString());
+            Assert.AreEqual(algorithm, root.GetProperty("alg").GetString());
+        }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/JsonWebKeyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/JsonWebKeyTests.cs
@@ -46,6 +46,28 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.That(deserialized, Is.EqualTo(jwk).Using(JsonWebKeyComparer.Shared));
         }
 
+        [TestCase("AKP")]
+        [TestCase("AKP-HSM")]
+        public void SerializeAkp(string keyType)
+        {
+            JsonWebKey jwk = new JsonWebKey
+            {
+                KeyType = new KeyType(keyType),
+                Algorithm = AkpAlgorithm.MLDsa65,
+                Pub = new byte[] { 1, 2, 3, 4, 5 },
+            };
+
+            ReadOnlyMemory<byte> serialized = jwk.Serialize();
+
+            using MemoryStream ms = new MemoryStream(serialized.ToArray());
+            JsonWebKey deserialized = new JsonWebKey();
+            deserialized.Deserialize(ms);
+
+            Assert.That(deserialized, Is.EqualTo(jwk).Using(JsonWebKeyComparer.Shared));
+            Assert.AreEqual(AkpAlgorithm.MLDsa65, deserialized.Algorithm);
+            CollectionAssert.AreEqual(jwk.Pub, deserialized.Pub);
+        }
+
         [Test]
         public void ToAes()
         {
@@ -518,6 +540,12 @@ namespace Azure.Security.KeyVault.Keys.Tests
                         && CollectionEquals(x.Y, y.Y);
                 }
 
+                if (x.KeyType == KeyType.Akp || x.KeyType == KeyType.AkpHsm)
+                {
+                    return Nullable.Equals(x.Algorithm, y.Algorithm)
+                        && CollectionEquals(x.Pub, y.Pub);
+                }
+
                 throw new NotImplementedException();
             }
 
@@ -541,6 +569,11 @@ namespace Azure.Security.KeyVault.Keys.Tests
                 if (obj.KeyType == KeyType.Ec)
                 {
                     return HashCodeBuilder.Combine(obj.KeyType, obj.X);
+                }
+
+                if (obj.KeyType == KeyType.Akp || obj.KeyType == KeyType.AkpHsm)
+                {
+                    return HashCodeBuilder.Combine(obj.KeyType, obj.Pub);
                 }
 
                 throw new NotImplementedException();

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientTests.cs
@@ -40,6 +40,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateEcKeyAsync(null));
             Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateRsaKeyAsync(null));
             Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateOctKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateAkpKeyAsync(null));
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 namespace Azure.Security.KeyVault.Keys.Tests
 {
     [ClientTestFixture(
+        KeyClientOptions.ServiceVersion.V2026_05_01_Preview,
         KeyClientOptions.ServiceVersion.V2026_01_01_Preview,
         KeyClientOptions.ServiceVersion.V2025_07_01,
         KeyClientOptions.ServiceVersion.V7_6,

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/MLDsaOptionsTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/MLDsaOptionsTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using NUnit.Framework;
+
+namespace Azure.Security.KeyVault.Keys.Tests
+{
+    public class MLDsaOptionsTests
+    {
+        private static readonly byte[] s_message = { 1, 2, 3, 4 };
+        private static readonly byte[] s_signature = { 5, 6, 7, 8 };
+        private static readonly byte[] s_externalMu = { 9, 10, 11, 12 };
+        private static readonly byte[] s_context = { 13, 14, 15, 16 };
+
+        [Test]
+        public void SignOptionsNullMessageThrows()
+        {
+            ArgumentException ex = Assert.Throws<ArgumentNullException>(() => new MLDsaSignOptions(null));
+            Assert.AreEqual("message", ex.ParamName);
+        }
+
+        [Test]
+        public void SignOptionsStoresMessage()
+        {
+            MLDsaSignOptions options = new MLDsaSignOptions(s_message);
+
+            Assert.AreSame(s_message, options.Message);
+            Assert.IsNull(options.ExternalMu);
+            Assert.IsNull(options.Context);
+        }
+
+        [Test]
+        public void VerifyOptionsNullMessageThrows()
+        {
+            ArgumentException ex = Assert.Throws<ArgumentNullException>(() => new MLDsaVerifyOptions(null, s_signature));
+            Assert.AreEqual("message", ex.ParamName);
+        }
+
+        [Test]
+        public void VerifyOptionsNullSignatureThrows()
+        {
+            ArgumentException ex = Assert.Throws<ArgumentNullException>(() => new MLDsaVerifyOptions(s_message, null));
+            Assert.AreEqual("signature", ex.ParamName);
+        }
+
+        [Test]
+        public void VerifyOptionsStoresMessageAndSignature()
+        {
+            MLDsaVerifyOptions options = new MLDsaVerifyOptions(s_message, s_signature);
+
+            Assert.AreSame(s_message, options.Message);
+            Assert.AreSame(s_signature, options.Signature);
+            Assert.IsNull(options.ExternalMu);
+            Assert.IsNull(options.Context);
+        }
+
+        [Test]
+        public void SignParametersSerializeMessageAndContext()
+        {
+            KeySignParameters parameters = new KeySignParameters
+            {
+                Digest = s_message,
+                Context = s_context,
+            };
+
+            using JsonDocument json = JsonDocument.Parse(((IJsonSerializable)parameters).Serialize());
+            JsonElement root = json.RootElement;
+
+            Assert.AreEqual(ToBase64Url(s_message), root.GetProperty("value").GetString());
+            Assert.AreEqual(ToBase64Url(s_context), root.GetProperty("context").GetString());
+            Assert.IsFalse(root.TryGetProperty("external_mu", out _));
+        }
+
+        [Test]
+        public void SignParametersSerializeExternalMu()
+        {
+            KeySignParameters parameters = new KeySignParameters
+            {
+                ExternalMu = s_externalMu,
+            };
+
+            using JsonDocument json = JsonDocument.Parse(((IJsonSerializable)parameters).Serialize());
+            JsonElement root = json.RootElement;
+
+            Assert.AreEqual(ToBase64Url(s_externalMu), root.GetProperty("external_mu").GetString());
+            Assert.IsFalse(root.TryGetProperty("value", out _));
+        }
+
+        [Test]
+        public void VerifyParametersSerializeExternalMuAndSignature()
+        {
+            KeyVerifyParameters parameters = new KeyVerifyParameters
+            {
+                Signature = s_signature,
+                ExternalMu = s_externalMu,
+            };
+
+            using JsonDocument json = JsonDocument.Parse(((IJsonSerializable)parameters).Serialize());
+            JsonElement root = json.RootElement;
+
+            Assert.AreEqual(ToBase64Url(s_signature), root.GetProperty("value").GetString());
+            Assert.AreEqual(ToBase64Url(s_externalMu), root.GetProperty("external_mu").GetString());
+        }
+
+        private static string ToBase64Url(byte[] value) =>
+            Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmCryptographyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmCryptographyClientLiveTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 namespace Azure.Security.KeyVault.Keys.Tests
 {
     [ClientTestFixture(
+        KeyClientOptions.ServiceVersion.V2026_05_01_Preview,
         KeyClientOptions.ServiceVersion.V2026_01_01_Preview,
         KeyClientOptions.ServiceVersion.V2025_07_01,
         KeyClientOptions.ServiceVersion.V7_6,

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmCryptographyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmCryptographyClientLiveTests.cs
@@ -271,6 +271,40 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.IsNotNull(unwrapResult.Key);
         }
 
+        [RecordedTest]
+        [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V2026_05_01_Preview)]
+        [Ignore("AKP sign/verify requires an INT Managed HSM; skipping until AKP GA.")]
+        public async Task MLDsaSignVerifyRoundTrip()
+        {
+            string keyName = Recording.GenerateId();
+            CreateAkpKeyOptions options = new CreateAkpKeyOptions(keyName, AkpAlgorithm.MLDsa65, hardwareProtected: true);
+            KeyVaultKey key = await Client.CreateAkpKeyAsync(options);
+            RegisterForCleanup(key.Name);
+
+            // ML-DSA sign/verify is remote-only; the algorithm is inferred from the key.
+            // TEMPORARY WORKAROUND: AKP keys require this in non-prod environments. The INT
+            // Managed HSM returns a key id whose host (e.g. "akp-sdk-test.managedhsm-int.azure-int.net")
+            // is not DNS-resolvable, so point the crypto client at the resolvable regional endpoint
+            // configured for the test. Can be removed and replaced with GetCryptoClient(key.Id, ...)
+            // when AKP goes GA and the returned key id host resolves.
+            Uri cryptoKeyId = new UriBuilder(key.Id) { Host = Uri.Host }.Uri;
+            CryptographyClient cryptoClient = GetCryptoClient(cryptoKeyId, forceRemote: true);
+
+            byte[] message = new byte[32];
+            Recording.Random.NextBytes(message);
+
+            SignResult signResult = await cryptoClient.SignAsync(new MLDsaSignOptions(message));
+
+            Assert.AreEqual(key.Id.ToString(), signResult.KeyId);
+            Assert.IsNotNull(signResult.Signature);
+
+            VerifyResult verifyResult = await cryptoClient.VerifyAsync(
+                new MLDsaVerifyOptions(message, signResult.Signature));
+
+            Assert.AreEqual(key.Id.ToString(), verifyResult.KeyId);
+            Assert.IsTrue(verifyResult.IsValid);
+        }
+
         private KeyReleasePolicy GetReleasePolicy()
         {
             BinaryData releasePolicy = BinaryData.FromObjectAsJson(new

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmLiveTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework.Internal.Commands;
 namespace Azure.Security.KeyVault.Keys.Tests
 {
     [ClientTestFixture(
+        KeyClientOptions.ServiceVersion.V2026_05_01_Preview,
         KeyClientOptions.ServiceVersion.V2026_01_01_Preview,
         KeyClientOptions.ServiceVersion.V2025_07_01,
         KeyClientOptions.ServiceVersion.V7_6,

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmLiveTests.cs
@@ -87,6 +87,26 @@ namespace Azure.Security.KeyVault.Keys.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V2026_05_01_Preview)]
+        [Ignore("AKP requires an INT Managed HSM; skipping until AKP GA.")]
+        public async Task CreateAkpKey()
+        {
+            string keyName = Recording.GenerateId();
+
+            CreateAkpKeyOptions options = new CreateAkpKeyOptions(keyName, AkpAlgorithm.MLDsa65, hardwareProtected: true);
+            KeyVaultKey akpKey = await Client.CreateAkpKeyAsync(options);
+            RegisterForCleanup(keyName);
+
+            KeyVaultKey keyReturned = await Client.GetKeyAsync(keyName);
+
+            AssertKeyVaultKeysEqual(akpKey, keyReturned);
+
+            Assert.AreEqual(KeyType.AkpHsm, keyReturned.KeyType);
+            Assert.AreEqual(AkpAlgorithm.MLDsa65, keyReturned.Key.Algorithm);
+            Assert.IsNotNull(keyReturned.Key.Pub);
+        }
+
+        [RecordedTest]
         [TestCase(16)]
         [TestCase(32)]
         [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V7_3)]


### PR DESCRIPTION
- Implemented AKP Key Type in Keys SDK
- Updated Service Version in Keys and Administration to 2026-05-01-preview
- Intentionally skipped Live Tests for AKP keys as they are not reay to be tested on Prod Clusters and require custom setup
- The Live Tests fpr AKP Kery passed locally, and these changes were also tested Manually
