### PR TITLE
Mark AsyncStreamingClientResult APIs as experimental (SCME0005)

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added sealed, one-shot `AsyncStreamingClientResult<T>` for asynchronous streaming responses, with factories for custom producers, server-sent events, and newline-delimited JSON.
+- Added sealed, one-shot experimental `AsyncStreamingClientResult<T>` (and the `AsyncStreamingClientResult` factory class) for asynchronous streaming responses, with factories for custom producers, server-sent events, and newline-delimited JSON. These types are marked experimental (`SCME0005`) and are subject to change or removal in future updates.
 
 ### Bugs Fixed
 

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net10.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net10.0.cs
@@ -13,6 +13,7 @@ namespace System.ClientModel
         public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         protected abstract System.Collections.Generic.IAsyncEnumerable<T> GetValuesFromPageAsync(System.ClientModel.ClientResult page);
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0005")]
     public static partial class AsyncStreamingClientResult
     {
         public static System.ClientModel.AsyncStreamingClientResult<System.BinaryData> CreateJsonLines(System.ClientModel.Primitives.PipelineResponse response, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -21,6 +22,7 @@ namespace System.ClientModel
         public static System.ClientModel.AsyncStreamingClientResult<System.Net.ServerSentEvents.SseItem<T>> CreateSse<T>(System.ClientModel.Primitives.PipelineResponse response, System.Net.ServerSentEvents.SseItemParser<T> itemParser, System.Func<System.Net.ServerSentEvents.SseItem<System.BinaryData>, bool>? isTerminal = null, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.ClientModel.AsyncStreamingClientResult<T> Create<T>(System.ClientModel.Primitives.PipelineResponse response, System.Func<System.IO.Stream, System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<T>> producer, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0005")]
     public sealed partial class AsyncStreamingClientResult<T> : System.Collections.Generic.IAsyncEnumerable<T>, System.IAsyncDisposable
     {
         internal AsyncStreamingClientResult() { }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
@@ -13,6 +13,7 @@ namespace System.ClientModel
         public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         protected abstract System.Collections.Generic.IAsyncEnumerable<T> GetValuesFromPageAsync(System.ClientModel.ClientResult page);
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0005")]
     public static partial class AsyncStreamingClientResult
     {
         public static System.ClientModel.AsyncStreamingClientResult<System.BinaryData> CreateJsonLines(System.ClientModel.Primitives.PipelineResponse response, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -21,6 +22,7 @@ namespace System.ClientModel
         public static System.ClientModel.AsyncStreamingClientResult<System.Net.ServerSentEvents.SseItem<T>> CreateSse<T>(System.ClientModel.Primitives.PipelineResponse response, System.Net.ServerSentEvents.SseItemParser<T> itemParser, System.Func<System.Net.ServerSentEvents.SseItem<System.BinaryData>, bool>? isTerminal = null, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.ClientModel.AsyncStreamingClientResult<T> Create<T>(System.ClientModel.Primitives.PipelineResponse response, System.Func<System.IO.Stream, System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<T>> producer, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0005")]
     public sealed partial class AsyncStreamingClientResult<T> : System.Collections.Generic.IAsyncEnumerable<T>, System.IAsyncDisposable
     {
         internal AsyncStreamingClientResult() { }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net9.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net9.0.cs
@@ -13,6 +13,7 @@ namespace System.ClientModel
         public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         protected abstract System.Collections.Generic.IAsyncEnumerable<T> GetValuesFromPageAsync(System.ClientModel.ClientResult page);
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0005")]
     public static partial class AsyncStreamingClientResult
     {
         public static System.ClientModel.AsyncStreamingClientResult<System.BinaryData> CreateJsonLines(System.ClientModel.Primitives.PipelineResponse response, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -21,6 +22,7 @@ namespace System.ClientModel
         public static System.ClientModel.AsyncStreamingClientResult<System.Net.ServerSentEvents.SseItem<T>> CreateSse<T>(System.ClientModel.Primitives.PipelineResponse response, System.Net.ServerSentEvents.SseItemParser<T> itemParser, System.Func<System.Net.ServerSentEvents.SseItem<System.BinaryData>, bool>? isTerminal = null, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.ClientModel.AsyncStreamingClientResult<T> Create<T>(System.ClientModel.Primitives.PipelineResponse response, System.Func<System.IO.Stream, System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<T>> producer, System.Threading.CancellationToken operationCancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0005")]
     public sealed partial class AsyncStreamingClientResult<T> : System.Collections.Generic.IAsyncEnumerable<T>, System.IAsyncDisposable
     {
         internal AsyncStreamingClientResult() { }

--- a/sdk/core/System.ClientModel/src/Convenience/AsyncStreamingClientResult.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/AsyncStreamingClientResult.cs
@@ -4,6 +4,7 @@
 using System.ClientModel.Internal;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.ServerSentEvents;
 using System.Runtime.CompilerServices;
@@ -20,6 +21,7 @@ namespace System.ClientModel;
 /// have a non-null <see cref="PipelineResponse.ContentStream"/>. Factories do
 /// not send a request or process response establishment errors.
 /// </remarks>
+[Experimental("SCME0005")]
 public static class AsyncStreamingClientResult
 {
     private const int DefaultJsonLineLengthLimit = 1024 * 1024 * 1024;

--- a/sdk/core/System.ClientModel/src/Convenience/AsyncStreamingClientResultOfT.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/AsyncStreamingClientResultOfT.cs
@@ -3,6 +3,7 @@
 
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,7 @@ namespace System.ClientModel;
 /// Enumerating a disposed result throws <see cref="ObjectDisposedException"/>;
 /// requesting a second enumerator throws <see cref="InvalidOperationException"/>.
 /// </remarks>
+[Experimental("SCME0005")]
 public sealed class AsyncStreamingClientResult<T> : IAsyncEnumerable<T>, IAsyncDisposable
 {
     private readonly PipelineResponse _response;

--- a/sdk/core/System.ClientModel/src/docs/ExperimentalFeatures.md
+++ b/sdk/core/System.ClientModel/src/docs/ExperimentalFeatures.md
@@ -159,3 +159,45 @@ Or in your project file:
   <NoWarn>$(NoWarn);SCME0004</NoWarn>
 </PropertyGroup>
 ```
+
+## SCME0005 - AsyncStreamingClientResult Experimental APIs
+
+### Description
+
+The `AsyncStreamingClientResult` and `AsyncStreamingClientResult<T>` types are experimental features for reading asynchronous streaming service responses, including custom producers, server-sent events, and newline-delimited JSON. These APIs are subject to change or removal in future updates as we gather feedback and refine the implementation.
+
+### Affected APIs
+
+- `System.ClientModel.AsyncStreamingClientResult`
+- `System.ClientModel.AsyncStreamingClientResult<T>`
+
+### Example Usage
+
+```csharp
+#pragma warning disable SCME0005
+// `response` is an established PipelineResponse with a content stream.
+await using AsyncStreamingClientResult<BinaryData> result =
+    AsyncStreamingClientResult.CreateJsonLines(response);
+
+await foreach (BinaryData item in result)
+{
+    // Process each streamed value.
+}
+#pragma warning restore SCME0005
+```
+
+### Suppression
+
+If you want to use these experimental APIs and accept the risk that they may change, you can suppress the warning:
+
+```csharp
+#pragma warning disable SCME0005 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+```
+
+Or in your project file:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);SCME0005</NoWarn>
+</PropertyGroup>
+```

--- a/sdk/core/System.ClientModel/tests/System.ClientModel.Tests.csproj
+++ b/sdk/core/System.ClientModel/tests/System.ClientModel.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);SCME0001;SCME0002</NoWarn>
+    <NoWarn>$(NoWarn);SCME0001;SCME0002;SCME0005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/core/System.ClientModel/tests/client/System.ClientModel.Tests.Client.csproj
+++ b/sdk/core/System.ClientModel/tests/client/System.ClientModel.Tests.Client.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsTestSupportProject>true</IsTestSupportProject>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);SCME0005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Marks the newly added `AsyncStreamingClientResult` streaming APIs in System.ClientModel as experimental, gated behind a new `SCME0005` diagnostic.

## Changes
- Added `[Experimental("SCME0005")]` to:
  - `System.ClientModel.AsyncStreamingClientResult` (static factory class)
  - `System.ClientModel.AsyncStreamingClientResult<T>`
- Regenerated the public API listings (net8.0, net9.0, net10.0, netstandard2.0) to reflect the attribute.
- Suppressed `SCME0005` in tests that consume these types, following the existing `SCME0001`/`SCME0002` NoWarn convention.
- Documented `SCME0005` in `src/docs/ExperimentalFeatures.md`.
- Updated `CHANGELOG.md`.

## Verification
- `dotnet build` (Release) - ApiCompat passes, 0 warnings / 0 errors.
- `StreamingClientResultTests` / `StreamingResultParsingTests` - all passing.