### PR TITLE
Fix provider-backed streaming response detection

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/StreamingResponseVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/StreamingResponseVisitor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.ClientModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -16,6 +15,8 @@ namespace Azure.Generator.Visitors
 {
     internal class StreamingResponseVisitor : ScmLibraryVisitor
     {
+        private static readonly TypeProvider s_asyncStreamingClientResultProvider = new AsyncStreamingClientResultProvider();
+
         protected override ValueExpression? VisitInvokeMethodExpression(InvokeMethodExpression expression, MethodProvider method)
         {
             if (expression.Arguments.Count > 0
@@ -31,11 +32,14 @@ namespace Azure.Generator.Visitors
             return base.VisitInvokeMethodExpression(expression, method);
         }
 
-#pragma warning disable SCME0005 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         private static bool IsStreamingResponseType(CSharpType? type)
-            => UnwrapTask(type) is { IsGenericType: true } streamingType &&
-               streamingType.GetGenericTypeDefinition().Equals(typeof(AsyncStreamingClientResult<>));
-#pragma warning restore SCME0005 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        {
+            var streamingType = UnwrapTask(type);
+            var expectedType = s_asyncStreamingClientResultProvider.Type;
+            return streamingType is { Arguments.Count: 1 } &&
+                streamingType.Name == expectedType.Name &&
+                streamingType.Namespace == expectedType.Namespace;
+        }
 
         private static bool IsAzureResponse(ValueExpression expression)
             => expression switch
@@ -54,5 +58,12 @@ namespace Azure.Generator.Visitors
                (type.FrameworkType == typeof(Task<>) || type.FrameworkType == typeof(ValueTask<>))
                 ? type.Arguments[0]
                 : type;
+
+        private sealed class AsyncStreamingClientResultProvider : TypeProvider
+        {
+            protected override string BuildName() => "AsyncStreamingClientResult";
+            protected override string BuildNamespace() => "System.ClientModel";
+            protected override string BuildRelativeFilePath() => throw new System.InvalidOperationException("This type should not be written.");
+        }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/StreamingResponseVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/StreamingResponseVisitorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Generator.Tests.TestHelpers;
@@ -45,6 +46,33 @@ namespace Azure.Generator.Tests.Visitors
             new TestStreamingResponseVisitor().Visit(expression, CreateMethod(typeof(BinaryData)));
 
             Assert.AreSame(response, expression.Arguments[0]);
+        }
+
+        [Test]
+        public void DoesNotWrapAzureResponseForProviderBackedGenericReturnType()
+        {
+            MockHelpers.LoadMockGenerator();
+            var response = new VariableExpression(typeof(Response), "response");
+            var expression = CreateInvocation("CreateResponse", typeof(BinaryData), response);
+
+            new TestStreamingResponseVisitor().Visit(expression, CreateMethod(new GenericTypeProvider("GenericType", "Sample").Type));
+
+            Assert.AreSame(response, expression.Arguments[0]);
+        }
+
+        [Test]
+        public void WrapsAzureResponseForProviderBackedStreamingReturnType()
+        {
+            MockHelpers.LoadMockGenerator();
+            var response = new VariableExpression(typeof(Response), "response");
+            var expression = CreateInvocation("CreateResponse", typeof(BinaryData), response);
+            var returnType = new GenericTypeProvider("AsyncStreamingClientResult", "System.ClientModel").Type;
+
+            new TestStreamingResponseVisitor().Visit(expression, CreateMethod(returnType));
+
+            var wrappedResponse = (expression.Arguments[0] as ScopedApi)?.Original as NewInstanceExpression;
+            Assert.IsNotNull(wrappedResponse);
+            Assert.AreSame(response, wrappedResponse!.Parameters[0]);
         }
 
         [Test]
@@ -103,6 +131,23 @@ namespace Azure.Generator.Tests.Visitors
                 : base(signature, new Mock<TypeProvider>().Object, null)
             {
             }
+        }
+
+        private class GenericTypeProvider : TypeProvider
+        {
+            private readonly string _name;
+            private readonly string _namespace;
+
+            public GenericTypeProvider(string name, string @namespace)
+            {
+                _name = name;
+                _namespace = @namespace;
+            }
+
+            protected override string BuildName() => _name;
+            protected override string BuildNamespace() => _namespace;
+            protected override string BuildRelativeFilePath() => Path.Combine("src", $"{Name}.cs");
+            protected override CSharpType[] GetTypeArguments() => [typeof(BinaryData)];
         }
     }
 }


### PR DESCRIPTION
## Summary

- identify `AsyncStreamingClientResult<T>` through provider-backed type metadata instead of reflection
- avoid calling `GetGenericTypeDefinition` for generic `CSharpType` instances backed by a `TypeProvider`
- cover both unrelated provider generics and provider-backed streaming results

## Validation

- `dotnet test eng/packages/http-client-csharp/generator/Azure.Generator/test/Azure.Generator.Tests.csproj --filter \"FullyQualifiedName~StreamingResponseVisitorTests\"`
- regenerated `Azure.Search.Documents` with the local TypeSpec generator through `RegenPreview.ps1`

Companion fix for microsoft/typespec#11605.

&#45; by copilot