### PR TITLE
Fix queue scale metrics: distinguish no visible messages from undecodable messages

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             ConcurrencyManager concurrencyManager = null,
             string functionId = null,
             TimeSpan? maxPollingInterval = null,
+            QueueClient rawQueue = null,
             IDrainModeManager drainModeManager = null)
         {
             if (queueOptions == null)
@@ -138,15 +139,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
             _concurrencyManager = concurrencyManager;
 
+            // Scale metrics need a client whose PeekMessages is not filtered by decode failures,
+            // otherwise an empty peek cannot distinguish "nothing visible" from "messages present
+            // but undecodable". Shared queues written and read by this extension always have
+            // matching encodings, so they can omit it and reuse the processing client.
+            QueueClient metricsQueue = rawQueue ?? queue;
+
             _targetScaler = new Lazy<QueueTargetScaler>(
                     () => new QueueTargetScaler(
                         _functionId,
-                        queue,
+                        metricsQueue,
                         queueOptions,
                         loggerFactory
                         ));
 
-            _scaleMonitor = new Lazy<QueueScaleMonitor>(() => new QueueScaleMonitor(_functionId, _queue, loggerFactory));
+            _scaleMonitor = new Lazy<QueueScaleMonitor>(() => new QueueScaleMonitor(_functionId, metricsQueue, loggerFactory));
             _drainModeManager = drainModeManager;
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -24,7 +24,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
         /// Instantiates a QueueMetricsProvider.
         /// </summary>
         /// <param name="functionId">The function id to make scale decisions for.</param>
-        /// <param name="queue">The QueueClient to use for metrics polling.</param>
+        /// <param name="queue">
+        /// The QueueClient to use for metrics polling. Its PeekMessages must not be subject to
+        /// decode filtering, otherwise an empty peek is ambiguous between "nothing is visible" and
+        /// "messages are present but undecodable" - two opposite scaling decisions. Use a
+        /// <see cref="QueueMessageEncoding.None"/> client, or one whose producer and consumer
+        /// always agree on the encoding.
+        /// </param>
         /// <param name="loggerFactory">Used to create an ILogger instance.</param>
         public QueueMetricsProvider(string functionId, QueueClient queue, ILoggerFactory loggerFactory)
         {
@@ -81,18 +87,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                 if (queueLength > 0)
                 {
                     PeekedMessage message = (await _queue.PeekMessagesAsync(1).ConfigureAwait(false)).Value.FirstOrDefault();
-                    if (message != null && message.InsertedOn.HasValue)
+                    if (message == null)
+                    {
+                        // Nothing is visible even though ApproximateMessagesCount is non-zero: the messages
+                        // are scheduled with a visibility delay, are in-flight on another worker, or the count
+                        // is stale after a drain. None of those can be dequeued now, so allocating workers for
+                        // them cannot reduce the backlog. Undecodable messages cannot reach this branch given
+                        // the encoding requirement on the client - see the constructor remarks.
+                        queueLength = 0;
+                    }
+                    else if (message.InsertedOn.HasValue)
                     {
                         queueTime = DateTime.UtcNow.Subtract(message.InsertedOn.Value.DateTime);
                     }
-                    // If peek returns null (e.g. message encoding mismatch where
-                    // MessageDecodingFailed handler silently filters out un-decodable
-                    // messages), we preserve ApproximateMessagesCount as the queue length.
-                    // Trade-off: ApproximateMessagesCount may briefly be stale after
-                    // a queue is fully drained, causing a transient over-count for one
-                    // poll cycle (~10s). This is preferable to the previous behavior
-                    // which permanently reported QueueLength=0 when messages existed
-                    // but couldn't be peeked.
                 }
             }
             catch (RequestFailedException ex)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix QueueMetricsProvider: preserve ApproximateMessagesCount when PeekMessages fails
+- Fixed queue scale metrics reporting `QueueLength=0` when messages were present but could not be decoded with the configured `MessageEncoding`, which prevented affected functions from scaling out. Scale metrics now read the queue using `QueueMessageEncoding.None`, so peek results are never filtered by decode failures. Message processing is unaffected and continues to use the configured encoding.
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Listeners/QueueListenerFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Listeners/QueueListenerFactory.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
         private static string poisonQueueSuffix = "-poison";
 
         private readonly QueueClient _queue;
+        private readonly QueueClient _rawQueue;
         private readonly QueueClient _poisonQueue;
         private readonly QueuesOptions _queueOptions;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
@@ -39,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
         public QueueListenerFactory(
             QueueServiceClient queueServiceClient,
             QueueClient queue,
+            QueueClient rawQueue,
             QueuesOptions queueOptions,
             IWebJobsExceptionHandler exceptionHandler,
             SharedQueueWatcher messageEnqueuedWatcherSetter,
@@ -51,6 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
             IDrainModeManager drainModeManager)
         {
             _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            _rawQueue = rawQueue ?? throw new ArgumentNullException(nameof(rawQueue));
             _queueOptions = queueOptions ?? throw new ArgumentNullException(nameof(queueOptions));
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
             _messageEnqueuedWatcherSetter = messageEnqueuedWatcherSetter ?? throw new ArgumentNullException(nameof(messageEnqueuedWatcherSetter));
@@ -82,6 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
                 queueProcessor,
                 _descriptor,
                 _concurrencyManager,
+                rawQueue: _rawQueue,
                 drainModeManager: _drainModeManager);
 
             return Task.FromResult(listener);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Listeners/QueueScalerProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Listeners/QueueScalerProvider.cs
@@ -42,6 +42,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
             _queueMetadata.ResolveProperties(serviceProvider.GetService<INameResolver>());
             _options = serviceProvider.GetService<IOptions<QueuesOptions>>();
 
+            // Scale metrics read the queue raw so that PeekMessages is never filtered by decode
+            // failures; see QueueServiceClientProvider.GetRaw. Message processing is unaffected and
+            // continues to use the configured encoding.
             QueueServiceClientProvider queueServiceClientProvider = new QueueServiceClientProvider(
                 serviceProvider.GetService<IConfiguration>(),
                 azureComponentFactory,
@@ -52,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
                 serviceProvider.GetService<IQueueProcessorFactory>(),
                 new SharedQueueWatcher());
 
-            QueueServiceClient serviceClient = queueServiceClientProvider.Get(_queueMetadata.Connection, serviceProvider.GetService<INameResolver>());
+            QueueServiceClient serviceClient = queueServiceClientProvider.GetRaw(_queueMetadata.Connection, serviceProvider.GetService<INameResolver>());
             _queueClient = serviceClient.GetQueueClient(_queueMetadata.QueueName);
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Listeners/QueueScalerProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Listeners/QueueScalerProvider.cs
@@ -42,9 +42,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
             _queueMetadata.ResolveProperties(serviceProvider.GetService<INameResolver>());
             _options = serviceProvider.GetService<IOptions<QueuesOptions>>();
 
-            // Scale metrics read the queue raw so that PeekMessages is never filtered by decode
-            // failures; see QueueServiceClientProvider.GetRaw. Message processing is unaffected and
-            // continues to use the configured encoding.
             QueueServiceClientProvider queueServiceClientProvider = new QueueServiceClientProvider(
                 serviceProvider.GetService<IConfiguration>(),
                 azureComponentFactory,
@@ -55,6 +52,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
                 serviceProvider.GetService<IQueueProcessorFactory>(),
                 new SharedQueueWatcher());
 
+            // Scale metrics read the queue raw so that PeekMessages is never filtered by decode
+            // failures; see QueueServiceClientProvider.GetRaw. Message processing is unaffected and
+            // continues to use the configured encoding.
             QueueServiceClient serviceClient = queueServiceClientProvider.GetRaw(_queueMetadata.Connection, serviceProvider.GetService<INameResolver>());
             _queueClient = serviceClient.GetQueueClient(_queueMetadata.QueueName);
         }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueServiceClientProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueServiceClientProvider.cs
@@ -22,6 +22,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         private readonly ILogger<QueueServiceClient> _logger;
         private readonly IQueueProcessorFactory _queueProcessorFactory;
         private readonly SharedQueueWatcher _messageEnqueuedWatcher;
+        private readonly IConfiguration _configuration;
+        private readonly AzureComponentFactory _componentFactory;
+        private readonly AzureEventSourceLogForwarder _logForwarder;
+        private QueueServiceClientProvider _rawProvider;
 
         public QueueServiceClientProvider(
             IConfiguration configuration,
@@ -39,6 +43,45 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
             _logger = logger;
             _queueProcessorFactory = queueProcessorFactory;
             _messageEnqueuedWatcher = messageEnqueuedWatcher;
+            _configuration = configuration;
+            _componentFactory = componentFactory;
+            _logForwarder = logForwarder;
+        }
+
+        /// <summary>
+        /// Gets a client that reads messages without decoding them, so results are never filtered by
+        /// decode failures. Intended for scale metrics only - it must not be used to process messages,
+        /// because it does not decode message bodies.
+        /// </summary>
+        /// <param name="name">Name of the connection to use.</param>
+        /// <param name="resolver">A resolver to interpret the provided connection <paramref name="name"/>.</param>
+        public virtual QueueServiceClient GetRaw(string name, INameResolver resolver)
+        {
+            // Delegating to Get keeps the raw client identical to the configured one apart from the
+            // encoding. The delegate's own GetRaw is never called, so this does not recurse.
+            _rawProvider ??= new QueueServiceClientProvider(
+                _configuration,
+                _componentFactory,
+                _logForwarder,
+                Options.Create(CreateRawOptions()),
+                _loggerFactory,
+                _logger,
+                _queueProcessorFactory,
+                _messageEnqueuedWatcher);
+
+            return _rawProvider.Get(name, resolver);
+        }
+
+        /// <summary>
+        /// Copies the configured options, overriding only the encoding, so the raw path cannot drift
+        /// from the message-processing path.
+        /// </summary>
+        protected virtual QueuesOptions CreateRawOptions()
+        {
+            QueuesOptions options = _queuesOptions.Clone();
+
+            options.MessageEncoding = QueueMessageEncoding.None;
+            return options;
         }
 
         /// <inheritdoc/>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerAttributeBindingProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerAttributeBindingProvider.cs
@@ -90,10 +90,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             QueueServiceClient client = _queueServiceClientProvider.Get(queueTrigger.Connection, _nameResolver);
             var queue = client.GetQueueClient(queueName);
 
+            // Scale metrics only; never used for message processing.
+            var rawQueue = _queueServiceClientProvider.GetRaw(queueTrigger.Connection, _nameResolver).GetQueueClient(queueName);
+
             ITriggerBinding binding = new QueueTriggerBinding(
                 parameter.Name,
                 client,
                 queue,
+                rawQueue,
                 argumentBinding,
                 _queueOptions,
                 _exceptionHandler,

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerBinding.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerBinding.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
         private readonly string _parameterName;
         private readonly QueueServiceClient _queueServiceClient;
         private readonly QueueClient _queue;
+        private readonly QueueClient _rawQueue;
         private readonly ITriggerDataArgumentBinding<QueueMessage> _argumentBinding;
         private readonly IReadOnlyDictionary<string, Type> _bindingDataContract;
         private readonly QueuesOptions _queueOptions;
@@ -45,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             string parameterName,
             QueueServiceClient queueServiceClient,
             QueueClient queue,
+            QueueClient rawQueue,
             ITriggerDataArgumentBinding<QueueMessage> argumentBinding,
             QueuesOptions queueOptions,
             IWebJobsExceptionHandler exceptionHandler,
@@ -57,6 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
         {
             _queueServiceClient = queueServiceClient ?? throw new ArgumentNullException(nameof(queueServiceClient));
             _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            _rawQueue = rawQueue ?? throw new ArgumentNullException(nameof(rawQueue));
             _argumentBinding = argumentBinding ?? throw new ArgumentNullException(nameof(argumentBinding));
             _bindingDataContract = CreateBindingDataContract(argumentBinding.BindingDataContract);
             _queueOptions = queueOptions ?? throw new ArgumentNullException(nameof(queueOptions));
@@ -146,6 +149,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             var factory = new QueueListenerFactory(
                 _queueServiceClient,
                 _queue,
+                _rawQueue,
                 _queueOptions,
                 _exceptionHandler,
                 _messageEnqueuedWatcherSetter,

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/FakeQueueServiceClientProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/FakeQueueServiceClientProvider.cs
@@ -21,5 +21,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         {
             return _queueServiceClient;
         }
+
+        public override QueueServiceClient GetRaw(string name, INameResolver resolver)
+        {
+            return _queueServiceClient;
+        }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -103,22 +103,73 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
         }
 
         [Test]
-        public async Task GetMetrics_PeekFailure_PreservesApproximateMessageCount()
+        public async Task GetMetrics_NoVisibleMessages_ReturnsZeroQueueLength()
         {
-            // Simulate: GetProperties returns 5 messages, but PeekMessages returns
-            // an empty array (e.g. MessageDecodingFailed handler silently filtered
-            // out un-decodable messages due to encoding mismatch).
-            // The queue length should be preserved as 5, not reset to 0.
+            // GetProperties reports 5 messages but nothing can be peeked. Because the metrics client
+            // reads raw, decoding cannot fail, so this means the messages are not visible: scheduled
+            // with a visibility delay, in-flight on another worker, or a stale count after a drain.
+            // None are dequeueable, so scaling out for them would not reduce the backlog.
             var queueProperties = QueuesModelFactory.QueueProperties(metadata: null, approximateMessagesCount: 5);
 
             _mockQueue.Setup(p => p.GetPropertiesAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response.FromValue(queueProperties, Mock.Of<Response>())));
 
-            // PeekMessages returns empty array (handler swallowed the decode failure)
             _mockQueue.Setup(p => p.PeekMessagesAsync(
                 It.IsAny<int?>(),
                 It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response.FromValue(Array.Empty<PeekedMessage>(), Mock.Of<Response>())));
+
+            var metrics = await _metricsProvider.GetMetricsAsync();
+
+            Assert.AreEqual(0, metrics.QueueLength);
+            Assert.AreEqual(TimeSpan.Zero, metrics.QueueTime);
+        }
+
+        [Test]
+        public async Task GetMetrics_VisibleMessage_ReturnsApproximateMessageCount()
+        {
+            // A message is visible, so the full ApproximateMessagesCount represents dequeueable work.
+            // Undecodable messages land here too: the raw client returns them, and scaling out lets the
+            // listener receive them and move them to the poison queue.
+            var queueProperties = QueuesModelFactory.QueueProperties(metadata: null, approximateMessagesCount: 5);
+            var peeked = QueuesModelFactory.PeekedMessage(
+                messageId: "1",
+                messageText: "<<<not-base64>>>",
+                dequeueCount: 0,
+                insertedOn: DateTimeOffset.UtcNow.AddMinutes(-2));
+
+            _mockQueue.Setup(p => p.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(queueProperties, Mock.Of<Response>())));
+
+            _mockQueue.Setup(p => p.PeekMessagesAsync(
+                It.IsAny<int?>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(new[] { peeked }, Mock.Of<Response>())));
+
+            var metrics = await _metricsProvider.GetMetricsAsync();
+
+            Assert.AreEqual(5, metrics.QueueLength);
+            Assert.Greater(metrics.QueueTime, TimeSpan.Zero);
+        }
+
+        [Test]
+        public async Task GetMetrics_VisibleMessageWithoutInsertedOn_ReturnsApproximateMessageCount()
+        {
+            // A message without a timestamp is still dequeueable work, so only QueueTime is unknown.
+            var queueProperties = QueuesModelFactory.QueueProperties(metadata: null, approximateMessagesCount: 5);
+            var peeked = QueuesModelFactory.PeekedMessage(
+                messageId: "1",
+                messageText: "message",
+                dequeueCount: 0,
+                insertedOn: null);
+
+            _mockQueue.Setup(p => p.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(queueProperties, Mock.Of<Response>())));
+
+            _mockQueue.Setup(p => p.PeekMessagesAsync(
+                It.IsAny<int?>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(new[] { peeked }, Mock.Of<Response>())));
 
             var metrics = await _metricsProvider.GetMetricsAsync();
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueScaleMetricsEncodingTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueScaleMetricsEncodingTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Queues;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
+{
+    /// <summary>
+    /// Guards the contract that scale metrics read the queue with <see cref="QueueMessageEncoding.None"/>.
+    /// Nothing in the type system enforces it - <see cref="QueueClient"/> does not expose its encoding -
+    /// so a refactor that reuses the configured-encoding client would silently reintroduce the
+    /// ambiguity between "nothing visible" and "messages present but undecodable".
+    /// </summary>
+    public class QueueScaleMetricsEncodingTests
+    {
+        [Test]
+        public void GetRaw_OverridesOnlyTheEncoding()
+        {
+            using IHost host = new HostBuilder()
+                .ConfigureDefaultTestHost(b => b.AddAzureStorageQueues())
+                .Build();
+
+            var configured = host.Services.GetRequiredService<IOptions<QueuesOptions>>().Value;
+            var provider = new TestableQueueServiceClientProvider(host.Services);
+
+            QueuesOptions raw = provider.GetRawOptions();
+
+            Assert.AreEqual(QueueMessageEncoding.None, raw.MessageEncoding);
+            Assert.AreEqual(configured.BatchSize, raw.BatchSize);
+            Assert.AreEqual(configured.NewBatchThreshold, raw.NewBatchThreshold);
+            Assert.AreEqual(configured.MaxDequeueCount, raw.MaxDequeueCount);
+            Assert.AreEqual(configured.MaxPollingInterval, raw.MaxPollingInterval);
+            Assert.AreEqual(configured.VisibilityTimeout, raw.VisibilityTimeout);
+            Assert.AreNotSame(configured, raw, "The configured options are a DI singleton shared with message processing.");
+            Assert.AreEqual(QueueMessageEncoding.Base64, configured.MessageEncoding, "Overriding the raw encoding must not mutate the configured options.");
+        }
+
+        [Test]
+        public void GetRaw_OnSubstitutedProvider_ResolvesThroughTheSubstitute()
+        {
+            // The raw client is reached through QueueServiceClientProvider rather than its own DI
+            // registration, so a host that swaps the provider does not have to know the raw path exists.
+            QueueServiceClient expected = new QueueServiceClient("UseDevelopmentStorage=true");
+            QueueServiceClientProvider provider = new FakeQueueServiceClientProvider(expected);
+
+            Assert.AreSame(expected, provider.GetRaw(null, new DefaultNameResolver(new ConfigurationBuilder().Build())));
+        }
+
+        [Test]
+        public void QueueServiceClientProvider_KeepsConfiguredEncoding()
+        {
+            // The message-processing client must not be affected by the metrics client.
+            using IHost host = new HostBuilder()
+                .ConfigureDefaultTestHost(b => b.AddAzureStorageQueues())
+                .Build();
+
+            Assert.AreEqual(
+                QueueMessageEncoding.Base64,
+                host.Services.GetRequiredService<IOptions<QueuesOptions>>().Value.MessageEncoding);
+        }
+
+        [Test]
+        public async Task GetMetrics_UndecodableMessages_RawClientReportsThem_ConfiguredClientDoesNot()
+        {
+            string queueName = $"rawencoding-{Guid.NewGuid()}";
+            var loggerFactory = new NullLoggerFactory();
+
+            QueueClient rawClient = AzuriteNUnitFixture.Instance
+                .GetQueueServiceClient(new QueueClientOptions { MessageEncoding = QueueMessageEncoding.None })
+                .GetQueueClient(queueName);
+
+            // Mirrors QueueServiceClientProvider: a registered handler makes the SDK filter
+            // undecodable messages out of peek results instead of throwing.
+            var configuredOptions = new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 };
+            configuredOptions.MessageDecodingFailed += args => Task.CompletedTask;
+            QueueClient configuredClient = AzuriteNUnitFixture.Instance
+                .GetQueueServiceClient(configuredOptions)
+                .GetQueueClient(queueName);
+
+            await rawClient.CreateIfNotExistsAsync();
+            try
+            {
+                // Written without Base64 encoding, as a non-.NET producer would.
+                await rawClient.SendMessageAsync("<<<not-base64>>>");
+
+                var rawMetrics = await new QueueMetricsProvider("testFunctionId", rawClient, loggerFactory).GetMetricsAsync();
+                var configuredMetrics = await new QueueMetricsProvider("testFunctionId", configuredClient, loggerFactory).GetMetricsAsync();
+
+                Assert.Greater(rawMetrics.QueueLength, 0, "Raw client must see messages that cannot be decoded so the app scales out and the listener can poison them.");
+                Assert.AreEqual(0, configuredMetrics.QueueLength, "Configured-encoding client cannot peek the message, which is why it must not be used for metrics.");
+            }
+            finally
+            {
+                await rawClient.DeleteIfExistsAsync();
+            }
+        }
+
+        /// Exposes the protected raw-options override for assertion.
+        private sealed class TestableQueueServiceClientProvider : QueueServiceClientProvider
+        {
+            public TestableQueueServiceClientProvider(IServiceProvider services)
+                : base(
+                    services.GetRequiredService<IConfiguration>(),
+                    services.GetRequiredService<AzureComponentFactory>(),
+                    services.GetRequiredService<AzureEventSourceLogForwarder>(),
+                    services.GetRequiredService<IOptions<QueuesOptions>>(),
+                    services.GetRequiredService<ILoggerFactory>(),
+                    services.GetRequiredService<ILogger<QueueServiceClient>>(),
+                    services.GetRequiredService<IQueueProcessorFactory>(),
+                    services.GetRequiredService<SharedQueueWatcher>())
+            {
+            }
+
+            public QueuesOptions GetRawOptions() => CreateRawOptions();
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueScaleMetricsEncodingTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueScaleMetricsEncodingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Storage.Queues;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
@@ -79,17 +80,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
             string queueName = $"rawencoding-{Guid.NewGuid()}";
             var loggerFactory = new NullLoggerFactory();
 
-            QueueClient rawClient = AzuriteNUnitFixture.Instance
-                .GetQueueServiceClient(new QueueClientOptions { MessageEncoding = QueueMessageEncoding.None })
-                .GetQueueClient(queueName);
+            using IHost host = new HostBuilder()
+                .ConfigureAppConfiguration(c => c.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "ConnectionStrings:AzureWebJobsStorage", AzuriteNUnitFixture.Instance.GetAzureAccount().ConnectionString }
+                }))
+                .ConfigureDefaultTestHost(b =>
+                {
+                    b.Services.AddAzureClients(builder =>
+                        builder.ConfigureDefaults(options => options.Transport = AzuriteNUnitFixture.Instance.GetTransport()));
+                    b.AddAzureStorageQueues();
+                })
+                .Build();
 
-            // Mirrors QueueServiceClientProvider: a registered handler makes the SDK filter
-            // undecodable messages out of peek results instead of throwing.
-            var configuredOptions = new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 };
-            configuredOptions.MessageDecodingFailed += args => Task.CompletedTask;
-            QueueClient configuredClient = AzuriteNUnitFixture.Instance
-                .GetQueueServiceClient(configuredOptions)
-                .GetQueueClient(queueName);
+            var provider = new TestableQueueServiceClientProvider(host.Services);
+            var resolver = new DefaultNameResolver(host.Services.GetRequiredService<IConfiguration>());
+
+            // Resolved through GetRaw rather than hand-built, so the metrics path itself is under test.
+            QueueClient rawClient = provider.GetRaw(null, resolver).GetQueueClient(queueName);
+            QueueClient configuredClient = provider.Get(null, resolver).GetQueueClient(queueName);
 
             await rawClient.CreateIfNotExistsAsync();
             try
@@ -109,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
             }
         }
 
-        /// Exposes the protected raw-options override for assertion.
+        /// Builds the real provider from DI, and exposes the protected raw-options override for assertion.
         private sealed class TestableQueueServiceClientProvider : QueueServiceClientProvider
         {
             public TestableQueueServiceClientProvider(IServiceProvider services)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTriggerBindingIntegrationTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTriggerBindingIntegrationTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
                 "parameterName",
                 queueServiceClient,
                 queue,
+                queue,
                 argumentBinding,
                 new QueuesOptions(),
                 exceptionHandler,


### PR DESCRIPTION
# Fix queue scale metrics: distinguish "no visible messages" from "undecodable messages"

## Summary

`QueueMetricsProvider` cannot tell two very different situations apart, because both produce
an empty `PeekMessages` result while `ApproximateMessagesCount > 0`:

1. **Nothing is visible** — messages are visibility-delayed, in-flight on another worker, or the
   count is briefly stale after a drain. No worker can dequeue them.
2. **Messages are present but undecodable** — the `MessageDecodingFailed` handler filters them
   out of peek results client-side. Real work is waiting.

These call for opposite scaling decisions. Before #57518 the provider assumed (1) always and
zeroed the queue length, which caused permanent under-scaling in case (2). #57518 assumed (2)
always and preserved the count, which causes over-provisioning in case (1).

This PR removes the ambiguity instead of choosing a side: **scale metrics now read the queue
through a `QueueMessageEncoding.None` client**. Raw decoding cannot fail, so peek is never
filtered and an empty peek unambiguously means nothing is currently dequeueable.

## Behaviour

| Scenario | Before #57518 | After #57518 | This PR |
|---|---|---|---|
| Visibility-delayed messages | 0 | full count :x: | **0** :white_check_mark: |
| In-flight on another worker | 0 | full count :x: | **0** :white_check_mark: |
| Stale count after drain | 0 | full count :warning: | **0** :white_check_mark: |
| Undecodable messages present | 0 :x: | full count | **full count** :white_check_mark: |
| Undecodable at queue head, decodable behind | 0 :x: | full count | **full count** :white_check_mark: |

Cases 1–3 are bounded by the queue's visibility timeout, not by count convergence, so the
over-provision could persist for as long as that timeout — not the "one poll cycle" that
#57518's trade-off note assumed. With a low `BatchSize` (effective concurrency of 1), each
non-dequeueable message requests its own instance.

## Implementation

- `QueueServiceClientProvider.GetRaw` returns a client that reads messages verbatim. It
  delegates to `Get` on a provider built from a **cloned `QueuesOptions`** whose only difference
  is `MessageEncoding = None`, so the raw client is identical to the configured one in every
  other respect (retry policy, timeouts, diagnostics) and cannot drift from it. The DI singleton
  options are never mutated.
- Both consumers go through `GetRaw`: `QueueScalerProvider` (out-of-process scale controller)
  and `QueueTriggerAttributeBindingProvider` (in-process listener).
- Reaching the raw client *through* `QueueServiceClientProvider`, rather than registering a
  second provider in DI, means a host that substitutes the provider substitutes both paths.
- The raw client is threaded to `QueueListener`, which uses it only for `IScaleMonitor` /
  `ITargetScaler`. It is optional; internal control queues written and read by this extension
  have matching encodings by construction and reuse the processing client.
- `QueueMetricsProvider` zeroes `QueueLength` only when nothing is visible at all. A peeked
  message with no `InsertedOn` is still dequeueable work, so only `QueueTime` is left unknown.
- **Message processing is unchanged** and continues to use the configured encoding, so
  undecodable messages are still routed to the poison queue by the listener.

## Note for reviewers

This **replaces the unit test added by #57518**
(`GetMetrics_PeekFailure_PreservesApproximateMessageCount`). That is intentional, not a
regression: the guarantee has moved from provider logic into the client's encoding. The
provider-level assertion therefore inverts, and the end-to-end guarantee is covered by a new
integration test that writes an undecodable message and asserts the raw client still reports it.

## Testing

New `QueueScaleMetricsEncodingTests`:
- `GetRaw_OverridesOnlyTheEncoding` — raw options match the configured options on every other
  member, and the configured DI singleton is not mutated
- `GetRaw_OnSubstitutedProvider_ResolvesThroughTheSubstitute` — a host that swaps the provider
  does not have to know the raw path exists
- `QueueServiceClientProvider_KeepsConfiguredEncoding` — pins that processing is unaffected
- `GetMetrics_UndecodableMessages_RawClientReportsThem_ConfiguredClientDoesNot` — end-to-end

Updated `QueueMetricsProviderTests`:
- `GetMetrics_NoVisibleMessages_ReturnsZeroQueueLength`
- `GetMetrics_VisibleMessage_ReturnsApproximateMessageCount`
- `GetMetrics_VisibleMessageWithoutInsertedOn_ReturnsApproximateMessageCount`

No public API change — every type touched is `internal`.
