### PR TITLE
Update commit hash after client.tsp merge to main

### DIFF
--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tsp-location.yaml
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/orbital/Microsoft.PlanetaryComputer
-commit: 6496ae99ecd3deaa26b12d98d9a949b436dc62e4
+commit: 162c2fda74d6187784e71735f293b65973b9cbc4
 repo: Azure/azure-rest-api-specs
 additionalDirectories:
 


### PR DESCRIPTION
Following the merge of the client.tsp on this [PR](https://github.com/Azure/azure-rest-api-specs/pull/44456), we have updated the commit hash to prepare for the release