### PR TITLE
[CodeTransparency] Prepare 1.0.0-beta.12 release

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.12 (Unreleased)
+## 1.0.0-beta.12 (2026-07-31)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 1.0.0-beta.12 (2026-07-31)
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed asynchronous registration and receipt retrieval against a still-pending transaction. When a
@@ -18,8 +14,6 @@
   `302` as retriable, and the client's default retry settings were raised (more, exponentially
   backed-off retries starting at 200 ms) so the pipeline polls until the committed receipt (`200`).
   All retry and delay values remain overridable through `CodeTransparencyClientOptions.Retry`.
-
-### Other Changes
 
 ## 1.0.0-beta.11 (2026-07-15)
 


### PR DESCRIPTION
Updates the `Azure.Security.CodeTransparency` changelog entry for `1.0.0-beta.12`, changing the release date from `Unreleased` to `2026-07-31` in preparation for release.

### Change
- `sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md`: `## 1.0.0-beta.12 (Unreleased)` → `## 1.0.0-beta.12 (2026-07-31)`

No source or test changes; the beta.12 feature work (async 302 polling / redirect `api-version` handling) is already merged in #61132.