### PR TITLE
Prepare Azure.Core 1.61.0 and System.ClientModel 1.15.0 releases

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Release History
 
-## 1.61.0-beta.1 (Unreleased)
+## 1.61.0 (2026-07-30)
 
 ### Features Added
 
 - Added `AzureAuthorityHosts.AzureBleuCloud` (`https://login.sovcloud-identity.fr/`), the Microsoft Entra authority host for Bleu Cloud, the national partner cloud for France. Interactive credentials' `Authenticate` methods now also resolve the default Azure Resource Manager scope for Bleu Cloud.
-
-### Breaking Changes
 
 ### Bugs Fixed
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.61.0-beta.1</Version>
+    <Version>1.61.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.60.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>

--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -1,18 +1,14 @@
 # Release History
 
-## 1.15.0-beta.1 (Unreleased)
+## 1.15.0 (2026-07-30)
 
 ### Features Added
 
 - Added sealed, one-shot `AsyncStreamingClientResult<T>` for asynchronous streaming responses, with factories for custom producers, server-sent events, and newline-delimited JSON.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed an issue where response content logging could emit more bytes than were actually read when a non-buffered (streaming) response was read into a buffer larger than the response body. Previously, when the read began at offset 0, `MessageLoggingPolicy` logged the entire caller-supplied buffer — including the bytes past the response payload, which for a pooled buffer contain unrelated in-process content — and the configured `MessageContentSizeLimit` was not applied. Only the bytes that were read are now logged. ([#61399](https://github.com/Azure/azure-sdk-for-net/issues/61399))
-
-### Other Changes
 
 ## 1.14.0 (2026-06-03)
 

--- a/sdk/core/System.ClientModel/src/System.ClientModel.csproj
+++ b/sdk/core/System.ClientModel/src/System.ClientModel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains building blocks for clients that call cloud services.</Description>
-    <Version>1.15.0-beta.1</Version>
+    <Version>1.15.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.14.0</ApiCompatVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Prepares the next minor GA releases for the two core packages.

## Changes
| Package | Version | Release date |
|---|---|---|
| Azure.Core | `1.61.0-beta.1` -> **`1.61.0`** | 2026-07-30 |
| System.ClientModel | `1.15.0-beta.1` -> **`1.15.0`** | 2026-07-30 |

Generated by running `eng/common/scripts/Prepare-Release.ps1` for each package: version bumps in the `.csproj` files and finalized `CHANGELOG.md` entries with the release date.