### PR TITLE
[ConfidentialLedger] Run one matrix leg on the nightly live test pipeline

### DIFF
--- a/sdk/confidentialledger/tests.yml
+++ b/sdk/confidentialledger/tests.yml
@@ -4,3 +4,10 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: confidentialledger
+    # Confidential Ledger test resources are expensive to provision: every matrix leg stands
+    # up a dedicated three-replica CCF cluster on confidential (SNP) hardware, which takes
+    # roughly eight minutes. Run one representative leg on the nightly pipeline and keep the
+    # full platform matrix on tests-weekly.
+    ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
+      MatrixFilters:
+        - CollectCoverage=true


### PR DESCRIPTION
### What

Adds a `MatrixFilters` entry to `sdk/confidentialledger/tests.yml` that applies **only to the nightly `tests` pipeline**, reducing it from 11 platform matrix legs to 1. The `tests-weekly` pipeline is unaffected and continues to run the full matrix.

One file, service-directory only. No changes under `eng/`.

### Why

Every matrix leg runs `Deploy test resources`, and `sdk/confidentialledger/test-resources.json` provisions a dedicated Azure Confidential Ledger. That resource is materially heavier than most test resources in this repo: it stands up a three-replica CCF cluster on confidential (SNP) hardware and takes roughly eight minutes to create.

The platform matrix for this service directory expands to 11 legs, so each pipeline run provisions 11 ledgers. Measured from the service side, this service directory created roughly 341 ledgers over the last 30 days.

Azure Confidential Ledger is a small service, and this load lands entirely in one region (`test-resources.json` hardcodes `southcentralus`). A burst of 11 near-simultaneous creates is harder on regional provisioning capacity than a higher but steadier rate would be, and recent bursts have coincided with regional provisioning failures.

### Prior art

`sdk/keyvault/tests.yml` already filters its matrix for the same reason, with the in-repo comment:

> Managed HSM test resources are expensive and provisioning has not been reliable.

The `tests-weekly` gate on `Build.DefinitionName` is the existing convention, used today by both `sdk/storage/tests.yml` and `sdk/keyvault/tests.yml`.

### Coverage impact

- `tests-weekly` is unchanged and still runs all 11 legs, so full platform coverage (Linux / Windows / macOS x net462 / net8.0 / net9.0 / net10.0 x ProjectRef / PackageRef x Debug / Release) is retained weekly.
- The nightly retains `Windows2022_NET100_Coverage_Record_PackageRef`, the leg carrying `CollectCoverage` and `SupportsRecording`, so coverage collection and test-recording regeneration continue to run nightly.
- No test source is modified. Reverting is a one-line change.

### Notes for reviewers

- `CollectCoverage` is set only on the matrix `include` entry, so this single filter line resolves to exactly one leg. `ProcessIncludes` runs before `FilterMatrix` in `job-matrix-functions.ps1`, so the filter does reach the include entry.
- The filter deliberately avoids `Pool` and `OSVmImage`, whose values are still unresolved environment variable references at filter time (`ProcessEnvironmentVariableReferences` runs after `FilterMatrix`).
- Separately, and not addressed by this PR: `net - confidentialledger - tests` and `net - confidentialledger - tests-weekly` have failed on every scheduled run for the past two months (40 of 40 runs since 2026-06-06). `Deploy test resources` succeeds on all 11 legs each time; the failures are in `Build & Test`, and a large share are `Azure.Security.CodeTransparency` tests aborting on a missing `CONFIDENTIALLEDGER_CODETRANSPARENCY_ENDPOINT` / `CODETRANSPARENCY_ENDPOINT` environment variable. This PR does not change that: the leg it retains is itself one of the failing legs, so no failure signal is lost. Glad to file that as a separate issue if it is not already tracked.
