### PR TITLE
[Baseline] Measure PR CI performance with large services

### DIFF
--- a/sdk/compute/Azure.ResourceManager.Compute/src/Customize/Extensions/ComputeExtensions.cs
+++ b/sdk/compute/Azure.ResourceManager.Compute/src/Customize/Extensions/ComputeExtensions.cs
@@ -14,7 +14,7 @@ namespace Azure.ResourceManager.Compute
 {
     public static partial class ComputeExtensions
     {
-        /// <summary> Lists all of the virtual machines in the specified subscription. Use the nextLink property in the response to get the next page of virtual machines. </summary>
+        /// <summary> Lists all virtual machines in the specified subscription. Use the nextLink property in the response to get the next page. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static AsyncPageable<VirtualMachineResource> GetVirtualMachinesAsync(this SubscriptionResource subscriptionResource, string statusOnly, string filter, CancellationToken cancellationToken)
         {

--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/LoadBalancerResource.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/LoadBalancerResource.cs
@@ -5,7 +5,7 @@
 
 namespace Azure.ResourceManager.Network
 {
-    /// <summary> Compatibility declaration for the LoadBalancerResource type. </summary>
+    /// <summary> Provides compatibility members for the <see cref="LoadBalancerResource"/> type. </summary>
     public partial class LoadBalancerResource
     {
         /// <summary> Invokes the Get compatibility operation. </summary>

--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/PublicIPPrefixData.ResourceIdentifierCompatibility.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/PublicIPPrefixData.ResourceIdentifierCompatibility.cs
@@ -3,9 +3,8 @@
 
 #nullable disable
 
-using Microsoft.TypeSpec.Generator.Customizations;
-
 using Azure.Core;
+using Microsoft.TypeSpec.Generator.Customizations;
 
 namespace Azure.ResourceManager.Network
 {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientBuilderExtensions.cs
@@ -14,7 +14,7 @@ using Microsoft.TypeSpec.Generator.Customizations;
 namespace Microsoft.Extensions.Azure
 {
     /// <summary>
-    /// Extension methods to add <see cref="BlobServiceClient"/> client to clients builder.
+    /// Extension methods for registering a <see cref="BlobServiceClient"/> with an Azure client builder.
     /// </summary>
     public static partial class BlobClientBuilderExtensions
     {

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobsModelFactory.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobsModelFactory.cs
@@ -7,8 +7,8 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 using Azure.Core;
-using Tags = System.Collections.Generic.IDictionary<string, string>;
 using Microsoft.TypeSpec.Generator.Customizations;
+using Tags = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.Blobs.Models
 {

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -339,7 +339,7 @@ namespace Azure.Storage.Blobs
             // until we are done with the initial response.
             using IEnumerator<HttpRange> remainingRanges = ranges.GetEnumerator();
             // -1 makes space for the initial response handles separately
-            while (bufferedTasks.Count < parallel-1 && remainingRanges.MoveNext())
+            while (bufferedTasks.Count < parallel - 1 && remainingRanges.MoveNext())
             {
                 bufferedTasks.Enqueue(DownloadAndBufferAsync(
                     remainingRanges.Current, conditionsWithEtag, cancellationToken));

--- a/sdk/websites/Azure.ResourceManager.AppService/src/Customization/AppService/Extensions/AppServiceExtensions.cs
+++ b/sdk/websites/Azure.ResourceManager.AppService/src/Customization/AppService/Extensions/AppServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace Azure.ResourceManager.AppService
     public static partial class AppServiceExtensions
     {
         /// <summary>
-        /// Description for List all apps that are assigned to a hostname.
+        /// Lists all apps that are assigned to a hostname.
         /// <list type="bullet">
         /// <item>
         /// <term>Request Path</term>


### PR DESCRIPTION
Baseline-only draft for measuring #61442. This PR is not intended to merge.

It contains the exact same four-service documentation workload as #61767, but is based directly on `main` and does not include the performance changes from #61442.

## Workload

- `Azure.ResourceManager.Network`
- `Azure.ResourceManager.AppService`
- `Azure.Storage.Blobs`
- `Azure.ResourceManager.Compute`

Compare this run directly with #61767 using:

- generated Build and Analyze batch composition
- slowest batch duration and runtime spread
- time from matrix completion to the last Build/Analyze completion
- total Build/Analyze agent-minutes
- `Verify Generated Code` duration and setup invocation count

The documentation edits do not change runtime behavior or public API signatures.
