### PR TITLE
[CODEOWNERS] Add secondary owners for fallback patterns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,14 +34,14 @@
 #########
 
 # Catch all
-/sdk/                                                              @jsquire
+/sdk/                                                              @jsquire @Azure/azure-sdk-write-net-core
 
 ####################
 # End-to-End Samples
 ####################
 
 # Samples catch-all
-/samples/                                                          @jsquire
+/samples/                                                          @jsquire @Azure/azure-sdk-write-net-core
 
 #PRLabel: Voice Live
 /samples/voicelive/                                                @emilyjiji @xitzhang @pankopon @amber-yujueWang
@@ -888,9 +888,9 @@
 /eng/apicompatbaselines/                                           @Azure/azure-sdk-write-net-core @jsquire
 
 # Add owners for package dependency changes
-/eng/centralpackagemanagement                                           @Azure/azure-sdk-write-net-core @jsquire
-/eng/centralpackagemanagement/Directory.Support.Packages.props          @Azure/azure-sdk-write-net-core @jsquire @ArthurMa1978 @jorgerangel-msft
-/eng/centralpackagemanagement/Directory.Generation.Packages.props       @Azure/azure-sdk-write-net-core @jsquire @ArthurMa1978 @jorgerangel-msft
+/eng/centralpackagemanagement                                      @Azure/azure-sdk-write-net-core @jsquire
+/eng/centralpackagemanagement/Directory.Support.Packages.props     @Azure/azure-sdk-write-net-core @jsquire @ArthurMa1978 @jorgerangel-msft
+/eng/centralpackagemanagement/Directory.Generation.Packages.props  @Azure/azure-sdk-write-net-core @jsquire @ArthurMa1978 @jorgerangel-msft
 
 # Add owners for emitter version changes
 /eng/azure-typespec-http-client-csharp-emitter-package.json             @JoshLove-msft @m-nash @jorgerangel-msft @live1206 @ArcturusZhang
@@ -945,7 +945,7 @@
 /.config/1espt/                                                    @benbp
 /.vscode/                                                          @jsquire @m-nash @JoshLove-msft
 /.devcontainer/                                                    @jsquire @m-nash @JoshLove-msft
-/doc/                                                              @jsquire
+/doc/                                                              @jsquire @m-nash @JoshLove-msft
 
 # Repository configuration that should not be overridden
 /sdk/**/NuGet.*                                                    @Azure/azure-sdk-write-net-core @jsquire


### PR DESCRIPTION
# Summary

The focus of these changes is to add secondary owners to the repository integration and fallback paths so that Jesse is not the sole owner and potential blocker on PRs.