### PR TITLE
Fix streaming visitor for provider generic types

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/StreamingResponseVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/StreamingResponseVisitor.cs
@@ -33,7 +33,7 @@ namespace Azure.Generator.Visitors
 
 #pragma warning disable SCME0005 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         private static bool IsStreamingResponseType(CSharpType? type)
-            => UnwrapTask(type) is { IsGenericType: true } streamingType &&
+            => UnwrapTask(type) is { IsFrameworkType: true, IsGenericType: true } streamingType &&
                streamingType.GetGenericTypeDefinition().Equals(typeof(AsyncStreamingClientResult<>));
 #pragma warning restore SCME0005 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/StreamingResponseVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/StreamingResponseVisitorTests.cs
@@ -62,6 +62,19 @@ namespace Azure.Generator.Tests.Visitors
             Assert.AreSame(response, expression.Arguments[0]);
         }
 
+        [Test]
+        public void DoesNotThrowForProviderBackedGenericReturnType()
+        {
+            MockHelpers.LoadMockGenerator();
+            var response = new VariableExpression(typeof(Response), "response");
+            var expression = CreateInvocation("CreateResult", typeof(BinaryData), response);
+            var returnType = new TestGenericTypeProvider().Type;
+
+            Assert.DoesNotThrow(() =>
+                new TestStreamingResponseVisitor().Visit(expression, CreateMethod(returnType)));
+            Assert.AreSame(response, expression.Arguments[0]);
+        }
+
         private static InvokeMethodExpression CreateInvocation(string name, CSharpType returnType, ValueExpression response)
         {
             var signature = new MethodSignature(
@@ -103,6 +116,17 @@ namespace Azure.Generator.Tests.Visitors
                 : base(signature, new Mock<TypeProvider>().Object, null)
             {
             }
+        }
+
+        private class TestGenericTypeProvider : TypeProvider
+        {
+            protected override string BuildName() => "SearchResult";
+
+            protected override string BuildNamespace() => "Azure.Search.Documents.Models";
+
+            protected override string BuildRelativeFilePath() => $"{Name}.cs";
+
+            protected override CSharpType[] GetTypeArguments() => [typeof(BinaryData)];
         }
     }
 }


### PR DESCRIPTION
## Summary
- guard `GetGenericTypeDefinition()` usage to framework-backed generic types
- add regression coverage for provider-backed generic return types such as Search models
- avoid the Search regeneration failure introduced by #61835

## Validation
- `dotnet test eng/packages/http-client-csharp/generator/Azure.Generator/test/Azure.Generator.Tests.csproj --filter FullyQualifiedName~StreamingResponseVisitorTests`
- `eng/packages/http-client-csharp/eng/scripts/Generate.ps1`

Upstream generic type support is tracked in microsoft/typespec#8164.