### PR TITLE
Preserve response fields in protocol pageables

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/AzureCollectionResultDefinition.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/AzureCollectionResultDefinition.cs
@@ -65,6 +65,11 @@ namespace Azure.Generator.Providers
         private string CreateRequestMethodName
             => Client.RestClient.GetCreateRequestMethod(_operation).Signature.Name;
 
+        private ValueExpression ProtocolSerializationOptions
+            => _operation.Responses.First(r => !r.IsErrorResponse).SerializationOptions?.Xml != null
+                ? Static<ModelReaderWriterOptions>().Property(nameof(ModelReaderWriterOptions.Xml))
+                : Static<ModelReaderWriterOptions>().Property(nameof(ModelReaderWriterOptions.Json));
+
         // We use "_diagnosticScope" rather than "_scope" to reduce collision risk with API parameters.
         // If a collision does occur, the framework's CodeWriter dedup renames declarations but not
         // AsValueExpression references, causing incorrect codegen. See: https://github.com/microsoft/typespec/issues/10130
@@ -229,7 +234,7 @@ namespace Azure.Generator.Providers
                     itemsVariable.Invoke("Add", Static(typeof(ModelReaderWriter)).Invoke(nameof(ModelReaderWriter.Write),
                         [
                             itemVariable,
-                            Static<ModelReaderWriterOptions>().Property(nameof(ModelReaderWriterOptions.Json)),
+                            ProtocolSerializationOptions,
                             Static<ModelReaderWriterContextDefinition>().Property("Default")
                         ])).Terminate()
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/AzureCollectionResultDefinition.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/AzureCollectionResultDefinition.cs
@@ -160,7 +160,7 @@ namespace Azure.Generator.Providers
             whileStatement.Add(CheckNextPageVariable(nextPageVariable));
 
             statements.Add(whileStatement);
-            return [..statements];
+            return [.. statements];
         }
 
         // Assigns the next page link/token from the current response into <paramref name="nextPageVariable"/>

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/AzureCollectionResultDefinition.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/AzureCollectionResultDefinition.cs
@@ -160,7 +160,7 @@ namespace Azure.Generator.Providers
             whileStatement.Add(CheckNextPageVariable(nextPageVariable));
 
             statements.Add(whileStatement);
-            return [.. statements];
+            return [..statements];
         }
 
         // Assigns the next page link/token from the current response into <paramref name="nextPageVariable"/>
@@ -229,7 +229,7 @@ namespace Azure.Generator.Providers
                     itemsVariable.Invoke("Add", Static(typeof(ModelReaderWriter)).Invoke(nameof(ModelReaderWriter.Write),
                         [
                             itemVariable,
-                            Static<ModelSerializationExtensionsDefinition>().Property(ModelSerializationExtensionsDefinition.WireOptionsFieldName),
+                            Static<ModelReaderWriterOptions>().Property(nameof(ModelReaderWriterOptions.Json)),
                             Static<ModelReaderWriterContextDefinition>().Property("Default")
                         ])).Terminate()
                 }
@@ -257,7 +257,7 @@ namespace Azure.Generator.Providers
                 statements.Add(YieldReturn(Static(new CSharpType(typeof(Page<>), [_itemModelType])).Invoke("FromValues", [BuildGetPropertyExpression(Paging.ItemPropertySegments, resultVariable).CastTo(new CSharpType(typeof(IReadOnlyList<>), _itemModelType)), Null, responseVariable])));
             }
 
-            return [..statements];
+            return [.. statements];
         }
 
         private MethodProvider BuildGetNextResponseMethod()

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/ListPageableTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/ListPageableTests.cs
@@ -7,6 +7,7 @@ using Azure.Generator.Tests.TestHelpers;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Azure.Generator.Tests.Providers.CollectionResultDefinitions
@@ -57,6 +58,26 @@ namespace Azure.Generator.Tests.Providers.CollectionResultDefinitions
         }
 
         [Test]
+        public void ProtocolPageableUsesXmlSerializationOptions()
+        {
+            CreatePagingOperation(
+                ["application/xml"],
+                new InputSerializationOptions(
+                    json: null,
+                    xml: new InputXmlSerializationOptions("page", false, null)));
+
+            var collectionResultDefinition = AzureClientGenerator.Instance.OutputLibrary.TypeProviders.FirstOrDefault(
+                t => t is AzureCollectionResultDefinition && t.Name == "CatClientGetCatsCollectionResult");
+            Assert.IsNotNull(collectionResultDefinition);
+
+            var writer = new TypeProviderWriter(collectionResultDefinition!);
+            var file = writer.Write();
+            Assert.That(file.Content, Does.Contain("ModelReaderWriterOptions.Xml"));
+            Assert.That(file.Content, Does.Not.Contain("ModelReaderWriterOptions.Json"));
+            Assert.That(file.Content, Does.Not.Contain("ModelSerializationExtensions.WireOptions"));
+        }
+
+        [Test]
         public void NoNextLinkOrContinuationTokenOfT()
         {
             CreatePagingOperation();
@@ -84,7 +105,9 @@ namespace Azure.Generator.Tests.Providers.CollectionResultDefinitions
             Assert.AreEqual(Helpers.GetExpectedFromFile(), file.Content);
         }
 
-        private static void CreatePagingOperation()
+        private static void CreatePagingOperation(
+            IReadOnlyList<string>? contentTypes = null,
+            InputSerializationOptions? serializationOptions = null)
         {
             var inputModel = InputFactory.Model("cat", properties:
             [
@@ -96,7 +119,9 @@ namespace Azure.Generator.Tests.Providers.CollectionResultDefinitions
                 [200],
                 InputFactory.Model(
                     "page",
-                    properties: [InputFactory.Property("cats", InputFactory.Array(inputModel))]));
+                    properties: [InputFactory.Property("cats", InputFactory.Array(inputModel))]),
+                contentTypes,
+                serializationOptions);
             var operation = InputFactory.Operation("getCats", parameters: [parameter], responses: [response]);
             var inputServiceMethod = InputFactory.PagingServiceMethod("getCats", operation, pagingMetadata: pagingMetadata);
             var client = InputFactory.Client("catClient", methods: [inputServiceMethod]);

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/ListPageableTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/ListPageableTests.cs
@@ -42,6 +42,21 @@ namespace Azure.Generator.Tests.Providers.CollectionResultDefinitions
         }
 
         [Test]
+        public void ProtocolPageableUsesJsonSerializationOptions()
+        {
+            CreatePagingOperation();
+
+            var collectionResultDefinition = AzureClientGenerator.Instance.OutputLibrary.TypeProviders.FirstOrDefault(
+                t => t is AzureCollectionResultDefinition && t.Name == "CatClientGetCatsCollectionResult");
+            Assert.IsNotNull(collectionResultDefinition);
+
+            var writer = new TypeProviderWriter(collectionResultDefinition!);
+            var file = writer.Write();
+            Assert.That(file.Content, Does.Contain("ModelReaderWriterOptions.Json"));
+            Assert.That(file.Content, Does.Not.Contain("ModelSerializationExtensions.WireOptions"));
+        }
+
+        [Test]
         public void NoNextLinkOrContinuationTokenOfT()
         {
             CreatePagingOperation();

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBody.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBody.cs
@@ -54,7 +54,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyAsync.cs
@@ -55,7 +55,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeader.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeader.cs
@@ -61,7 +61,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderAsync.cs
@@ -62,7 +62,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/MaxPageSizePassedToNextRequest.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/MaxPageSizePassedToNextRequest.cs
@@ -57,7 +57,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/MaxPageSizeRequiredPassedToNextRequest.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/MaxPageSizeRequiredPassedToNextRequest.cs
@@ -57,7 +57,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationToken.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationToken.cs
@@ -46,7 +46,7 @@ namespace Samples
             global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
             foreach (var item in result.Cats)
             {
-                items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
             }
             yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, null, response);
         }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationTokenAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationTokenAsync.cs
@@ -47,7 +47,7 @@ namespace Samples
             global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
             foreach (var item in result.Cats)
             {
-                items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
             }
             yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, null, response);
         }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/MaxPageSizePassedToNextRequest.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/MaxPageSizePassedToNextRequest.cs
@@ -54,7 +54,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/MaxPageSizeRequiredPassedToNextRequest.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/MaxPageSizeRequiredPassedToNextRequest.cs
@@ -54,7 +54,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBody.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBody.cs
@@ -51,7 +51,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyAsync.cs
@@ -52,7 +52,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyWithStringProperty.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInBodyWithStringProperty.cs
@@ -52,7 +52,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeader.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeader.cs
@@ -58,7 +58,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeaderAsync.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/CollectionResultDefinitions/TestData/NextLinkTests/NextLinkInHeaderAsync.cs
@@ -59,7 +59,7 @@ namespace Samples
                 global::System.Collections.Generic.List<global::System.BinaryData> items = new global::System.Collections.Generic.List<global::System.BinaryData>();
                 foreach (var item in result.Cats)
                 {
-                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::Samples.ModelSerializationExtensions.WireOptions, global::Samples.SamplesContext.Default));
+                    items.Add(global::System.ClientModel.Primitives.ModelReaderWriter.Write(item, global::System.ClientModel.Primitives.ModelReaderWriterOptions.Json, global::Samples.SamplesContext.Default));
                 }
                 yield return global::Azure.Page<global::System.BinaryData>.FromValues(items, (nextPage?.IsAbsoluteUri == true) ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if ((nextPage == null))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/common/InputFactory.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/common/InputFactory.cs
@@ -649,15 +649,22 @@ namespace Azure.Generator.Tests.Common
         /// </summary>
         /// <param name="statusCodes"></param>
         /// <param name="bodytype"></param>
+        /// <param name="contentTypes"></param>
+        /// <param name="serializationOptions"></param>
         /// <returns></returns>
-        public static InputOperationResponse OperationResponse(IEnumerable<int>? statusCodes = null, InputType? bodytype = null)
+        public static InputOperationResponse OperationResponse(
+            IEnumerable<int>? statusCodes = null,
+            InputType? bodytype = null,
+            IReadOnlyList<string>? contentTypes = null,
+            InputSerializationOptions? serializationOptions = null)
         {
             return new InputOperationResponse(
                 statusCodes is null ? [200] : [.. statusCodes],
                 bodytype,
                 [],
                 false,
-                ["application/json"]);
+                contentTypes ?? ["application/json"],
+                serializationOptions);
         }
 
         private static readonly Dictionary<InputClient, IList<InputClient>> _childClientsCache = new();

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenAsyncCollectionResult.cs
@@ -54,7 +54,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenCollectionResult.cs
@@ -53,7 +53,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResult.cs
@@ -61,7 +61,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResult.cs
@@ -60,7 +60,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageAsyncCollectionResult.cs
@@ -57,7 +57,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithContinuationTokenWithMaxPageCollectionResult.cs
@@ -56,7 +56,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage, response);
                 if (string.IsNullOrEmpty(nextPage))

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkAsyncCollectionResult.cs
@@ -58,7 +58,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkCollectionResult.cs
@@ -57,7 +57,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageAsyncCollectionResult.cs
@@ -61,7 +61,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithHeaderNextLinkWithMaxPageCollectionResult.cs
@@ -60,7 +60,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkAsyncCollectionResult.cs
@@ -51,7 +51,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithNextLinkCollectionResult.cs
@@ -50,7 +50,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithPagingAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithPagingAsyncCollectionResult.cs
@@ -43,7 +43,7 @@ namespace BasicTypeSpec
             List<BinaryData> items = new List<BinaryData>();
             foreach (var item in result.Items)
             {
-                items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
             }
             yield return Page<BinaryData>.FromValues(items, null, response);
         }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithPagingCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithPagingCollectionResult.cs
@@ -42,7 +42,7 @@ namespace BasicTypeSpec
             List<BinaryData> items = new List<BinaryData>();
             foreach (var item in result.Items)
             {
-                items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
             }
             yield return Page<BinaryData>.FromValues(items, null, response);
         }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkAsyncCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkAsyncCollectionResult.cs
@@ -52,7 +52,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkCollectionResult.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/CollectionResults/BasicTypeSpecClientGetWithStringNextLinkCollectionResult.cs
@@ -51,7 +51,7 @@ namespace BasicTypeSpec
                 List<BinaryData> items = new List<BinaryData>();
                 foreach (var item in result.Things)
                 {
-                    items.Add(ModelReaderWriter.Write(item, ModelSerializationExtensions.WireOptions, BasicTypeSpecContext.Default));
+                    items.Add(ModelReaderWriter.Write(item, ModelReaderWriterOptions.Json, BasicTypeSpecContext.Default));
                 }
                 yield return Page<BinaryData>.FromValues(items, nextPage?.IsAbsoluteUri == true ? nextPage.AbsoluteUri : nextPage?.OriginalString, response);
                 if (nextPage == null)


### PR DESCRIPTION
## Description

Protocol `Pageable<BinaryData>` implementations currently reserialize response items with `ModelSerializationExtensions.WireOptions`. Request-wire visibility omits response-only properties, causing fields such as `transactionId` and `userId` to disappear from protocol pageable values.

Serialize protocol pageable items with `ModelReaderWriterOptions.Json` so the complete deserialized response model, including response-only and unknown properties, is retained.

## Validation

- Regenerated the Basic-TypeSpec test project
- Added focused protocol pageable serialization coverage
- Ran all Azure generator tests (253 passed)