### PR TITLE
Add the suppression to unblock builds

### DIFF
--- a/eng/apicompatbaselines/Azure.AI.Agents.Persistent.xml
+++ b/eng/apicompatbaselines/Azure.AI.Agents.Persistent.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>M:Azure.AI.Agents.Persistent.ToolOutput.JsonModelWriteCore(System.Text.Json.Utf8JsonWriter,System.ClientModel.Primitives.ModelReaderWriterOptions)</Target>
+  </Suppression>
+</Suppressions>


### PR DESCRIPTION
After the introduction of new mechanism to check for API compatibility, we have started seeing the failures as below:
> Cannot remove 'virtual' keyword from member 'Azure.AI.Agents.Persistent.ToolOutput.JsonModelWriteCore(System.Text.Json.Utf8JsonWriter, System.ClientModel.Primitives.ModelReaderWriterOptions)'

However, the method in question is [generated](https://github.com/Azure/azure-sdk-for-net/blob/1e3c42f0276f3cc7ac59835471104a9450978302/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/Models/ToolOutput.Serialization.cs#L69) one.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
