### PR TITLE
Set provisioning package release dates

### DIFF
--- a/sdk/compute/Azure.Provisioning.Compute/CHANGELOG.md
+++ b/sdk/compute/Azure.Provisioning.Compute/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2026-08-11)
 
 ### Features Added
 

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/CHANGELOG.md
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0-beta.2 (Unreleased)
+## 1.2.0-beta.2 (2026-08-11)
 
 ### Other Changes
 


### PR DESCRIPTION
Updates the release dates to 2026-08-11 for:

- Azure.Provisioning.Compute 1.0.0-beta.2
- Azure.Provisioning.OperationalInsights 1.2.0-beta.2

The affected changelog entries do not contain empty sections.