### PR TITLE
Use Entra ID for VoiceLive live tests

### DIFF
--- a/sdk/voicelive/Azure.AI.VoiceLive/tests/.env.example
+++ b/sdk/voicelive/Azure.AI.VoiceLive/tests/.env.example
@@ -4,7 +4,7 @@
 
 # ===== Core Service Configuration =====
 VOICELIVE_ENDPOINT=https://my-resource.cognitiveservices.azure.com
-VOICELIVE_API_KEY=your-api-key-here
+# Live tests authenticate with DefaultAzureCredential. Sign in with Azure CLI or another supported Entra ID credential.
 VOICELIVE_REGION=eastus
 
 # ===== Model Configuration =====

--- a/sdk/voicelive/Azure.AI.VoiceLive/tests/Infrastructure/VoiceLiveTestEnvironment.cs
+++ b/sdk/voicelive/Azure.AI.VoiceLive/tests/Infrastructure/VoiceLiveTestEnvironment.cs
@@ -24,12 +24,6 @@ namespace Azure.AI.VoiceLive.Tests.Infrastructure
         public string Endpoint => GetVariable("AI_SERVICES_ENDPOINT");
 
         /// <summary>
-        /// API key for authentication (alternative to Azure AD).
-        /// Keep secret and never record.
-        /// </summary>
-        public string ApiKey => GetOptionalVariable("AI_SERVICES_KEY");
-
-        /// <summary>
         /// Model deployment name from Bicep template.
         /// Maps to Bicep parameter: modelName (default: "gpt-4o")
         /// Fallback handles both Bicep and legacy configurations.

--- a/sdk/voicelive/Azure.AI.VoiceLive/tests/LiveTests/SessionConfigTests.cs
+++ b/sdk/voicelive/Azure.AI.VoiceLive/tests/LiveTests/SessionConfigTests.cs
@@ -96,9 +96,7 @@ namespace Azure.AI.VoiceLive.Tests
         [TestCase]
         public async Task RequireToolCalls()
         {
-            var vlc = string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true)) :
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            var vlc = new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true));
 
             var options = new VoiceLiveSessionOptions()
             {
@@ -136,9 +134,7 @@ namespace Azure.AI.VoiceLive.Tests
         [TestCase]
         public async Task RequireToolCallByName()
         {
-            var vlc = string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true)) :
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            var vlc = new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true));
 
             var options = new VoiceLiveSessionOptions()
             {
@@ -181,9 +177,7 @@ namespace Azure.AI.VoiceLive.Tests
         [TestCase]
         public async Task AnimationOutputs()
         {
-            var vlc = string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true)) :
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            var vlc = new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true));
 
             var options = new VoiceLiveSessionOptions()
             {
@@ -237,9 +231,7 @@ namespace Azure.AI.VoiceLive.Tests
         [TestCase]
         public async Task AnimationOutputs_blend()
         {
-            var vlc = string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true)) :
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            var vlc = new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true));
 
             var options = new VoiceLiveSessionOptions()
             {
@@ -287,9 +279,7 @@ namespace Azure.AI.VoiceLive.Tests
         [TestCase]
         public async Task MaxTokens()
         {
-            var vlc = string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true)) :
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            var vlc = new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true));
 
             var options = new VoiceLiveSessionOptions()
             {
@@ -326,9 +316,7 @@ namespace Azure.AI.VoiceLive.Tests
         [TestCase]
         public async Task SpeechRecoOptions()
         {
-            var vlc = string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true)) :
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            var vlc = new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true));
 
             var options = new VoiceLiveSessionOptions()
             {
@@ -356,9 +344,7 @@ namespace Azure.AI.VoiceLive.Tests
         [TestCase]
         public async Task MultipleModalities()
         {
-            var vlc = string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true)) :
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            var vlc = new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true));
 
             var options = new VoiceLiveSessionOptions()
             {

--- a/sdk/voicelive/Azure.AI.VoiceLive/tests/VoiceLiveTestBase.cs
+++ b/sdk/voicelive/Azure.AI.VoiceLive/tests/VoiceLiveTestBase.cs
@@ -60,18 +60,14 @@ namespace Azure.AI.VoiceLive.Tests
             optionsLocal.Diagnostics.IsLoggingContentEnabled = true;
             optionsLocal.Diagnostics.IsLoggingEnabled = true;
 
-            return string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true), optionsLocal) :
-                new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey), optionsLocal);
+            return new VoiceLiveClient(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true), optionsLocal);
         }
 
         internal TestableVoiceLiveSession GetTestableSession(VoiceLiveClient client)
         {
             var testEndpoint = TestEnvironment.Endpoint.Replace("https:", "wss:").Replace("http:", "ws:");
 
-            return string.IsNullOrEmpty(TestEnvironment.ApiKey) ?
-                new TestableVoiceLiveSession(client, new Uri(testEndpoint), new DefaultAzureCredential(true)) :
-                new TestableVoiceLiveSession(client, new Uri(testEndpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            return new TestableVoiceLiveSession(client, new Uri(testEndpoint), new DefaultAzureCredential(true));
         }
 
         /// <summary>
@@ -94,7 +90,7 @@ namespace Azure.AI.VoiceLive.Tests
             return null!;
 #else
             var of = SpeechSynthesisOutputFormat.Riff24Khz16BitMonoPcm;
-            var sc = SpeechConfig.FromEndpoint(new Uri(TestEnvironment.Endpoint), new AzureKeyCredential(TestEnvironment.ApiKey));
+            var sc = SpeechConfig.FromEndpoint(new Uri(TestEnvironment.Endpoint), new DefaultAzureCredential(true));
             sc.SetSpeechSynthesisOutputFormat(of);
 
             using (var outputStream = AudioOutputStream.CreatePullStream())

--- a/sdk/voicelive/test-resources.bicep
+++ b/sdk/voicelive/test-resources.bicep
@@ -59,6 +59,5 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 // Outputs become environment variables injected into the test run
 output AI_SERVICES_NAME string = aiServices.name
 output AI_SERVICES_ENDPOINT string = aiServices.properties.endpoints['AI Foundry API']
-output AI_SERVICES_KEY string = aiServices.listKeys().key1
 output DEFAULT_PROJECT_NAME string = defaultProjectName
 output AGENT_PROJECT_ENDPOINT string = aiServices::defaultProject.properties.endpoints['AI Foundry API']


### PR DESCRIPTION
## Summary
- remove the `AI_SERVICES_KEY` Bicep output so `listKeys` is not persisted in ARM deployment history
- require `DefaultAzureCredential` for VoiceLive live-test clients, WebSocket sessions, and Speech synthesis
- update the local test environment example to describe Entra ID authentication

The existing Cognitive Services User assignment for `testApplicationOid` remains unchanged.

## Validation
- `az bicep build --file sdk/voicelive/test-resources.bicep`
- `dotnet build sdk/voicelive/Azure.AI.VoiceLive/tests/Azure.AI.VoiceLive.Tests.csproj`

## Operational note
The stored local test key did not match either current key on the matching resource, so it was already inactive and no active key was rotated. Key rotation is a separate operational action and is not performed by this code change.