### PR TITLE
Remove stale eng/ignore-links.txt entries that now resolve

### DIFF
--- a/eng/ignore-links.txt
+++ b/eng/ignore-links.txt
@@ -1,18 +1,6 @@
 #private preview
 https://github.com/Azure/adx-documentation-pr/blob/master/engineering/adx_netsdk_process.md
 https://github.com/Azure/azure-digital-twins/blob/private-preview/Documentation/how-to-manage-routes.md#filter-events
-https://www.nuget.org/packages/Azure.ResourceManager.DigitalTwins
 https://contoso.azureedge.net/urlsigning/test?expires=2145916800&amp;keyid:key1&amp;signature=iTsrLX9rVAIJkSahBA_j5o9Azf5-j331ohxDR1Gx2js=
 https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/testproxy/transition-scripts/generate-assets-json.ps1
-https://learn.microsoft.com/dotnet/api/overview/azure/monitor.query.logs-readme
-https://www.nuget.org/packages/Azure.Monitor.Query.Logs
 https://learn.microsoft.com/dotnet/api/azure.monitor.query.logs.logsqueryclient.queryworkspaceasync
-https://www.nuget.org/packages/Azure.Monitor.Query.Metrics
-https://learn.microsoft.com/dotnet/api/overview/azure/monitor.query.metrics-readme?view=azure-dotnet
-#pre-release packages and directories not yet on main
-https://www.nuget.org/packages/Azure.AI.AgentServer.Core
-https://www.nuget.org/packages/Azure.AI.AgentServer.Responses
-https://www.nuget.org/packages/Azure.AI.AgentServer.Invocations
-https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Responses
-https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Responses/samples
-https://www.nuget.org/packages/Microsoft.Azure.PostgreSQL.Auth


### PR DESCRIPTION
`eng/ignore-links.txt` suppresses link-check failures for `eng/common/scripts/Verify-Links.ps1`. Most of its entries were added because a package or docs page **had not published yet**. Those entries are self-healing in effect, but nobody ever deletes them once the URL goes live, so they linger.

A stale entry is not harmless. Once `https://www.nuget.org/packages/Azure.Monitor.Query.Logs` resolves, the entry no longer suppresses a *pending* link — it permanently masks **every future failure** of that URL, including a genuine typo or a rename introduced years later.

This removes the 11 entries that now resolve, and keeps the 5 that still need suppression.

## How this was verified

All 16 entries were re-checked with `Invoke-WebRequest -Method Get`.

**`GET`, not `HEAD`.** `nuget.org` returns 404 for `HEAD` even on packages that plainly exist — confirmed against `Azure.Core` and `Newtonsoft.Json`, both `HEAD` 404 / `GET` 200. A HEAD-based sweep reports that every entry is still needed, which is wrong.

Results are graded against the checker's own failure set, `@(400, 404, 11001, 11004, -131073)`, so a 403 or a redirect counts as a pass.

As a control that `GET` actually discriminates, a fabricated package and a fabricated docs page were checked alongside a real one:

| Result | Control URL |
|---|---|
| 404 | `https://www.nuget.org/packages/Azure.Totally.Fake.Package.Xyz123` |
| 404 | `https://learn.microsoft.com/dotnet/api/overview/azure/totally.fake.thing-readme` |
| 200 | `https://www.nuget.org/packages/Azure.Core` |

### Removed — 11 entries, all now 200

| Status | URL |
|---|---|
| 200 | `https://www.nuget.org/packages/Azure.ResourceManager.DigitalTwins` |
| 200 | `https://learn.microsoft.com/dotnet/api/overview/azure/monitor.query.logs-readme` |
| 200 | `https://www.nuget.org/packages/Azure.Monitor.Query.Logs` |
| 200 | `https://www.nuget.org/packages/Azure.Monitor.Query.Metrics` |
| 200 | `https://learn.microsoft.com/dotnet/api/overview/azure/monitor.query.metrics-readme?view=azure-dotnet` |
| 200 | `https://www.nuget.org/packages/Azure.AI.AgentServer.Core` |
| 200 | `https://www.nuget.org/packages/Azure.AI.AgentServer.Responses` |
| 200 | `https://www.nuget.org/packages/Azure.AI.AgentServer.Invocations` |
| 200 | `https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Responses` |
| 200 | `https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Responses/samples` |
| 200 | `https://www.nuget.org/packages/Microsoft.Azure.PostgreSQL.Auth` |

### Kept — 5 entries

| Status | URL | Why it stays |
|---|---|---|
| 404 | `https://github.com/Azure/adx-documentation-pr/blob/master/engineering/adx_netsdk_process.md` | Private repo, not readable unauthenticated |
| 404 | `https://github.com/Azure/azure-digital-twins/blob/private-preview/Documentation/how-to-manage-routes.md#filter-events` | Private repo / private-preview branch |
| DNS failure | `https://contoso.azureedge.net/urlsigning/test?expires=...` | Fabricated sample URL; the host does not exist. Maps to `SocketError.HostNotFound` (`11001`), which is in the failure set |
| 404 | `https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/testproxy/transition-scripts/generate-assets-json.ps1` | Genuinely 404 — see *Out of scope* |
| 404 | `https://learn.microsoft.com/dotnet/api/azure.monitor.query.logs.logsqueryclient.queryworkspaceasync` | Genuinely 404 — see *Out of scope* |

## The two in-repo links never needed an entry

`https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Responses` and its `/samples` sibling are links into **this** repo. `Verify-Links.ps1` short-circuits those: `ProcessLink` matches `https://github.com/Azure/<repo>/(blob|tree)/main/<path>`, and when `-localBuildRepoName` equals that `org/repo` it joins the path onto `-localBuildRepoPath` and returns success on `Test-Path` without issuing a web request.

Both CI invocations pass those parameters — `.github/workflows/verify-links.yml` passes `-localBuildRepoName '${{ github.repository }}'` and `-localBuildRepoPath $env:GITHUB_WORKSPACE`, and `eng/common/pipelines/templates/steps/verify-links.yml` passes `"$env:BUILD_REPOSITORY_NAME"` and `$(Build.SourcesDirectory)`. So these resolve against the working tree. They also return 200 over the wire, so they pass either way.

## Validation

`Verify-Links.ps1` was run over the affected markdown with the updated ignore file:

```
Checked 472 links. No broken links found.
```

That covered the 115 markdown files whose paths match `monitor|agentserver|digitaltwins|postgresql`, run with `-localBuildRepoName 'Azure/azure-sdk-for-net'`. No entry had to be restored.

10 of the 11 removed entries are referenced by markdown inside that validated set, so their removal was genuinely exercised rather than assumed. The 11th, `Azure.ResourceManager.DigitalTwins`, is referenced by no file in the repo at all — that entry was dead in both directions.

The run also surfaced some pre-existing, unrelated noise that is **not** counted as a broken link and is untouched by this change: `azure.microsoft.com` request timeouts, 403s from `stackoverflow.com` and `platform.openai.com`, and a script quirk where cross-repo `github.com/Azure/azure-sdk-for-{java,python}` links hit the local-clone branch with an empty `-localGithubClonedRoot` and throw on `Join-Path`.

## Out of scope — not fixed here

Two kept entries are suppressing what look like **real broken links**, worth a separate look:

- `https://learn.microsoft.com/dotnet/api/azure.monitor.query.logs.logsqueryclient.queryworkspaceasync` — 404
- `https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/testproxy/transition-scripts/generate-assets-json.ps1` — 404

Both are left in place so this PR stays a pure cleanup; fixing or removing the underlying links is a separate change.

## Notes on the diff

- The `#pre-release packages and directories not yet on main` header is removed because its entire group was removed. The `#private preview` header stays, since entries remain under it.
- No surviving line was reordered or reformatted — the diff is 12 pure deletions, no additions.

---
🤖 m-nash-copilot
