### PR TITLE
Bump vulnerable deps for High-severity CVEs (CPM)

### DIFF
--- a/eng/centralpackagemanagement/Directory.Extensions.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Extensions.Packages.props
@@ -29,8 +29,8 @@
       package, causing warnings.  To avoid these warnings, we use the last 8.0 version of the package for net8.0
       builds and the latest 10.x version for all other target frameworks.
     -->
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" Condition="'$(TargetFramework)' != 'net8.0'" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.26" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.10" Condition="'$(TargetFramework)' != 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.29" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageVersion Include="Microsoft.AspNetCore.Http.Connections" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />

--- a/eng/centralpackagemanagement/Directory.Integration.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Integration.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="CloudNative.CloudEvents.SystemTextJson" Version="$(CloudNativeCloudEventsSystemTextJsonVersion)" />
     <PackageVersion Include="Google.Protobuf" Version="3.33.2" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" PrivateAssets="all" />
-    <PackageVersion Include="MessagePack" Version="2.5.192" />
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.32.0" />
     <PackageVersion Include="Microsoft.Azure.SignalR.Protocols" Version="1.32.0" />
     <PackageVersion Include="Microsoft.Azure.SignalR.Serverless.Protocols" Version="1.10.0" />

--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -17,21 +17,21 @@
     <MicrosoftAspNetCoreHttpVersion>2.3.0</MicrosoftAspNetCoreHttpVersion>
     <MicrosoftAspNetCoreVersion>2.3.0</MicrosoftAspNetCoreVersion>
     <MicrosoftExtensionsAzureVersion>1.14.0</MicrosoftExtensionsAzureVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.9</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationBinderVersion>10.0.9</MicrosoftExtensionsConfigurationBinderVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>10.0.9</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.9</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.9</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationUserSecretsVersion>10.0.9</MicrosoftExtensionsConfigurationUserSecretsVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.9</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.9</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsHostingVersion>10.0.9</MicrosoftExtensionsHostingVersion>
-    <MicrosoftExtensionsHttpVersion>10.0.9</MicrosoftExtensionsHttpVersion>
-    <MicrosoftExtensionsLoggingConfigurationVersion>10.0.9</MicrosoftExtensionsLoggingConfigurationVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.9</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.9</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.9</MicrosoftExtensionsPrimitivesVersion>
-    <SystemIOPipelinesVersion>10.0.9</SystemIOPipelinesVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.10</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationBinderVersion>10.0.10</MicrosoftExtensionsConfigurationBinderVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>10.0.10</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.10</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.10</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationUserSecretsVersion>10.0.10</MicrosoftExtensionsConfigurationUserSecretsVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.10</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.10</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsHostingVersion>10.0.10</MicrosoftExtensionsHostingVersion>
+    <MicrosoftExtensionsHttpVersion>10.0.10</MicrosoftExtensionsHttpVersion>
+    <MicrosoftExtensionsLoggingConfigurationVersion>10.0.10</MicrosoftExtensionsLoggingConfigurationVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.10</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.10</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.10</MicrosoftExtensionsPrimitivesVersion>
+    <SystemIOPipelinesVersion>10.0.10</SystemIOPipelinesVersion>
     <MicrosoftSpatialVersion>7.5.3</MicrosoftSpatialVersion>
     <NewtonsoftJsonVersion>13.0.4</NewtonsoftJsonVersion>
     <MSTestVersion>1.3.2</MSTestVersion>
@@ -77,26 +77,26 @@
       or '$(IsStressProject)' == 'true'">
 
     <!-- BCL packages -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.ClientModel" Version="1.15.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.9" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.10" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Memory.Data" Version="10.0.9" />
+    <PackageVersion Include="System.Memory.Data" Version="10.0.10" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.9" />
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.10" />
     <PackageVersion Include="System.Numerics.Vectors" Version="4.6.1" />
     <PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageVersion Include="System.Security.Cryptography.Cose" Version="10.0.9" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.9" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
-    <PackageVersion Include="System.Threading.Channels" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Cose" Version="10.0.10" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
+    <PackageVersion Include="System.Threading.Channels" Version="10.0.10" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
 
@@ -182,7 +182,7 @@
     <PackageVersion Include="Azure.Provisioning.Network" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.Storage" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.Bcl.Numerics" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Bcl.Numerics" Version="10.0.10" />
 
     <!-- Other approved packages -->
     <PackageVersion Include="Microsoft.Azure.Amqp" Version="2.7.0" />
@@ -201,8 +201,8 @@
     <PackageVersion Include="CoreWCF.Queue" Version="1.7.0" />
     <PackageVersion Include="CoreWCF.Primitives" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="$(MicrosoftExtensionsConfigurationUserSecretsVersion)" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.10" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.10" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="6.2.0" />
     <PackageVersion Update="Azure.Storage.Files.Shares" Version="12.21.0" />
     <PackageVersion Update="Azure.Storage.Queues" Version="12.21.0" />

--- a/eng/centralpackagemanagement/Directory.Support.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Support.Packages.props
@@ -126,7 +126,7 @@
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
-    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.9" />
+    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.10" />
     <PackageVersion Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Runtime.InteropServices" Version="4.3.0" />


### PR DESCRIPTION
# Summary

Resolves **six High-severity transitive advisories** surfaced by dependency scanning, and applies the current **.NET 10 servicing patch** across the central package management files. All changes are confined to `eng/centralpackagemanagement/` and are same-minor patch bumps.

## Vulnerabilities addressed

### `System.Security.Cryptography.Xml` — High ×5

Flagged (transitively) in the shipped libraries `Azure.Extensions.AspNetCore.DataProtection.Blobs` and `Azure.Extensions.AspNetCore.DataProtection.Keys`, where it arrives via `Microsoft.AspNetCore.DataProtection`.

| Advisory | CVE |
| --- | --- |
| GHSA-g8r8-53c2-pm3f | CVE-2026-47304 |
| GHSA-8q5v-6pqq-x66h | CVE-2026-50525 |
| GHSA-23rf-6693-g89p | CVE-2026-50648 |
| GHSA-cvvh-rhrc-wg4q | CVE-2026-47302 |
| GHSA-mmjf-rqrv-855v | CVE-2026-50527 |

Resolved versions before the change were `10.0.7` (net10.0/netstandard2.0) and `8.0.3` (net8.0) — both vulnerable. Patched at `10.0.10` / `8.0.4`.

**Fix:** bump the direct dependency so the patched transitive flows in naturally:
- `Microsoft.AspNetCore.DataProtection` `10.0.7` → `10.0.10` (pulls `System.Security.Cryptography.Xml` `10.0.10`)
- `Microsoft.AspNetCore.DataProtection` `8.0.26` → `8.0.29` (pulls `System.Security.Cryptography.Xml` `8.0.4`)

> **Why not pin the package directly?** `System.Security.Cryptography.Xml` is not a direct/managed dependency anywhere in the repo, and this repository does **not** enable `CentralPackageTransitivePinning`. A bare `PackageVersion` entry would therefore be inert. Bumping the direct dependency is the effective, idiomatic fix and leaves the libraries' public dependency surface unchanged.

### `MessagePack` — High ×1

Flagged (direct `PackageReference`, CPM-versioned) in `Microsoft.Azure.WebJobs.Extensions.SignalRService`.

| Advisory | CVE |
| --- | --- |
| GHSA-hv8m-jj95-wg3x | CVE-2026-48109 |

**Fix:** `MessagePack` `2.5.192` → `2.5.302` (patched at `2.5.301`; `2.5.302` is the latest 2.5.x patch).

The bump stays within the `2.5` minor. It is safe for SignalR:
- None of `Microsoft.Azure.SignalR` / `.Protocols` / `.Management` (1.32.0) declare a MessagePack dependency, so no version-range conflict is possible.
- `2.5.192` and `2.5.302` have an identical transitive closure (only `MessagePack.Annotations` moves in lockstep).
- The MessagePack serialization APIs used by the extension are stable core 2.x APIs, unchanged across the patch.
- The previously observed SignalR conflict was `Azure.Identity 1.11.4` (injected by `Microsoft.Azure.SignalR.Management`), which is handled by a separate, untouched override — unrelated to MessagePack.

## .NET 10 servicing patch (`10.0.9` → `10.0.10`)

Applies the current .NET 10 servicing release across the `Microsoft.Extensions.*` and `System.*` version stamps and package entries in `Directory.Packages.props` (30 occurrences) and `Directory.Support.Packages.props` (`System.Linq.AsyncEnumerable`). `10.0.9` was the affected ceiling for the `System.Security.Cryptography.Xml` advisories above, so this is a security-relevant servicing bump, not just housekeeping.

## Files changed

| File | Change |
| --- | --- |
| `Directory.Extensions.Packages.props` | `Microsoft.AspNetCore.DataProtection` `10.0.7`→`10.0.10`, `8.0.26`→`8.0.29` |
| `Directory.Integration.Packages.props` | `MessagePack` `2.5.192`→`2.5.302` |
| `Directory.Packages.props` | 30× `10.0.9`→`10.0.10` (stamps + BCL/System entries) |
| `Directory.Support.Packages.props` | `System.Linq.AsyncEnumerable` `10.0.9`→`10.0.10` |

## Validation

- **Vulnerability audit** (`dotnet list package --vulnerable --include-transitive`): scanned a 24-library cross-section of the shipped surface; only the three libraries above were flagged. After the change, all three are **clean**.
- **Builds:** `DataProtection.Blobs`, `DataProtection.Keys`, and `WebJobs.Extensions.SignalRService` (plus its test project) build with **0 warnings / 0 errors**, including a forced `-t:Rebuild`.
- **Azure Functions compatibility:** every bumped package was checked against `azure-functions-host`'s `runtimeassemblies.json`. All changes are same-minor patch bumps, which cannot alter Functions assembly unification under any policy (`private`, `minorMatchOrLower`, or `runtimeVersion`). `MessagePack` is not a Functions-unified assembly.

## Notes

- No breaking changes; all bumps are within an existing major.minor.