### PR TITLE
Pin the CI .NET SDK install to the version in global.json

### DIFF
--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -7,12 +7,28 @@ steps:
   # Need to authenticate so our pipeline can update packages in the feed.
   - task: NuGetAuthenticate@1
 
+  # UseDotNet's useGlobalJson applies the rollForward policy against the set of downloadable
+  # SDKs, so 'feature' installs the newest 10.0.x rather than the version named in global.json.
+  # That drags CI onto same-day SDK releases whose implicit ILLink/ILCompiler packs may not have
+  # reached our NuGet feed yet. Install the exact version instead; rollForward is still honored
+  # when selecting among installed SDKs, so local development is unaffected.
+  - pwsh: |
+      $globalJsonPath = Join-Path '$(Build.SourcesDirectory)' 'global.json'
+      $sdkVersion = (Get-Content $globalJsonPath -Raw | ConvertFrom-Json).sdk.version
+      if (-not $sdkVersion) {
+        Write-Error "Unable to read sdk.version from $globalJsonPath"
+        exit 1
+      }
+      Write-Host "Pinning the .NET SDK install to $sdkVersion (from global.json)"
+      echo "##vso[task.setvariable variable=DotNetSdkVersion]$sdkVersion"
+    displayName: 'Resolve .NET SDK version from global.json'
+
   # Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
   - task: UseDotNet@2
     displayName: 'Use .NET SDK'
     retryCountOnTaskFailure: 3
     inputs:
-      useGlobalJson: true
+      version: $(DotNetSdkVersion)
       performMultiLevelLookup: true
   - task: UseDotNet@2 # We need .NET 9 for the .NET 9 tests
     displayName: 'Use .NET 9.0 SDK'


### PR DESCRIPTION
## Problem

CI installs the .NET SDK with `UseDotNet@2` + `useGlobalJson: true`. That task applies the
`rollForward` policy from `global.json` against the set of *downloadable* SDKs rather than
against SDKs already installed, so `rollForward: feature` resolved to spec `10.0.x` and
installed **10.0.400** instead of the **10.0.103** named in `global.json`.

That matters because of implicit package references. When a library sets `IsTrimmable` or
`IsAotCompatible`, `ProcessFrameworkReferences` injects `PackageReference` items for
`Microsoft.NET.ILLink.Tasks` and `Microsoft.DotNet.ILCompiler`, versioned from
`KnownILLinkPack` / `KnownILCompilerPack` inside the SDK. Those versions appear nowhere in this
repo (implicit references are exempt from Central Package Management), and they change with
every SDK release.

The net effect is that CI silently begins demanding packs that were published to nuget.org only
hours earlier and have not yet propagated to our NuGet feed, producing NU1103/NU1603 restore
failures such as [build 6687067](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6687067&view=logs&j=c3e74943-23a9-5e82-9b42-8286fce989d4&t=b1e97aba-7d35-5e53-38e9-02800872eaf6&l=394).

This is not a one-off. .NET servicing releases ship SDK patches across every live feature band on
the same day, all carrying the same runtime and therefore the same IL pack versions:

| Release date | Runtime / ILLink | SDKs shipped |
|---|---|---|
| 2026-08-11 | 10.0.11 | 10.0.400, 10.0.303, 10.0.111 |
| 2026-07-14 | 10.0.10 | 10.0.302, 10.0.110 |
| 2026-06-09 | 10.0.9  | 10.0.301, 10.0.109 |

So the exposure recurs monthly for whichever SDK CI happens to float onto.

## Fix

Read `sdk.version` out of `global.json` and pass it to `UseDotNet@2` as an exact `version:`.
Reading it from the file rather than hardcoding keeps a single source of truth, so bumping
`global.json` still bumps CI.

## Local development is unaffected

`global.json` is not modified. `rollForward` still governs selection among installed SDKs; it is
only the *download* that is pinned. Verified against real SDK installs:

| global.json | rollForward | Installed | Selected |
|---|---|---|---|
| 10.0.103 | feature | 10.0.103, 10.0.302 | 10.0.103 (exact match wins, no float) |
| 10.0.200 | feature | no 2xx band present | 10.0.302 (reproduces the CI failure mode) |

The first row is the post-pin CI state. The second shows why CI rolled forward previously: with
only a 4xx band installed, `feature` has no in-band candidate and must roll.

## Scope

- Perf pipelines pass this same template as `InstallLanguageSteps`, so they are covered by this
  change automatically.
- The other `useGlobalJson: true` in `eng/common/pipelines/templates/jobs/perf.yml` sets
  `workingDirectory: azure-sdk-tools`, so it reads that repo's `global.json` to build
  PerfAutomation. It is intentionally untouched.

## Note on what this does and does not solve

This does not make the feed propagation issue disappear; it makes it predictable. The set of IL
pack versions CI can demand is now fixed until someone edits `global.json`, so exposure is
confined to that single reviewable PR instead of arriving unannounced on .NET servicing day and
breaking unrelated PRs.