### PR TITLE
Fix misspelled IsAnalzyer MSBuild property

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -24,7 +24,7 @@
     <IncludeAutorestDependency Condition="'$(IncludeAutorestDependency)' != 'true' or '$(IsClientLibrary)' != 'true'">false</IncludeAutorestDependency>
     <IsFunctionsLibrary Condition="'$(IsFunctionsLibrary)' == '' and $(MSBuildProjectName.StartsWith('Microsoft.Azure.WebJobs.Extensions.'))">true</IsFunctionsLibrary>
     <IsSourceGenerator Condition="'$(IsSourceGenerator)' == '' and $(MSBuildProjectName.EndsWith('.SourceGeneration'))">true</IsSourceGenerator>
-    <IsAnalzyer Condition="'$(IsAnalzyer)' == '' and $(MSBuildProjectName.EndsWith('Analyzers'))">true</IsAnalzyer>
+    <IsAnalyzer Condition="'$(IsAnalyzer)' == '' and $(MSBuildProjectName.EndsWith('Analyzers'))">true</IsAnalyzer>
 
     <IsTestProject Condition="'$(IsTestProject)' == '' and $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
     <IsSamplesProject Condition="'$(IsSamplesProject)' == '' and $(MSBuildProjectName.EndsWith('.Samples'))">true</IsSamplesProject>
@@ -32,7 +32,7 @@
     <IsStressProject Condition="'$(IsStressProject)' == '' and $(MSBuildProjectName.EndsWith('.Stress'))">true</IsStressProject>
     <IsTestSupportProject Condition="'$(IsTestSupportProject)' == '' and '$(IsTestProject)' != 'true' and ($(MSBuildProjectDirectory.Contains('/tests/')) or $(MSBuildProjectDirectory.Contains('\tests\')))">true</IsTestSupportProject>
     <IsShippingLibrary Condition="'$(IsShippingLibrary)' == '' and '$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true' and '$(IsPerfProject)' != 'true' and '$(IsSamplesProject)' != 'true' and '$(IsStressProject)' != 'true'">true</IsShippingLibrary>
-    <IsShippingClientLibrary Condition="'$(IsClientLibrary)' == 'true' and '$(IsShippingLibrary)' == 'true' and '$(IsSourceGenerator)' != 'true' and '$(IsAnalzyer)' != 'true'">true</IsShippingClientLibrary>
+    <IsShippingClientLibrary Condition="'$(IsClientLibrary)' == 'true' and '$(IsShippingLibrary)' == 'true' and '$(IsSourceGenerator)' != 'true' and '$(IsAnalyzer)' != 'true'">true</IsShippingClientLibrary>
     <TestFrameworkSupportFiles>$(MSBuildThisFileDirectory)/../sdk/core/Azure.Core.TestFramework/src/Shared/*.cs</TestFrameworkSupportFiles>
 
     <IncludeOperationsSharedSource Condition="'$(IncludeOperationsSharedSource)' == '' and ('$(IsMgmtLibrary)' == 'true' or '$(IsGeneratorLibraryGenerationTest)' == 'true') and '$(IsTestProject)' != 'true' and '$(IsPerfProject)' != 'true'">true</IncludeOperationsSharedSource>
@@ -230,7 +230,7 @@
     <RequiredTargetFrameworks Condition="'$(SupportsNetStandard20)' == 'true'">$(RequiredRunnableTargetFrameworks);netstandard2.0</RequiredTargetFrameworks>
 
     <!-- Source generators, such as System.ClientModel.SourceGeneration, must only target netstandard2.0 -->
-    <RequiredTargetFrameworks Condition="'$(IsSourceGenerator)' == 'true' or '$(IsAnalzyer)' == 'true'">netstandard2.0</RequiredTargetFrameworks>
+    <RequiredTargetFrameworks Condition="'$(IsSourceGenerator)' == 'true' or '$(IsAnalyzer)' == 'true'">netstandard2.0</RequiredTargetFrameworks>
 
     <!-- Libraries that are part of our code generator only support the current LTS framework -->
     <RequiredTargetFrameworks Condition="'$(IsGeneratorLibrary)' == 'true'">$(LtsTargetFramework)</RequiredTargetFrameworks>
@@ -270,7 +270,7 @@
   </ItemGroup>
 
   <!-- SourceGeneration common settings -->
-  <PropertyGroup Condition="'$(IsSourceGenerator)' == 'true' or '$(IsAnalzyer)' == 'true'">
+  <PropertyGroup Condition="'$(IsSourceGenerator)' == 'true' or '$(IsAnalyzer)' == 'true'">
     <OutputItemType>Analyzer</OutputItemType>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>

--- a/sdk/tools/Azure.SdkAnalyzers.CodeFixes/Directory.Build.props
+++ b/sdk/tools/Azure.SdkAnalyzers.CodeFixes/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <IsAnalzyer>true</IsAnalzyer>
+    <IsAnalyzer>true</IsAnalyzer>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 </Project>


### PR DESCRIPTION
Renames the MSBuild property `IsAnalzyer` to the correctly-spelled `IsAnalyzer`.

## This is a latent trap, not a live bug

The build is **correct today**. The misspelling is used consistently at every
occurrence — the definition, every condition that reads it, and the one project that
sets it explicitly — so it currently resolves the way it was meant to.

The problem is what happens to the next person. Because MSBuild silently evaluates an
undefined property to the empty string, anyone who reasonably writes the correctly-spelled
`IsAnalyzer` gets **no error and no warning** — the property is simply ignored, and their
analyzer project quietly picks up the wrong target frameworks instead of `netstandard2.0`.

That trap is not hypothetical. `Azure.SdkAnalyzers.CodeFixes` does not end in `Analyzers`,
so it cannot rely on the name-based auto-derivation and has to set the property explicitly.
Whoever added it had to first discover the typo and then deliberately copy it.

## Changes

All five occurrences renamed in a single commit — a partial rename would break analyzer
target-framework selection silently:

| File | What it does |
| --- | --- |
| `eng/Directory.Build.Common.props:27` | Definition, auto-derived from a project name ending in `Analyzers` |
| `eng/Directory.Build.Common.props:35` | The `IsShippingClientLibrary` condition |
| `eng/Directory.Build.Common.props:233` | Sets `RequiredTargetFrameworks` to `netstandard2.0` |
| `eng/Directory.Build.Common.props:273` | `PropertyGroup` condition applying analyzer settings |
| `sdk/tools/Azure.SdkAnalyzers.CodeFixes/Directory.Build.props:3` | The one explicit consumer |

A repo-wide case-insensitive search confirms **zero** remaining occurrences of the
misspelling, and `IsAnalyzer` had **zero** pre-existing occurrences before this change, so
every hit for the new spelling comes from this PR.

No backward-compatibility alias was added. A GitHub-wide code search for the misspelling
found no consumer outside this repository — the only other hits are unrelated C# identifiers
in unrelated projects, plus this repo’s own `azure-sdk-for-net-pr` mirror.

## Validation

This property controls target-framework selection, so the bar is that target frameworks are
byte-for-byte unchanged. Evaluated before and after the rename:

| Project | Before | After |
| --- | --- | --- |
| `Azure.SdkAnalyzers.CodeFixes` (explicit consumer) | `netstandard2.0` | `netstandard2.0` |
| `Azure.SdkAnalyzers` (name-based auto-derivation) | `netstandard2.0` | `netstandard2.0` |
| `Azure.SdkAnalyzers.CodeFixes.Tests` | `net10.0;net8.0;net9.0;net462` | `net10.0;net8.0;net9.0;net462` |

Both the definition path and the auto-derivation path are covered. `IsShippingClientLibrary`
is also unchanged for the analyzer projects.

Additionally:

- Evaluating the old `IsAnalzyer` name now returns empty, confirming nothing still reads it.
- `Azure.SdkAnalyzers`, `Azure.SdkAnalyzers.CodeFixes` and the test project all build clean
  (0 warnings, 0 errors), and the output paths land in the expected target-framework folders.

---
🤖 m-nash-copilot