### PR TITLE
[Experiment] Combine LOC-balanced regeneration with shallow checkout

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -313,6 +313,8 @@ extends:
         - job: Initialize
           steps:
           - checkout: self
+            fetchDepth: 1
+            fetchTags: false
 
           - template: /eng/common/pipelines/templates/steps/login-to-github.yml
             parameters:
@@ -410,6 +412,8 @@ extends:
             emitterNpmrcPath: $(Agent.TempDirectory)/${{ parameters.EmitterPackagePath }}/.npmrc
           steps:
           - checkout: self
+            fetchDepth: 1
+            fetchTags: false
 
           - template: /eng/common/pipelines/templates/steps/login-to-github.yml
             parameters:

--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -72,6 +72,15 @@ parameters:
   type: string
   default: ''
 
+# Balance regeneration jobs using existing C# LOC plus a per-package base cost.
+- name: UseLocWeighting
+  type: boolean
+  default: false
+
+- name: LocBaseCost
+  type: number
+  default: 30000
+
 # Paths to sparse checkout
 - name: SparseCheckoutPaths
   type: object
@@ -383,6 +392,8 @@ extends:
                 -MinimumPerJob ${{ parameters.MinimumPerJob }}
                 -OnlyTypespec ${{ parameters.OnlyGenerateTypespec }}
                 -DirectoryFilterPattern '${{ parameters.DirectoryFilterPattern }}'
+                -UseLocWeighting ${{ parameters.UseLocWeighting }}
+                -LocBaseCost ${{ parameters.LocBaseCost }}
               workingDirectory: $(Build.SourcesDirectory)
 
           - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml

--- a/eng/common/scripts/New-RegenerateMatrix.ps1
+++ b/eng/common/scripts/New-RegenerateMatrix.ps1
@@ -19,12 +19,79 @@ param (
   # Optional comma-separated filter patterns applied to package directory names
   # (e.g., 'Azure.ResourceManager*,Azure.Provisioning*')
   [Parameter()]
-  [string]$DirectoryFilterPattern
+  [string]$DirectoryFilterPattern,
+
+  # Balance jobs by existing C# LOC plus a fixed per-package cost instead of by
+  # package count. The generated source is a strong proxy for regeneration time.
+  [Parameter()]
+  [string]$UseLocWeighting,
+
+  [Parameter()]
+  [ValidateRange(0, [int]::MaxValue)]
+  [int]$LocBaseCost = 30000
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
 
 [bool]$OnlyTypespec = $OnlyTypespec -in @("true", "t", "1", "yes", "y")
+[bool]$UseLocWeighting = $UseLocWeighting -in @("true", "t", "1", "yes", "y")
+
+if ($UseLocWeighting) {
+  Add-Type -TypeDefinition @"
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+public static class RegenerationLocCounter
+{
+    private const int BufferSize = 64 * 1024;
+
+    private static long CountDirectory(string root)
+    {
+        if (!Directory.Exists(root))
+        {
+            return 1;
+        }
+
+        long total = 0;
+        byte[] buffer = new byte[BufferSize];
+        foreach (string file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            using (var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 1, FileOptions.SequentialScan))
+            {
+                int read;
+                bool any = false;
+                byte last = 0;
+                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    any = true;
+                    for (int i = 0; i < read; i++)
+                    {
+                        if (buffer[i] == (byte)10)
+                        {
+                            total++;
+                        }
+                    }
+                    last = buffer[read - 1];
+                }
+                if (any && last != (byte)10)
+                {
+                    total++;
+                }
+            }
+        }
+        return Math.Max(total, 1);
+    }
+
+    public static long[] CountAll(string[] roots)
+    {
+        var results = new long[roots.Length];
+        Parallel.For(0, roots.Length, i => results[i] = CountDirectory(roots[i]));
+        return results;
+    }
+}
+"@
+}
 
 # Divide the items into groups of approximately equal size.
 function Split-Items([array]$Items) {
@@ -55,6 +122,56 @@ function Split-Items([array]$Items) {
 
   Write-Host "$itemCount items split into $JobCount groups of approximately $itemsPerGroup items each."
 
+  return , $groups
+}
+
+function Split-ItemsByWeight([array]$Items) {
+  $itemCount = $Items.Length
+  $jobsForMinimum = $itemCount -lt $MinimumPerJob ? 1 : [math]::Floor($itemCount / $MinimumPerJob)
+  $effectiveJobCount = [math]::Min($JobCount, $jobsForMinimum)
+
+  $sourceRoots = [string[]]@($Items | ForEach-Object {
+    Join-Path $RepoRoot "sdk/$($_.PackageDirectory)/src"
+  })
+  $locCounts = [RegenerationLocCounter]::CountAll($sourceRoots)
+
+  $weightedItems = for ($i = 0; $i -lt $Items.Length; $i++) {
+    [PSCustomObject]@{
+      Item = $Items[$i]
+      Loc = $locCounts[$i]
+      Weight = $locCounts[$i] + $LocBaseCost
+    }
+  }
+  $weightedItems = @($weightedItems | Sort-Object -Property Weight -Descending)
+
+  $buckets = @(
+    for ($i = 0; $i -lt $effectiveJobCount; $i++) {
+      [PSCustomObject]@{
+        Items = [System.Collections.ArrayList]::new()
+        TotalLoc = [long]0
+        TotalWeight = [long]0
+      }
+    }
+  )
+
+  foreach ($weightedItem in $weightedItems) {
+    $bucket = $buckets | Sort-Object -Property TotalWeight | Select-Object -First 1
+    [void]$bucket.Items.Add($weightedItem.Item)
+    $bucket.TotalLoc += $weightedItem.Loc
+    $bucket.TotalWeight += $weightedItem.Weight
+  }
+
+  for ($i = 0; $i -lt $buckets.Count; $i++) {
+    $bucket = $buckets[$i]
+    $bucket.Items = [System.Collections.ArrayList]@($bucket.Items | Sort-Object -Property PackageDirectory)
+    Write-Host "Weighted group $i`: $($bucket.Items.Count) packages, $($bucket.TotalLoc) LOC, weight $($bucket.TotalWeight)"
+  }
+  Write-Host "$itemCount items split into $effectiveJobCount LOC-weighted groups with base cost $LocBaseCost per package."
+
+  $groups = [object[]]::new($buckets.Count)
+  for ($i = 0; $i -lt $buckets.Count; $i++) {
+    $groups[$i] = [object[]]$buckets[$i].Items
+  }
   return , $groups
 }
 
@@ -97,7 +214,12 @@ if ($directoriesForGeneration.Count -eq 0) {
   }
 }
 
-$batches = Split-Items -Items $packageDirectories
+$batches = if ($UseLocWeighting) {
+  Split-ItemsByWeight -Items $packageDirectories
+}
+else {
+  Split-Items -Items $packageDirectories
+}
 
 $matrix = [ordered]@{}
 for ($i = 0; $i -lt $batches.Length; $i++) {

--- a/eng/packages/http-client-csharp-mgmt/ci.yml
+++ b/eng/packages/http-client-csharp-mgmt/ci.yml
@@ -85,15 +85,14 @@ extends:
         PublishDependsOnTest: false
         PublishPublic: ${{ and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
         HasNugetPackages: true
-      # Workaround: keep regen groups small enough to avoid the public release
-      # pipeline's 1-hour timeout. Azure.ResourceManager.Network takes much
-      # longer than most packages and should be optimized eventually; the shared
-      # matrix generator only supports count-based batching, not per-package
-      # isolation.
+      # Keep 18 jobs to match the observed pool concurrency, but balance their
+      # generation cost using existing C# LOC plus a fixed per-package cost.
       RegenerationJobCount: 18
       MinimumPerJob: 10
       OnlyGenerateTypespec: true
       DirectoryFilterPattern: 'Azure.ResourceManager*,Azure.Provisioning*'
+      UseLocWeighting: true
+      LocBaseCost: 30000
     TestMatrix:
       All:
         TestArguments: -UnitTests -GenerationChecks -Filter .NET


### PR DESCRIPTION
> **Combined experiment — do not merge from this repository.** `eng/common/**` is mirrored from Azure/azure-sdk-tools. LOC weighting and shallow checkout were measured independently; this revision combines them to validate the end-to-end regeneration stage. Final shared changes belong upstream.

## Changes

Use `fetchDepth: 1` / `fetchTags: false` for the `Initialize` and `Generate` checkouts (verified separately in #61512), and keep the regeneration matrix at **18 jobs** (matching the observed pool concurrency), but replace alphabetical equal-count grouping with LPT bin-packing:

```text
package weight = existing src C# LOC + 30,000
```

Packages are sorted by weight descending and assigned to the currently lightest job. Existing generated C# LOC is used because it strongly predicts regeneration work; the 30K base cost accounts for per-package setup that LOC misses.

Inspired by the weighted batching infrastructure in #61442, but regeneration deliberately keeps a fixed job count rather than deriving it from a target weight.

## Why this should help

Reconstructing the original 18 groups and comparing their C# LOC with measured `Call regeneration script` duration:

| Statistic | Result |
|---|---:|
| Pearson correlation | **0.934** |
| Spearman rank correlation | **0.897** |
| Regression R² | **0.874** |
| Estimated per-package base cost | **33,160 LOC equivalent** |

The old alphabetical grouping was highly uneven:

| Group | LOC | Regen time |
|---|---:|---:|
| Network group | 1.10M | **17.58 min** |
| Smallest group | 0.22M | **7.30 min** |
| Mean | 0.57M | **10.68 min** |

With `LocBaseCost: 30000`, the model predicts the slowest regeneration task at approximately **11.5 minutes**, around **6 minutes below** the previous 17.6-minute critical job.

## Local validation on latest main

The repository currently contains 233 matching TypeSpec packages:

- **18** matrix jobs
- **233/233 unique packages**, no loss or duplication
- **9–14 packages/job**
- Weighted totals: 981K–1,014K (**~3.3% spread**)
- Matrix generation: **2.5 seconds**
- Identical output across repeated runs
- PowerShell and YAML parse successfully

The weighted path also avoids the existing count-split remainder bug naturally because every package is assigned by LPT. Consequently the experimental run may regenerate more packages than older 18-job baselines; compare critical-job duration and normalize aggregate work rather than looking only at total agent-minutes.

## What to measure

Compare against the previous timeline:

1. Slowest `Call regeneration script` task (target: ~11.5 min vs 17.6 min).
2. Spread between fastest and slowest regeneration tasks.
3. Overall `Regenerate` stage duration.
4. Confirm all 233 package paths appear exactly once in the matrix artifacts.

The first weighted-only run reduced the old critical regeneration task from **17m 35s to 12m 13s**, but one full checkout took **23m 26s** and masked the gain. This revision adds the independently verified shallow checkout so the next run measures the combined stage result. The corresponding upstream checkout change is Azure/azure-sdk-tools#16644.

