### PR TITLE
Regenerate Azure Search SDK from TypeSpec

### DIFF
--- a/sdk/search/Azure.Search.Documents/CHANGELOG.md
+++ b/sdk/search/Azure.Search.Documents/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.1.0-beta.2 (Unreleased)
 
 ### Features Added
+Dummy Change
 
 ### Breaking Changes
 

--- a/sdk/search/Azure.Search.Documents/tsp-location.yaml
+++ b/sdk/search/Azure.Search.Documents/tsp-location.yaml
@@ -1,4 +1,4 @@
 repo: Azure/azure-rest-api-specs
-commit: 8be8c75d9bb11ea95d8a7e251db74aa78b5cd76c
+commit: c19e358860e3cb89a8c7021e8c5a181ab6ef7f62
 directory: specification/search/data-plane/Search
 emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-emitter-package.json


### PR DESCRIPTION
Generated from AzureSearch TypeSpec at public spec commit `c19e358860e3cb89a8c7021e8c5a181ab6ef7f62`.