### PR TITLE
Peel Service Bus, Event Hubs and Tables WebJobs extensions off the NoWarn skip list

### DIFF
--- a/eng/NoWarnSkipValidation.txt
+++ b/eng/NoWarnSkipValidation.txt
@@ -20,12 +20,7 @@ Azure.AI.Inference
 Azure.AI.Language.QuestionAnswering.Inference
 Azure.AI.OpenAI
 Azure.AI.OpenAI.Assistants
-Azure.Messaging.ServiceBus
-Azure.Monitor.OpenTelemetry.AspNetCore
 Azure.Projects
 Azure.Projects.Provisioning
 Azure.Provisioning
 Azure.ResourceManager.InformaticaDataManagement
-Microsoft.Azure.WebJobs.Extensions.EventHubs
-Microsoft.Azure.WebJobs.Extensions.ServiceBus
-Microsoft.Azure.WebJobs.Extensions.Tables

--- a/eng/analyzerallowlist/Azure.Messaging.ServiceBus.txt
+++ b/eng/analyzerallowlist/Azure.Messaging.ServiceBus.txt
@@ -1,0 +1,11 @@
+# Azure.Messaging.ServiceBus approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# ServiceBusClient does provide the with-options / without-options constructor pairs that
+# AZC0007 asks for, but the analyzer cannot see them: it only recognises an options bag
+# that derives from Azure.Core.ClientOptions, and ServiceBusClientOptions intentionally
+# does not. Service Bus is an AMQP client and does not build on the Azure.Core HTTP
+# pipeline, so there is nothing for its options type to inherit. Changing the base type
+# is a breaking change to a GA'd public type. Suppressed for this one type only; the
+# analyzer stays live for every other client in the package.
+nowarn:AZC0007 T:Azure.Messaging.ServiceBus.ServiceBusClient

--- a/eng/analyzerallowlist/Azure.Monitor.OpenTelemetry.AspNetCore.txt
+++ b/eng/analyzerallowlist/Azure.Monitor.OpenTelemetry.AspNetCore.txt
@@ -1,0 +1,19 @@
+# Azure.Monitor.OpenTelemetry.AspNetCore approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# OpenTelemetryBuilderExtensions is a GA'd public type name that intentionally
+# mirrors the same-named type in the sibling Azure.Monitor.OpenTelemetry.Exporter
+# package — the two distro packages expose parallel builder-extension entry points.
+# Renaming the public type would be a breaking change, so AZC0034 is suppressed for
+# this specific type only (the analyzer stays live for every other type).
+nowarn:AZC0034 T:Azure.Monitor.OpenTelemetry.AspNetCore.OpenTelemetryBuilderExtensions
+
+# SA1636 (file header copyright text should match) fires only on the vendored,
+# unmodified third-party OpenTelemetry source under src/Vendoring/, which carries the
+# upstream "Copyright The OpenTelemetry Authors" Apache-2.0 header and must not be
+# rewritten (doing so would diverge from upstream and create ongoing merge burden).
+# A scoped suppression is not achievable here: eng/CodeAnalysis.ruleset pins SA1636
+# severity and outranks an editorconfig severity override, and marking the subtree as
+# generated_code breaks the nullable context (CS8669). Every SA1636 site is confined to
+# vendored code, so the suppression is approved at the project level.
+nowarn:SA1636

--- a/eng/analyzerallowlist/Microsoft.Azure.WebJobs.Extensions.EventHubs.txt
+++ b/eng/analyzerallowlist/Microsoft.Azure.WebJobs.Extensions.EventHubs.txt
@@ -1,0 +1,15 @@
+# Microsoft.Azure.WebJobs.Extensions.EventHubs approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# SA1636 (file header copyright text should match) cannot be satisfied by this project.
+# It compiles source of two different provenances:
+#   * WebJobs SDK derived code carrying the ".NET Foundation" header, which is what this
+#     project's own stylecop.json declares as the expected copyright text; and
+#   * Microsoft-copyright helpers that are shared/linked in from elsewhere in this repo
+#     (sdk/core/Azure.Core/src/Shared, sdk/eventhub/Azure.Messaging.EventHubs.Shared/src,
+#     sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared).
+# The shared files are compiled into Microsoft-headered projects as well, so their header
+# is correct and must not be rewritten. StyleCop supports only a single copyrightText per
+# project, so no configuration can satisfy both sets and the suppression must be
+# project-level.
+nowarn:SA1636

--- a/eng/analyzerallowlist/Microsoft.Azure.WebJobs.Extensions.ServiceBus.txt
+++ b/eng/analyzerallowlist/Microsoft.Azure.WebJobs.Extensions.ServiceBus.txt
@@ -1,0 +1,17 @@
+# Microsoft.Azure.WebJobs.Extensions.ServiceBus approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# SA1636 (file header copyright text should match) cannot be satisfied by this project.
+# It compiles source of two different provenances: WebJobs SDK derived code carrying the
+# ".NET Foundation" header (including read-only content files supplied by the external
+# Microsoft.Azure.WebJobs.Sources package, which this repo cannot edit) and
+# Microsoft-copyright files owned by this repo. StyleCop supports only a single
+# copyrightText per project, so no configuration can satisfy both sets and the
+# suppression must be project-level.
+nowarn:SA1636
+
+# SA1402 (file may only contain a single type) fires only on DictionaryExtensions.cs,
+# which is delivered as a read-only content file by the external
+# Microsoft.Azure.WebJobs.Sources package. The file is not part of this repo and cannot
+# be split, so the suppression must be project-level.
+nowarn:SA1402

--- a/eng/analyzerallowlist/Microsoft.Azure.WebJobs.Extensions.Tables.txt
+++ b/eng/analyzerallowlist/Microsoft.Azure.WebJobs.Extensions.Tables.txt
@@ -1,0 +1,25 @@
+# Microsoft.Azure.WebJobs.Extensions.Tables approved analyzer suppressions.
+# See eng/analyzerallowlist/README.md for the file format and review policy.
+
+# SA1636 (file header copyright text should match) cannot be satisfied by this project.
+# It compiles source of two different provenances: WebJobs SDK derived code carrying the
+# ".NET Foundation" header (including read-only content files supplied by the external
+# Microsoft.Azure.WebJobs.Sources package, which this repo cannot edit) and
+# Microsoft-copyright files owned by this repo. StyleCop supports only a single
+# copyrightText per project, so no configuration can satisfy both sets and the
+# suppression must be project-level.
+nowarn:SA1636
+
+# SA1402 (file may only contain a single type) fires only on DictionaryExtensions.cs,
+# which is delivered as a read-only content file by the external
+# Microsoft.Azure.WebJobs.Sources package. The file is not part of this repo and cannot
+# be split, so the suppression must be project-level.
+nowarn:SA1402
+
+# The WebJobs SDK marks IResolutionPolicy as "Not ready for public consumption" and
+# FluentBindingRule<T>.SetPostResolveHook as "Will be removed in a future version", but
+# both remain the only supported way for a binding extension to plug in custom template
+# resolution and post-resolve parameter descriptors. There is no replacement API, so
+# CS0618 is suppressed for the two types that consume them and stays live everywhere else.
+nowarn:CS0618 T:Microsoft.Azure.WebJobs.Extensions.Tables.ODataFilterResolutionPolicy
+nowarn:CS0618 T:Microsoft.Azure.WebJobs.Extensions.Tables.TablesExtensionConfigProvider

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -59,7 +59,8 @@ extends:
         # See https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1378/Glob-Format
         # Exclude Microsoft.Azure.KeyVault.Core.dll track 1 dependency that we no longer support but is causing issues
         # Exclude capstone.dll third-party native DLL from Gee.External.Capstone (transitive dep of BenchmarkDotNet.Diagnostics.Windows)
-        analyzeTargetGlob: +:file|**/*.dll;+:file|**/*.exe;-:f|**/net452/Microsoft.Azure.KeyVault.Core.dll;-:f|**/net461/Microsoft.Azure.KeyVault.Core.dll;-:f|**/tools/NuGet.exe;-:f|**/tools/gpg/**/*.dll;-:f|**/tools/gpg/**/*.exe;-:f|**/tools/azcopy/**/*.exe;-:f|**/tools/azcopy/**/*.dll;-:f|**/aotcompatibility/**/*.exe;-:f|**/capstone.dll
+        # Exclude Microsoft.Azure.Documents.ServiceInterop.dll third-party native DLL from Microsoft.Azure.DocumentDB.Core (transitive test dep via legacy Microsoft.Azure.Cosmos.Table)
+        analyzeTargetGlob: +:file|**/*.dll;+:file|**/*.exe;-:f|**/net452/Microsoft.Azure.KeyVault.Core.dll;-:f|**/net461/Microsoft.Azure.KeyVault.Core.dll;-:f|**/tools/NuGet.exe;-:f|**/tools/gpg/**/*.dll;-:f|**/tools/gpg/**/*.exe;-:f|**/tools/azcopy/**/*.exe;-:f|**/tools/azcopy/**/*.dll;-:f|**/aotcompatibility/**/*.exe;-:f|**/capstone.dll;-:f|**/Microsoft.Azure.Documents.ServiceInterop.dll
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false
       codeql:

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
@@ -14,8 +14,14 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.EventHubs
 {
+    /// <summary>
+    /// Provides configuration options for the Event Hubs binding and trigger.
+    /// </summary>
     public class EventHubOptions : IOptionsFormatter
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventHubOptions"/> class.
+        /// </summary>
         public EventHubOptions()
         {
             MaxEventBatchSize = 100;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubWebJobsBuilderExtensions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubWebJobsBuilderExtensions.cs
@@ -16,8 +16,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// Extension methods for registering the Event Hubs extension with an <see cref="IWebJobsBuilder"/>.
+    /// </summary>
     public static class EventHubWebJobsBuilderExtensions
     {
+        /// <summary>
+        /// Adds the Event Hubs extension to the provided <see cref="IWebJobsBuilder"/>.
+        /// </summary>
+        /// <param name="builder">The builder to add the extension to.</param>
+        /// <returns>The <paramref name="builder"/> so that additional calls can be chained.</returns>
         public static IWebJobsBuilder AddEventHubs(this IWebJobsBuilder builder)
         {
             if (builder == null)
@@ -29,6 +37,12 @@ namespace Microsoft.Extensions.Hosting
             return builder;
         }
 
+        /// <summary>
+        /// Adds the Event Hubs extension to the provided <see cref="IWebJobsBuilder"/>.
+        /// </summary>
+        /// <param name="builder">The builder to add the extension to.</param>
+        /// <param name="configure">A delegate used to configure the <see cref="EventHubOptions"/>.</param>
+        /// <returns>The <paramref name="builder"/> so that additional calls can be chained.</returns>
         public static IWebJobsBuilder AddEventHubs(this IWebJobsBuilder builder, Action<EventHubOptions> configure)
         {
             if (builder == null)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/EventHubWebJobsExtensions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/EventHubWebJobsExtensions.cs
@@ -9,6 +9,9 @@ using Microsoft.Azure.WebJobs.EventHubs;
 
 namespace Microsoft.Azure.WebJobs
 {
+    /// <summary>
+    /// Event Hubs specific extension methods for the WebJobs binding types.
+    /// </summary>
     public static class EventHubWebJobsExtensions
     {
         /// <summary>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -6,7 +6,6 @@
     <Version>6.6.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>6.5.3</ApiCompatVersion>
-    <NoWarn>$(NoWarn);CS1591;SA1636</NoWarn>
     <AssemblyOriginatorKeyFile>sign.snk</AssemblyOriginatorKeyFile>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
     <AotCompatOptOut>true</AotCompatOptOut>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -8,7 +8,6 @@
     <PackageTags>Azure Monitor OpenTelemetry Exporter Distro ApplicationInsights</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <NoWarn>$(NoWarn);SA1636;AZC0011;AZC0034</NoWarn>
     <DefineConstants>$(DefineConstants);ASP_NET_CORE_DISTRO;</DefineConstants>
     <AotCompatOptOut>true</AotCompatOptOut>
   </PropertyGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/Directory.Build.props
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/Directory.Build.props
@@ -3,15 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  
-  <PropertyGroup>
-    <!--
-    These analyzers are blocked by https://github.com/Azure/azure-sdk-tools/issues/127
-     -->
-    <NoWarn>
-      $(NoWarn);
-      AZC0007;
-    </NoWarn>
-  </PropertyGroup>
-  
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -7,9 +7,6 @@
     <PackageTags>Azure;Service Bus;ServiceBus;.NET;AMQP;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableBannedApiAnalyzers>false</EnableBannedApiAnalyzers>
-    <NoWarn>
-      $(NoWarn);CA2213
-    </NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -21,8 +21,16 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// Extension methods for registering the Service Bus extension with an <see cref="IWebJobsBuilder"/>.
+    /// </summary>
     public static class ServiceBusHostBuilderExtensions
     {
+        /// <summary>
+        /// Adds the Service Bus extension to the provided <see cref="IWebJobsBuilder"/>.
+        /// </summary>
+        /// <param name="builder">The builder to add the extension to.</param>
+        /// <returns>The <paramref name="builder"/> so that additional calls can be chained.</returns>
         public static IWebJobsBuilder AddServiceBus(this IWebJobsBuilder builder)
         {
             if (builder == null)
@@ -34,6 +42,12 @@ namespace Microsoft.Extensions.Hosting
             return builder;
         }
 
+        /// <summary>
+        /// Adds the Service Bus extension to the provided <see cref="IWebJobsBuilder"/>.
+        /// </summary>
+        /// <param name="builder">The builder to add the extension to.</param>
+        /// <param name="configure">A delegate used to configure the <see cref="ServiceBusOptions"/>.</param>
+        /// <returns>The <paramref name="builder"/> so that additional calls can be chained.</returns>
         public static IWebJobsBuilder AddServiceBus(this IWebJobsBuilder builder, Action<ServiceBusOptions> configure)
         {
             if (builder == null)

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -6,7 +6,6 @@
     <Version>5.18.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.17.0</ApiCompatVersion>
-    <NoWarn>$(NoWarn);CS1591;SA1636;SA1402;AZC0007;AZC0015</NoWarn>
     <SignAssembly>true</SignAssembly>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
     <InheritDocTrimLevel>internal</InheritDocTrimLevel>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/SessionMessageProcessor.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/SessionMessageProcessor.cs
@@ -9,6 +9,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
+    /// <summary>
+    /// Processes messages that are received from a session-enabled Service Bus entity, allowing custom
+    /// logic to run before the job function is invoked and after it has completed.
+    /// </summary>
     public class SessionMessageProcessor
     {
         /// <summary>

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/Microsoft.Azure.WebJobs.Extensions.Tables.csproj
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/Microsoft.Azure.WebJobs.Extensions.Tables.csproj
@@ -6,12 +6,6 @@
         <ApiCompatVersion>1.4.0</ApiCompatVersion>
         <Description>This package extends the Microsoft.Azure.WebJobs library with Table triggers using Azure Table service.</Description>
         <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-        <NoWarn>$(NoWarn);
-            SA1636;<!-- Some code was copied, we can't change the license header -->
-            CS0618; <!-- Obsolete APIs -->
-            CS1591; <!-- XML docs -->
-            SA1402; <!-- Webjobs sources package has files with multiple types -->
-        </NoWarn>
         <InheritDocTrimLevel>internal</InheritDocTrimLevel>
         <AotCompatOptOut>true</AotCompatOptOut>
     </PropertyGroup>

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/TablesWebJobsBuilderExtensions.cs
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/TablesWebJobsBuilderExtensions.cs
@@ -8,8 +8,16 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// Extension methods for registering the Tables extension with an <see cref="IWebJobsBuilder"/>.
+    /// </summary>
     public static class TablesWebJobsBuilderExtensions
     {
+        /// <summary>
+        /// Adds the Tables extension to the provided <see cref="IWebJobsBuilder"/>.
+        /// </summary>
+        /// <param name="builder">The builder to add the extension to.</param>
+        /// <returns>The <paramref name="builder"/> so that additional calls can be chained.</returns>
         public static IWebJobsBuilder AddTables(this IWebJobsBuilder builder)
         {
             builder.Services.AddAzureClientsCore();


### PR DESCRIPTION
Peels five packages off `eng/NoWarnSkipValidation.txt` (14 → 9), continuing the effort to make every analyzer suppression explicitly reviewed and approved.

| Package | Codes | Resolution |
|---|---|---|
| `Azure.Monitor.OpenTelemetry.AspNetCore` | AZC0011, AZC0034, SA1636 | AZC0011 dead; AZC0034 scoped per-type; SA1636 project-level |
| `Azure.Messaging.ServiceBus` | CA2213, AZC0007 | CA2213 dead; AZC0007 narrowed from package-wide props to one type |
| `Microsoft.Azure.WebJobs.Extensions.EventHubs` | CS1591, SA1636 | CS1591 documented; SA1636 project-level |
| `Microsoft.Azure.WebJobs.Extensions.ServiceBus` | CS1591, SA1636, SA1402, AZC0007, AZC0015 | AZC0007/AZC0015 dead; CS1591 documented; SA1636/SA1402 project-level |
| `Microsoft.Azure.WebJobs.Extensions.Tables` | CS1591, CS0618, SA1636, SA1402 | CS1591 documented; CS0618 scoped per-type; SA1636/SA1402 project-level |

## Highlights

**AZC0007 and AZC0015 are now dead on the ServiceBus WebJobs extension.** Both were false positives, and both were fixed by the in-repo `ClientConstructorAnalyzer` / `ClientMethodReturnTypeAnalyzer` migration. The suppressions simply go away.

**`Azure.Messaging.ServiceBus` had a package-wide AZC0007 suppression in `Directory.Build.props`** annotated *"blocked by azure-sdk-tools#127"*. That props applies to `src`, `tests`, `stress` and the snippets project alike. It is replaced by a suppression scoped to `ServiceBusClient` only. `ServiceBusClient` does provide the with-options / without-options constructor pairs AZC0007 asks for, but the analyzer only recognises an options bag deriving from `Azure.Core.ClientOptions`, and `ServiceBusClientOptions` intentionally does not — Service Bus is an AMQP client and does not build on the Azure.Core HTTP pipeline, so there is nothing for it to inherit. Changing the base type of a GA'd public type would be breaking.

**CS1591 was fixed by writing docs, not suppressing.** Twelve undocumented public members across the three WebJobs extensions now have real `<summary>` text.

## Why SA1636 stays project-level

The WebJobs extension projects compile source of two different provenances:

- `.NET Foundation`-headered code inherited from the WebJobs SDK — including read-only content files supplied by the `Microsoft.Azure.WebJobs.Sources` NuGet package, which this repo cannot edit at all; and
- Microsoft-copyright helpers shared/linked in from `sdk/core/Azure.Core/src/Shared`, `sdk/eventhub/Azure.Messaging.EventHubs.Shared/src` and `sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared`, whose headers are correct and are also compiled into Microsoft-headered projects.

StyleCop supports exactly one `copyrightText` per project, so no configuration can satisfy both sets. `SA1402` is the same story — it fires only on `DictionaryExtensions.cs`, a read-only content file from the same external package. For `Azure.Monitor.OpenTelemetry.AspNetCore`, every SA1636 site is confined to the vendored upstream OpenTelemetry source under `src/Vendoring/`, whose Apache-2.0 header must not be rewritten.

## Verification

All five packages build clean under warnings-as-errors across every target framework, with `AZSDK0002` enforced (no longer skip-listed). The full `Azure.Messaging.ServiceBus` solution — `src`, `tests`, `stress` and `PluginSnippets` — also builds clean after the props-level AZC0007 removal.
