### PR TITLE
Retry restore when a package is not on the feed yet

### DIFF
--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -31,6 +31,7 @@ Set-StrictMode -Version 1
 
 . (Join-Path $PSScriptRoot\..\common\scripts common.ps1)
 . (Join-Path $PSScriptRoot CodeChecks.Helpers.ps1)
+. (Join-Path $PSScriptRoot RestoreRetry.Helpers.ps1)
 
 [string[]] $errors = @()
 
@@ -149,7 +150,9 @@ try {
 
             Write-Host "Re-generating clients"
             Invoke-Block {
-                & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory $diagnosticArguments /p:ProjectListOverrideFile="$scopedOverrideFile"
+                Invoke-WithRestoreRetry {
+                    & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory $diagnosticArguments /p:ProjectListOverrideFile="$scopedOverrideFile"
+                }
             }
         }
     }

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -20,6 +20,7 @@ if ($SpellCheckPublicApiSurface -and -not (Get-Command 'npx')) {
 }
 
 . $PSScriptRoot/../common/scripts/Helpers/CommandInvocation-Helpers.ps1
+. $PSScriptRoot/RestoreRetry.Helpers.ps1
 
 $relativePackagePath = $ServiceDirectory
 $apiListingFilesFilter = "$PSScriptRoot/../../sdk/$ServiceDirectory/*/api/*.cs"
@@ -42,7 +43,7 @@ if ($ProjectListOverrideFile) {
     $projectListOverrideArgument = "/p:ProjectListOverrideFile=`"$ProjectListOverrideFile`""
 }
 
-Invoke-LoggedMsbuildCommand "dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope=`"$relativePackagePath`" /p:SDKType=$SDKType $projectListOverrideArgument /restore $servicesProj $diagnosticArguments"
+Invoke-WithRestoreRetry -MsBuildLogging -ExitOnFailure -Command "dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope=`"$relativePackagePath`" /p:SDKType=$SDKType $projectListOverrideArgument /restore $servicesProj $diagnosticArguments"
 
 # Normalize line endings to LF in generated API listing files
 Write-Host "Normalizing line endings in API listing files"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -9,6 +9,7 @@ $PackageRepositoryUri = "https://www.nuget.org/packages"
 
 . "$PSScriptRoot/docs/Docs-ToC.ps1"
 . "$PSScriptRoot/ProjectScopedEngFiles.ps1"
+. "$PSScriptRoot/RestoreRetry.Helpers.ps1"
 function Get-AllPackageInfoFromRepo($serviceDirectory)
 {
   $allPackageProps = @()
@@ -565,7 +566,7 @@ function Update-dotnet-GeneratedSdks([string]$PackageDirectoriesFile) {
     $showSummary = ($env:SYSTEM_DEBUG -eq 'true') -or ($VerbosePreference -ne 'SilentlyContinue')
     $summaryArgs = $showSummary ? "/v:n /ds" : ""
 
-    Invoke-LoggedCommand "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
+    Invoke-WithRestoreRetry -ExitOnFailure -Command "dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$(Resolve-Path $projectListOverrideFile -Relative) $summaryArgs eng\service.proj"
   }
   finally {
     Pop-Location

--- a/eng/scripts/RestoreRetry.Helpers.ps1
+++ b/eng/scripts/RestoreRetry.Helpers.ps1
@@ -24,6 +24,12 @@ breaks are not delayed.
 # builds that treat warnings as errors, and it has the same cause.
 $TransientRestoreErrorPattern = '\bNU(1101|1102|1103|1301|1603)\b'
 
+function Clear-NuGetHttpCache {
+    # NuGet caches the "not found" response, so without clearing it a retry would replay the cached
+    # miss instead of asking the feed again.
+    dotnet nuget locals http-cache --clear | Out-Null
+}
+
 function Invoke-WithRestoreRetry {
     <#
     .PARAMETER Command
@@ -100,9 +106,7 @@ function Invoke-WithRestoreRetry {
 
         Write-Host "Restore failed because a package is not on the feed yet. This is usually our feed still mirroring a version that a newly released .NET SDK asked for."
 
-        # NuGet caches the "not found" response, so without clearing it a retry would replay the
-        # cached miss instead of asking the feed again.
-        dotnet nuget locals http-cache --clear | Out-Null
+        Clear-NuGetHttpCache
 
         $delay = $RetryDelaySeconds * $attempt
         Write-Host "Retrying in $delay seconds (attempt $($attempt + 1) of $MaxAttempts)."

--- a/eng/scripts/RestoreRetry.Helpers.ps1
+++ b/eng/scripts/RestoreRetry.Helpers.ps1
@@ -1,0 +1,111 @@
+<#
+.SYNOPSIS
+Helpers for retrying commands that fail because a package is not on our NuGet feed yet.
+
+.DESCRIPTION
+The .NET SDK references a number of packages implicitly, at versions baked into whichever SDK the
+build resolved: the trimming and native AOT tool packs (Microsoft.NET.ILLink.Tasks,
+Microsoft.DotNet.ILCompiler) plus the targeting, runtime and host packs. Every new SDK patch brings
+brand new versions of those packages, and global.json rolls forward, so CI picks them up as soon as
+they ship.
+
+Our feed mirrors nuget.org automatically, but the mirroring is not instantaneous. The first build to
+ask for a just-released version can outrun it and fail restore with NU1101/NU1102/NU1103 even though
+nothing is wrong with the repo. Waiting briefly and asking again resolves it.
+
+Only that specific class of failure is retried. Anything else fails on the first attempt so that real
+breaks are not delayed.
+#>
+
+. $PSScriptRoot/../common/scripts/logging.ps1
+
+# NuGet codes meaning "the requested package or version is not on the feed", plus NU1301 for a feed
+# that could not be reached at all. NU1603 is a warning by default but is escalated to an error in
+# builds that treat warnings as errors, and it has the same cause.
+$TransientRestoreErrorPattern = '\bNU(1101|1102|1103|1301|1603)\b'
+
+function Invoke-WithRestoreRetry {
+    <#
+    .PARAMETER Command
+    Command line to run through Invoke-Expression, matching how Invoke-LoggedCommand is called.
+
+    .PARAMETER ScriptBlock
+    Script block to run, for callers that already handle a non-zero $LASTEXITCODE themselves.
+
+    .PARAMETER MsBuildLogging
+    Surface msbuild error and warning lines as pipeline issues, the way Invoke-LoggedMsbuildCommand
+    does. Transient restore errors are left undecorated while retries remain, so that an attempt we
+    are about to discard does not register an error against the build.
+
+    .PARAMETER ExitOnFailure
+    Log the failure and exit, matching Invoke-LoggedCommand. Omit this when the caller inspects
+    $LASTEXITCODE itself.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Command', Position = 0)]
+        [string] $Command,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ScriptBlock', Position = 0)]
+        [scriptblock] $ScriptBlock,
+
+        [switch] $MsBuildLogging,
+        [switch] $ExitOnFailure,
+        [int] $MaxAttempts = 3,
+        [int] $RetryDelaySeconds = 30
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        $output = [System.Collections.Generic.List[string]]::new()
+        $suppressTransientIssues = $attempt -lt $MaxAttempts
+        $startTime = Get-Date
+
+        if ($PSCmdlet.ParameterSetName -eq 'Command') {
+            Write-Host "> $Command"
+            $invocation = { Invoke-Expression $Command }
+        }
+        else {
+            $invocation = $ScriptBlock
+        }
+
+        & $invocation 2>&1 | ForEach-Object {
+            $line = "$_"
+            $output.Add($line)
+
+            if ($MsBuildLogging -and -not ($suppressTransientIssues -and $line -match $TransientRestoreErrorPattern)) {
+                ProcessMsBuildLogLine $line
+            }
+            else {
+                $line
+            }
+        }
+
+        $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+        $duration = (Get-Date) - $startTime
+
+        if ($exitCode -eq 0) {
+            if ($PSCmdlet.ParameterSetName -eq 'Command') {
+                Write-Host "Command succeeded ($duration)`n"
+            }
+            return
+        }
+
+        if (-not $suppressTransientIssues -or -not ($output -match $TransientRestoreErrorPattern)) {
+            if ($ExitOnFailure) {
+                LogError "Command failed to execute ($duration) after $attempt attempt(s).`n"
+                exit $exitCode
+            }
+            return
+        }
+
+        Write-Host "Restore failed because a package is not on the feed yet. This is usually our feed still mirroring a version that a newly released .NET SDK asked for."
+
+        # NuGet caches the "not found" response, so without clearing it a retry would replay the
+        # cached miss instead of asking the feed again.
+        dotnet nuget locals http-cache --clear | Out-Null
+
+        $delay = $RetryDelaySeconds * $attempt
+        Write-Host "Retrying in $delay seconds (attempt $($attempt + 1) of $MaxAttempts)."
+        Start-Sleep -Seconds $delay
+    }
+}

--- a/eng/scripts/compatibility/Check-AOT-Compatibility.ps1
+++ b/eng/scripts/compatibility/Check-AOT-Compatibility.ps1
@@ -13,6 +13,8 @@ param(
   [string]$DirectoryName
 )
 
+. "$PSScriptRoot/../RestoreRetry.Helpers.ps1"
+
 # Convert ServiceDirectory + PackageName to PackagePath if needed
 if ($PSCmdlet.ParameterSetName -eq 'ByNameAndDirectory') {
     # Use DirectoryName if provided, otherwise default to PackageName
@@ -105,7 +107,7 @@ $programFileContent | Set-Content -Path $programFile
 Write-Host "Collecting the set of trimming warnings."
 
 dotnet clean aotcompatibility.csproj | Out-Null
-dotnet restore aotcompatibility.csproj | Out-Null
+Invoke-WithRestoreRetry { dotnet restore aotcompatibility.csproj } | Out-Null
 $publishOutput = dotnet publish aotcompatibility.csproj -nodeReuse:false /p:UseSharedCompilation=false /p:ExposeExperimentalFeatures=true
 
 if ($LASTEXITCODE -ne 0)

--- a/eng/scripts/tests/RestoreRetry.Tests.ps1
+++ b/eng/scripts/tests/RestoreRetry.Tests.ps1
@@ -19,13 +19,6 @@ Install-ModuleIfNotInstalled "Pester" "5.3.3" | Import-Module
 BeforeAll {
     . "$PSScriptRoot/../RestoreRetry.Helpers.ps1"
 
-    # Shadow dotnet so clearing the http cache does not touch the real one, and so the tests can
-    # assert that it happens.
-    $script:dotnetArgs = [System.Collections.Generic.List[string]]::new()
-    function global:dotnet {
-        $script:dotnetArgs.Add($args -join ' ')
-    }
-
     # Stands in for the restore command: prints the given output and fails the first $FailTimes
     # invocations, tracking how many times it ran.
     $script:fakeRestore = Join-Path $TestDrive "fake-restore.ps1"
@@ -67,11 +60,12 @@ exit 0
     $script:compilerError = "C:\r\P.cs(10,5): error CS0103: The name 'x' does not exist in the current context"
 }
 
-AfterAll {
-    Remove-Item function:global:dotnet -ErrorAction SilentlyContinue
-}
-
 Describe "Invoke-WithRestoreRetry" -Tag "UnitTest" {
+
+    BeforeAll {
+        # Keeps the retry path from wiping the real http cache, and lets the tests observe it.
+        Mock Clear-NuGetHttpCache { }
+    }
 
     Context "recognizing a transient restore failure" {
 
@@ -161,21 +155,19 @@ Describe "Invoke-WithRestoreRetry" -Tag "UnitTest" {
     Context "NuGet http cache" {
 
         It "clears the http cache before retrying so the retry does not replay the cached miss" {
-            $script:dotnetArgs.Clear()
             $counter = New-CounterFile
 
             Invoke-FakeRestore -CounterFile $counter -FailTimes 1 -Message $script:transientError | Out-Null
 
-            $script:dotnetArgs | Should -Contain "nuget locals http-cache --clear"
+            Should -Invoke Clear-NuGetHttpCache -Times 1 -Exactly
         }
 
         It "does not clear the http cache when nothing is retried" {
-            $script:dotnetArgs.Clear()
             $counter = New-CounterFile
 
             Invoke-FakeRestore -CounterFile $counter -FailTimes 0 -Message "" | Out-Null
 
-            $script:dotnetArgs.Count | Should -Be 0
+            Should -Invoke Clear-NuGetHttpCache -Times 0 -Exactly
         }
     }
 

--- a/eng/scripts/tests/RestoreRetry.Tests.ps1
+++ b/eng/scripts/tests/RestoreRetry.Tests.ps1
@@ -1,0 +1,248 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Unit tests for Invoke-WithRestoreRetry in RestoreRetry.Helpers.ps1.
+
+.DESCRIPTION
+    Covers which failures are retried, which are allowed to fail immediately, the attempt
+    limit, clearing of the NuGet http cache between attempts, and how transient failures are
+    reported to Azure DevOps while retries remain.
+
+.How-To-Run
+    Run these tests (Pester is installed automatically via PSModule-Helpers):
+        Invoke-Pester -Output Detailed $PSScriptRoot/RestoreRetry.Tests.ps1
+#>
+
+. (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "Helpers" PSModule-Helpers.ps1)
+Install-ModuleIfNotInstalled "Pester" "5.3.3" | Import-Module
+
+BeforeAll {
+    . "$PSScriptRoot/../RestoreRetry.Helpers.ps1"
+
+    # Shadow dotnet so clearing the http cache does not touch the real one, and so the tests can
+    # assert that it happens.
+    $script:dotnetArgs = [System.Collections.Generic.List[string]]::new()
+    function global:dotnet {
+        $script:dotnetArgs.Add($args -join ' ')
+    }
+
+    # Stands in for the restore command: prints the given output and fails the first $FailTimes
+    # invocations, tracking how many times it ran.
+    $script:fakeRestore = Join-Path $TestDrive "fake-restore.ps1"
+    Set-Content -Path $script:fakeRestore -Value @'
+param([string]$CounterFile, [int]$FailTimes, [string]$Message)
+$attempt = 1
+if (Test-Path $CounterFile) { $attempt = [int](Get-Content $CounterFile) + 1 }
+Set-Content -Path $CounterFile -Value $attempt
+Write-Output "  Determining projects to restore..."
+if ($attempt -le $FailTimes) {
+    Write-Output $Message
+    exit 1
+}
+Write-Output "  Restored fake.csproj (in 100 ms)."
+exit 0
+'@
+
+    function New-CounterFile {
+        Join-Path $TestDrive "attempts-$([guid]::NewGuid().ToString('N')).txt"
+    }
+
+    function Get-AttemptCount([string] $counterFile) {
+        if (Test-Path $counterFile) { [int](Get-Content $counterFile) } else { 0 }
+    }
+
+    function Invoke-FakeRestore {
+        param(
+            [string] $CounterFile,
+            [int] $FailTimes,
+            [string] $Message,
+            [switch] $MsBuildLogging
+        )
+
+        $command = "pwsh -NoProfile -File `"$script:fakeRestore`" -CounterFile `"$CounterFile`" -FailTimes $FailTimes -Message `"$Message`""
+        Invoke-WithRestoreRetry -Command $command -RetryDelaySeconds 0 -MsBuildLogging:$MsBuildLogging
+    }
+
+    $script:transientError = "C:\r\p.csproj : error NU1103: Unable to find a stable package Microsoft.NET.ILLink.Tasks with version (>= 10.0.11)"
+    $script:compilerError = "C:\r\P.cs(10,5): error CS0103: The name 'x' does not exist in the current context"
+}
+
+AfterAll {
+    Remove-Item function:global:dotnet -ErrorAction SilentlyContinue
+}
+
+Describe "Invoke-WithRestoreRetry" -Tag "UnitTest" {
+
+    Context "recognizing a transient restore failure" {
+
+        It "detects the pattern in the captured output collection" {
+            # The retry decision tests the whole captured output, not one line at a time, so the
+            # collection type has to work with -match.
+            $output = [System.Collections.Generic.List[string]]::new()
+            $output.Add("  Determining projects to restore...")
+            $output.Add($script:transientError)
+
+            [bool]($output -match $TransientRestoreErrorPattern) | Should -BeTrue
+        }
+
+        It "does not detect the pattern when the output holds an unrelated error" {
+            $output = [System.Collections.Generic.List[string]]::new()
+            $output.Add($script:compilerError)
+
+            [bool]($output -match $TransientRestoreErrorPattern) | Should -BeFalse
+        }
+
+        It "retries <code> and succeeds on the second attempt" -TestCases @(
+            @{ code = "NU1101" }
+            @{ code = "NU1102" }
+            @{ code = "NU1103" }
+            @{ code = "NU1301" }
+            @{ code = "NU1603" }
+        ) {
+            $counter = New-CounterFile
+            $message = "C:\r\p.csproj : error ${code}: Unable to find package Microsoft.NET.ILLink.Tasks"
+
+            Invoke-FakeRestore -CounterFile $counter -FailTimes 1 -Message $message | Out-Null
+
+            Get-AttemptCount $counter | Should -Be 2
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    Context "failures that should not be retried" {
+
+        It "runs a failing compiler error only once" {
+            $counter = New-CounterFile
+
+            Invoke-FakeRestore -CounterFile $counter -FailTimes 1 -Message $script:compilerError | Out-Null
+
+            Get-AttemptCount $counter | Should -Be 1
+        }
+
+        It "leaves the failing exit code for the caller" {
+            $counter = New-CounterFile
+
+            Invoke-FakeRestore -CounterFile $counter -FailTimes 1 -Message $script:compilerError | Out-Null
+
+            $LASTEXITCODE | Should -Be 1
+        }
+    }
+
+    Context "attempt limits" {
+
+        It "runs once when the command succeeds" {
+            $counter = New-CounterFile
+
+            Invoke-FakeRestore -CounterFile $counter -FailTimes 0 -Message "" | Out-Null
+
+            Get-AttemptCount $counter | Should -Be 1
+            $LASTEXITCODE | Should -Be 0
+        }
+
+        It "stops after the maximum number of attempts when the failure persists" {
+            $counter = New-CounterFile
+
+            Invoke-FakeRestore -CounterFile $counter -FailTimes 99 -Message $script:transientError | Out-Null
+
+            Get-AttemptCount $counter | Should -Be 3
+            $LASTEXITCODE | Should -Be 1
+        }
+
+        It "honors an explicit MaxAttempts" {
+            $counter = New-CounterFile
+            $command = "pwsh -NoProfile -File `"$script:fakeRestore`" -CounterFile `"$counter`" -FailTimes 99 -Message `"$script:transientError`""
+
+            Invoke-WithRestoreRetry -Command $command -RetryDelaySeconds 0 -MaxAttempts 2 | Out-Null
+
+            Get-AttemptCount $counter | Should -Be 2
+        }
+    }
+
+    Context "NuGet http cache" {
+
+        It "clears the http cache before retrying so the retry does not replay the cached miss" {
+            $script:dotnetArgs.Clear()
+            $counter = New-CounterFile
+
+            Invoke-FakeRestore -CounterFile $counter -FailTimes 1 -Message $script:transientError | Out-Null
+
+            $script:dotnetArgs | Should -Contain "nuget locals http-cache --clear"
+        }
+
+        It "does not clear the http cache when nothing is retried" {
+            $script:dotnetArgs.Clear()
+            $counter = New-CounterFile
+
+            Invoke-FakeRestore -CounterFile $counter -FailTimes 0 -Message "" | Out-Null
+
+            $script:dotnetArgs.Count | Should -Be 0
+        }
+    }
+
+    Context "ScriptBlock parameter set" {
+
+        It "retries a transient failure" {
+            $counter = New-CounterFile
+            $fake = $script:fakeRestore
+            $message = $script:transientError
+
+            Invoke-WithRestoreRetry -RetryDelaySeconds 0 {
+                pwsh -NoProfile -File $fake -CounterFile $counter -FailTimes 1 -Message $message
+            } | Out-Null
+
+            Get-AttemptCount $counter | Should -Be 2
+            $LASTEXITCODE | Should -Be 0
+        }
+
+        It "leaves a failing exit code for the caller to act on" {
+            $counter = New-CounterFile
+            $fake = $script:fakeRestore
+            $message = $script:compilerError
+
+            Invoke-WithRestoreRetry -RetryDelaySeconds 0 {
+                pwsh -NoProfile -File $fake -CounterFile $counter -FailTimes 1 -Message $message
+            } | Out-Null
+
+            $LASTEXITCODE | Should -Be 1
+        }
+    }
+
+    Context "Azure DevOps issue logging" {
+
+        BeforeAll {
+            $script:originalTeamProjectId = $env:SYSTEM_TEAMPROJECTID
+            $env:SYSTEM_TEAMPROJECTID = "pester"
+        }
+
+        AfterAll {
+            $env:SYSTEM_TEAMPROJECTID = $script:originalTeamProjectId
+        }
+
+        It "does not report a transient failure on an attempt that will be retried" {
+            $counter = New-CounterFile
+
+            $output = Invoke-FakeRestore -CounterFile $counter -FailTimes 1 -Message $script:transientError -MsBuildLogging |
+                Out-String
+
+            $output | Should -Not -Match '##vso.*NU1103'
+        }
+
+        It "reports a transient failure once no retries remain" {
+            $counter = New-CounterFile
+
+            $output = Invoke-FakeRestore -CounterFile $counter -FailTimes 99 -Message $script:transientError -MsBuildLogging |
+                Out-String
+
+            $output | Should -Match '##vso.*NU1103'
+        }
+
+        It "reports an unrelated error on the first attempt" {
+            $counter = New-CounterFile
+
+            $output = Invoke-FakeRestore -CounterFile $counter -FailTimes 1 -Message $script:compilerError -MsBuildLogging |
+                Out-String
+
+            $output | Should -Match '##vso.*CS0103'
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The .NET SDK adds a number of `PackageReference` items implicitly, at versions baked into whichever SDK the build resolved. The trimming and native AOT tool packs are the ones that bite us:

- `Microsoft.NET.ILLink.Tasks` — added whenever a project sets `IsTrimmable` or `IsAotCompatible`
- `Microsoft.DotNet.ILCompiler` — added whenever something publishes with `PublishAot`

The versions come from `KnownILLinkPack` / `KnownILCompilerPack` in the SDK's `Microsoft.NETCoreSdk.BundledVersions.props`, and `ProcessFrameworkReferences` turns them into implicit package references. Because they are implicit, they are exempt from Central Package Management, which is why the versions appear nowhere in this repo.

Our `global.json` uses `rollForward: feature`, so CI resolves the SDK spec to `10.0.x` and installs whatever the newest feature band is. Every new SDK ships brand new ILLink/ILCompiler versions. Our feed mirrors nuget.org automatically, but not instantaneously, so the first build to ask for a just-released version can outrun the mirroring and fail restore:

```
error NU1103: Unable to find a stable package Microsoft.NET.ILLink.Tasks with version (>= 10.0.11)
```

Nothing is wrong with the repo, and the same build passes on a rerun once the mirror catches up. This took out `Verify Generated Code` in [build 6687067](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6687067).

## Approach

I first prototyped pinning both packs through CPM. It works, but it means hand-maintaining three version bands (net8/net9/net10) for two packages, plus pinning `RuntimeFrameworkVersion` in lockstep — native AOT refuses to link when the NativeAOT pack and the runtime pack disagree (`Overriding System.Private.CoreLib.dll with a newer version is not supported`). That is a lot of standing maintenance to work around a delay that resolves itself.

Retrying is the cheaper fix, and we already do exactly this in `eng/scripts/InstallationCheck.ps1`, which loops on `dotnet restore` for the same feed-availability reason.

## Change

New `eng/scripts/RestoreRetry.Helpers.ps1` exposing `Invoke-WithRestoreRetry`:

- Retries **only** on `NU1101`, `NU1102`, `NU1103`, `NU1301` and `NU1603` — "the package or version is not on the feed" and "the feed could not be reached". Anything else fails on the first attempt, so real breaks are not delayed.
- 3 attempts, backing off 30s then 60s.
- Clears the NuGet http cache between attempts. NuGet caches the "not found" response for ~30 minutes, so without this the retry would just replay the cached miss.
- Withholds Azure DevOps `##vso` error decoration for transient lines while retries remain, so an attempt we are about to discard does not register an error against the build. The last attempt is decorated normally.
- Mirrors the `Invoke-LoggedCommand` / `Invoke-LoggedMsbuildCommand` contract (command echo, duration, `-ExitOnFailure`) so call sites read the same. Those live in `eng/common` and are synced from `azure-sdk-tools`, so they could not be changed directly.

Applied to the repo-owned restore call sites:

| File | Call |
| --- | --- |
| `eng/scripts/CodeChecks.ps1` | `service.proj /restore /t:GenerateCode` — the step that failed in the linked build |
| `eng/scripts/Export-API.ps1` | `dotnet build /t:ExportApi ... /restore` |
| `eng/scripts/Language-Settings.ps1` | codegen restore in `Update-dotnet-GeneratedSdks` |
| `eng/scripts/compatibility/Check-AOT-Compatibility.ps1` | the AOT test app restore — the only place that actually pulls ILCompiler |

## Validation

- 14 behavior tests covering: retry on each transient code, fail-fast on a real compiler error, attempt counts, exit code passthrough in both parameter sets, and `##vso` decoration being withheld on discarded attempts but present on the final one.
- `Invoke-Block` interop — a non-zero `$LASTEXITCODE` still propagates and still throws.
- Works under `Set-StrictMode -Version 1` (`CodeChecks.ps1` sets it).
- Real runs: `Export-API.ps1 -ServiceDirectory advisor` and `Check-AOT-Compatibility.ps1` for `Azure.Messaging.EventHubs` both exit 0 with unchanged output.

## Follow-up worth considering

Tightening `global.json` `rollForward` from `feature` to `patch` would stop CI floating onto brand-new SDKs in the first place. That is a separate discussion, since it changes which SDK we validate against.
