### PR TITLE
Install Azurite from CFS-backed registry in storage tests

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -43,7 +43,7 @@ extends:
       # Do not add CFSClean until packages are published through ESRP instead of directly to NuGet.
       # Even conditional usage of CFSClean causes the pipeline to be classified as always CFSClean
       # in the backend, which blocks publishing to NuGet.
-      networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
+      networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -43,7 +43,7 @@ extends:
       # Do not add CFSClean until packages are published through ESRP instead of directly to NuGet.
       # Even conditional usage of CFSClean causes the pipeline to be classified as always CFSClean
       # in the backend, which blocks publishing to NuGet.
-      networkIsolationPolicy: Permissive, CFSClean2, CFSClean3
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'net - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/sdk/storage/tests-install-azurite.yml
+++ b/sdk/storage/tests-install-azurite.yml
@@ -14,12 +14,21 @@ steps:
       cacheHitVar: STORAGE_AZURITE_CACHE_RESTORED
     displayName: Cache Azurite installation
     continueOnError: true
+  # Point npm at the CFS-backed azure-sdk-for-js Azure Artifacts registry (instead of the public npmjs.org)
+  # and authenticate it, so the Azurite install below does not reach out to npmjs.org.
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/azurite-install/.npmrc
+      registryUrl: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
+      CustomCondition: and(succeeded(), ne(variables.STORAGE_AZURITE_CACHE_RESTORED, 'true'))
   - task: Npm@1
     inputs:
       command: custom
       customCommand: install --prefix ${{ parameters.AzuriteLocation }} azurite@${{ parameters.AzuriteVersion }}
     condition: and(succeeded(), ne(variables.STORAGE_AZURITE_CACHE_RESTORED, 'true'))
     displayName: Install Azurite
+    env:
+      NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/azurite-install/.npmrc
   - task: PowerShell@2
     displayName: Add Azurite location as environment variable
     inputs:

--- a/sdk/storage/tests-install-azurite.yml
+++ b/sdk/storage/tests-install-azurite.yml
@@ -21,10 +21,10 @@ steps:
       npmrcPath: $(Agent.TempDirectory)/azurite-install/.npmrc
       registryUrl: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
       CustomCondition: and(succeeded(), ne(variables.STORAGE_AZURITE_CACHE_RESTORED, 'true'))
-  - task: Npm@1
-    inputs:
-      command: custom
-      customCommand: install --prefix ${{ parameters.AzuriteLocation }} azurite@${{ parameters.AzuriteVersion }}
+  # Invoke npm directly (not the Npm@1 task) so our authenticated .npmrc is honored via
+  # NPM_CONFIG_USERCONFIG. The Npm@1 task generates its own npmrc and overrides userconfig,
+  # which would bypass the CFS registry and fall back to npmjs.org.
+  - pwsh: npm install --prefix "${{ parameters.AzuriteLocation }}" azurite@${{ parameters.AzuriteVersion }}
     condition: and(succeeded(), ne(variables.STORAGE_AZURITE_CACHE_RESTORED, 'true'))
     displayName: Install Azurite
     env:


### PR DESCRIPTION
## Description

Updates the storage test Azurite install pipeline to use the CFS-backed Azure SDK for JS Azure Artifacts npm registry instead of reaching out to public npmjs.org.

The install step now creates an authenticated npmrc when the Azurite cache is missed and passes it to npm through `NPM_CONFIG_USERCONFIG`.

## Testing

Not run; pipeline YAML change only.