### PR TITLE
Experiment with per-package cost in PR batching

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -79,10 +79,11 @@ jobs:
               ForceDirect: true
               ExcludePaths: ${{ parameters.ExcludePaths }}
               EnableLocWeighting: true
-              LocTarget: 1200000
+              LocTarget: 1300000
+              LocBaseCost: 5000
               PublishArtifact: true
 
-    # Analyze matrix - smaller LOC batches (300k) for more parallelism so analyze wall-clock matches build.
+    # Analyze matrix - smaller LOC batches for more parallelism so analyze wall-clock matches build.
     - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
       parameters:
         GenerateJobName: generate_analyze_matrix
@@ -116,7 +117,12 @@ jobs:
               ForceDirect: true
               ExcludePaths: ${{ parameters.ExcludePaths }}
               EnableLocWeighting: true
-              LocTarget: 300000
+              # Analyze cost per package is fixed-cost heavy (per-package codegen, snippet and
+              # API-export cycles), so it carries a larger base cost than Build. Target raised
+              # from 300k to keep the job count neutral now that each package also carries a
+              # 15k base cost, so this rebalances batches without adding jobs.
+              LocTarget: 400000
+              LocBaseCost: 15000
               PublishArtifact: true
 
   - ${{ else }}:

--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -15,6 +15,9 @@ parameters:
   - name: LocTarget
     type: number
     default: 474000
+  - name: LocBaseCost
+    type: number
+    default: 0
   - name: PublishArtifact
     type: boolean
     default: true
@@ -85,6 +88,7 @@ steps:
         eng/scripts/Apply-WeightedBatching.ps1 `
           -PackageInfoFolder "$(Build.ArtifactStagingDirectory)/PackageInfo" `
           -WeightsFile "$(Build.ArtifactStagingDirectory)/loc-weights.json" `
-          -Target ${{ parameters.LocTarget }}
-      displayName: Apply LOC-weighted batching (target ${{ parameters.LocTarget }})
+          -Target ${{ parameters.LocTarget }} `
+          -BaseCost ${{ parameters.LocBaseCost }}
+      displayName: Apply LOC-weighted batching (target ${{ parameters.LocTarget }}, base cost ${{ parameters.LocBaseCost }})
       condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/eng/scripts/Apply-WeightedBatching.ps1
+++ b/eng/scripts/Apply-WeightedBatching.ps1
@@ -32,6 +32,19 @@ Indirect packages only run on Linux, so they can use a higher target than direct
 
 .PARAMETER DefaultWeight
 Weight assigned to packages not found in the weights file. Default is 1.
+
+.PARAMETER BaseCost
+Fixed per-package cost added to every package's weight before bin-packing, expressed in the
+same units as the weights file (LOC). Job cost is not purely proportional to LOC:
+
+  job_time = fixed_job_overhead + N_packages * fixed_package_overhead + f(LOC)
+
+Each package in a batch pays its own codegen/restore, snippet update and API export cycle
+regardless of size. With BaseCost 0, a batch of 20 small packages and a batch containing one
+large package look identical to the packer even though the former does 20x the fixed work.
+Setting BaseCost makes package count contribute to the weight, which matters more as
+generation (the LOC-proportional term) gets faster. Default is 0, which preserves the
+previous pure-LOC behavior.
 #>
 
 [CmdletBinding()]
@@ -40,7 +53,8 @@ param (
   [Parameter(Mandatory = $true)][string]$WeightsFile,
   [Parameter()][int]$Target = 1800,
   [Parameter()][int]$IndirectTarget = 0,
-  [Parameter()][int]$DefaultWeight = 1
+  [Parameter()][int]$DefaultWeight = 1,
+  [Parameter()][ValidateRange(0, [int]::MaxValue)][int]$BaseCost = 0
 )
 
 Set-StrictMode -Version 4
@@ -95,6 +109,7 @@ function Apply-LPTBatching {
     [hashtable]$Weights,
     [int]$Target,
     [int]$DefaultWeight,
+    [int]$BaseCost,
     [string]$Label
   )
 
@@ -103,11 +118,12 @@ function Apply-LPTBatching {
     return
   }
 
-  # Build weighted items
+  # Build weighted items. BaseCost models the fixed per-package cost that is paid regardless
+  # of package size, so batches full of small packages are not treated as nearly free.
   $items = @(foreach ($pkg in $Packages) {
     $name = $pkg.Json.ArtifactName
     $weight = if ($Weights.ContainsKey($name)) { [int]$Weights[$name] } else { $DefaultWeight }
-    [PSCustomObject]@{ Package = $pkg; Weight = $weight; Name = $name }
+    [PSCustomObject]@{ Package = $pkg; Weight = $weight + $BaseCost; Name = $name }
   })
 
   # Sort by weight descending (LPT: largest first)
@@ -121,7 +137,7 @@ function Apply-LPTBatching {
   # Don't create more buckets than packages
   $numBuckets = [math]::Min($numBuckets, $Packages.Count)
 
-  Write-Host "  $Label`: $($Packages.Count) packages, total weight ${totalWeight}, target ${Target} -> $numBuckets buckets"
+  Write-Host "  $Label`: $($Packages.Count) packages, total weight ${totalWeight} (base cost ${BaseCost}/pkg), target ${Target} -> $numBuckets buckets"
 
   # Create buckets
   $buckets = @()
@@ -176,12 +192,12 @@ function Apply-LPTBatching {
 # Apply LPT batching to direct and indirect packages separately
 if ($directPackages.Count -gt 0) {
   Apply-LPTBatching -Packages $directPackages -Weights $weights `
-    -Target $Target -DefaultWeight $DefaultWeight -Label "Direct"
+    -Target $Target -DefaultWeight $DefaultWeight -BaseCost $BaseCost -Label "Direct"
 }
 
 if ($indirectPackages.Count -gt 0) {
   Apply-LPTBatching -Packages $indirectPackages -Weights $weights `
-    -Target $IndirectTarget -DefaultWeight $DefaultWeight -Label "Indirect"
+    -Target $IndirectTarget -DefaultWeight $DefaultWeight -BaseCost $BaseCost -Label "Indirect"
 }
 
 # Verify


### PR DESCRIPTION
Draft experiment split from #61442 for independent tuning and measurement.

## Change

Adds an optional per-package `BaseCost` to LOC-weighted batching so fixed package work contributes to batch weight. The default remains zero.

The current experimental values are:

- Build: target 1.3M, base cost 5K
- Analyze: target 400K, base cost 15K

## Initial benchmark

Using the four-service workload in #61769 and #61767:

- Analyze jobs decreased from five to four.
- Analyze duration spread improved from 10m38s to 4m44s.
- Slowest Analyze duration was effectively unchanged.
- Analyze agent-minutes increased by approximately three minutes.
- Build composition and latency did not improve.

This remains a draft because the weighting and targets need more tuning before demonstrating a net latency or cost benefit.
