### PR TITLE
[Event Hubs] Respect retry policy delay when receiving events

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -16,6 +16,8 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Fixed a bug where `EventHubBufferedProducerClient` could get stuck during `FlushAsync` or `CloseAsync` until `MaximumWaitTime` elapsed.
 
+- Fixed a bug where consumer retries waited for the maximum event wait time instead of the configured retry delay.
+
 ### Other Changes
 
 ## 5.12.2 (2025-06-12)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -358,7 +358,8 @@ namespace Azure.Messaging.EventHubs.Amqp
                         if ((retryDelay.HasValue) && (!ConnectionScope.IsDisposed) && (!_closed) && (!cancellationToken.IsCancellationRequested))
                         {
                             EventHubsEventSource.Log.EventReceiveError(EventHubName, ConsumerGroup, PartitionId, operationId, activeEx.Message);
-                            await Task.Delay(waitTime.CalculateRemaining(stopWatch.GetElapsedTime()), cancellationToken).ConfigureAwait(false);
+                            var remainingWaitTime = waitTime.CalculateRemaining(stopWatch.GetElapsedTime());
+                            await Task.Delay((retryDelay.Value < remainingWaitTime) ? retryDelay.Value : remainingWaitTime, cancellationToken).ConfigureAwait(false);
 
                             tryTimeout = RetryPolicy.CalculateTryTimeout(failedAttemptCount);
                         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -267,6 +267,62 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies that retries made by <see cref="AmqpConsumer.ReceiveAsync" />
+        ///   honor the retry policy delay rather than the maximum event wait time.
+        /// </summary>
+        ///
+        [TestCase(10, 30_000)]
+        [TestCase(30_000, 10)]
+        public void ReceiveAsyncUsesTheShorterRetryOrRemainingWaitDelay(int retryDelayMilliseconds,
+                                                                        int maximumWaitTimeMilliseconds)
+        {
+            var retryDelay = TimeSpan.FromMilliseconds(retryDelayMilliseconds);
+            var maximumWaitTime = TimeSpan.FromMilliseconds(maximumWaitTimeMilliseconds);
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions
+            {
+                MaximumRetries = 1,
+                Delay = retryDelay,
+                MaximumDelay = retryDelay,
+                Mode = EventHubsRetryMode.Fixed
+            });
+            var retriableException = new EventHubsException(true, "Test");
+            var mockScope = new Mock<AmqpConnectionScope>();
+
+            mockScope
+                .Setup(scope => scope.OpenConsumerLinkAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<uint>(),
+                    It.IsAny<long?>(),
+                    It.IsAny<long?>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(retriableException);
+
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", "test", EventPosition.Earliest, false, true, null, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            using var cancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            Assert.That(async () => await consumer.ReceiveAsync(100, maximumWaitTime, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
+            mockScope.Verify(scope => scope.OpenConsumerLinkAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<EventPosition>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<uint>(),
+                It.IsAny<long?>(),
+                It.IsAny<long?>(),
+                It.IsAny<bool>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="AmqpConsumer.ReceiveAsync" />
         ///   method.
         /// </summary>


### PR DESCRIPTION
Disclaimer: We observed this bug in production. It manifests as sudden 60 seconds delays in event hub processing.
This PR was generated by AI.

## Description

Fixes `AmqpConsumer.ReceiveAsync` to honor the configured retry policy delay after a transient receive failure.

The method currently calculates `retryDelay` but ignores its value, instead delaying for the entire remaining `MaximumWaitTime`. With default settings, a brief transient failure can therefore pause a partition consumer for nearly 60 seconds while events accumulate.

This restores the previous behavior by waiting for the smaller of:

- The retry policy delay.
- The remaining receive wait time.

The AMQP link creation timeout continues to use the configured `TryTimeout`; this change does not restore the former 30-second link creation cap.

## Regression

Introduced in [#35641: Remove AMQP creation timeout cap](https://github.com/Azure/azure-sdk-for-net/pull/35641), where the receive retry delay was unintentionally changed from `min(retryDelay, remainingWaitTime)` to `remainingWaitTime`.

## Testing

- Added deterministic coverage for both boundaries: retry delay shorter than remaining wait, and remaining wait shorter than retry delay.
- `AmqpConsumerTests`: 39 passed.
- Full non-live Event Hubs test suite on .NET 8: 1,691 passed.

## Additional Changes

- Added an unreleased changelog entry describing the corrected receive retry behavior.