### PR TITLE
test(agrifood): add ExtensionData reflection test

### DIFF
--- a/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/tests/Unit/ExtensionDataTests.cs
+++ b/sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/tests/Unit/ExtensionDataTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.AgFoodPlatform.Tests.Unit
+{
+    public class ExtensionDataTests
+    {
+        [Test]
+        public void ExtensionIdCanBeSetThroughReflection()
+        {
+            var data = new ExtensionData();
+            FieldInfo extensionIdField = typeof(ExtensionData).GetField("<ExtensionId>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.That(extensionIdField, Is.Not.Null);
+            extensionIdField.SetValue(data, "extension-id");
+
+            Assert.That(data.ExtensionId, Is.EqualTo("extension-id"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a unit test that initializes `ExtensionData`
- set its read-only `ExtensionId` property through reflection and verify the value

## Testing
- `dotnet test sdk/agrifood/Azure.ResourceManager.AgFoodPlatform/tests/Azure.ResourceManager.AgFoodPlatform.Tests.csproj --filter FullyQualifiedName~ExtensionDataTests /p:WarningsNotAsErrors=NU1904`

> The test passed on net462, net8.0, and net9.0. `NU1904` is an existing transitive test-framework dependency warning.