### PR TITLE
Skip unused dependent package calculation for direct-only matrices

### DIFF
--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -22,6 +22,12 @@ parameters:
 steps:
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
+  # ForceDirect removes indirect packages before matrix generation, so avoid calculating them.
+  - ${{ if eq(parameters.ForceDirect, true) }}:
+    - pwsh: |
+        Write-Host "##vso[task.setvariable variable=AZURESDK_SKIP_DEPENDENT_PACKAGE_CALCULATION;]true"
+      displayName: Skip dependent package calculation (direct packages only)
+
   - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
     parameters:
       ServiceDirectory: ${{parameters.ServiceDirectory}}

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -110,6 +110,12 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
     }
   }
 
+  # ForceDirect matrix passes discard indirect packages, so their dependency calculation is unused.
+  if ($env:AZURESDK_SKIP_DEPENDENT_PACKAGE_CALCULATION -eq 'true') {
+    Write-Host "Skipping cross-package dependency calculation; only direct packages are needed for this pass."
+    return $additionalValidationPackages
+  }
+
   # Use all directly changed packages for dependency calculation. This ensures that
   # when any package changes, all cross-service packages that depend on it are included
   # as indirect packages for validation testing.


### PR DESCRIPTION
Split from #61442 so the dependency-expansion optimization can be reviewed and measured independently.

## Change

Build and Analyze matrix generation already use `ForceDirect`, which removes all indirect packages before creating their matrices. Package discovery nevertheless performs a full-repository `ProjectDependsOn` build to calculate those indirect packages first.

For `ForceDirect` passes, this change skips that unused calculation. The Test matrix is unchanged and continues to expand dependent packages.

## Previous combined-run measurement

The earlier combined version of #61442 showed:

| Matrix generation | Baseline | Combined PR | Delta |
|---|---:|---:|---:|
| Build | 257s | 43s | -214s |
| Analyze | 265s | 41s | -224s |
| Test (control; skip disabled) | 265s | 263s | -2s |

This isolated PR will provide a clean measurement of the dependency-expansion skip without the LOC weighting and CodeChecks optimizations remaining in #61442.

## Follow-up

The environment variable is a narrow bridge to the existing language-specific package-discovery hook. A first-class direct-only package-discovery option in the shared job API will be handled separately.
