### PR TITLE
Optimize .NET validation for spec pull requests

### DIFF
--- a/eng/scripts/Invoke-GenerateAndBuildV2.ps1
+++ b/eng/scripts/Invoke-GenerateAndBuildV2.ps1
@@ -44,6 +44,7 @@ $autorestConfig = $inputJson.autorestConfig
 $relatedTypeSpecProjectFolder = $inputJson.relatedTypeSpecProjectFolder
 $apiVersion = $inputJson.apiVersion
 $sdkReleaseType = $inputJson.sdkReleaseType
+$runMode = $inputJson.runMode
 
 function Test-MgmtSdkUsingNewGenerator {
     param(
@@ -224,7 +225,7 @@ for ($i = 0; $i -le $readmeFiles.Count - 1; $i++) {
         $readmeFiles[$i] = $readme
         $autorestConfigYaml = ConvertTo-YAML $yml
     }
-    Invoke-GenerateAndBuildSDK -readmeAbsolutePath $readme -sdkRootPath $sdkPath -autorestConfigYaml "$autorestConfigYaml" -downloadUrlPrefix "$downloadUrlPrefix" -generatedSDKPackages $generatedSDKPackages
+    Invoke-GenerateAndBuildSDK -readmeAbsolutePath $readme -sdkRootPath $sdkPath -autorestConfigYaml "$autorestConfigYaml" -downloadUrlPrefix "$downloadUrlPrefix" -runMode $runMode -generatedSDKPackages $generatedSDKPackages
     $generatedSDKPackages[$generatedSDKPackages.Count - 1]['readmeMd'] = @($readmeFile)
 }
 
@@ -245,7 +246,7 @@ foreach( $file in $inputFilePaths) {
 }
 
 if ($inputFileToGen) {
-    UpdateExistingSDKByInputFiles -inputFilePaths $inputFileToGen -sdkRootPath $sdkPath -headSha $commitid -repoHttpsUrl $repoHttpsUrl -downloadUrlPrefix "$downloadUrlPrefix" -generatedSDKPackages $generatedSDKPackages
+    UpdateExistingSDKByInputFiles -inputFilePaths $inputFileToGen -sdkRootPath $sdkPath -headSha $commitid -repoHttpsUrl $repoHttpsUrl -downloadUrlPrefix "$downloadUrlPrefix" -runMode $runMode -generatedSDKPackages $generatedSDKPackages
 }
 
 $exitCode = 0
@@ -331,6 +332,7 @@ if ($relatedTypeSpecProjectFolder) {
             -path $relativeSdkPath `
             -downloadUrlPrefix $downloadUrlPrefix `
             -serviceType $serviceType `
+            -runMode $runMode `
             -skipGenerate `
             -generatedSDKPackages $generatedSDKPackages `
             -specRepoRoot $swaggerDir

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -946,6 +946,11 @@ function Get-SpecPullRequestValidationPlan {
             "--configuration"
             "Release"
             "/p:RunApiCompat=false"
+            "/p:IncludeTests=false"
+            "/p:IncludeSamples=false"
+            "/p:IncludePerf=false"
+            "/p:IncludeStress=false"
+            "/p:IncludeIntegrationTests=false"
         )
         ApiExportArguments = @{
             PackagePath = $projectFolder
@@ -1043,14 +1048,16 @@ function GeneratePackage()
 
                 if ($hasBreakingChange) {
                     Write-Host "Breaking changes detected. Packing with API compatibility disabled to produce the APIView artifact."
-                    $artifactPackArguments = $validationPlan.ArtifactPackArguments
-                    dotnet @artifactPackArguments
-                    if (!$?) {
-                        Write-Host "[WARNING] Failed to pack the existing sdk build output: $packageName for service: $service. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
-                        $result = "warning"
-                    }
                 } else {
+                    Write-Host "[WARNING] The initial package validation failed without recognized breaking-change diagnostics. Retrying with API compatibility disabled to preserve any build artifact."
+                }
+
+                $artifactPackArguments = $validationPlan.ArtifactPackArguments
+                dotnet @artifactPackArguments
+                if (!$?) {
                     Write-Host "[WARNING] Failed to build and pack the sdk package: $packageName for service: $service. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+                    $result = "warning"
+                } elseif (!$hasBreakingChange) {
                     $result = "warning"
                 }
             }

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -920,43 +920,33 @@ function New-MgmtPackageScaffolding()
     Write-Host "Management SDK scaffolding complete for $packageName"
 }
 
-function Get-SpecPullRequestValidationPlan {
-    param(
-        [string]$srcPath,
-        [string]$projectFolder,
-        [string]$sdkRootPath
-    )
+function Get-ApiCompatBreakingChangeItems {
+    param([string]$logFilePath)
 
-    return [PSCustomObject]@{
-        PackArguments = @(
-            "pack"
-            $srcPath
-            "--configuration"
-            "Release"
-            "/p:ValidateRunApiCompat=true"
-            "/p:IncludeTests=false"
-            "/p:IncludeSamples=false"
-            "/p:IncludePerf=false"
-            "/p:IncludeStress=false"
-            "/p:IncludeIntegrationTests=false"
-        )
-        ArtifactPackArguments = @(
-            "pack"
-            $srcPath
-            "--configuration"
-            "Release"
-            "/p:RunApiCompat=false"
-            "/p:IncludeTests=false"
-            "/p:IncludeSamples=false"
-            "/p:IncludePerf=false"
-            "/p:IncludeStress=false"
-            "/p:IncludeIntegrationTests=false"
-        )
-        ApiExportArguments = @{
-            PackagePath = $projectFolder
-            SdkRepoPath = $sdkRootPath
+    $breakingChangeItems = @()
+    if (Test-Path $logFilePath) {
+        foreach ($line in (Get-Content -Path $logFilePath)) {
+            if ($line -match "error\s+CP\d{4}\s*:\s*(?<breakingChange>.*)\s+\[[^\]]+\]\s*$") {
+                $breakingChangeItems += $matches["breakingChange"]
+            }
         }
     }
+
+    return $breakingChangeItems
+}
+
+function Test-ApiCompatFailure {
+    param([string]$logFilePath)
+
+    if (Test-Path $logFilePath) {
+        foreach ($line in (Get-Content -Path $logFilePath)) {
+            if ($line -match "(?i)\berror\b.*(?:\bCP\d{4}\b|Api\s*Compat)") {
+                return $true
+            }
+        }
+    }
+
+    return $false
 }
 
 function GeneratePackage()
@@ -1021,43 +1011,32 @@ function GeneratePackage()
         }
 
         if ($runMode -eq "spec-pull-request") {
-            $validationPlan = Get-SpecPullRequestValidationPlan `
-                -srcPath $srcPath `
-                -projectFolder $projectFolder `
-                -sdkRootPath $sdkRootPath
             $logFilePath = Join-Path $srcPath 'log.txt'
-            $packArguments = $validationPlan.PackArguments + @("/flp:v=m;LogFile=$logFilePath")
 
             Write-Host "Start package-scoped Release build, pack, and API compatibility validation: $srcPath"
-            dotnet @packArguments
-            if (!$?) {
-                if (Test-Path $logFilePath) {
-                    $logFile = Get-Content -Path $logFilePath | Select-Object -SkipLast 1
-                    $regex = "error( ?):( ?)(?<breakingChange>.*) .*\["
-                    foreach ($line in $logFile) {
-                        if ($line -match $regex) {
-                            $breakingChangeItems += $matches["breakingChange"]
-                        }
-                    }
-                    if ($breakingChangeItems.Count -gt 0) {
-                        $breakingChanges = $breakingChangeItems -join ",`n"
-                        $content = "Breaking Changes: $breakingChanges"
-                        $hasBreakingChange = $true
-                    }
-                }
-
-                if ($hasBreakingChange) {
+            dotnet pack $srcPath --configuration Release /p:ValidateRunApiCompat=true "/flp:v=m;LogFile=$logFilePath"
+            if ($LASTEXITCODE) {
+                $breakingChangeItems = @(Get-ApiCompatBreakingChangeItems -logFilePath $logFilePath)
+                if ($breakingChangeItems.Count -gt 0) {
+                    $breakingChanges = $breakingChangeItems -join ",`n"
+                    $content = "Breaking Changes: $breakingChanges"
+                    $hasBreakingChange = $true
                     Write-Host "Breaking changes detected. Packing with API compatibility disabled to produce the APIView artifact."
-                } else {
-                    Write-Host "[WARNING] The initial package validation failed without recognized breaking-change diagnostics. Retrying with API compatibility disabled to preserve any build artifact."
                 }
 
-                $artifactPackArguments = $validationPlan.ArtifactPackArguments
-                dotnet @artifactPackArguments
-                if (!$?) {
-                    Write-Host "[WARNING] Failed to build and pack the sdk package: $packageName for service: $service. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
-                    $result = "warning"
-                } elseif (!$hasBreakingChange) {
+                if (Test-ApiCompatFailure -logFilePath $logFilePath) {
+                    if (!$hasBreakingChange) {
+                        Write-Host "[WARNING] API compatibility validation failed without breaking-change diagnostics. Packing with API compatibility disabled to produce the APIView artifact."
+                    }
+                    dotnet pack $srcPath --configuration Release /p:RunApiCompat=false
+                    if ($LASTEXITCODE) {
+                        Write-Host "[WARNING] Failed to build and pack the sdk package: $packageName for service: $service. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+                        $result = "warning"
+                    } elseif (!$hasBreakingChange) {
+                        $result = "warning"
+                    }
+                } else {
+                    Write-Host "[WARNING] Package validation failed without ApiCompat diagnostics. Skipping the fallback pack because disabling API compatibility cannot repair this failure."
                     $result = "warning"
                 }
             }
@@ -1089,10 +1068,8 @@ function GeneratePackage()
                     lite = $full
                 }
             }
-
             Write-Host "Start to export api for $packageName"
-            $apiExportArguments = $validationPlan.ApiExportArguments
-            & $sdkRootPath/eng/scripts/Export-API.ps1 @apiExportArguments
+            & $sdkRootPath/eng/scripts/Export-API.ps1 -PackagePath $projectFolder -SdkRepoPath $sdkRootPath
             if (!$?) {
                 Write-Host "[WARNING] Failed to export api for sdk. exit code: $?. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
                 $result = "warning"
@@ -1174,16 +1151,14 @@ function GeneratePackage()
             }
             else {
                 Write-Host "Breaking changes detected in the build log."
-                $logFile = Get-Content -Path $logFilePath | select-object -SkipLast 1
-                $regex = "error( ?):( ?)(?<breakingChange>.*) .*\["
-                foreach ($line in $logFile) {
-                    if ($line -match $regex) {
-                        $breakingChangeItems += $matches["breakingChange"]
-                    }
+                $breakingChangeItems = @(Get-ApiCompatBreakingChangeItems -logFilePath $logFilePath)
+                if ($breakingChangeItems.Count -gt 0) {
+                    $breakingChanges = $breakingChangeItems -join ",`n"
+                    $content = "Breaking Changes: $breakingChanges"
+                    $hasBreakingChange = $true
+                } else {
+                    Write-Host "[WARNING] API compatibility validation failed without recognized ApiCompat diagnostics."
                 }
-                $breakingChanges = $breakingChangeItems -join ",`n"
-                $content = "Breaking Changes: $breakingChanges"
-                $hasBreakingChange = $true
             }
 
             if (Test-Path $logFilePath) {

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -565,6 +565,7 @@ function Invoke-GenerateAndBuildSDK () {
         [string]$sdkRootPath,
         [string]$autorestConfigYaml = "",
         [string]$downloadUrlPrefix = "",
+        [string]$runMode = "",
         [object]$generatedSDKPackages
     )
     $readmeFile = $readmeAbsolutePath -replace "\\", "/"
@@ -687,7 +688,7 @@ function Invoke-GenerateAndBuildSDK () {
         # $packageName = $package.packageName
         Write-Host "projectFolder:$projectFolder"
 
-        GeneratePackage -projectFolder $projectFolder -sdkRootPath $sdkRootPath -path $path -downloadUrlPrefix $downloadUrlPrefix -serviceType $serviceType -generatedSDKPackages $generatedSDKPackages
+        GeneratePackage -projectFolder $projectFolder -sdkRootPath $sdkRootPath -path $path -downloadUrlPrefix $downloadUrlPrefix -serviceType $serviceType -runMode $runMode -generatedSDKPackages $generatedSDKPackages
     }
 }
 
@@ -919,6 +920,40 @@ function New-MgmtPackageScaffolding()
     Write-Host "Management SDK scaffolding complete for $packageName"
 }
 
+function Get-SpecPullRequestValidationPlan {
+    param(
+        [string]$srcPath,
+        [string]$projectFolder,
+        [string]$sdkRootPath
+    )
+
+    return [PSCustomObject]@{
+        PackArguments = @(
+            "pack"
+            $srcPath
+            "--configuration"
+            "Release"
+            "/p:ValidateRunApiCompat=true"
+            "/p:IncludeTests=false"
+            "/p:IncludeSamples=false"
+            "/p:IncludePerf=false"
+            "/p:IncludeStress=false"
+            "/p:IncludeIntegrationTests=false"
+        )
+        ArtifactPackArguments = @(
+            "pack"
+            $srcPath
+            "--configuration"
+            "Release"
+            "/p:RunApiCompat=false"
+        )
+        ApiExportArguments = @{
+            PackagePath = $projectFolder
+            SdkRepoPath = $sdkRootPath
+        }
+    }
+}
+
 function GeneratePackage()
 {
     param(
@@ -927,6 +962,7 @@ function GeneratePackage()
         [string]$path,
         [string]$downloadUrlPrefix="",
         [string]$serviceType="data-plane",
+        [string]$runMode="",
         [switch]$skipGenerate,
         [object]$generatedSDKPackages,
         [string]$specRepoRoot=""
@@ -978,7 +1014,83 @@ function GeneratePackage()
         if (![string]::IsNullOrWhiteSpace($version)) {
             New-ChangeLogIfNotExists -projectFolder $projectFolder -version $version
         }
-        
+
+        if ($runMode -eq "spec-pull-request") {
+            $validationPlan = Get-SpecPullRequestValidationPlan `
+                -srcPath $srcPath `
+                -projectFolder $projectFolder `
+                -sdkRootPath $sdkRootPath
+            $logFilePath = Join-Path $srcPath 'log.txt'
+            $packArguments = $validationPlan.PackArguments + @("/flp:v=m;LogFile=$logFilePath")
+
+            Write-Host "Start package-scoped Release build, pack, and API compatibility validation: $srcPath"
+            dotnet @packArguments
+            if (!$?) {
+                if (Test-Path $logFilePath) {
+                    $logFile = Get-Content -Path $logFilePath | Select-Object -SkipLast 1
+                    $regex = "error( ?):( ?)(?<breakingChange>.*) .*\["
+                    foreach ($line in $logFile) {
+                        if ($line -match $regex) {
+                            $breakingChangeItems += $matches["breakingChange"]
+                        }
+                    }
+                    if ($breakingChangeItems.Count -gt 0) {
+                        $breakingChanges = $breakingChangeItems -join ",`n"
+                        $content = "Breaking Changes: $breakingChanges"
+                        $hasBreakingChange = $true
+                    }
+                }
+
+                if ($hasBreakingChange) {
+                    Write-Host "Breaking changes detected. Packing with API compatibility disabled to produce the APIView artifact."
+                    $artifactPackArguments = $validationPlan.ArtifactPackArguments
+                    dotnet @artifactPackArguments
+                    if (!$?) {
+                        Write-Host "[WARNING] Failed to pack the existing sdk build output: $packageName for service: $service. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+                        $result = "warning"
+                    }
+                } else {
+                    Write-Host "[WARNING] Failed to build and pack the sdk package: $packageName for service: $service. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+                    $result = "warning"
+                }
+            }
+
+            if (Test-Path $logFilePath) {
+                Remove-Item $logFilePath
+            }
+
+            Push-Location $sdkRootPath
+            $artifactsPath = (Join-Path "artifacts" "packages" "Release" $packageName)
+            if (-not (Test-Path $artifactsPath)) {
+                Write-Host "[ERROR] Artifact folder not found for $artifactsPath. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+            } else {
+                $artifacts += Get-ChildItem $artifactsPath -Filter *.nupkg -exclude *.symbols.nupkg -Recurse | Select-Object -ExpandProperty FullName | Resolve-Path -Relative
+            }
+
+            if ($artifacts.count -eq 0) {
+                Write-Host "[ERROR] Failed to generate sdk artifact. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+            } else {
+                $apiViewArtifact = $artifacts[0]
+            }
+            Pop-Location
+
+            if ($artifacts.count -gt 0) {
+                $fileName = Split-Path $artifacts[0] -Leaf
+                $full = "Download the $packageName package from [here]($downloadUrlPrefix/$fileName)"
+                $installInstructions = [PSCustomObject]@{
+                    full = $full
+                    lite = $full
+                }
+            }
+
+            Write-Host "Start to export api for $packageName"
+            $apiExportArguments = $validationPlan.ApiExportArguments
+            & $sdkRootPath/eng/scripts/Export-API.ps1 @apiExportArguments
+            if (!$?) {
+                Write-Host "[WARNING] Failed to export api for sdk. exit code: $?. Please review the detail errors for potential fixes. If the issue persists, contact the DotNet language support channel at $DotNetSupportChannelLink and include this spec pull request."
+                $result = "warning"
+            }
+        } else {
         # Build project when successfully generated the code
         Write-Host "Start to build sdk project: $srcPath"
         dotnet build $srcPath /p:RunApiCompat=$false
@@ -1071,6 +1183,7 @@ function GeneratePackage()
                 Remove-Item $logFilePath
             }
         }
+        }
     }
 
     $changelog = [PSCustomObject]@{
@@ -1115,6 +1228,7 @@ function UpdateExistingSDKByInputFiles()
         [string]$headSha = "",
         [string]$repoHttpsUrl,
         [string]$downloadUrlPrefix="",
+        [string]$runMode="",
         [object]$generatedSDKPackages
     )
 
@@ -1151,7 +1265,7 @@ function UpdateExistingSDKByInputFiles()
         $serviceType = $matches["serviceType"]
         $projectFolder = Join-Path $sdkRootPath $sdkPath
         $projectFolder = Resolve-Path -Path $projectFolder
-        GeneratePackage -projectFolder $projectFolder -sdkRootPath $sdkRootPath -path $path -downloadUrlPrefix "$downloadUrlPrefix" -serviceType $serviceType -generatedSDKPackages $generatedSDKPackages
+        GeneratePackage -projectFolder $projectFolder -sdkRootPath $sdkRootPath -path $path -downloadUrlPrefix "$downloadUrlPrefix" -serviceType $serviceType -runMode $runMode -generatedSDKPackages $generatedSDKPackages
     }
 
 }

--- a/eng/scripts/tests/GenerateAndBuildLib.tests.ps1
+++ b/eng/scripts/tests/GenerateAndBuildLib.tests.ps1
@@ -4,7 +4,7 @@ BeforeAll {
     . (Join-Path $PSScriptRoot ".." "automation" "GenerateAndBuildLib.ps1")
 }
 
-Describe "Get-ApiCompatBreakingChangeItems" {
+Describe "Get-ApiCompatBreakingChangeItems" -Tag "UnitTest" {
     It "returns only ApiCompat diagnostics" {
         $logFilePath = Join-Path $TestDrive "log.txt"
         @(
@@ -26,7 +26,7 @@ Describe "Get-ApiCompatBreakingChangeItems" {
     }
 }
 
-Describe "GeneratePackage spec pull request validation" {
+Describe "GeneratePackage spec pull request validation" -Tag "UnitTest" {
     BeforeEach {
         $script:sdkRootPath = Join-Path $TestDrive "repo"
         $script:projectFolder = Join-Path $sdkRootPath "sdk" "network" "Azure.ResourceManager.Network"

--- a/eng/scripts/tests/GenerateAndBuildLib.tests.ps1
+++ b/eng/scripts/tests/GenerateAndBuildLib.tests.ps1
@@ -4,38 +4,171 @@ BeforeAll {
     . (Join-Path $PSScriptRoot ".." "automation" "GenerateAndBuildLib.ps1")
 }
 
-Describe "Get-SpecPullRequestValidationPlan" {
-    It "uses one package-scoped Release pack with API compatibility" {
-        $plan = Get-SpecPullRequestValidationPlan `
-            -srcPath "/repo/sdk/network/Azure.ResourceManager.Network/src" `
-            -projectFolder "/repo/sdk/network/Azure.ResourceManager.Network" `
-            -sdkRootPath "/repo"
+Describe "Get-ApiCompatBreakingChangeItems" {
+    It "returns only ApiCompat diagnostics" {
+        $logFilePath = Join-Path $TestDrive "log.txt"
+        @(
+            "error CS1002: ; expected [/repo/sdk/network/Azure.ResourceManager.Network/src/Azure.ResourceManager.Network.csproj]"
+            "error CP0002: Member 'void Example.OldMethod()' does not exist [/repo/sdk/network/Azure.ResourceManager.Network/src/Azure.ResourceManager.Network.csproj::TargetFramework=net8.0]"
+        ) | Set-Content $logFilePath
 
-        $plan.PackArguments | Should -Be @(
+        Get-ApiCompatBreakingChangeItems -logFilePath $logFilePath | Should -Be @(
+            "Member 'void Example.OldMethod()' does not exist"
+        )
+    }
+
+    It "recognizes repository ApiCompat validation failures without CP diagnostics" {
+        $logFilePath = Join-Path $TestDrive "log.txt"
+        "error : ApiCompatVersion is missing from Azure.ResourceManager.Network. [/repo/sdk/network/Azure.ResourceManager.Network/src/Azure.ResourceManager.Network.csproj]" |
+            Set-Content $logFilePath
+
+        Test-ApiCompatFailure -logFilePath $logFilePath | Should -BeTrue
+    }
+}
+
+Describe "GeneratePackage spec pull request validation" {
+    BeforeEach {
+        $script:sdkRootPath = Join-Path $TestDrive "repo"
+        $script:projectFolder = Join-Path $sdkRootPath "sdk" "network" "Azure.ResourceManager.Network"
+        $script:srcPath = Join-Path $projectFolder "src"
+        $script:logFilePath = Join-Path $srcPath "log.txt"
+        $script:artifactPath = Join-Path $sdkRootPath "artifacts" "packages" "Release" "Azure.ResourceManager.Network"
+        $script:exportApiArgumentsPath = Join-Path $sdkRootPath "export-api-arguments.txt"
+        $script:dotnetCalls = @()
+        $script:dotnetExitCodes = @(0)
+        $script:dotnetCallIndex = 0
+
+        New-Item -ItemType Directory -Path $srcPath -Force | Out-Null
+        New-Item -ItemType Directory -Path $artifactPath -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $sdkRootPath "eng" "scripts") -Force | Out-Null
+        '<Project />' | Set-Content (Join-Path $srcPath "Azure.ResourceManager.Network.csproj")
+        "package" | Set-Content (Join-Path $artifactPath "Azure.ResourceManager.Network.1.0.0.nupkg")
+        @'
+param(
+    [string]$PackagePath,
+    [string]$SdkRepoPath
+)
+"$PackagePath|$SdkRepoPath" | Set-Content (Join-Path $SdkRepoPath "export-api-arguments.txt")
+'@ | Set-Content (Join-Path $sdkRootPath "eng" "scripts" "Export-API.ps1")
+
+        Mock dotnet {
+            $script:dotnetCalls += ,@($args)
+            $global:LASTEXITCODE = $script:dotnetExitCodes[$script:dotnetCallIndex]
+            $script:dotnetCallIndex++
+        }
+    }
+
+    It "uses one package-scoped Release pack and exports only that package" {
+        $generatedSDKPackages = [System.Collections.ArrayList]::new()
+
+        GeneratePackage `
+            -projectFolder $projectFolder `
+            -sdkRootPath $sdkRootPath `
+            -path "sdk/network/Azure.ResourceManager.Network" `
+            -downloadUrlPrefix "https://example.test" `
+            -serviceType "resource-manager" `
+            -runMode "spec-pull-request" `
+            -skipGenerate `
+            -generatedSDKPackages $generatedSDKPackages
+
+        $dotnetCalls.Count | Should -Be 1
+        $dotnetCalls[0] | Should -Be @(
             "pack"
-            "/repo/sdk/network/Azure.ResourceManager.Network/src"
+            $srcPath
             "--configuration"
             "Release"
             "/p:ValidateRunApiCompat=true"
-            "/p:IncludeTests=false"
-            "/p:IncludeSamples=false"
-            "/p:IncludePerf=false"
-            "/p:IncludeStress=false"
-            "/p:IncludeIntegrationTests=false"
+            "/flp:v=m;LogFile=$logFilePath"
         )
-        $plan.ArtifactPackArguments | Should -Be @(
+        Get-Content $exportApiArgumentsPath | Should -Be "$projectFolder|$sdkRootPath"
+        $generatedSDKPackages[0].result | Should -Be "succeeded"
+    }
+
+    It "retries without API compatibility only for an ApiCompat failure" {
+        $script:dotnetExitCodes = @(1, 0)
+        Mock dotnet {
+            $script:dotnetCalls += ,@($args)
+            if ($script:dotnetCallIndex -eq 0) {
+                "error CP0002: Member 'void Example.OldMethod()' does not exist [$srcPath/Azure.ResourceManager.Network.csproj::TargetFramework=net8.0]" |
+                    Set-Content $logFilePath
+            }
+            $global:LASTEXITCODE = $script:dotnetExitCodes[$script:dotnetCallIndex]
+            $script:dotnetCallIndex++
+        }
+        $generatedSDKPackages = [System.Collections.ArrayList]::new()
+
+        GeneratePackage `
+            -projectFolder $projectFolder `
+            -sdkRootPath $sdkRootPath `
+            -path "sdk/network/Azure.ResourceManager.Network" `
+            -serviceType "data-plane" `
+            -runMode "spec-pull-request" `
+            -skipGenerate `
+            -generatedSDKPackages $generatedSDKPackages
+
+        $dotnetCalls.Count | Should -Be 2
+        $dotnetCalls[1] | Should -Be @(
             "pack"
-            "/repo/sdk/network/Azure.ResourceManager.Network/src"
+            $srcPath
             "--configuration"
             "Release"
             "/p:RunApiCompat=false"
-            "/p:IncludeTests=false"
-            "/p:IncludeSamples=false"
-            "/p:IncludePerf=false"
-            "/p:IncludeStress=false"
-            "/p:IncludeIntegrationTests=false"
         )
-        $plan.ApiExportArguments.PackagePath | Should -Be "/repo/sdk/network/Azure.ResourceManager.Network"
-        $plan.ApiExportArguments.SdkRepoPath | Should -Be "/repo"
+        $generatedSDKPackages[0].changelog.hasBreakingChange | Should -BeTrue
+        $generatedSDKPackages[0].changelog.breakingChangeItems | Should -Be @(
+            "Member 'void Example.OldMethod()' does not exist"
+        )
+    }
+
+    It "does not retry an unrelated pack failure" {
+        $script:dotnetExitCodes = @(1)
+        Mock dotnet {
+            $script:dotnetCalls += ,@($args)
+            "error CS1002: ; expected [$srcPath/Azure.ResourceManager.Network.csproj]" | Set-Content $logFilePath
+            $global:LASTEXITCODE = $script:dotnetExitCodes[$script:dotnetCallIndex]
+            $script:dotnetCallIndex++
+        }
+        $generatedSDKPackages = [System.Collections.ArrayList]::new()
+
+        GeneratePackage `
+            -projectFolder $projectFolder `
+            -sdkRootPath $sdkRootPath `
+            -path "sdk/network/Azure.ResourceManager.Network" `
+            -serviceType "data-plane" `
+            -runMode "spec-pull-request" `
+            -skipGenerate `
+            -generatedSDKPackages $generatedSDKPackages
+
+        $dotnetCalls.Count | Should -Be 1
+        $generatedSDKPackages[0].result | Should -Be "warning"
+        $generatedSDKPackages[0].changelog.hasBreakingChange | Should -BeFalse
+    }
+
+    It "retries a repository ApiCompat validation failure without marking a breaking change" {
+        $script:dotnetExitCodes = @(1, 0)
+        Mock dotnet {
+            $script:dotnetCalls += ,@($args)
+            if ($script:dotnetCallIndex -eq 0) {
+                "error : ApiCompatVersion is missing from Azure.ResourceManager.Network. [$srcPath/Azure.ResourceManager.Network.csproj]" |
+                    Set-Content $logFilePath
+            }
+            $global:LASTEXITCODE = $script:dotnetExitCodes[$script:dotnetCallIndex]
+            $script:dotnetCallIndex++
+        }
+        $generatedSDKPackages = [System.Collections.ArrayList]::new()
+
+        GeneratePackage `
+            -projectFolder $projectFolder `
+            -sdkRootPath $sdkRootPath `
+            -path "sdk/network/Azure.ResourceManager.Network" `
+            -serviceType "data-plane" `
+            -runMode "spec-pull-request" `
+            -skipGenerate `
+            -generatedSDKPackages $generatedSDKPackages
+
+        $dotnetCalls.Count | Should -Be 2
+        $dotnetCalls[1] | Should -Contain "/p:RunApiCompat=false"
+        $generatedSDKPackages[0].result | Should -Be "warning"
+        $generatedSDKPackages[0].changelog.hasBreakingChange | Should -BeFalse
     }
 }

--- a/eng/scripts/tests/GenerateAndBuildLib.tests.ps1
+++ b/eng/scripts/tests/GenerateAndBuildLib.tests.ps1
@@ -29,6 +29,11 @@ Describe "Get-SpecPullRequestValidationPlan" {
             "--configuration"
             "Release"
             "/p:RunApiCompat=false"
+            "/p:IncludeTests=false"
+            "/p:IncludeSamples=false"
+            "/p:IncludePerf=false"
+            "/p:IncludeStress=false"
+            "/p:IncludeIntegrationTests=false"
         )
         $plan.ApiExportArguments.PackagePath | Should -Be "/repo/sdk/network/Azure.ResourceManager.Network"
         $plan.ApiExportArguments.SdkRepoPath | Should -Be "/repo"

--- a/eng/scripts/tests/GenerateAndBuildLib.tests.ps1
+++ b/eng/scripts/tests/GenerateAndBuildLib.tests.ps1
@@ -1,0 +1,36 @@
+#Requires -Version 7.0
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot ".." "automation" "GenerateAndBuildLib.ps1")
+}
+
+Describe "Get-SpecPullRequestValidationPlan" {
+    It "uses one package-scoped Release pack with API compatibility" {
+        $plan = Get-SpecPullRequestValidationPlan `
+            -srcPath "/repo/sdk/network/Azure.ResourceManager.Network/src" `
+            -projectFolder "/repo/sdk/network/Azure.ResourceManager.Network" `
+            -sdkRootPath "/repo"
+
+        $plan.PackArguments | Should -Be @(
+            "pack"
+            "/repo/sdk/network/Azure.ResourceManager.Network/src"
+            "--configuration"
+            "Release"
+            "/p:ValidateRunApiCompat=true"
+            "/p:IncludeTests=false"
+            "/p:IncludeSamples=false"
+            "/p:IncludePerf=false"
+            "/p:IncludeStress=false"
+            "/p:IncludeIntegrationTests=false"
+        )
+        $plan.ArtifactPackArguments | Should -Be @(
+            "pack"
+            "/repo/sdk/network/Azure.ResourceManager.Network/src"
+            "--configuration"
+            "Release"
+            "/p:RunApiCompat=false"
+        )
+        $plan.ApiExportArguments.PackagePath | Should -Be "/repo/sdk/network/Azure.ResourceManager.Network"
+        $plan.ApiExportArguments.SdkRepoPath | Should -Be "/repo"
+    }
+}


### PR DESCRIPTION
## Summary

- use `runMode: spec-pull-request` to select a package-scoped validation path
- replace repeated Debug builds and separate compatibility validation with one Release pack that runs API compatibility
- exclude test, sample, performance, stress, and integration projects
- scope API export to the generated package instead of the full service directory
- preserve APIView artifacts when API compatibility reports breaking changes

Fixes #61653

\- by copilot
