### PR TITLE
[AgentServer] Set StateStore release dates

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.28 (Unreleased)
+## 1.0.0-beta.28 (2026-08-12)
 
 ### Features Added
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -14,8 +14,6 @@
   - Resumable event streaming with `AgentEventStreamRegistry` / `AgentEventStream` and `AddAgentEventStreams()`, supporting in-memory live, in-memory replay, and file-backed replay backings via `AgentEventStreamOptions`. The event representation is `System.Net.ServerSentEvents.SseItem<string>`: the caller places the serialized event text in `SseItem<string>.Data` and an opaque `SseItem<string>.EventId` is the resume/reconnect token (`Subscribe(afterEventId)`, `GetLastEventIdAsync()`). Because the data is already a string, there is no payload codec — `SseFormatter` can frame a `Subscribe(...)` stream directly onto an HTTP response.
   - A single `ResilientTaskException` carrying an extensible `ResilientTaskErrorCode` (`HandlerError`, `ExhaustedRetries`, `Conflict`, `PreconditionFailed`, `QueueFull`) with code-specific data exposed as nullable properties (`CurrentStatus`, `ActualLastInputId`, `Failure`). Argument validation surfaces as `ArgumentException` and cancellation as `OperationCanceledException`; recovery deferral (`ExitForRecoveryAsync`) is an internal lifecycle handoff and never surfaces as an exception. The streaming layer keeps its `AgentEventStreamException` hierarchy.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Kept the task lease renewed across retry backoff delays so a long inter-attempt backoff cannot let the lease lapse and allow a concurrent re-invocation of the same task turn.
@@ -28,8 +26,6 @@
 - A turn transition that replaces and disposes a handler's cancellation source concurrently with a cancel/steering signal no longer surfaces `ObjectDisposedException` from the cancel path.
 - `AddResilientTasks` and `AddAgentEventStreams` are now safe against repeated registration: `AddResilientTasks` no longer registers the durability hosted service more than once (and rejects a conflicting second credential), and `AddAgentEventStreams` rejects a second configuring call instead of silently discarding its configuration.
 - Steering inputs that were queued but not yet drained when a process crashed are no longer stranded: on recovery the persisted `pending_inputs` queue is rehydrated into the in-process steering FIFO, so a recovered chain drains them instead of silently dropping them. Each queued input's per-turn `InputId` is persisted alongside it so a recovered turn keeps its own identity and advances the chain head (`last_input_id`) exactly as it would without a crash.
-
-### Other Changes
 
 ## 1.0.0-beta.27 (2026-07-29)
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.6 (Unreleased)
+## 1.0.0-beta.6 (2026-08-12)
 
 ### Features Added
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
@@ -13,10 +13,6 @@
   that OpenAPI cannot express. The path extension is authoritative for the
   returned content type — no `Accept` negotiation and no format conversion.
 
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
 
 - Updated the resilient research and multi-turn samples to use `FoundryStateStore`

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -45,8 +45,6 @@
   in-memory replay, upgraded automatically to durable file-backed replay when resilient
   background is enabled outside a hosted environment.
 
-### Bugs Fixed
-
 ### Other Changes
 - Retired the interim .NET ↔ Python resilience parity reports now that the port has
   converged.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.8 (Unreleased)
+## 1.0.0-beta.8 (2026-08-12)
 
 ### Features Added
 - Resilient responses. Resilient background responses (`ResponsesServerOptions.ResilientBackground`)


### PR DESCRIPTION
## Summary

- set the `Azure.AI.AgentServer.Core` 1.0.0-beta.28 release date to 2026-08-12
- set the `Azure.AI.AgentServer.Invocations` 1.0.0-beta.6 release date to 2026-08-12
- set the `Azure.AI.AgentServer.Responses` 1.0.0-beta.8 release date to 2026-08-12

## Related

- .NET equivalent of Azure/azure-sdk-for-python#48532