### PR TITLE
Fix function call output lifecycle statuses

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/ResponseEventStream.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/ResponseEventStream.cs
@@ -599,7 +599,7 @@ public class ResponseEventStream
     {
         var itemId = IdGenerator.NewFunctionCallOutputItemId(_context.ResponseId);
         var builder = AddOutputItem<OutputItemFunctionToolCallOutput>(itemId);
-        var item = new OutputItemFunctionToolCallOutput(
+        var addedItem = new OutputItemFunctionToolCallOutput(
             OutputItemType.FunctionCallOutput,
             createdBy: null,
             agentReference: null,
@@ -608,9 +608,20 @@ public class ResponseEventStream
             id: itemId,
             callId: callId,
             output: output,
-            status: null);
-        yield return builder.EmitAdded(item);
-        yield return builder.EmitDone(item);
+            status: OutputItemFunctionToolCallOutputStatus.InProgress);
+        yield return builder.EmitAdded(addedItem);
+
+        var doneItem = new OutputItemFunctionToolCallOutput(
+            OutputItemType.FunctionCallOutput,
+            createdBy: null,
+            agentReference: null,
+            responseId: null,
+            additionalBinaryDataProperties: null,
+            id: itemId,
+            callId: callId,
+            output: output,
+            status: OutputItemFunctionToolCallOutputStatus.Completed);
+        yield return builder.EmitDone(doneItem);
     }
 
     /// <summary>

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/ConvenienceGeneratorTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/ConvenienceGeneratorTests.cs
@@ -399,6 +399,24 @@ public class ConvenienceGeneratorTests
         Assert.That(fco.Output.ToString(), Is.EqualTo("\"72 degrees\""));
     }
 
+    [Test]
+    public void OutputItemFunctionCallOutput_EmitsLifecycleStatuses()
+    {
+        var stream = CreateStream();
+
+        var events = stream.OutputItemFunctionCallOutput(
+            "call_1",
+            BinaryData.FromString("\"72 degrees\"")).ToList();
+
+        var added = XAssert.IsType<ResponseOutputItemAddedEvent>(events[0]);
+        var addedOutput = XAssert.IsType<OutputItemFunctionToolCallOutput>(added.Item);
+        Assert.That(addedOutput.Status, Is.EqualTo(OutputItemFunctionToolCallOutputStatus.InProgress));
+
+        var done = XAssert.IsType<ResponseOutputItemDoneEvent>(events[1]);
+        var doneOutput = XAssert.IsType<OutputItemFunctionToolCallOutput>(done.Item);
+        Assert.That(doneOutput.Status, Is.EqualTo(OutputItemFunctionToolCallOutputStatus.Completed));
+    }
+
     // ──────────────────────────────────────────────────────────
     //  S-056: Output-Item Convenience – ReasoningItem
     // ──────────────────────────────────────────────────────────

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SseEventContractTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SseEventContractTests.cs
@@ -96,6 +96,24 @@ public class SseEventContractTests : ProtocolTestBase
         Assert.That(doc.RootElement.GetProperty("sequence_number").GetInt64(), Is.EqualTo(0));
     }
 
+    [Test]
+    public async Task SSE_Stream_FunctionCallOutput_IncludesLifecycleStatuses()
+    {
+        Handler.EventFactory = (req, ctx, ct) => FunctionCallOutputLifecycleStream(ctx, ct);
+
+        var response = await PostResponsesAsync(new { model = "test", stream = true });
+
+        var events = await ParseSseAsync(response);
+        var added = events.Single(e => e.EventType == "response.output_item.added");
+        var done = events.Single(e => e.EventType == "response.output_item.done");
+
+        using var addedDocument = JsonDocument.Parse(added.Data);
+        Assert.That(addedDocument.RootElement.GetProperty("item").GetProperty("status").GetString(), Is.EqualTo("in_progress"));
+
+        using var doneDocument = JsonDocument.Parse(done.Data);
+        Assert.That(doneDocument.RootElement.GetProperty("item").GetProperty("status").GetString(), Is.EqualTo("completed"));
+    }
+
     // ── Helper event factories ─────────────────────────────────
 
     private static async IAsyncEnumerable<ResponseStreamEvent> FullLifecycleStream(
@@ -105,6 +123,22 @@ public class SseEventContractTests : ProtocolTestBase
         var stream = new ResponseEventStream(ctx, new CreateResponse { Model = "test" });
         yield return stream.EmitCreated();
         yield return stream.EmitInProgress();
+        yield return stream.EmitCompleted();
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ResponseStreamEvent> FunctionCallOutputLifecycleStream(
+        ResponseContext ctx,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var stream = new ResponseEventStream(ctx, new CreateResponse { Model = "test" });
+        yield return stream.EmitCreated();
+        yield return stream.EmitInProgress();
+        foreach (var evt in stream.OutputItemFunctionCallOutput("call_1", BinaryData.FromString("\"result\"")))
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return evt;
+        }
         yield return stream.EmitCompleted();
         await Task.CompletedTask;
     }


### PR DESCRIPTION
Fixes #61917.

`OutputItemFunctionCallOutput` now emits distinct lifecycle items: `in_progress` for `response.output_item.added` and `completed` for `response.output_item.done`. This brings the serialized SSE payload in line with the documented `OutputItemFunctionToolCallOutput.Status` contract.

The change includes builder-level coverage and a full HTTP/SSE protocol test.