### PR TITLE
Reset unpublished provisioning changelog dates

### DIFF
--- a/sdk/compute/Azure.Provisioning.Compute/CHANGELOG.md
+++ b/sdk/compute/Azure.Provisioning.Compute/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (2026-07-30)
+## 1.0.0-beta.2 (Unreleased)
 
 ### Features Added
 

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/CHANGELOG.md
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0-beta.2 (2026-07-30)
+## 1.2.0-beta.2 (Unreleased)
 
 ### Other Changes
 


### PR DESCRIPTION
## Summary

- reset the latest Azure.Provisioning.Compute changelog section to Unreleased
- reset the latest Azure.Provisioning.OperationalInsights changelog section to Unreleased
- confirm all 50 Azure.Provisioning package changelogs now have an Unreleased latest section

## NuGet verification

- Azure.Provisioning.Compute 1.0.0-beta.2 is not published
- Azure.Provisioning.OperationalInsights 1.2.0-beta.2 is not published