### PR TITLE
Csev2 cache downgrade

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug in client-side encryption where version downgrades were only detected at the start of a download.
+
 ### Other Changes
 
 ## 12.30.0-beta.1 (2026-07-21)

--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a bug where client-side encryption 2.0 could not detect a rearrangement of otherwise-untampered authenticated regions in blob content. This is now detected and exceptions are thrown. For data recovery purposes, this behavior can be reverted by enabling "Azure.Storage.CseV2AllowMisorderedAuthRegions" in the AppContext switch or "AZURE_STORAGE_CSE_V2_ALLOW_MISORDERED_AUTH_REGIONS" in environment variables.
+- Fixed a bug in client-side encryption where version downgrades were only detected at the start of a download.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.Common;
 using Azure.Storage.Cryptography;
 using Azure.Storage.Cryptography.Models;
 using Azure.Storage.Sas;

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -3406,9 +3406,12 @@ namespace Azure.Storage.Blobs.Specialized
                     long blobContentLength = blobProperties.Value.ContentLength;
                     EncryptionData encryptionData = null;
                     BlobClientSideDecryptor decryptor = null;
-                    if (UsingClientSideEncryption && !allowModifications)
+                    if (UsingClientSideEncryption)
                     {
                         decryptor = new(new(ClientSideEncryption));
+                    }
+                    if (UsingClientSideEncryption && !allowModifications)
+                    {
                         encryptionData = BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(blobProperties?.Value?.Metadata);
                     }
 
@@ -3435,7 +3438,7 @@ namespace Azure.Storage.Blobs.Specialized
                                 async,
                                 cancellationToken).ConfigureAwait(false);
 
-                            if (UsingClientSideEncryption)
+                            if (decryptor != null)
                             {
                                 response.Value.Content = await decryptor.DecryptInternal(
                                         response.Value.Content,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -3053,13 +3053,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken = default)
         {
             DownloadTransferValidationOptions validationOptions = transferValidationOverride ?? ClientConfiguration.TransferValidation.Download;
-
             PartitionedDownloader downloader = new PartitionedDownloader(this, transferOptions, validationOptions, progressHandler);
-
-            if (UsingClientSideEncryption)
-            {
-                ClientSideDecryptor.BeginContentEncryptionKeyCaching();
-            }
             return await downloader.DownloadToInternal(destination, conditions, async, cancellationToken).ConfigureAwait(false);
         }
         #endregion Parallel Download
@@ -3412,11 +3406,11 @@ namespace Azure.Storage.Blobs.Specialized
                     }
 
                     long blobContentLength = blobProperties.Value.ContentLength;
-                    ClientSideDecryptor.ContentEncryptionKeyCache contentEncryptionKeyCache = default;
                     EncryptionData encryptionData = null;
+                    BlobClientSideDecryptor decryptor = null;
                     if (UsingClientSideEncryption && !allowModifications)
                     {
-                        contentEncryptionKeyCache = new();
+                        decryptor = new(new(ClientSideEncryption));
                         encryptionData = BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(blobProperties?.Value?.Metadata);
                     }
 
@@ -3433,7 +3427,6 @@ namespace Azure.Storage.Blobs.Specialized
                             long cseStartRegion = 0;
                             if (UsingClientSideEncryption)
                             {
-                                ClientSideDecryptor.BeginContentEncryptionKeyCaching(contentEncryptionKeyCache);
                                 (range, cseStartRegion) = rangeAdjustmentFunc(requestedRange);
                             }
                             Response<BlobDownloadStreamingResult> response = await DownloadStreamingInternal(
@@ -3447,8 +3440,7 @@ namespace Azure.Storage.Blobs.Specialized
 
                             if (UsingClientSideEncryption)
                             {
-                                response.Value.Content = await new BlobClientSideDecryptor(
-                                    new ClientSideDecryptor(ClientSideEncryption)).DecryptInternal(
+                                response.Value.Content = await decryptor.DecryptInternal(
                                         response.Value.Content,
                                         response.Value.Details.Metadata,
                                         requestedRange,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -3408,9 +3408,12 @@ namespace Azure.Storage.Blobs.Specialized
                     long blobContentLength = blobProperties.Value.ContentLength;
                     EncryptionData encryptionData = null;
                     BlobClientSideDecryptor decryptor = null;
-                    if (UsingClientSideEncryption && !allowModifications)
+                    if (UsingClientSideEncryption)
                     {
                         decryptor = new(new(ClientSideEncryption));
+                    }
+                    if (UsingClientSideEncryption && !allowModifications)
+                    {
                         encryptionData = BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(blobProperties?.Value?.Metadata);
                     }
 
@@ -3438,7 +3441,7 @@ namespace Azure.Storage.Blobs.Specialized
                                 async,
                                 cancellationToken).ConfigureAwait(false);
 
-                            if (UsingClientSideEncryption)
+                            if (decryptor != null)
                             {
                                 response.Value.Content = await decryptor.DecryptInternal(
                                         response.Value.Content,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -3051,13 +3051,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken = default)
         {
             DownloadTransferValidationOptions validationOptions = transferValidationOverride ?? ClientConfiguration.TransferValidation.Download;
-
             PartitionedDownloader downloader = new PartitionedDownloader(this, transferOptions, validationOptions, progressHandler);
-
-            if (UsingClientSideEncryption)
-            {
-                ClientSideDecryptor.BeginContentEncryptionKeyCaching();
-            }
             return await downloader.DownloadToInternal(destination, conditions, async, cancellationToken).ConfigureAwait(false);
         }
         #endregion Parallel Download
@@ -3410,11 +3404,11 @@ namespace Azure.Storage.Blobs.Specialized
                     }
 
                     long blobContentLength = blobProperties.Value.ContentLength;
-                    ClientSideDecryptor.ContentEncryptionKeyCache contentEncryptionKeyCache = default;
                     EncryptionData encryptionData = null;
+                    BlobClientSideDecryptor decryptor = null;
                     if (UsingClientSideEncryption && !allowModifications)
                     {
-                        contentEncryptionKeyCache = new();
+                        decryptor = new(new(ClientSideEncryption));
                         encryptionData = BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(blobProperties?.Value?.Metadata);
                     }
 
@@ -3430,7 +3424,6 @@ namespace Azure.Storage.Blobs.Specialized
                             HttpRange requestedRange = range;
                             if (UsingClientSideEncryption)
                             {
-                                ClientSideDecryptor.BeginContentEncryptionKeyCaching(contentEncryptionKeyCache);
                                 range = rangeAdjustmentFunc(requestedRange);
                             }
                             Response<BlobDownloadStreamingResult> response = await DownloadStreamingInternal(
@@ -3444,8 +3437,7 @@ namespace Azure.Storage.Blobs.Specialized
 
                             if (UsingClientSideEncryption)
                             {
-                                response.Value.Content = await new BlobClientSideDecryptor(
-                                    new ClientSideDecryptor(ClientSideEncryption)).DecryptInternal(
+                                response.Value.Content = await decryptor.DecryptInternal(
                                         response.Value.Content,
                                         response.Value.Details.Metadata,
                                         requestedRange,

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -476,9 +476,9 @@ namespace Azure.Storage.Cryptography
         /// <summary>
         /// A cache for a content encryption key (CEK), to avoid multiple key envelope unwraps over
         /// a multipart download, as unwraps may be costly or otherwise rate limited.
-        /// This cache tracks the key encryption key (KEK) ID which unwrapped as well as the
+        /// This cache tracks the key encryption key (KEK) ID that unwrapped the CEK as well as the
         /// client-side encryption version being used for this particular storage resource. If the
-        /// encryption metadata from a particular downloar partition does not match, the key will
+        /// encryption metadata from a particular download partition does not match, the key will
         /// not be returned.
         /// </summary>
         internal class ContentEncryptionKeyCache
@@ -498,7 +498,7 @@ namespace Azure.Storage.Cryptography
             /// Returns the encapsulated key only if the encryption metadata matches what is cached
             /// alongside the key.
             /// </summary>
-            /// <param name="match">Encrytpion data to match against.</param>
+            /// <param name="match">Encryption data to match against.</param>
             /// <param name="key">Key output.</param>
             /// <returns>
             /// True if the match is valid and a key has been returned in the out parameter.

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -458,9 +458,9 @@ namespace Azure.Storage.Cryptography
         /// <summary>
         /// A cache for a content encryption key (CEK), to avoid multiple key envelope unwraps over
         /// a multipart download, as unwraps may be costly or otherwise rate limited.
-        /// This cache tracks the key encryption key (KEK) ID which unwrapped as well as the
+        /// This cache tracks the key encryption key (KEK) ID that unwrapped the CEK as well as the
         /// client-side encryption version being used for this particular storage resource. If the
-        /// encryption metadata from a particular downloar partition does not match, the key will
+        /// encryption metadata from a particular download partition does not match, the key will
         /// not be returned.
         /// </summary>
         internal class ContentEncryptionKeyCache
@@ -480,7 +480,7 @@ namespace Azure.Storage.Cryptography
             /// Returns the encapsulated key only if the encryption metadata matches what is cached
             /// alongside the key.
             /// </summary>
-            /// <param name="match">Encrytpion data to match against.</param>
+            /// <param name="match">Encryption data to match against.</param>
             /// <param name="key">Key output.</param>
             /// <returns>
             /// True if the match is valid and a key has been returned in the out parameter.

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -20,7 +20,7 @@ namespace Azure.Storage.Cryptography
         /// <summary>
         /// A cache for encryption key if high level API spans across multiple service calls.
         /// </summary>
-        private ContentEncryptionKeyCache s_contentEncryptionKeyCache;
+        private ContentEncryptionKeyCache _contentEncryptionKeyCache;
 
         /// <summary>
         /// Clients that can upload data have a key encryption key stored on them. Checking if
@@ -390,9 +390,9 @@ namespace Azure.Storage.Cryptography
             bool async,
             CancellationToken cancellationToken)
         {
-            if (s_contentEncryptionKeyCache != null)
+            if (_contentEncryptionKeyCache != null)
             {
-                if (s_contentEncryptionKeyCache.TryGetKey(encryptionData, out Memory<byte> cek))
+                if (_contentEncryptionKeyCache.TryGetKey(encryptionData, out Memory<byte> cek))
                 {
                     return cek;
                 }
@@ -465,7 +465,7 @@ namespace Azure.Storage.Cryptography
                     throw Errors.InvalidArgument(nameof(encryptionData));
             }
 
-            s_contentEncryptionKeyCache = new(
+            _contentEncryptionKeyCache = new(
                 unwrappedKey,
                 encryptionData.WrappedContentKey.KeyId,
                 encryptionData.EncryptionAgent.EncryptionVersion);

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -8,18 +8,26 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Cryptography;
-using Azure.Core.Pipeline;
 using Azure.Storage.Cryptography.Models;
 using static Azure.Storage.Cryptography.Models.ClientSideEncryptionVersionExtensions;
 
 namespace Azure.Storage.Cryptography
 {
+    /// <summary>
+    /// Decryptor for a single storage resource being downloaded. Security protections exist for
+    /// multi-part downloads within that single resource, but prevent this decryptor from being
+    /// used for multiple different resource downloads.
+    /// </summary>
     internal class ClientSideDecryptor
     {
         /// <summary>
-        /// A cache for encryption key if high level API spans across multiple service calls.
+        /// A cache for the content encryption key if high level API spans across multiple service calls
+        /// (e.g. partitioned download).
+        /// This cache implements protections against a downgrade attack during a multi-part download.
+        /// Those protections only work for the single resource being downloaded. Cache cannot be reused
+        /// across multiple different resources.
         /// </summary>
-        private static readonly AsyncLocal<ContentEncryptionKeyCache> s_contentEncryptionKeyCache = new();
+        private readonly AsyncLocal<ContentEncryptionKeyCache> s_contentEncryptionKeyCache = new();
 
         /// <summary>
         /// Clients that can upload data have a key encryption key stored on them. Checking if
@@ -37,6 +45,9 @@ namespace Azure.Storage.Cryptography
         {
             _potentialCachedIKeyEncryptionKey = options.KeyEncryptionKey;
             _keyResolver = options.KeyResolver;
+            // We don't care about CSE version here.
+            // The download version is whatever the metadata says it is.
+            // We verify the metadata elsewhere.
         }
 
         /// <summary>
@@ -373,9 +384,19 @@ namespace Azure.Storage.Cryptography
             bool async,
             CancellationToken cancellationToken)
         {
-            if (s_contentEncryptionKeyCache.Value?.Key.HasValue ?? false)
+            ContentEncryptionKeyCache cekCache = s_contentEncryptionKeyCache.Value;
+            if (cekCache != null)
             {
-                return s_contentEncryptionKeyCache.Value.Key.Value;
+                if (cekCache.TryGetKey(encryptionData, out Memory<byte> cek))
+                {
+                    return cek;
+                }
+                else
+                {
+                    /* The encryption data did not match the encryption data the CEK was originally
+                     * wrapped inside of. This is a downgrade attack. Fail the entire download.*/
+                    throw new CryptographicException("Mismatched encryption data.");
+                }
             }
 
             IKeyEncryptionKey key = default;
@@ -447,14 +468,57 @@ namespace Azure.Storage.Cryptography
             return unwrappedKey;
         }
 
-        internal static void BeginContentEncryptionKeyCaching(ContentEncryptionKeyCache cache = default)
-        {
-            s_contentEncryptionKeyCache.Value = cache ?? new ContentEncryptionKeyCache();
-        }
-
+        /// <summary>
+        /// A cache for a content encryption key (CEK), to avoid multiple key envelope unwraps over
+        /// a multipart download, as unwraps may be costly or otherwise rate limited.
+        /// This cache tracks the key encryption key (KEK) ID which unwrapped as well as the
+        /// client-side encryption version being used for this particular storage resource. If the
+        /// encryption metadata from a particular downloar partition does not match, the key will
+        /// not be returned.
+        /// </summary>
         internal class ContentEncryptionKeyCache
         {
-            public Memory<byte>? Key { get; set; }
+            private Memory<byte> _key;
+            private string _kekId;
+            private ClientSideEncryptionVersionInternal _cseVersion;
+
+            public ContentEncryptionKeyCache(Memory<byte> key, string kekId, ClientSideEncryptionVersionInternal cseVersion)
+            {
+                _key = key;
+                _kekId = kekId;
+                _cseVersion = cseVersion;
+            }
+
+            /// <summary>
+            /// Returns the encapsulated key only if the encryption metadata matches what is cached
+            /// alongside the key.
+            /// </summary>
+            /// <param name="match">Encrytpion data to match against.</param>
+            /// <param name="key">Key output.</param>
+            /// <returns>
+            /// True if the match is valid and a key has been returned in the out parameter.
+            /// Otherwise, false.
+            /// </returns>
+            public bool TryGetKey(EncryptionData match, out Memory<byte> key)
+            {
+                if (Matches(match))
+                {
+                    key = _key;
+                    return true;
+                }
+                key = Memory<byte>.Empty;
+                return false;
+            }
+
+            public bool Matches(EncryptionData encryptionData)
+            {
+                if (encryptionData == null)
+                {
+                    return false;
+                }
+                return encryptionData.EncryptionAgent.EncryptionVersion == _cseVersion &&
+                    encryptionData.WrappedContentKey.KeyId == _kekId;
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -15,21 +15,12 @@ using static Azure.Storage.Cryptography.Models.ClientSideEncryptionVersionExtens
 
 namespace Azure.Storage.Cryptography
 {
-    /// <summary>
-    /// Decryptor for a single storage resource being downloaded. Security protections exist for
-    /// multi-part downloads within that single resource, but prevent this decryptor from being
-    /// used for multiple different resource downloads.
-    /// </summary>
     internal class ClientSideDecryptor
     {
         /// <summary>
-        /// A cache for the content encryption key if high level API spans across multiple service calls
-        /// (e.g. partitioned download).
-        /// This cache implements protections against a downgrade attack during a multi-part download.
-        /// Those protections only work for the single resource being downloaded. Cache cannot be reused
-        /// across multiple different resources.
+        /// A cache for encryption key if high level API spans across multiple service calls.
         /// </summary>
-        private readonly AsyncLocal<ContentEncryptionKeyCache> s_contentEncryptionKeyCache = new();
+        private ContentEncryptionKeyCache s_contentEncryptionKeyCache;
 
         /// <summary>
         /// Clients that can upload data have a key encryption key stored on them. Checking if
@@ -47,9 +38,6 @@ namespace Azure.Storage.Cryptography
         {
             _potentialCachedIKeyEncryptionKey = options.KeyEncryptionKey;
             _keyResolver = options.KeyResolver;
-            // We don't care about CSE version here.
-            // The download version is whatever the metadata says it is.
-            // We verify the metadata elsewhere.
         }
 
         /// <summary>
@@ -402,10 +390,9 @@ namespace Azure.Storage.Cryptography
             bool async,
             CancellationToken cancellationToken)
         {
-            ContentEncryptionKeyCache cekCache = s_contentEncryptionKeyCache.Value;
-            if (cekCache != null)
+            if (s_contentEncryptionKeyCache != null)
             {
-                if (cekCache.TryGetKey(encryptionData, out Memory<byte> cek))
+                if (s_contentEncryptionKeyCache.TryGetKey(encryptionData, out Memory<byte> cek))
                 {
                     return cek;
                 }
@@ -478,10 +465,10 @@ namespace Azure.Storage.Cryptography
                     throw Errors.InvalidArgument(nameof(encryptionData));
             }
 
-            if (s_contentEncryptionKeyCache.Value != default)
-            {
-                s_contentEncryptionKeyCache.Value.Key = unwrappedKey;
-            }
+            s_contentEncryptionKeyCache = new(
+                unwrappedKey,
+                encryptionData.WrappedContentKey.KeyId,
+                encryptionData.EncryptionAgent.EncryptionVersion);
 
             return unwrappedKey;
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Cryptography;
-using Azure.Core.Pipeline;
 using Azure.Storage.Common;
 using Azure.Storage.Cryptography.Models;
 using static Azure.Storage.Cryptography.Models.ClientSideEncryptionVersionExtensions;

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -13,21 +13,12 @@ using static Azure.Storage.Cryptography.Models.ClientSideEncryptionVersionExtens
 
 namespace Azure.Storage.Cryptography
 {
-    /// <summary>
-    /// Decryptor for a single storage resource being downloaded. Security protections exist for
-    /// multi-part downloads within that single resource, but prevent this decryptor from being
-    /// used for multiple different resource downloads.
-    /// </summary>
     internal class ClientSideDecryptor
     {
         /// <summary>
-        /// A cache for the content encryption key if high level API spans across multiple service calls
-        /// (e.g. partitioned download).
-        /// This cache implements protections against a downgrade attack during a multi-part download.
-        /// Those protections only work for the single resource being downloaded. Cache cannot be reused
-        /// across multiple different resources.
+        /// A cache for encryption key if high level API spans across multiple service calls.
         /// </summary>
-        private readonly AsyncLocal<ContentEncryptionKeyCache> s_contentEncryptionKeyCache = new();
+        private ContentEncryptionKeyCache s_contentEncryptionKeyCache;
 
         /// <summary>
         /// Clients that can upload data have a key encryption key stored on them. Checking if
@@ -45,9 +36,6 @@ namespace Azure.Storage.Cryptography
         {
             _potentialCachedIKeyEncryptionKey = options.KeyEncryptionKey;
             _keyResolver = options.KeyResolver;
-            // We don't care about CSE version here.
-            // The download version is whatever the metadata says it is.
-            // We verify the metadata elsewhere.
         }
 
         /// <summary>
@@ -384,10 +372,9 @@ namespace Azure.Storage.Cryptography
             bool async,
             CancellationToken cancellationToken)
         {
-            ContentEncryptionKeyCache cekCache = s_contentEncryptionKeyCache.Value;
-            if (cekCache != null)
+            if (s_contentEncryptionKeyCache != null)
             {
-                if (cekCache.TryGetKey(encryptionData, out Memory<byte> cek))
+                if (s_contentEncryptionKeyCache.TryGetKey(encryptionData, out Memory<byte> cek))
                 {
                     return cek;
                 }
@@ -460,10 +447,10 @@ namespace Azure.Storage.Cryptography
                     throw Errors.InvalidArgument(nameof(encryptionData));
             }
 
-            if (s_contentEncryptionKeyCache.Value != default)
-            {
-                s_contentEncryptionKeyCache.Value.Key = unwrappedKey;
-            }
+            s_contentEncryptionKeyCache = new(
+                unwrappedKey,
+                encryptionData.WrappedContentKey.KeyId,
+                encryptionData.EncryptionAgent.EncryptionVersion);
 
             return unwrappedKey;
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -382,7 +382,7 @@ namespace Azure.Storage.Cryptography
                 {
                     /* The encryption data did not match the encryption data the CEK was originally
                      * wrapped inside of. This is a downgrade attack. Fail the entire download.*/
-                    throw new CryptographicException("Mismatched encryption data.");
+                    throw new CryptographicException("Enryption data modified during decryption process.");
                 }
             }
 
@@ -438,7 +438,7 @@ namespace Azure.Storage.Cryptography
                         .Trim('\0');
                     if (unwrappedProtocolString != encryptionData.EncryptionAgent.EncryptionVersion.Serialize())
                     {
-                        throw new CryptographicException("Encryption metadata has been tampered.");
+                        throw new CryptographicException("Mismatched encryption data.");
                     }
                     unwrappedKey = new Memory<byte>(unwrappedContent)
                         .Slice(Constants.ClientSideEncryption.V2.WrappedDataVersionLength).ToArray();
@@ -465,9 +465,9 @@ namespace Azure.Storage.Cryptography
         /// </summary>
         internal class ContentEncryptionKeyCache
         {
-            private Memory<byte> _key;
-            private string _kekId;
-            private ClientSideEncryptionVersionInternal _cseVersion;
+            private readonly Memory<byte> _key;
+            private readonly string _kekId;
+            private readonly ClientSideEncryptionVersionInternal _cseVersion;
 
             public ContentEncryptionKeyCache(Memory<byte> key, string kekId, ClientSideEncryptionVersionInternal cseVersion)
             {

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -15,12 +15,21 @@ using static Azure.Storage.Cryptography.Models.ClientSideEncryptionVersionExtens
 
 namespace Azure.Storage.Cryptography
 {
+    /// <summary>
+    /// Decryptor for a single storage resource being downloaded. Security protections exist for
+    /// multi-part downloads within that single resource, but prevent this decryptor from being
+    /// used for multiple different resource downloads.
+    /// </summary>
     internal class ClientSideDecryptor
     {
         /// <summary>
-        /// A cache for encryption key if high level API spans across multiple service calls.
+        /// A cache for the content encryption key if high level API spans across multiple service calls
+        /// (e.g. partitioned download).
+        /// This cache implements protections against a downgrade attack during a multi-part download.
+        /// Those protections only work for the single resource being downloaded. Cache cannot be reused
+        /// across multiple different resources.
         /// </summary>
-        private static readonly AsyncLocal<ContentEncryptionKeyCache> s_contentEncryptionKeyCache = new();
+        private readonly AsyncLocal<ContentEncryptionKeyCache> s_contentEncryptionKeyCache = new();
 
         /// <summary>
         /// Clients that can upload data have a key encryption key stored on them. Checking if
@@ -38,6 +47,9 @@ namespace Azure.Storage.Cryptography
         {
             _potentialCachedIKeyEncryptionKey = options.KeyEncryptionKey;
             _keyResolver = options.KeyResolver;
+            // We don't care about CSE version here.
+            // The download version is whatever the metadata says it is.
+            // We verify the metadata elsewhere.
         }
 
         /// <summary>
@@ -390,9 +402,19 @@ namespace Azure.Storage.Cryptography
             bool async,
             CancellationToken cancellationToken)
         {
-            if (s_contentEncryptionKeyCache.Value?.Key.HasValue ?? false)
+            ContentEncryptionKeyCache cekCache = s_contentEncryptionKeyCache.Value;
+            if (cekCache != null)
             {
-                return s_contentEncryptionKeyCache.Value.Key.Value;
+                if (cekCache.TryGetKey(encryptionData, out Memory<byte> cek))
+                {
+                    return cek;
+                }
+                else
+                {
+                    /* The encryption data did not match the encryption data the CEK was originally
+                     * wrapped inside of. This is a downgrade attack. Fail the entire download.*/
+                    throw new CryptographicException("Mismatched encryption data.");
+                }
             }
 
             IKeyEncryptionKey key = default;
@@ -464,14 +486,57 @@ namespace Azure.Storage.Cryptography
             return unwrappedKey;
         }
 
-        internal static void BeginContentEncryptionKeyCaching(ContentEncryptionKeyCache cache = default)
-        {
-            s_contentEncryptionKeyCache.Value = cache ?? new ContentEncryptionKeyCache();
-        }
-
+        /// <summary>
+        /// A cache for a content encryption key (CEK), to avoid multiple key envelope unwraps over
+        /// a multipart download, as unwraps may be costly or otherwise rate limited.
+        /// This cache tracks the key encryption key (KEK) ID which unwrapped as well as the
+        /// client-side encryption version being used for this particular storage resource. If the
+        /// encryption metadata from a particular downloar partition does not match, the key will
+        /// not be returned.
+        /// </summary>
         internal class ContentEncryptionKeyCache
         {
-            public Memory<byte>? Key { get; set; }
+            private Memory<byte> _key;
+            private string _kekId;
+            private ClientSideEncryptionVersionInternal _cseVersion;
+
+            public ContentEncryptionKeyCache(Memory<byte> key, string kekId, ClientSideEncryptionVersionInternal cseVersion)
+            {
+                _key = key;
+                _kekId = kekId;
+                _cseVersion = cseVersion;
+            }
+
+            /// <summary>
+            /// Returns the encapsulated key only if the encryption metadata matches what is cached
+            /// alongside the key.
+            /// </summary>
+            /// <param name="match">Encrytpion data to match against.</param>
+            /// <param name="key">Key output.</param>
+            /// <returns>
+            /// True if the match is valid and a key has been returned in the out parameter.
+            /// Otherwise, false.
+            /// </returns>
+            public bool TryGetKey(EncryptionData match, out Memory<byte> key)
+            {
+                if (Matches(match))
+                {
+                    key = _key;
+                    return true;
+                }
+                key = Memory<byte>.Empty;
+                return false;
+            }
+
+            public bool Matches(EncryptionData encryptionData)
+            {
+                if (encryptionData == null)
+                {
+                    return false;
+                }
+                return encryptionData.EncryptionAgent.EncryptionVersion == _cseVersion &&
+                    encryptionData.WrappedContentKey.KeyId == _kekId;
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -400,7 +400,7 @@ namespace Azure.Storage.Cryptography
                 {
                     /* The encryption data did not match the encryption data the CEK was originally
                      * wrapped inside of. This is a downgrade attack. Fail the entire download.*/
-                    throw new CryptographicException("Mismatched encryption data.");
+                    throw new CryptographicException("Enryption data modified during decryption process.");
                 }
             }
 
@@ -456,7 +456,7 @@ namespace Azure.Storage.Cryptography
                         .Trim('\0');
                     if (unwrappedProtocolString != encryptionData.EncryptionAgent.EncryptionVersion.Serialize())
                     {
-                        throw new CryptographicException("Encryption metadata has been tampered.");
+                        throw new CryptographicException("Mismatched encryption data.");
                     }
                     unwrappedKey = new Memory<byte>(unwrappedContent)
                         .Slice(Constants.ClientSideEncryption.V2.WrappedDataVersionLength).ToArray();
@@ -483,9 +483,9 @@ namespace Azure.Storage.Cryptography
         /// </summary>
         internal class ContentEncryptionKeyCache
         {
-            private Memory<byte> _key;
-            private string _kekId;
-            private ClientSideEncryptionVersionInternal _cseVersion;
+            private readonly Memory<byte> _key;
+            private readonly string _kekId;
+            private readonly ClientSideEncryptionVersionInternal _cseVersion;
 
             public ContentEncryptionKeyCache(Memory<byte> key, string kekId, ClientSideEncryptionVersionInternal cseVersion)
             {

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -18,7 +18,7 @@ namespace Azure.Storage.Cryptography
         /// <summary>
         /// A cache for encryption key if high level API spans across multiple service calls.
         /// </summary>
-        private ContentEncryptionKeyCache s_contentEncryptionKeyCache;
+        private ContentEncryptionKeyCache _contentEncryptionKeyCache;
 
         /// <summary>
         /// Clients that can upload data have a key encryption key stored on them. Checking if
@@ -372,9 +372,9 @@ namespace Azure.Storage.Cryptography
             bool async,
             CancellationToken cancellationToken)
         {
-            if (s_contentEncryptionKeyCache != null)
+            if (_contentEncryptionKeyCache != null)
             {
-                if (s_contentEncryptionKeyCache.TryGetKey(encryptionData, out Memory<byte> cek))
+                if (_contentEncryptionKeyCache.TryGetKey(encryptionData, out Memory<byte> cek))
                 {
                     return cek;
                 }
@@ -447,7 +447,7 @@ namespace Azure.Storage.Cryptography
                     throw Errors.InvalidArgument(nameof(encryptionData));
             }
 
-            s_contentEncryptionKeyCache = new(
+            _contentEncryptionKeyCache = new(
                 unwrappedKey,
                 encryptionData.WrappedContentKey.KeyId,
                 encryptionData.EncryptionAgent.EncryptionVersion);


### PR DESCRIPTION
Restructures the content encryption key cache for CSE. Was previously a static `AsyncLocal` cache. Now it is instanced per decryptor.

Now, key metadata is stored alongside the cached key, including key encryption key ID and CSE version. When accessing the cached key, this information is compared against. Mismatch throws, as this is the result of tampering mid-decryption.