### PR TITLE
Remove library inventory from Analyze check

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -78,16 +78,6 @@ steps:
     displayName: Verify MCP config (.mcp.json vs .vscode/mcp.json) are in sync
 
   - pwsh: |
-      ./doc/GeneratorMigration/Library_Inventory.ps1
-      git diff --exit-code -- doc/GeneratorMigration/Library_Inventory.md
-      if ($LASTEXITCODE -ne 0) {
-        Write-Error "Library_Inventory.md is out of date. Run 'pwsh doc/GeneratorMigration/Library_Inventory.ps1' and commit the result."
-        exit 1
-      }
-    displayName: Verify library inventory
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-
-  - pwsh: |
       $failed = $false
       if ('$(ProjectNames)' -and '$(ProjectNames)' -notlike '$(*') {
         $serviceDirectories = "$(ChangedServices)" -split ","


### PR DESCRIPTION
## Summary
- remove the Library Inventory regeneration and diff check from the Analyze pipeline
- stop unrelated pull requests from conflicting over the generated inventory markdown
- track migration of the inventory to an internal Excel spreadsheet in #61951

## Motivation
`Library_Inventory.md` changes frequently as libraries and generator configurations evolve. Enforcing regeneration in Analyze causes unrelated pull requests to update the same generated file, resulting in recurring merge conflicts.

Related to #61951