### PR TITLE
Centralized and standardized Change Feed errors

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Azure.Storage.Blobs.ChangeFeed.csproj
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Azure.Storage.Blobs.ChangeFeed.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="$(AzureStorageChangeFeedCommonSources)IChangeFeedEvent.cs" LinkBase="Shared\ChangeFeed" />
     <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedConfiguration.cs" LinkBase="Shared\ChangeFeed" />
+    <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedErrors.cs" LinkBase="Shared\ChangeFeed" />
     <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedExtensionsBase.cs" LinkBase="Shared\ChangeFeed" />
     <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedBase.cs" LinkBase="Shared\ChangeFeed" />
     <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedFactoryBase.cs" LinkBase="Shared\ChangeFeed" />

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/BlobChangeFeedClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/BlobChangeFeedClient.cs
@@ -288,9 +288,7 @@ namespace Azure.Storage.Blobs.ChangeFeed
         {
             if (start.HasValue && end.HasValue && start.Value > end.Value)
             {
-                throw new ArgumentException(
-                    $"{nameof(start)} ({start.Value:O}) must be earlier than or equal to {nameof(end)} ({end.Value:O}).",
-                    nameof(start));
+                throw ChangeFeedErrors.StartAfterEnd(start.Value, end.Value, nameof(start));
             }
         }
 
@@ -298,15 +296,7 @@ namespace Azure.Storage.Blobs.ChangeFeed
         {
             if (continuationToken != null && _includeNonFinalizedEvents)
             {
-                throw new ArgumentException(
-                    "Resuming from a continuation token is not supported when " +
-                    nameof(BlobChangeFeedClientOptions.IncludeNonFinalizedEvents) +
-                    " is enabled on " + nameof(BlobChangeFeedClientOptions) + ". " +
-                    "Non-finalized reads do not produce continuation tokens because segments past " +
-                    "the finalized watermark may change between calls. Disable " +
-                    nameof(BlobChangeFeedClientOptions.IncludeNonFinalizedEvents) +
-                    " to resume from a saved position.",
-                    nameof(continuationToken));
+                throw BlobChangeFeedErrors.ContinuationNotSupportedWithNonFinalized(nameof(continuationToken));
             }
         }
         #endregion GetChanges

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/BlobChangeFeedErrors.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/BlobChangeFeedErrors.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.Blobs.ChangeFeed
+{
+    /// <summary>
+    /// Creates exceptions for error cases unique to the Blob Change Feed package.
+    /// Factory methods return (rather than throw) the exception so callers write
+    /// <c>throw BlobChangeFeedErrors.X(...)</c> at the throw site.
+    /// </summary>
+    internal static class BlobChangeFeedErrors
+    {
+        public static ArgumentException ContinuationNotSupportedWithNonFinalized(string paramName)
+            => new ArgumentException(
+                $"Resuming from a continuation token is not supported when " +
+                $"{nameof(BlobChangeFeedClientOptions.IncludeNonFinalizedEvents)} is enabled on " +
+                $"{nameof(BlobChangeFeedClientOptions)}. Non-finalized reads do not produce continuation tokens " +
+                "because segments past the finalized watermark may change between calls. Disable " +
+                $"{nameof(BlobChangeFeedClientOptions.IncludeNonFinalizedEvents)} to resume from a saved position.",
+                paramName);
+    }
+}

--- a/sdk/storage/Azure.Storage.ChangeFeed.Common/src/ChangeFeedErrors.cs
+++ b/sdk/storage/Azure.Storage.ChangeFeed.Common/src/ChangeFeedErrors.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.ChangeFeed.Common
+{
+    /// <summary>
+    /// Creates exceptions for error cases shared across the Change Feed packages.
+    /// Factory methods return (rather than throw) the exception so callers write
+    /// <c>throw ChangeFeedErrors.X(...)</c> at the throw site.
+    /// </summary>
+    internal static class ChangeFeedErrors
+    {
+        public static InvalidOperationException ChangeFeedNotEnabled()
+            => new InvalidOperationException(
+                "Change Feed is not enabled on this account, or is currently being enabled.");
+
+        public static ArgumentException CursorHostMismatch(string paramName)
+            => new ArgumentException(
+                "The continuation token was issued for a different storage account host and cannot be used here.",
+                paramName);
+
+        public static ArgumentException UnsupportedCursorVersion(string paramName)
+            => new ArgumentException(
+                "The continuation token uses an unsupported cursor version.",
+                paramName);
+
+        public static ArgumentException MalformedContinuationToken(string paramName, Exception inner)
+            => new ArgumentException(
+                "The continuation token is malformed and could not be parsed.",
+                paramName,
+                inner);
+
+        public static ArgumentException InvalidSegmentPath(string segmentPath)
+            => new ArgumentException(
+                $"'{segmentPath}' is not a valid change feed segment path.");
+
+        public static ArgumentException StartAfterEnd(DateTimeOffset start, DateTimeOffset end, string paramName)
+            => new ArgumentException(
+                $"'{start:O}' must be earlier than or equal to '{end:O}'.",
+                paramName);
+
+        public static ArgumentException ContinuationNotSupportedWithNonFinalized(string optionsTypeName, string paramName)
+            => new ArgumentException(
+                $"Resuming from a continuation token is not supported when IncludeNonFinalizedEvents is enabled on {optionsTypeName}. " +
+                "Non-finalized reads do not produce continuation tokens because segments past the finalized watermark may change between calls. " +
+                "Disable IncludeNonFinalizedEvents to resume from a saved position.",
+                paramName);
+
+        public static ArgumentNullException NullContinuation(string paramName)
+            => new ArgumentNullException(paramName);
+    }
+}

--- a/sdk/storage/Azure.Storage.ChangeFeed.Common/src/ChangeFeedExtensionsBase.cs
+++ b/sdk/storage/Azure.Storage.ChangeFeed.Common/src/ChangeFeedExtensionsBase.cs
@@ -29,20 +29,37 @@ namespace Azure.Storage.ChangeFeed.Common
 
             string[] splitPath = segmentPath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             if (splitPath.Length < 3)
-                throw new ArgumentException($"{nameof(segmentPath)} is not a valid segment path.");
+                throw ChangeFeedErrors.InvalidSegmentPath(segmentPath);
 
             int timeValue = splitPath.Length >= 6
-                ? int.Parse(splitPath[5], CultureInfo.InvariantCulture)
+                ? ParseSegmentComponent(splitPath[5], segmentPath)
                 : 0;
 
-            return new DateTimeOffset(
-                year: int.Parse(splitPath[2], CultureInfo.InvariantCulture),
-                month: splitPath.Length >= 4 ? int.Parse(splitPath[3], CultureInfo.InvariantCulture) : 1,
-                day: splitPath.Length >= 5 ? int.Parse(splitPath[4], CultureInfo.InvariantCulture) : 1,
-                hour: timeValue / 100,    // HHmm encoded: integer division extracts the hour component
-                minute: timeValue % 100,  // HHmm encoded: modulo extracts the minute component
-                second: 0,
-                offset: TimeSpan.Zero);
+            try
+            {
+                return new DateTimeOffset(
+                    year: ParseSegmentComponent(splitPath[2], segmentPath),
+                    month: splitPath.Length >= 4 ? ParseSegmentComponent(splitPath[3], segmentPath) : 1,
+                    day: splitPath.Length >= 5 ? ParseSegmentComponent(splitPath[4], segmentPath) : 1,
+                    hour: timeValue / 100,    // HHmm encoded: integer division extracts the hour component
+                    minute: timeValue % 100,  // HHmm encoded: modulo extracts the minute component
+                    second: 0,
+                    offset: TimeSpan.Zero);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // A syntactically numeric but out-of-range component (e.g. month 13) would
+                // otherwise surface as a raw ArgumentOutOfRangeException from DateTimeOffset.
+                throw ChangeFeedErrors.InvalidSegmentPath(segmentPath);
+            }
+        }
+
+        private static int ParseSegmentComponent(string component, string segmentPath)
+        {
+            if (!int.TryParse(component, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value))
+                throw ChangeFeedErrors.InvalidSegmentPath(segmentPath);
+
+            return value;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.ChangeFeed.Common/src/ChangeFeedFactoryBase.cs
+++ b/sdk/storage/Azure.Storage.ChangeFeed.Common/src/ChangeFeedFactoryBase.cs
@@ -108,7 +108,15 @@ namespace Azure.Storage.ChangeFeed.Common
             // Resume path: deserialize the cursor and extract the start/end times from it.
             if (continuation != null)
             {
-                cursor = JsonSerializer.Deserialize<ChangeFeedCursor>(continuation);
+                try
+                {
+                    cursor = JsonSerializer.Deserialize<ChangeFeedCursor>(continuation);
+                }
+                catch (JsonException e)
+                {
+                    throw ChangeFeedErrors.MalformedContinuationToken(nameof(continuation), e);
+                }
+
                 ValidateCursor(_containerClient, cursor);
                 startTime = ChangeFeedExtensionsBase.ToDateTimeOffset(cursor.CurrentSegmentCursor.SegmentPath).Value;
                 endTime = cursor.EndTime;
@@ -139,7 +147,7 @@ namespace Azure.Storage.ChangeFeed.Common
             if (cursor == null)
                 throw new ArgumentNullException(nameof(cursor));
 
-            ValidateCursor(_containerClient, cursor);
+            ValidateCursor(_containerClient, cursor, nameof(cursor));
             DateTimeOffset? startTime = ChangeFeedExtensionsBase.ToDateTimeOffset(cursor.CurrentSegmentCursor.SegmentPath).Value;
             DateTimeOffset? endTime = cursor.EndTime;
 
@@ -173,7 +181,7 @@ namespace Azure.Storage.ChangeFeed.Common
                 changeFeedContainerExists = _containerClient.Exists(cancellationToken: cancellationToken);
 
             if (!changeFeedContainerExists)
-                throw new ArgumentException("Change Feed hasn't been enabled on this account, or is currently being enabled.");
+                throw ChangeFeedErrors.ChangeFeedNotEnabled();
 
             DateTimeOffset? lastConsumableNullable = await GetLastConsumableInternal(
                 _containerClient,
@@ -255,13 +263,14 @@ namespace Azure.Storage.ChangeFeed.Common
         /// </summary>
         private static void ValidateCursor(
             BlobContainerClient containerClient,
-            ChangeFeedCursor cursor)
+            ChangeFeedCursor cursor,
+            string paramName = "continuation")
         {
             if (!string.Equals(containerClient.Uri.Host, cursor.UrlHost, StringComparison.OrdinalIgnoreCase))
-                throw new ArgumentException("Cursor URL Host does not match container URL host.");
+                throw ChangeFeedErrors.CursorHostMismatch(paramName);
 
             if (cursor.CursorVersion != 1)
-                throw new ArgumentException("Unsupported cursor version.");
+                throw ChangeFeedErrors.UnsupportedCursorVersion(paramName);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.ChangeFeed.Common/tests/ChangeFeedFactoryBaseTests.cs
+++ b/sdk/storage/Azure.Storage.ChangeFeed.Common/tests/ChangeFeedFactoryBaseTests.cs
@@ -44,7 +44,7 @@ namespace Azure.Storage.ChangeFeed.Common.Tests
                 new Mock<SegmentFactoryBase<TestEvent>>().Object,
                 CreateTestConfig());
 
-            Assert.ThrowsAsync<ArgumentException>(
+            Assert.ThrowsAsync<InvalidOperationException>(
                 async () => await factory.BuildChangeFeed(null, null, null, IsAsync, CancellationToken.None));
         }
 
@@ -89,8 +89,8 @@ namespace Azure.Storage.ChangeFeed.Common.Tests
             containerClient.Setup(r => r.Uri).Returns(new Uri("https://account1.blob.core.windows.net/container"));
 
             // Make the existence check fail right after ValidateCursor returns. The resulting
-            // ArgumentException carries a different message, which lets us prove we got past
-            // the cursor check rather than relying on absence of throw.
+            // InvalidOperationException carries a different message, which lets us prove we got
+            // past the cursor check rather than relying on absence of throw.
             if (IsAsync)
                 containerClient.Setup(r => r.ExistsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Response.FromValue(false, null));
             else
@@ -105,10 +105,10 @@ namespace Azure.Storage.ChangeFeed.Common.Tests
                 new Mock<SegmentFactoryBase<TestEvent>>().Object,
                 CreateTestConfig());
 
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentException>(
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
                 async () => await factory.BuildChangeFeed(null, null, continuation, IsAsync, CancellationToken.None));
-            StringAssert.DoesNotContain("URL Host", ex.Message);
-            StringAssert.Contains("Change Feed hasn't been enabled", ex.Message);
+            StringAssert.DoesNotContain("host", ex.Message);
+            StringAssert.Contains("Change Feed is not enabled", ex.Message);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Azure.Storage.Files.Shares.ChangeFeed.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/Azure.Storage.Files.Shares.ChangeFeed.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="$(AzureStorageChangeFeedCommonSources)IChangeFeedEvent.cs" LinkBase="Shared\ChangeFeed" />
     <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedConfiguration.cs" LinkBase="Shared\ChangeFeed" />
+    <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedErrors.cs" LinkBase="Shared\ChangeFeed" />
     <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedExtensionsBase.cs" LinkBase="Shared\ChangeFeed" />
     <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedBase.cs" LinkBase="Shared\ChangeFeed" />
     <Compile Include="$(AzureStorageChangeFeedCommonSources)ChangeFeedFactoryBase.cs" LinkBase="Shared\ChangeFeed" />

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ContainerDiscovery.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ContainerDiscovery.cs
@@ -46,23 +46,17 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             Response rawResponse = response.GetRawResponse();
             if (!rawResponse.Headers.TryGetValue(Constants.FilesChangeFeed.ChangeFeedContainerHeader, out string containerName))
             {
-                throw new InvalidOperationException(
-                    $"Change Feed is not enabled for share '{shareClient.Name}'. " +
-                    $"Enable it by setting x-ms-file-enable-change-feed: true when creating or updating the share.");
+                throw ShareChangeFeedErrors.ChangeFeedNotEnabledForShare(shareClient.Name);
             }
 
             if (string.IsNullOrEmpty(containerName))
             {
-                throw new InvalidOperationException(
-                    $"Change Feed container header for share '{shareClient.Name}' was present but empty. " +
-                    "The service returned an unexpected response.");
+                throw ShareChangeFeedErrors.ChangeFeedContainerHeaderEmpty(rawResponse, shareClient.Name);
             }
 
             if (containerName[0] != '$')
             {
-                throw new InvalidOperationException(
-                    $"Change Feed container name '{containerName}' for share '{shareClient.Name}' does not begin with the expected '$' prefix. " +
-                    "The service returned an unexpected response.");
+                throw ShareChangeFeedErrors.ChangeFeedContainerBadPrefix(rawResponse, containerName, shareClient.Name);
             }
 
             return containerName;

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedClient.cs
@@ -41,9 +41,9 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ShareChangeFeedClientOptions changeFeedOptions = default)
         {
             if (string.IsNullOrEmpty(connectionString))
-                throw new ArgumentNullException(nameof(connectionString));
+                throw ShareChangeFeedErrors.ArgumentNull(nameof(connectionString));
             if (string.IsNullOrEmpty(shareName))
-                throw new ArgumentNullException(nameof(shareName));
+                throw ShareChangeFeedErrors.ArgumentNull(nameof(shareName));
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
 
@@ -63,9 +63,9 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ShareChangeFeedClientOptions changeFeedOptions = default)
         {
             if (fileServiceUri == null)
-                throw new ArgumentNullException(nameof(fileServiceUri));
+                throw ShareChangeFeedErrors.ArgumentNull(nameof(fileServiceUri));
             if (string.IsNullOrEmpty(shareName))
-                throw new ArgumentNullException(nameof(shareName));
+                throw ShareChangeFeedErrors.ArgumentNull(nameof(shareName));
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
 
@@ -87,9 +87,9 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ShareChangeFeedClientOptions changeFeedOptions = default)
         {
             if (fileServiceUri == null)
-                throw new ArgumentNullException(nameof(fileServiceUri));
+                throw ShareChangeFeedErrors.ArgumentNull(nameof(fileServiceUri));
             if (string.IsNullOrEmpty(shareName))
-                throw new ArgumentNullException(nameof(shareName));
+                throw ShareChangeFeedErrors.ArgumentNull(nameof(shareName));
 
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
@@ -111,9 +111,9 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             ShareChangeFeedClientOptions changeFeedOptions = default)
         {
             if (fileServiceUri == null)
-                throw new ArgumentNullException(nameof(fileServiceUri));
+                throw ShareChangeFeedErrors.ArgumentNull(nameof(fileServiceUri));
             if (string.IsNullOrEmpty(shareName))
-                throw new ArgumentNullException(nameof(shareName));
+                throw ShareChangeFeedErrors.ArgumentNull(nameof(shareName));
 
             _maxTransferSize = changeFeedOptions?.MaximumTransferSize;
             _includeNonFinalizedEvents = changeFeedOptions?.IncludeNonFinalizedEvents ?? false;
@@ -225,9 +225,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         {
             if (start.HasValue && end.HasValue && start.Value > end.Value)
             {
-                throw new ArgumentException(
-                    $"{nameof(start)} ({start.Value:O}) must be earlier than or equal to {nameof(end)} ({end.Value:O}).",
-                    nameof(start));
+                throw ChangeFeedErrors.StartAfterEnd(start.Value, end.Value, nameof(start));
             }
         }
 
@@ -291,15 +289,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         {
             if (continuationToken != null && _includeNonFinalizedEvents)
             {
-                throw new ArgumentException(
-                    "Resuming from a continuation token is not supported when " +
-                    nameof(ShareChangeFeedClientOptions.IncludeNonFinalizedEvents) +
-                    " is enabled on " + nameof(ShareChangeFeedClientOptions) + ". " +
-                    "Non-finalized reads do not produce continuation tokens because segments past " +
-                    "the finalized watermark may change between calls. Disable " +
-                    nameof(ShareChangeFeedClientOptions.IncludeNonFinalizedEvents) +
-                    " to resume from a saved position.",
-                    nameof(continuationToken));
+                throw ShareChangeFeedErrors.ContinuationNotSupportedWithNonFinalized(nameof(continuationToken));
             }
         }
         #endregion GetChanges

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedErrors.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedErrors.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage.Files.Shares.ChangeFeed
+{
+    /// <summary>
+    /// Creates exceptions for error cases unique to the Files Share Change Feed package.
+    /// Factory methods return (rather than throw) the exception so callers write
+    /// <c>throw ShareChangeFeedErrors.X(...)</c> at the throw site.
+    /// </summary>
+    internal static class ShareChangeFeedErrors
+    {
+        public static ArgumentNullException ArgumentNull(string paramName)
+            => new ArgumentNullException(paramName);
+
+        public static ArgumentException ContinuationNotSupportedWithNonFinalized(string paramName)
+            => new ArgumentException(
+                $"Resuming from a continuation token is not supported when " +
+                $"{nameof(ShareChangeFeedClientOptions.IncludeNonFinalizedEvents)} is enabled on " +
+                $"{nameof(ShareChangeFeedClientOptions)}. Non-finalized reads do not produce continuation tokens " +
+                "because segments past the finalized watermark may change between calls. Disable " +
+                $"{nameof(ShareChangeFeedClientOptions.IncludeNonFinalizedEvents)} to resume from a saved position.",
+                paramName);
+
+        public static InvalidOperationException ChangeFeedNotEnabledForShare(string shareName)
+            => new InvalidOperationException(
+                $"Change Feed is not enabled for share '{shareName}'. " +
+                "Enable it by setting 'x-ms-file-enable-change-feed: true' when creating or updating the share.");
+
+        public static RequestFailedException ChangeFeedContainerHeaderEmpty(Response response, string shareName)
+            => new RequestFailedException(
+                response,
+                new InvalidOperationException(
+                    $"The Change Feed container header for share '{shareName}' was present but empty. " +
+                    "The service returned an unexpected response."));
+
+        public static RequestFailedException ChangeFeedContainerBadPrefix(Response response, string containerName, string shareName)
+            => new RequestFailedException(
+                response,
+                new InvalidOperationException(
+                    $"The Change Feed container name '{containerName}' for share '{shareName}' does not begin with the expected '$' prefix. " +
+                    "The service returned an unexpected response."));
+
+        public static ArgumentException InvalidSnapshotTimestamp(string snapshot, string paramName)
+            => new ArgumentException(
+                $"'{snapshot}' is not a valid UTC ISO 8601 snapshot timestamp (must end with 'Z').",
+                paramName);
+
+        public static ArgumentException SnapshotNotFinalized(string snapshotLabel, string snapshot, string status, string paramName)
+            => new ArgumentException(
+                $"{snapshotLabel} snapshot '{snapshot}' is not finalized (status: {status}). " +
+                "Wait for the snapshot to be finalized before querying.",
+                paramName);
+
+        public static ArgumentException BeginSnapshotAfterEnd(
+            string beginSnapshot,
+            DateTimeOffset beginTimestamp,
+            string endSnapshot,
+            DateTimeOffset endTimestamp,
+            string paramName)
+            => new ArgumentException(
+                $"Begin snapshot '{beginSnapshot}' (taken {beginTimestamp:O}) is later than " +
+                $"end snapshot '{endSnapshot}' (taken {endTimestamp:O}).",
+                paramName);
+
+        public static ArgumentException BeginSnapshotCvIdExceedsEnd(long beginCvId, long endCvId, string paramName)
+            => new ArgumentException(
+                $"Begin snapshot CvId ({beginCvId}) exceeds end snapshot CvId ({endCvId}).",
+                paramName);
+
+        public static ArgumentException EmptySnapshotRange(long cvId, string paramName)
+            => new ArgumentException(
+                $"Begin and end snapshots have the same CvId ({cvId}); the query range is empty.",
+                paramName);
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotAsyncPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotAsyncPageable.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             string continuation)
         {
             if (string.IsNullOrEmpty(continuation))
-                throw new ArgumentNullException(nameof(continuation));
+                throw ChangeFeedErrors.NullContinuation(nameof(continuation));
             _client = client;
             _maxTransferSize = maxTransferSize;
             _continuation = continuation;

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotPageable.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedSnapshotPageable.cs
@@ -37,7 +37,7 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             string continuation)
         {
             if (string.IsNullOrEmpty(continuation))
-                throw new ArgumentNullException(nameof(continuation));
+                throw ChangeFeedErrors.NullContinuation(nameof(continuation));
             _client = client;
             _maxTransferSize = maxTransferSize;
             _continuation = continuation;

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/SnapshotInputValidator.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/src/SnapshotInputValidator.cs
@@ -30,12 +30,10 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
         public static void ValidateInputString(string snapshot, string paramName)
         {
             if (string.IsNullOrEmpty(snapshot))
-                throw new ArgumentNullException(paramName);
+                throw ShareChangeFeedErrors.ArgumentNull(paramName);
 
             if (!IsValidUtcSnapshot(snapshot))
-                throw new ArgumentException(
-                    $"'{snapshot}' is not a valid UTC ISO 8601 snapshot timestamp (must end with 'Z').",
-                    paramName);
+                throw ShareChangeFeedErrors.InvalidSnapshotTimestamp(snapshot, paramName);
         }
 
         // Snapshot timestamps are surfaced by the service in UTC ISO 8601 with an uppercase 'Z'
@@ -62,32 +60,24 @@ namespace Azure.Storage.Files.Shares.ChangeFeed
             string endSnapshot)
         {
             if (!beginMeta.Status.Equals("Finalized", StringComparison.OrdinalIgnoreCase))
-                throw new ArgumentException(
-                    $"Begin snapshot '{beginSnapshot}' is not finalized (status: {beginMeta.Status}). " +
-                    "Wait for the snapshot to be finalized before querying.",
-                    nameof(beginSnapshot));
+                throw ShareChangeFeedErrors.SnapshotNotFinalized("Begin", beginSnapshot, beginMeta.Status, nameof(beginSnapshot));
 
             if (!endMeta.Status.Equals("Finalized", StringComparison.OrdinalIgnoreCase))
-                throw new ArgumentException(
-                    $"End snapshot '{endSnapshot}' is not finalized (status: {endMeta.Status}). " +
-                    "Wait for the snapshot to be finalized before querying.",
-                    nameof(endSnapshot));
+                throw ShareChangeFeedErrors.SnapshotNotFinalized("End", endSnapshot, endMeta.Status, nameof(endSnapshot));
 
             if (beginMeta.SnapshotTimestamp > endMeta.SnapshotTimestamp)
-                throw new ArgumentException(
-                    $"Begin snapshot '{beginSnapshot}' (taken {beginMeta.SnapshotTimestamp:O}) is later than " +
-                    $"end snapshot '{endSnapshot}' (taken {endMeta.SnapshotTimestamp:O}).",
+                throw ShareChangeFeedErrors.BeginSnapshotAfterEnd(
+                    beginSnapshot,
+                    beginMeta.SnapshotTimestamp,
+                    endSnapshot,
+                    endMeta.SnapshotTimestamp,
                     nameof(beginSnapshot));
 
             if (beginMeta.CvId > endMeta.CvId)
-                throw new ArgumentException(
-                    $"Begin snapshot CvId ({beginMeta.CvId}) exceeds end snapshot CvId ({endMeta.CvId}).",
-                    nameof(beginSnapshot));
+                throw ShareChangeFeedErrors.BeginSnapshotCvIdExceedsEnd(beginMeta.CvId, endMeta.CvId, nameof(beginSnapshot));
 
             if (beginMeta.CvId == endMeta.CvId)
-                throw new ArgumentException(
-                    $"Begin and end snapshots have the same CvId ({beginMeta.CvId}); the query range is empty.",
-                    nameof(endSnapshot));
+                throw ShareChangeFeedErrors.EmptySnapshotRange(beginMeta.CvId, nameof(endSnapshot));
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ContainerDiscoveryTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares.ChangeFeed/tests/ContainerDiscoveryTests.cs
@@ -128,9 +128,9 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
             Mock<ShareClient> shareClient = new Mock<ShareClient>();
             SetupMockShareWithHeader(shareClient, "");
 
-            System.InvalidOperationException ex = Assert.ThrowsAsync<System.InvalidOperationException>(
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await ContainerDiscovery.DiscoverContainerNameAsync(shareClient.Object, IsAsync, CancellationToken.None));
-            StringAssert.Contains("empty", ex.Message);
+            StringAssert.Contains("empty", ex.InnerException.Message);
         }
 
         [Test]
@@ -139,9 +139,9 @@ namespace Azure.Storage.Files.Shares.ChangeFeed.Tests
             Mock<ShareClient> shareClient = new Mock<ShareClient>();
             SetupMockShareWithHeader(shareClient, "fileschangefeed-no-prefix");
 
-            System.InvalidOperationException ex = Assert.ThrowsAsync<System.InvalidOperationException>(
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await ContainerDiscovery.DiscoverContainerNameAsync(shareClient.Object, IsAsync, CancellationToken.None));
-            StringAssert.Contains("'$' prefix", ex.Message);
+            StringAssert.Contains("'$' prefix", ex.InnerException.Message);
         }
 
         [Test]


### PR DESCRIPTION
# Standardize Change Feed exceptions and error messages

## Summary

This PR consolidates and normalizes all customer-facing exceptions across the three Change Feed packages — **Blob Change Feed**, **Files Share Change Feed**, and the shared **Change Feed Common** library. Previously, exceptions were thrown inline at each call site with inconsistent types, duplicated logic, and ad-hoc message wording. Some low-level framework exceptions (`JsonException`, `FormatException`) also leaked to callers with non-actionable messages.

Exceptions are now produced by centralized error-factory classes (following the established `Azure.Storage.Errors` / `BatchErrors` pattern), with normalized wording, corrected exception types, and guards around raw framework exceptions.

## Motivation

- **Inconsistent types** — the "change feed not enabled" condition threw `ArgumentException` in the Blob path but `InvalidOperationException` in the Files path.
- **Leaky exceptions** — malformed continuation tokens surfaced a raw `JsonException`; malformed segment paths surfaced `FormatException`/`OverflowException`.
- **Duplicated throw logic** — `ThrowIfStartAfterEnd` / `ThrowIfContinuationDisallowed` were copy-pasted between the Blob and Files clients.
- **Message drift** — inconsistent casing, punctuation, and a couple of typos.

## Approach

| Concern | Before | After |
|---|---|---|
| Error creation | Inline `throw new ...` at each site | Static factory classes returning exceptions (`throw ChangeFeedErrors.X(...)`) |
| Shared errors | n/a | `ChangeFeedErrors` in `Azure.Storage.ChangeFeed.Common` |
| Package-unique errors | n/a | `BlobChangeFeedErrors`, `ShareChangeFeedErrors` |
| Not-enabled type | `ArgumentException` (Blob) / `InvalidOperationException` (Files) | Unified on `InvalidOperationException` |
| Malformed token | raw `JsonException` | `ArgumentException` (inner = `JsonException`) |
| Malformed segment path | `FormatException` / `OverflowException` | `ArgumentException` |
| Discovery response anomalies | `InvalidOperationException` | `RequestFailedException` (carries `Response`) |

## New files

- `Azure.Storage.ChangeFeed.Common/src/ChangeFeedErrors.cs`
- `Azure.Storage.Blobs.ChangeFeed/src/BlobChangeFeedErrors.cs`
- `Azure.Storage.Files.Shares.ChangeFeed/src/ShareChangeFeedErrors.cs`

(The Common source is linked into both consumer packages via explicit `Compile Include` entries, so both `.csproj` files were updated.)

---

## Exceptions and messages by scenario

### `Azure.Storage.ChangeFeed.Common` (shared)

| Scenario | Exception type | Message | Change |
|---|---|---|---|
| Change feed container does not exist | `InvalidOperationException` | `Change Feed is not enabled on this account, or is currently being enabled.` | Type changed from `ArgumentException`; wording normalized |
| Continuation token cannot be deserialized | `ArgumentException` (param `continuation`, inner `JsonException`) | `The continuation token is malformed and could not be parsed.` | **New guard** — previously leaked raw `JsonException` |
| Cursor host ≠ container host | `ArgumentException` (param `continuation`) | `The continuation token was issued for a different storage account host and cannot be used here.` | Wording normalized; `paramName` added |
| Unsupported cursor version | `ArgumentException` (param `continuation`) | `The continuation token uses an unsupported cursor version.` | Wording normalized; `paramName` added |
| Null typed cursor to `BuildChangeFeed(cursor,…)` | `ArgumentNullException` (param `cursor`) | *(default)* | Unchanged |
| Segment path malformed (too short / non-numeric / out-of-range component) | `ArgumentException` | `'{segmentPath}' is not a valid change feed segment path.` | **New guard** — previously leaked `FormatException`/`OverflowException`; wording normalized |

### `Azure.Storage.Blobs.ChangeFeed`

| Scenario | Exception type | Message | Change |
|---|---|---|---|
| `start` later than `end` | `ArgumentException` (param `start`) | `'{start:O}' must be earlier than or equal to '{end:O}'.` | Wording normalized; routed through `ChangeFeedErrors` |
| Continuation token supplied while `IncludeNonFinalizedEvents` enabled | `ArgumentException` (param `continuationToken`) | `Resuming from a continuation token is not supported when IncludeNonFinalizedEvents is enabled on BlobChangeFeedClientOptions. Non-finalized reads do not produce continuation tokens because segments past the finalized watermark may change between calls. Disable IncludeNonFinalizedEvents to resume from a saved position.` | Routed through `BlobChangeFeedErrors` |
| Change feed not enabled (via factory) | `InvalidOperationException` | *(see Common)* | Type changed from `ArgumentException` |

### `Azure.Storage.Files.Shares.ChangeFeed`

**Client construction & query options — `ShareChangeFeedClient.cs`**

| Scenario | Exception type | Message | Change |
|---|---|---|---|
| Null/empty `connectionString` | `ArgumentNullException` (param `connectionString`) | *(default)* | Routed through factory |
| Null/empty `shareName` | `ArgumentNullException` (param `shareName`) | *(default)* | Routed through factory |
| Null `fileServiceUri` | `ArgumentNullException` (param `fileServiceUri`) | *(default)* | Routed through factory |
| `start` later than `end` | `ArgumentException` (param `start`) | `'{start:O}' must be earlier than or equal to '{end:O}'.` | Shared with Blob via `ChangeFeedErrors` |
| Continuation token with `IncludeNonFinalizedEvents` enabled | `ArgumentException` (param `continuationToken`) | `Resuming from a continuation token is not supported when IncludeNonFinalizedEvents is enabled on ShareChangeFeedClientOptions. …Disable IncludeNonFinalizedEvents to resume from a saved position.` | Routed through `ShareChangeFeedErrors` |

**Container discovery — `ContainerDiscovery.cs`**

| Scenario | Exception type | Message | Change |
|---|---|---|---|
| Change feed container header missing (not enabled) | `InvalidOperationException` | `Change Feed is not enabled for share '{shareName}'. Enable it by setting 'x-ms-file-enable-change-feed: true' when creating or updating the share.` | Wording normalized |
| Header present but empty | `RequestFailedException` (inner `InvalidOperationException`) | `The Change Feed container header for share '{shareName}' was present but empty. The service returned an unexpected response.` | **Type changed** to `RequestFailedException` (carries `Response`) |
| Container name missing `$` prefix | `RequestFailedException` (inner `InvalidOperationException`) | `The Change Feed container name '{containerName}' for share '{shareName}' does not begin with the expected '$' prefix. The service returned an unexpected response.` | **Type changed** to `RequestFailedException` (carries `Response`) |

**Snapshot input validation — `SnapshotInputValidator.cs`**

| Scenario | Exception type | Message | Change |
|---|---|---|---|
| Null/empty snapshot string | `ArgumentNullException` | *(default)* | Routed through factory |
| Snapshot not valid UTC ISO 8601 (must end with `Z`) | `ArgumentException` | `'{snapshot}' is not a valid UTC ISO 8601 snapshot timestamp (must end with 'Z').` | Routed through factory |
| Begin snapshot not finalized | `ArgumentException` (param `beginSnapshot`) | `Begin snapshot '{begin}' is not finalized (status: {status}). Wait for the snapshot to be finalized before querying.` | Routed through factory |
| End snapshot not finalized | `ArgumentException` (param `endSnapshot`) | `End snapshot '{end}' is not finalized (status: {status}). Wait for the snapshot to be finalized before querying.` | Routed through factory |
| Begin taken later than end | `ArgumentException` (param `beginSnapshot`) | `Begin snapshot '{begin}' (taken {ts:O}) is later than end snapshot '{end}' (taken {ts:O}).` | Routed through factory |
| Begin CvId > end CvId | `ArgumentException` (param `beginSnapshot`) | `Begin snapshot CvId ({beginCvId}) exceeds end snapshot CvId ({endCvId}).` | Routed through factory |
| Begin CvId == end CvId (empty range) | `ArgumentException` (param `endSnapshot`) | `Begin and end snapshots have the same CvId ({cvId}); the query range is empty.` | Routed through factory |

**Snapshot pageables — `ShareChangeFeedSnapshotPageable.cs` / `…AsyncPageable.cs`**

| Scenario | Exception type | Message | Change |
|---|---|---|---|
| Null/empty continuation to resume-only ctor | `ArgumentNullException` (param `continuation`) | *(default)* | Routed through `ChangeFeedErrors.NullContinuation` |

---

## Breaking-behavior notes

These are runtime exception-type changes callers may be catching:

- **Blob** `GetChanges` when change feed isn't enabled: `ArgumentException` → **`InvalidOperationException`**.
- **Files** container-discovery anomalies (empty header / bad prefix): `InvalidOperationException` → **`RequestFailedException`**.
- Malformed continuation tokens and segment paths no longer surface `JsonException` / `FormatException`; they now surface **`ArgumentException`**.

## Testing

- Full solution build succeeds.
- All Change Feed unit tests pass across all target frameworks (net462, net8.0, net9.0, net10.0): **1576 passed, 0 failed**.
- Updated tests to reflect the new types/messages:
  - `ChangeFeedFactoryBaseTests`: not-enabled → `InvalidOperationException`; host-case-insensitivity marker updated.
  - `ContainerDiscoveryTests`: empty-header / bad-prefix → `RequestFailedException` (asserts inner-exception message).
- `dotnet format` clean on new sources.

## Notes

- New error classes are `internal`, so there is **no public API surface change** (public API listings unaffected).
- Changelog updates intentionally omitted from this PR.
- A pre-existing, unrelated test compile issue in `ShareChangeFeedEventTests.cs` (references `NewParentFileId`/`NewFullFilePath` model members) is **out of scope** for this change.
