### PR TITLE
Cache repository setup across CodeChecks invocations

### DIFF
--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -73,9 +73,18 @@ try {
         $preExistingChanges = $preExistingChanges | Sort-Object -Unique
     }
 
-    Write-Host "Restore ./node_modules"
-    Invoke-Block {
-        & npm ci --prefix $RepoRoot
+    # The analyze job invokes this script once per changed service directory, all within a
+    # single pwsh session. Restoring ./node_modules is repo-global, not service-scoped, so
+    # doing it once per service directory is pure duplicated cost that grows with batch size.
+    if (Test-Path variable:global:AzSdkCodeChecksNodeModulesRestored) {
+        Write-Host "./node_modules already restored in this session, skipping npm ci"
+    }
+    else {
+        Write-Host "Restore ./node_modules"
+        Invoke-Block {
+            & npm ci --prefix $RepoRoot
+        }
+        $global:AzSdkCodeChecksNodeModulesRestored = $true
     }
 
     if ($ProjectDirectory -and -not $ServiceDirectory)
@@ -103,9 +112,13 @@ try {
             }
         }
 
-        Write-Host "Force .NET Welcome experience"
-        Invoke-Block {
-            & dotnet msbuild -version
+        # Also repo-global rather than service-scoped: only needed once per session.
+        if (-not (Test-Path variable:global:AzSdkCodeChecksDotnetWarmed)) {
+            Write-Host "Force .NET Welcome experience"
+            Invoke-Block {
+                & dotnet msbuild -version
+            }
+            $global:AzSdkCodeChecksDotnetWarmed = $true
         }
 
         Write-Host "`nChecking that solutions are up to date"


### PR DESCRIPTION
Draft experiment split from #61442 for independent measurement.

## Change

Avoids repeating repository-global setup when `CodeChecks.ps1` is invoked for multiple service directories within one PowerShell session:

- run root `npm ci` once
- run the .NET welcome/warmup command once

## Initial benchmark

The multi-service benchmark confirmed that later CodeChecks invocations skipped repeated `npm ci`. The observed saving was modest and batching changed at the same time, so the impact was not isolated.

This remains a draft until it is measured with identical batching and multiple service directories in one Analyze job.
