### PR TITLE
[AgentServer] Gate resilient-task recovery loop on registered tasks

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Other Changes
 
+- The resilient-task durability recovery loop is now opt-in: the cold-start recovery scan and the periodic reclaim sweep only run when at least one task handler is registered. A process that adds `AddResilientTasks()` but registers no tasks no longer lists the task store on every startup and interval (Python parity — with no registered tasks there is nothing to recover).
+
 ## 1.0.0-beta.27 (2026-07-29)
 
 ### Features Added

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskDurabilityService.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskDurabilityService.cs
@@ -67,6 +67,16 @@ internal sealed class TaskDurabilityService : IHostedService, IAsyncDisposable
             _stopCts = new CancellationTokenSource();
         }
 
+        // The task subsystem is opt-in: with no registered handlers there is nothing to recover,
+        // so keep the durability loop inert instead of listing the store on every boot and interval
+        // (Python parity — the recovery loop is gated on the task registry being non-empty). All
+        // registrations complete before the host starts hosted services, so this check is stable.
+        if (!_engine.HasRegisteredTasks)
+        {
+            _logger.RecoveryLoopDisabledNoRegisteredTasks();
+            return;
+        }
+
         // Emit the operator-facing startup marker once per process boot, carrying the stable lease
         // instance id (worker-<pid>-<hex>-<epoch>). A cross-process restart therefore surfaces as a
         // NEW instance in the logs — parity with Python's "TaskManager starting (owner, instance,

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskDurabilityService.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskDurabilityService.cs
@@ -69,8 +69,11 @@ internal sealed class TaskDurabilityService : IHostedService, IAsyncDisposable
 
         // The task subsystem is opt-in: with no registered handlers there is nothing to recover,
         // so keep the durability loop inert instead of listing the store on every boot and interval
-        // (Python parity — the recovery loop is gated on the task registry being non-empty). All
-        // registrations complete before the host starts hosted services, so this check is stable.
+        // (Python parity — the recovery loop is gated on the task registry being non-empty). This
+        // relies on the documented usage that tasks are registered at startup, before the host runs
+        // its hosted services: a handler added to the builder *after* startup will not retroactively
+        // enable the loop (a later restart picks it up). Registering all tasks up front — as every
+        // sample and the guide do — is therefore the supported pattern.
         if (!_engine.HasRegisteredTasks)
         {
             _logger.RecoveryLoopDisabledNoRegisteredTasks();

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskEngine.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskEngine.cs
@@ -64,6 +64,13 @@ internal sealed partial class TaskEngine : ITaskInvoker, IMultiTurnTask, IDispos
 
     internal bool IsActive(string taskId) => _activeRuns.ContainsKey(taskId);
 
+    /// <summary>
+    /// <see langword="true"/> when at least one task handler is registered. Gates the durability
+    /// recovery loop: with no registered handlers there is nothing to recover, so the cold-start
+    /// scan and periodic sweep are skipped (Python parity — the task subsystem is opt-in).
+    /// </summary>
+    internal bool HasRegisteredTasks => !_registry.IsEmpty;
+
     internal string InstanceId => _lease.InstanceId;
 
     internal LeaseManager Lease => _lease;

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskRegistry.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskRegistry.cs
@@ -15,6 +15,14 @@ internal sealed class TaskRegistry
     private readonly ConcurrentDictionary<string, TaskRegistration> _registrations =
         new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// <see langword="true"/> when no task handlers have been registered. The durability
+    /// recovery loop uses this to stay inert when the task API is unused (Python parity: no
+    /// registered tasks means nothing to recover, so the startup scan and periodic sweep are
+    /// skipped rather than listing the store on every boot/interval).
+    /// </summary>
+    public bool IsEmpty => _registrations.IsEmpty;
+
     /// <summary>Adds a registration, rejecting duplicate names.</summary>
     /// <param name="registration">The registration to add.</param>
     /// <exception cref="InvalidOperationException">A task with the same name is already registered.</exception>

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskTelemetry.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tasks/Engine/TaskTelemetry.cs
@@ -64,4 +64,11 @@ internal static partial class TaskTelemetry
         Level = LogLevel.Information,
         Message = "Reclaimed stale task {TaskId} (generation will increment).")]
     public static partial void StaleTaskReclaimed(this ILogger logger, string taskId);
+
+    [LoggerMessage(
+        EventId = 13,
+        EventName = "resilient_task_recovery_loop_disabled",
+        Level = LogLevel.Information,
+        Message = "Resilient-task recovery loop disabled: no task handlers are registered, so the startup scan and periodic recovery sweep are skipped.")]
+    public static partial void RecoveryLoopDisabledNoRegisteredTasks(this ILogger logger);
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/Tasks/Engine/RecoveryObservabilityTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/Tasks/Engine/RecoveryObservabilityTests.cs
@@ -33,6 +33,10 @@ public sealed class RecoveryObservabilityTests
         var logger = new CapturingLogger();
         using TaskTestHost host = TaskTestHost.Create(logger: logger);
 
+        // The recovery loop is opt-in (gated on a non-empty registry), so register a handler —
+        // a process that logs "TaskManager starting" is by definition one that uses resilient tasks.
+        host.Builder.AddTask<string, string>("startup", (ctx, ct) => Task.FromResult(ctx.Input));
+
         var scanner = new RecoveryScanner(host.Engine);
         await using var durability = new TaskDurabilityService(scanner, host.Engine, TimeSpan.FromMinutes(10), logger: logger);
         await durability.StartAsync();

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/Tasks/RecoveryLoopGatingTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/Tasks/RecoveryLoopGatingTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Azure.AI.AgentServer.Core.Tasks;
+using Azure.AI.AgentServer.Core.Tasks.Engine;
+using Azure.AI.AgentServer.Core.Tasks.Providers;
+using NUnit.Framework;
+
+namespace Azure.AI.AgentServer.Core.Tests.Tasks;
+
+/// <summary>
+/// The durability recovery loop is opt-in: it runs only when at least one task handler is
+/// registered. With an empty registry the cold-start scan and periodic sweep stay inert so a
+/// process that never uses resilient tasks does not list the task store on every boot/interval
+/// (Python parity — no registered tasks means nothing to recover).
+/// </summary>
+[TestFixture]
+public sealed class RecoveryLoopGatingTests
+{
+    [Test]
+    public void HasRegisteredTasksReflectsRegistryState()
+    {
+        using var host = TaskTestHost.Create();
+        Assert.That(host.Engine.HasRegisteredTasks, Is.False, "no handlers registered yet");
+
+        host.Builder.AddTask<string, string>("t", (ctx, ct) => Task.FromResult(ctx.Input));
+
+        Assert.That(host.Engine.HasRegisteredTasks, Is.True, "a handler is now registered");
+    }
+
+    [Test]
+    public async Task EmptyRegistrySkipsColdStartScan()
+    {
+        using var host = TaskTestHost.Create();
+        await SeedLegacyInProgressRecordAsync(host, "gated-1");
+
+        var service = new TaskDurabilityService(
+            new RecoveryScanner(host.Engine), host.Engine, scanInterval: TimeSpan.FromHours(1));
+
+        await service.StartAsync();
+
+        // The scan never listed the store, so the record the scan would otherwise have cleaned up
+        // is left untouched — proof the recovery loop stayed inert with an empty registry.
+        Assert.That(await host.Store.GetAsync("gated-1"), Is.Not.Null,
+            "an empty registry must not trigger a store scan");
+
+        await service.StopAsync();
+    }
+
+    [Test]
+    public async Task NonEmptyRegistryRunsColdStartScan()
+    {
+        using var host = TaskTestHost.Create();
+        host.Builder.AddTask<string, string>("unrelated", (ctx, ct) => Task.FromResult(ctx.Input));
+        await SeedLegacyInProgressRecordAsync(host, "gated-2");
+
+        var service = new TaskDurabilityService(
+            new RecoveryScanner(host.Engine), host.Engine, scanInterval: TimeSpan.FromHours(1));
+
+        await service.StartAsync();
+
+        // With a registered handler the cold-start scan runs and cleans up the legacy record.
+        Assert.That(await host.Store.GetAsync("gated-2"), Is.Null,
+            "a non-empty registry must run the startup recovery scan");
+
+        await service.StopAsync();
+    }
+
+    // Seeds a pre-schema in_progress record (legacy wire format: no payload.schema_version) owned
+    // by this engine. If the recovery scan runs, this record is force-deleted (legacy cleanup); if
+    // the scan is skipped, it survives — making it a deterministic witness for whether the scan ran.
+    private static Task SeedLegacyInProgressRecordAsync(TaskTestHost host, string id)
+    {
+        string owner = LeaseManager.FormatOwner(host.AgentName, host.SessionId);
+        return host.Store.CreateAsync(new TaskCreateRequest
+        {
+            Id = id,
+            AgentName = host.AgentName,
+            SessionId = host.SessionId,
+            Title = "Legacy",
+            Status = "in_progress",
+            LeaseOwner = owner,
+            LeaseInstanceId = "old-worker",
+            LeaseDurationSeconds = 60,
+            Payload = new JsonObject
+            {
+                ["input"] = "stale",
+                ["last_input_id"] = id,
+                // NOTE: deliberately no schema_version — this is the legacy shape.
+            },
+            Source = new JsonObject
+            {
+                ["type"] = "agentserver.task",
+                ["name"] = "legacy",
+                ["server_version"] = "py/0.0.1",
+            },
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Make the resilient-task **durability recovery loop opt-in**: the cold-start recovery scan and the periodic reclaim sweep run only when at least one task handler is registered. A process that calls `AddResilientTasks()` but registers no tasks no longer lists the task store on every startup and every interval — with no registered handlers there is nothing to recover.

This is the no-config replacement for the earlier (reverted) `FOUNDRY_TASK_API_ENABLED` env-var experiment. It matches the Python SDK, where the durable-task subsystem is opt-in and the recovery infrastructure stays inert until a task is registered.

## Changes

- **`TaskRegistry.IsEmpty` / `TaskEngine.HasRegisteredTasks`** — expose whether any handler is registered.
- **`TaskDurabilityService.StartAsync`** short-circuits when the registry is empty, emitting a new `resilient_task_recovery_loop_disabled` log instead of running the scan / starting the loop. All task registrations (including the sample harness's post-build registrations, which run before `app.StartAsync()`) complete before hosted services start, so the check is stable.
- **New `RecoveryLoopGatingTests`** — deterministically prove that an empty registry skips the store scan (a seeded legacy record survives) while a non-empty registry runs the cold-start scan (the record is cleaned up).
- **`RecoveryObservabilityTests`** now registers a handler before asserting the "TaskManager starting" startup log — a process that logs it is by definition one that uses resilient tasks.

## Testing

- Core: **476/476** non-live tests pass on **net8.0** and **net10.0**. (The excluded live tests are AppInsights telemetry tests gated on `AGENTSERVER_CONNECTION_STRING`.)
- **No public API change** — all additions are on internal types; `Export-API.ps1 agentserver` produced no `api/*.cs` diff.
- `dotnet format whitespace` applied.

Relates to #61751.
