### PR TITLE
Support optional success response bodies in Azure emitter

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Azure.Generator.csproj
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Azure.Generator.csproj
@@ -51,6 +51,7 @@
       $(MSBuildThisFileDirectory)..\..\..\..\..\..\sdk\core\Azure.Core\src\Shared\OperationInternalOfT.cs;
       $(MSBuildThisFileDirectory)..\..\..\..\..\..\sdk\core\Azure.Core\src\Shared\AsyncLockWithValue.cs;
       $(MSBuildThisFileDirectory)..\..\..\..\..\..\sdk\core\Azure.Core\src\Shared\NextLinkOperationImplementation.cs;
+      $(MSBuildThisFileDirectory)..\..\..\..\..\..\sdk\core\Azure.Core\src\Shared\NoValueResponseOfT.cs;
       $(MSBuildThisFileDirectory)..\..\..\..\..\..\sdk\core\Azure.Core\src\Shared\IOperationSource.cs;
       $(MSBuildThisFileDirectory)..\..\..\..\..\..\sdk\core\Azure.Core\src\Shared\TaskExtensions.cs;
       $(MSBuildThisFileDirectory)..\..\..\..\..\..\sdk\core\Azure.Core\src\Shared\OperationPoller.cs;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureClientGenerator.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureClientGenerator.cs
@@ -102,6 +102,7 @@ public class AzureClientGenerator : ScmCodeModelGenerator
         AddVisitor(new SystemTextJsonConverterVisitor());
         AddVisitor(new MultiPartFormDataVisitor());
         AddVisitor(new MultiPartFormDataConvenienceMethodVisitor());
+        AddVisitor(new OptionalResponseBodyVisitor());
         AddVisitor(new StreamingResponseVisitor());
         AddVisitor(new InvokeDelimitedMethodVisitor());
         AddVisitor(new XmlSerializableVisitor());

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
@@ -85,9 +85,14 @@ namespace Azure.Generator.Primitives
             "XmlWriterContent.cs",
         ];
 
-        private static void TraverseInput(InputClient rootClient, ref bool hasOperation, ref bool hasLongRunningOperation, ref bool hasStreamingOperation)
+        private static void TraverseInput(
+            InputClient rootClient,
+            ref bool hasOperation,
+            ref bool hasLongRunningOperation,
+            ref bool hasStreamingOperation,
+            ref bool hasOptionalResponseBody)
         {
-            if (hasOperation && hasLongRunningOperation && hasStreamingOperation)
+            if (hasOperation && hasLongRunningOperation && hasStreamingOperation && hasOptionalResponseBody)
             {
                 return;
             }
@@ -103,10 +108,21 @@ namespace Azure.Generator.Primitives
                 {
                     hasStreamingOperation = true;
                 }
+                var successResponses = method.Operation.Responses.Where(response => !response.IsErrorResponse);
+                if (successResponses.Any(response => response.BodyType is not null)
+                    && successResponses.Any(response => response.BodyType is null))
+                {
+                    hasOptionalResponseBody = true;
+                }
             }
             foreach (var inputClient in rootClient.Children)
             {
-                TraverseInput(inputClient, ref hasOperation, ref hasLongRunningOperation, ref hasStreamingOperation);
+                TraverseInput(
+                    inputClient,
+                    ref hasOperation,
+                    ref hasLongRunningOperation,
+                    ref hasStreamingOperation,
+                    ref hasOptionalResponseBody);
             }
         }
 
@@ -166,9 +182,15 @@ namespace Azure.Generator.Primitives
             bool hasOperation = false;
             bool hasLongRunningOperation = false;
             bool hasStreamingOperation = false;
+            bool hasOptionalResponseBody = false;
             foreach (var client in AzureClientGenerator.Instance.InputLibrary.InputNamespace.Clients)
             {
-                TraverseInput(client, ref hasOperation, ref hasLongRunningOperation, ref hasStreamingOperation);
+                TraverseInput(
+                    client,
+                    ref hasOperation,
+                    ref hasLongRunningOperation,
+                    ref hasStreamingOperation,
+                    ref hasOptionalResponseBody);
             }
 
             // Add operation-related shared files if operations are present
@@ -192,6 +214,11 @@ namespace Azure.Generator.Primitives
             if (hasStreamingOperation)
             {
                 compileIncludes.Add(new CSharpProjectCompileInclude(GetCompileInclude("AzurePipelineResponse.cs"), SharedSourceLinkBase));
+            }
+
+            if (hasOptionalResponseBody)
+            {
+                compileIncludes.Add(new CSharpProjectCompileInclude(GetCompileInclude("NoValueResponseOfT.cs"), SharedSourceLinkBase));
             }
 
             // Add TaskExtensions if there are multipart form data operations and it hasn't already been added for LRO

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs
@@ -109,8 +109,15 @@ namespace Azure.Generator.Primitives
                     hasStreamingOperation = true;
                 }
                 var successResponses = method.Operation.Responses.Where(response => !response.IsErrorResponse);
-                if (successResponses.Any(response => response.BodyType is not null)
-                    && successResponses.Any(response => response.BodyType is null))
+                var bodyStatusCodes = successResponses
+                    .Where(response => response.BodyType is not null)
+                    .SelectMany(response => response.StatusCodes)
+                    .ToHashSet();
+                if (bodyStatusCodes.Count > 0
+                    && successResponses
+                    .Where(response => response.BodyType is null)
+                    .SelectMany(response => response.StatusCodes)
+                    .Any(statusCode => !bodyStatusCodes.Contains(statusCode)))
                 {
                     hasOptionalResponseBody = true;
                 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/OptionalResponseBodyVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/OptionalResponseBodyVisitor.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure;
+using Microsoft.TypeSpec.Generator.ClientModel;
+using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Snippets;
+using Microsoft.TypeSpec.Generator.Statements;
+using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
+
+namespace Azure.Generator.Visitors
+{
+    internal class OptionalResponseBodyVisitor : ScmLibraryVisitor
+    {
+        protected override ScmMethodProvider? VisitMethod(ScmMethodProvider method)
+        {
+            if (method.Kind != ScmMethodKind.Convenience
+                || method.ServiceMethod is null
+                || method.BodyStatements is null
+                || !TryGetOptionalResponse(method, out var responseBodyType, out var noBodyStatusCodes))
+            {
+                return method;
+            }
+
+            var statements = method.BodyStatements.ToList();
+            VariableExpression? result = null;
+            int resultDeclarationIndex = -1;
+            for (int i = 0; i < statements.Count; i++)
+            {
+                if (statements[i] is ExpressionStatement
+                    {
+                        Expression: AssignmentExpression
+                        {
+                            Variable: DeclarationExpression declaration
+                        }
+                    }
+                    && declaration.Variable.Type.Equals(typeof(Response)))
+                {
+                    result = declaration.Variable;
+                    resultDeclarationIndex = i;
+                    break;
+                }
+            }
+
+            if (result is null)
+            {
+                return method;
+            }
+
+            ScopedApi<bool>? noBodyCondition = null;
+            foreach (int statusCode in noBodyStatusCodes)
+            {
+                var statusCondition = result.Property(nameof(Response.Status)).As<int>().Equal(Literal(statusCode));
+                noBodyCondition = noBodyCondition is null
+                    ? statusCondition
+                    : noBodyCondition.Or(statusCondition);
+            }
+
+            if (noBodyCondition is null)
+            {
+                return method;
+            }
+
+            statements.Insert(
+                resultDeclarationIndex + 1,
+                new IfStatement(noBodyCondition)
+                {
+                    Return(New.Instance(
+                        new CSharpType(typeof(NoValueResponse<>), responseBodyType),
+                        result))
+                });
+
+            var nullableResponseType = new CSharpType(typeof(NullableResponse<>), responseBodyType);
+            var returnType = method.Signature.ReturnType is
+                {
+                    IsFrameworkType: true,
+                    FrameworkType: not null,
+                    Arguments.Count: 1
+                } methodReturnType
+                && methodReturnType.FrameworkType == typeof(Task<>)
+                    ? new CSharpType(typeof(Task<>), nullableResponseType)
+                    : nullableResponseType;
+
+            method.Signature.Update(returnType: returnType);
+            method.Update(signature: method.Signature, bodyStatements: statements);
+            return method;
+        }
+
+        private static bool TryGetOptionalResponse(
+            ScmMethodProvider method,
+            out CSharpType responseBodyType,
+            out IReadOnlyList<int> noBodyStatusCodes)
+        {
+            responseBodyType = null!;
+            noBodyStatusCodes = [];
+
+            var successResponses = method.ServiceMethod!.Operation.Responses
+                .Where(response => !response.IsErrorResponse)
+                .ToList();
+            if (!successResponses.Any(response => response.BodyType is not null)
+                || !successResponses.Any(response => response.BodyType is null))
+            {
+                return false;
+            }
+
+            var returnType = method.Signature.ReturnType;
+            if (returnType is
+                {
+                    IsFrameworkType: true,
+                    FrameworkType: not null,
+                    Arguments.Count: 1
+                }
+                && returnType.FrameworkType == typeof(Task<>))
+            {
+                returnType = returnType.Arguments[0];
+            }
+
+            if (returnType is not
+                {
+                    IsFrameworkType: true,
+                    FrameworkType: not null,
+                    Arguments.Count: 1
+                }
+                || returnType.FrameworkType != typeof(Response<>))
+            {
+                return false;
+            }
+
+            responseBodyType = returnType.Arguments[0].WithNullable(false);
+            noBodyStatusCodes =
+            [
+                .. successResponses
+                    .Where(response => response.BodyType is null)
+                    .SelectMany(response => response.StatusCodes)
+                    .Distinct()
+            ];
+            return noBodyStatusCodes.Count > 0;
+        }
+    }
+}

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/OptionalResponseBodyVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/OptionalResponseBodyVisitor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure;
@@ -95,17 +96,44 @@ namespace Azure.Generator.Visitors
 
         private static bool TryGetOptionalResponse(
             ScmMethodProvider method,
-            out CSharpType responseBodyType,
+            [NotNullWhen(true)] out CSharpType? responseBodyType,
             out IReadOnlyList<int> noBodyStatusCodes)
         {
-            responseBodyType = null!;
+            responseBodyType = null;
             noBodyStatusCodes = [];
 
-            var successResponses = method.ServiceMethod!.Operation.Responses
-                .Where(response => !response.IsErrorResponse)
-                .ToList();
-            if (!successResponses.Any(response => response.BodyType is not null)
-                || !successResponses.Any(response => response.BodyType is null))
+            var bodyStatusCodes = new HashSet<int>();
+            var candidateNoBodyStatusCodes = new List<int>();
+            var candidateNoBodyStatusCodeSet = new HashSet<int>();
+            foreach (var response in method.ServiceMethod!.Operation.Responses)
+            {
+                if (response.IsErrorResponse)
+                {
+                    continue;
+                }
+
+                if (response.BodyType is not null)
+                {
+                    bodyStatusCodes.UnionWith(response.StatusCodes);
+                    continue;
+                }
+
+                foreach (int statusCode in response.StatusCodes)
+                {
+                    if (candidateNoBodyStatusCodeSet.Add(statusCode))
+                    {
+                        candidateNoBodyStatusCodes.Add(statusCode);
+                    }
+                }
+            }
+
+            if (bodyStatusCodes.Count == 0 || candidateNoBodyStatusCodes.Count == 0)
+            {
+                return false;
+            }
+
+            candidateNoBodyStatusCodes.RemoveAll(bodyStatusCodes.Contains);
+            if (candidateNoBodyStatusCodes.Count == 0)
             {
                 return false;
             }
@@ -134,19 +162,8 @@ namespace Azure.Generator.Visitors
             }
 
             responseBodyType = returnType.Arguments[0].WithNullable(false);
-            var bodyStatusCodes = successResponses
-                .Where(response => response.BodyType is not null)
-                .SelectMany(response => response.StatusCodes)
-                .ToHashSet();
-            noBodyStatusCodes =
-            [
-                .. successResponses
-                    .Where(response => response.BodyType is null)
-                    .SelectMany(response => response.StatusCodes)
-                    .Where(statusCode => !bodyStatusCodes.Contains(statusCode))
-                    .Distinct()
-            ];
-            return noBodyStatusCodes.Count > 0;
+            noBodyStatusCodes = candidateNoBodyStatusCodes;
+            return true;
         }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/OptionalResponseBodyVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/OptionalResponseBodyVisitor.cs
@@ -134,11 +134,16 @@ namespace Azure.Generator.Visitors
             }
 
             responseBodyType = returnType.Arguments[0].WithNullable(false);
+            var bodyStatusCodes = successResponses
+                .Where(response => response.BodyType is not null)
+                .SelectMany(response => response.StatusCodes)
+                .ToHashSet();
             noBodyStatusCodes =
             [
                 .. successResponses
                     .Where(response => response.BodyType is null)
                     .SelectMany(response => response.StatusCodes)
+                    .Where(statusCode => !bodyStatusCodes.Contains(statusCode))
                     .Distinct()
             ];
             return noBodyStatusCodes.Count > 0;

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/OptionalResponseBodyVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/OptionalResponseBodyVisitorTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using Azure;
+using Azure.Generator.Tests.Common;
+using Azure.Generator.Tests.TestHelpers;
+using Azure.Generator.Visitors;
+using Microsoft.TypeSpec.Generator.ClientModel;
+using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
+using NUnit.Framework;
+
+namespace Azure.Generator.Tests.Visitors
+{
+    public class OptionalResponseBodyVisitorTests
+    {
+        [Test]
+        public void UsesNullableResponseForOptionalResponseBody()
+        {
+            var operation = InputFactory.Operation(
+                "GetLayout",
+                responses:
+                [
+                    InputFactory.OperationResponse([200], InputPrimitiveType.String),
+                    InputFactory.OperationResponse([204])
+                ]);
+            var serviceMethod = InputFactory.BasicServiceMethod("GetLayout", operation);
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+
+            MockHelpers.LoadMockGenerator(
+                createCSharpTypeCore: inputType => inputType == InputPrimitiveType.String
+                    ? new CSharpType(typeof(string))
+                    : new CSharpType(typeof(bool)),
+                clients: () => [inputClient]);
+
+            var client = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, client!);
+            var method = methodCollection.Single(
+                m => m.Kind == ScmMethodKind.Convenience && m.Signature.Name == "GetLayout");
+
+            new TestOptionalResponseBodyVisitor().Visit(method);
+
+            Assert.AreEqual(
+                new CSharpType(typeof(NullableResponse<>), typeof(string)),
+                method.Signature.ReturnType);
+            var methodBody = method.BodyStatements!.ToDisplayString();
+            StringAssert.Contains("result.Status == 204", methodBody);
+            StringAssert.Contains(
+                "return new global::Azure.NoValueResponse<string>(result);",
+                methodBody);
+            StringAssert.Contains(
+                "return global::Azure.Response.FromValue",
+                methodBody);
+        }
+
+        private sealed class TestOptionalResponseBodyVisitor : OptionalResponseBodyVisitor
+        {
+            public void Visit(ScmMethodProvider method) => VisitMethod(method);
+        }
+    }
+}

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/OptionalResponseBodyVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/OptionalResponseBodyVisitorTests.cs
@@ -57,6 +57,38 @@ namespace Azure.Generator.Tests.Visitors
         }
 
         [Test]
+        public void CombinesMultipleNoBodyStatusCodes()
+        {
+            var operation = InputFactory.Operation(
+                "GetLayout",
+                responses:
+                [
+                    InputFactory.OperationResponse([200], InputPrimitiveType.String),
+                    InputFactory.OperationResponse([204, 205])
+                ]);
+            var serviceMethod = InputFactory.BasicServiceMethod("GetLayout", operation);
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+
+            MockHelpers.LoadMockGenerator(
+                createCSharpTypeCore: inputType => inputType == InputPrimitiveType.String
+                    ? new CSharpType(typeof(string))
+                    : new CSharpType(typeof(bool)),
+                clients: () => [inputClient]);
+
+            var client = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, client!);
+            var method = methodCollection.Single(
+                m => m.Kind == ScmMethodKind.Convenience && m.Signature.Name == "GetLayout");
+
+            new TestOptionalResponseBodyVisitor().Visit(method);
+
+            StringAssert.Contains(
+                "if (((result.Status == 204) || (result.Status == 205)))",
+                method.BodyStatements!.ToDisplayString());
+        }
+
+        [Test]
         public void DoesNotUseNullableResponseWhenStatusCodeCannotDiscriminateBody()
         {
             var operation = InputFactory.Operation(

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/OptionalResponseBodyVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/OptionalResponseBodyVisitorTests.cs
@@ -56,6 +56,39 @@ namespace Azure.Generator.Tests.Visitors
                 methodBody);
         }
 
+        [Test]
+        public void DoesNotUseNullableResponseWhenStatusCodeCannotDiscriminateBody()
+        {
+            var operation = InputFactory.Operation(
+                "GetLayout",
+                responses:
+                [
+                    InputFactory.OperationResponse([200], InputPrimitiveType.String),
+                    InputFactory.OperationResponse([200])
+                ]);
+            var serviceMethod = InputFactory.BasicServiceMethod("GetLayout", operation);
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+
+            MockHelpers.LoadMockGenerator(
+                createCSharpTypeCore: inputType => inputType == InputPrimitiveType.String
+                    ? new CSharpType(typeof(string))
+                    : new CSharpType(typeof(bool)),
+                clients: () => [inputClient]);
+
+            var client = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, client!);
+            var method = methodCollection.Single(
+                m => m.Kind == ScmMethodKind.Convenience && m.Signature.Name == "GetLayout");
+            var originalReturnType = method.Signature.ReturnType;
+            var originalBody = method.BodyStatements!.ToDisplayString();
+
+            new TestOptionalResponseBodyVisitor().Visit(method);
+
+            Assert.AreEqual(originalReturnType, method.Signature.ReturnType);
+            Assert.AreEqual(originalBody, method.BodyStatements!.ToDisplayString());
+        }
+
         private sealed class TestOptionalResponseBodyVisitor : OptionalResponseBodyVisitor
         {
             public void Visit(ScmMethodProvider method) => VisitMethod(method);

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local.Tests/TestProjects.Local.Tests.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local.Tests/TestProjects.Local.Tests.csproj
@@ -46,6 +46,7 @@
 		<Compile Include="$(MSBuildThisFileDirectory)../../../../../../sdk/core/Azure.Core/src/Shared/TaskExtensions.cs" LinkBase="Shared/Core" />
 		<Compile Include="$(MSBuildThisFileDirectory)../../../../../../sdk/core/Azure.Core/src/Shared/TrimmingAttribute.cs" LinkBase="Shared/Core" />
 		<Compile Include="$(MSBuildThisFileDirectory)../../../../../../sdk/core/Azure.Core/src/Shared/AzurePipelineResponse.cs" LinkBase="Shared/Core" />
+		<Compile Include="$(MSBuildThisFileDirectory)../../../../../../sdk/core/Azure.Core/src/Shared/NoValueResponseOfT.cs" LinkBase="Shared/Core" />
 		<Compile Include="$(MSBuildThisFileDirectory)../../../../../../sdk/core/Azure.Core/src/Shared/VoidValue.cs" LinkBase="Shared/Core" />
 		<Compile Include="$(MSBuildThisFileDirectory)../../../../../../sdk/core/Azure.Core/src/Shared/IXmlSerializable.cs" LinkBase="Shared/Core" />
 		<Compile Include="$(MSBuildThisFileDirectory)../../../../../../sdk/core/Azure.Core/src/Shared/XmlWriterContent.cs" LinkBase="Shared/Core" />

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/Basic-TypeSpec.tsp
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/Basic-TypeSpec.tsp
@@ -811,3 +811,12 @@ op receiveJsonLines(): JsonlStream<StreamingItem>;
 @get
 @route("/streaming/sse/receive")
 op receiveSse(): SSEStream<SampleEvents>;
+
+@get
+@route("/optional-response")
+op getOptionalResponse(): {
+  @statusCode statusCode: 200;
+  @body body: ThingModel;
+} | {
+  @statusCode statusCode: 204;
+};

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/BasicTypeSpec.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/BasicTypeSpec.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)TrimmingAttribute.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)AzurePipelineResponse.cs" LinkBase="Shared/Core" />
+    <Compile Include="$(AzureCoreSharedSources)NoValueResponseOfT.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)IXmlSerializable.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)XmlWriterContent.cs" LinkBase="Shared/Core" />

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecClient.RestClient.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecClient.RestClient.cs
@@ -15,9 +15,12 @@ namespace BasicTypeSpec
     public partial class BasicTypeSpecClient
     {
         private static ResponseClassifier _pipelineMessageClassifier200;
+        private static ResponseClassifier _pipelineMessageClassifier200204;
         private static ResponseClassifier _pipelineMessageClassifier204;
 
         private static ResponseClassifier PipelineMessageClassifier200 => _pipelineMessageClassifier200 ??= new StatusCodeClassifier(stackalloc ushort[] { 200 });
+
+        private static ResponseClassifier PipelineMessageClassifier200204 => _pipelineMessageClassifier200204 ??= new StatusCodeClassifier(stackalloc ushort[] { 200, 204 });
 
         private static ResponseClassifier PipelineMessageClassifier204 => _pipelineMessageClassifier204 ??= new StatusCodeClassifier(stackalloc ushort[] { 204 });
 
@@ -633,6 +636,19 @@ namespace BasicTypeSpec
             request.Uri = uri;
             request.Method = RequestMethod.Get;
             request.Headers.SetValue("Accept", "text/event-stream");
+            return message;
+        }
+
+        internal HttpMessage CreateGetOptionalResponseRequest(RequestContext context)
+        {
+            RawRequestUriBuilder uri = new RawRequestUriBuilder();
+            uri.Reset(_endpoint);
+            uri.AppendPath("/optional-response", false);
+            HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200204);
+            Request request = message.Request;
+            request.Uri = uri;
+            request.Method = RequestMethod.Get;
+            request.Headers.SetValue("Accept", "application/json");
             return message;
         }
     }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecClient.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecClient.cs
@@ -2847,6 +2847,84 @@ namespace BasicTypeSpec
         }
 #pragma warning restore SCME0005 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
+        /// <summary>
+        /// [Protocol Method] GetOptionalResponse
+        /// <list type="bullet">
+        /// <item>
+        /// <description> This <see href="https://aka.ms/azsdk/net/protocol-methods">protocol method</see> allows explicit creation of the request and processing of the response for advanced scenarios. </description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="context"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. </returns>
+        public virtual Response GetOptionalResponse(RequestContext context)
+        {
+            using DiagnosticScope scope = ClientDiagnostics.CreateScope("BasicTypeSpecClient.GetOptionalResponse");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetOptionalResponseRequest(context);
+                return Pipeline.ProcessMessage(message, context);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// [Protocol Method] GetOptionalResponse
+        /// <list type="bullet">
+        /// <item>
+        /// <description> This <see href="https://aka.ms/azsdk/net/protocol-methods">protocol method</see> allows explicit creation of the request and processing of the response for advanced scenarios. </description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="context"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. </returns>
+        public virtual async Task<Response> GetOptionalResponseAsync(RequestContext context)
+        {
+            using DiagnosticScope scope = ClientDiagnostics.CreateScope("BasicTypeSpecClient.GetOptionalResponse");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetOptionalResponseRequest(context);
+                return await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> GetOptionalResponse. </summary>
+        /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+        public virtual NullableResponse<ThingModel> GetOptionalResponse(CancellationToken cancellationToken = default)
+        {
+            Response result = GetOptionalResponse(cancellationToken.ToRequestContext());
+            if (result.Status == 204)
+            {
+                return new NoValueResponse<ThingModel>(result);
+            }
+            return Response.FromValue((ThingModel)result, result);
+        }
+
+        /// <summary> GetOptionalResponse. </summary>
+        /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+        public virtual async Task<NullableResponse<ThingModel>> GetOptionalResponseAsync(CancellationToken cancellationToken = default)
+        {
+            Response result = await GetOptionalResponseAsync(cancellationToken.ToRequestContext()).ConfigureAwait(false);
+            if (result.Status == 204)
+            {
+                return new NoValueResponse<ThingModel>(result);
+            }
+            return Response.FromValue((ThingModel)result, result);
+        }
+
         /// <summary> Initializes a new instance of PlantOperations. </summary>
         public virtual PlantOperations GetPlantOperationsClient()
         {

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/tspCodeModel.json
@@ -1983,7 +1983,7 @@
     {
       "$id": "204",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType6",
+      "name": "GetTreeAsJsonResponseContentType32",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -1993,14 +1993,14 @@
         "crossLanguageDefinitionId": "TypeSpec.string",
         "decorators": []
       },
-      "value": "application/xml",
+      "value": "application/json",
       "decorators": [],
       "isExactName": false
     },
     {
       "$id": "206",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType7",
+      "name": "GetXmlAdvancedModelResponseContentType6",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2017,7 +2017,7 @@
     {
       "$id": "208",
       "kind": "constant",
-      "name": "GetTreeAsJsonResponseContentType32",
+      "name": "GetXmlAdvancedModelResponseContentType7",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2027,7 +2027,7 @@
         "crossLanguageDefinitionId": "TypeSpec.string",
         "decorators": []
       },
-      "value": "application/json",
+      "value": "application/xml",
       "decorators": [],
       "isExactName": false
     },
@@ -2051,7 +2051,7 @@
     {
       "$id": "212",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType8",
+      "name": "GetTreeAsJsonResponseContentType34",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2061,14 +2061,14 @@
         "crossLanguageDefinitionId": "TypeSpec.string",
         "decorators": []
       },
-      "value": "application/xml",
+      "value": "application/json",
       "decorators": [],
       "isExactName": false
     },
     {
       "$id": "214",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType9",
+      "name": "GetXmlAdvancedModelResponseContentType8",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2085,7 +2085,7 @@
     {
       "$id": "216",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType10",
+      "name": "GetXmlAdvancedModelResponseContentType9",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2102,7 +2102,7 @@
     {
       "$id": "218",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType11",
+      "name": "GetXmlAdvancedModelResponseContentType10",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2119,7 +2119,7 @@
     {
       "$id": "220",
       "kind": "constant",
-      "name": "GetTreeAsJsonResponseContentType34",
+      "name": "GetXmlAdvancedModelResponseContentType11",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2129,7 +2129,7 @@
         "crossLanguageDefinitionId": "TypeSpec.string",
         "decorators": []
       },
-      "value": "application/json",
+      "value": "application/xml",
       "decorators": [],
       "isExactName": false
     },
@@ -2183,11 +2183,28 @@
       "value": "application/json",
       "decorators": [],
       "isExactName": false
+    },
+    {
+      "$id": "228",
+      "kind": "constant",
+      "name": "GetTreeAsJsonResponseContentType38",
+      "namespace": "",
+      "usage": "None",
+      "valueType": {
+        "$id": "229",
+        "kind": "string",
+        "name": "string",
+        "crossLanguageDefinitionId": "TypeSpec.string",
+        "decorators": []
+      },
+      "value": "application/json",
+      "decorators": [],
+      "isExactName": false
     }
   ],
   "models": [
     {
-      "$id": "228",
+      "$id": "230",
       "kind": "model",
       "name": "ThingModel",
       "namespace": "BasicTypeSpec",
@@ -2203,13 +2220,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "229",
+          "$id": "231",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "name of the ThingModel",
           "type": {
-            "$id": "230",
+            "$id": "232",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2230,29 +2247,29 @@
           "isExactName": false
         },
         {
-          "$id": "231",
+          "$id": "233",
           "kind": "property",
           "name": "requiredUnion",
           "serializedName": "requiredUnion",
           "doc": "required Union",
           "type": {
-            "$id": "232",
+            "$id": "234",
             "kind": "union",
             "name": "ThingModelRequiredUnion",
             "variantTypes": [
               {
-                "$id": "233",
+                "$id": "235",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
                 "decorators": []
               },
               {
-                "$id": "234",
+                "$id": "236",
                 "kind": "array",
                 "name": "Array",
                 "valueType": {
-                  "$id": "235",
+                  "$id": "237",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2262,7 +2279,7 @@
                 "decorators": []
               },
               {
-                "$id": "236",
+                "$id": "238",
                 "kind": "int32",
                 "name": "int32",
                 "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -2288,7 +2305,7 @@
           "isExactName": false
         },
         {
-          "$id": "237",
+          "$id": "239",
           "kind": "property",
           "name": "requiredLiteralString",
           "serializedName": "requiredLiteralString",
@@ -2311,7 +2328,7 @@
           "isExactName": false
         },
         {
-          "$id": "238",
+          "$id": "240",
           "kind": "property",
           "name": "requiredLiteralInt",
           "serializedName": "requiredLiteralInt",
@@ -2334,7 +2351,7 @@
           "isExactName": false
         },
         {
-          "$id": "239",
+          "$id": "241",
           "kind": "property",
           "name": "requiredLiteralFloat",
           "serializedName": "requiredLiteralFloat",
@@ -2357,7 +2374,7 @@
           "isExactName": false
         },
         {
-          "$id": "240",
+          "$id": "242",
           "kind": "property",
           "name": "requiredLiteralBool",
           "serializedName": "requiredLiteralBool",
@@ -2380,7 +2397,7 @@
           "isExactName": false
         },
         {
-          "$id": "241",
+          "$id": "243",
           "kind": "property",
           "name": "optionalLiteralString",
           "serializedName": "optionalLiteralString",
@@ -2403,7 +2420,7 @@
           "isExactName": false
         },
         {
-          "$id": "242",
+          "$id": "244",
           "kind": "property",
           "name": "optionalLiteralInt",
           "serializedName": "optionalLiteralInt",
@@ -2426,7 +2443,7 @@
           "isExactName": false
         },
         {
-          "$id": "243",
+          "$id": "245",
           "kind": "property",
           "name": "optionalLiteralFloat",
           "serializedName": "optionalLiteralFloat",
@@ -2449,7 +2466,7 @@
           "isExactName": false
         },
         {
-          "$id": "244",
+          "$id": "246",
           "kind": "property",
           "name": "optionalLiteralBool",
           "serializedName": "optionalLiteralBool",
@@ -2472,13 +2489,13 @@
           "isExactName": false
         },
         {
-          "$id": "245",
+          "$id": "247",
           "kind": "property",
           "name": "requiredBadDescription",
           "serializedName": "requiredBadDescription",
           "doc": "description with xml <|endoftext|>",
           "type": {
-            "$id": "246",
+            "$id": "248",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2499,20 +2516,20 @@
           "isExactName": false
         },
         {
-          "$id": "247",
+          "$id": "249",
           "kind": "property",
           "name": "optionalNullableList",
           "serializedName": "optionalNullableList",
           "doc": "optional nullable collection",
           "type": {
-            "$id": "248",
+            "$id": "250",
             "kind": "nullable",
             "type": {
-              "$id": "249",
+              "$id": "251",
               "kind": "array",
               "name": "Array1",
               "valueType": {
-                "$id": "250",
+                "$id": "252",
                 "kind": "int32",
                 "name": "int32",
                 "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -2538,16 +2555,16 @@
           "isExactName": false
         },
         {
-          "$id": "251",
+          "$id": "253",
           "kind": "property",
           "name": "requiredNullableList",
           "serializedName": "requiredNullableList",
           "doc": "required nullable collection",
           "type": {
-            "$id": "252",
+            "$id": "254",
             "kind": "nullable",
             "type": {
-              "$ref": "249"
+              "$ref": "251"
             },
             "namespace": "BasicTypeSpec"
           },
@@ -2568,7 +2585,7 @@
       ]
     },
     {
-      "$id": "253",
+      "$id": "255",
       "kind": "model",
       "name": "RoundTripModel",
       "namespace": "BasicTypeSpec",
@@ -2589,13 +2606,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "254",
+          "$id": "256",
           "kind": "property",
           "name": "requiredString",
           "serializedName": "requiredString",
           "doc": "Required string, illustrating a reference type property.",
           "type": {
-            "$id": "255",
+            "$id": "257",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2616,13 +2633,13 @@
           "isExactName": false
         },
         {
-          "$id": "256",
+          "$id": "258",
           "kind": "property",
           "name": "requiredInt",
           "serializedName": "requiredInt",
           "doc": "Required int, illustrating a value type property.",
           "type": {
-            "$id": "257",
+            "$id": "259",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -2643,13 +2660,13 @@
           "isExactName": false
         },
         {
-          "$id": "258",
+          "$id": "260",
           "kind": "property",
           "name": "requiredCollection",
           "serializedName": "requiredCollection",
           "doc": "Required collection of enums",
           "type": {
-            "$id": "259",
+            "$id": "261",
             "kind": "array",
             "name": "ArrayStringFixedEnum",
             "valueType": {
@@ -2673,16 +2690,16 @@
           "isExactName": false
         },
         {
-          "$id": "260",
+          "$id": "262",
           "kind": "property",
           "name": "requiredDictionary",
           "serializedName": "requiredDictionary",
           "doc": "Required dictionary of enums",
           "type": {
-            "$id": "261",
+            "$id": "263",
             "kind": "dict",
             "keyType": {
-              "$id": "262",
+              "$id": "264",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2708,13 +2725,13 @@
           "isExactName": false
         },
         {
-          "$id": "263",
+          "$id": "265",
           "kind": "property",
           "name": "requiredModel",
           "serializedName": "requiredModel",
           "doc": "Required model",
           "type": {
-            "$ref": "228"
+            "$ref": "230"
           },
           "optional": false,
           "readOnly": false,
@@ -2731,7 +2748,7 @@
           "isExactName": false
         },
         {
-          "$id": "264",
+          "$id": "266",
           "kind": "property",
           "name": "intExtensibleEnum",
           "serializedName": "intExtensibleEnum",
@@ -2754,13 +2771,13 @@
           "isExactName": false
         },
         {
-          "$id": "265",
+          "$id": "267",
           "kind": "property",
           "name": "intExtensibleEnumCollection",
           "serializedName": "intExtensibleEnumCollection",
           "doc": "this is a collection of int based extensible enum",
           "type": {
-            "$id": "266",
+            "$id": "268",
             "kind": "array",
             "name": "ArrayIntExtensibleEnum",
             "valueType": {
@@ -2784,7 +2801,7 @@
           "isExactName": false
         },
         {
-          "$id": "267",
+          "$id": "269",
           "kind": "property",
           "name": "floatExtensibleEnum",
           "serializedName": "floatExtensibleEnum",
@@ -2807,7 +2824,7 @@
           "isExactName": false
         },
         {
-          "$id": "268",
+          "$id": "270",
           "kind": "property",
           "name": "floatExtensibleEnumWithIntValue",
           "serializedName": "floatExtensibleEnumWithIntValue",
@@ -2830,13 +2847,13 @@
           "isExactName": false
         },
         {
-          "$id": "269",
+          "$id": "271",
           "kind": "property",
           "name": "floatExtensibleEnumCollection",
           "serializedName": "floatExtensibleEnumCollection",
           "doc": "this is a collection of float based extensible enum",
           "type": {
-            "$id": "270",
+            "$id": "272",
             "kind": "array",
             "name": "ArrayFloatExtensibleEnum",
             "valueType": {
@@ -2860,7 +2877,7 @@
           "isExactName": false
         },
         {
-          "$id": "271",
+          "$id": "273",
           "kind": "property",
           "name": "floatFixedEnum",
           "serializedName": "floatFixedEnum",
@@ -2883,7 +2900,7 @@
           "isExactName": false
         },
         {
-          "$id": "272",
+          "$id": "274",
           "kind": "property",
           "name": "floatFixedEnumWithIntValue",
           "serializedName": "floatFixedEnumWithIntValue",
@@ -2906,13 +2923,13 @@
           "isExactName": false
         },
         {
-          "$id": "273",
+          "$id": "275",
           "kind": "property",
           "name": "floatFixedEnumCollection",
           "serializedName": "floatFixedEnumCollection",
           "doc": "this is a collection of float based fixed enum",
           "type": {
-            "$id": "274",
+            "$id": "276",
             "kind": "array",
             "name": "ArrayFloatFixedEnum",
             "valueType": {
@@ -2936,7 +2953,7 @@
           "isExactName": false
         },
         {
-          "$id": "275",
+          "$id": "277",
           "kind": "property",
           "name": "intFixedEnum",
           "serializedName": "intFixedEnum",
@@ -2959,13 +2976,13 @@
           "isExactName": false
         },
         {
-          "$id": "276",
+          "$id": "278",
           "kind": "property",
           "name": "intFixedEnumCollection",
           "serializedName": "intFixedEnumCollection",
           "doc": "this is a collection of int based fixed enum",
           "type": {
-            "$id": "277",
+            "$id": "279",
             "kind": "array",
             "name": "ArrayIntFixedEnum",
             "valueType": {
@@ -2989,7 +3006,7 @@
           "isExactName": false
         },
         {
-          "$id": "278",
+          "$id": "280",
           "kind": "property",
           "name": "stringFixedEnum",
           "serializedName": "stringFixedEnum",
@@ -3012,13 +3029,13 @@
           "isExactName": false
         },
         {
-          "$id": "279",
+          "$id": "281",
           "kind": "property",
           "name": "requiredUnknown",
           "serializedName": "requiredUnknown",
           "doc": "required unknown",
           "type": {
-            "$id": "280",
+            "$id": "282",
             "kind": "unknown",
             "name": "unknown",
             "crossLanguageDefinitionId": "",
@@ -3039,13 +3056,13 @@
           "isExactName": false
         },
         {
-          "$id": "281",
+          "$id": "283",
           "kind": "property",
           "name": "optionalUnknown",
           "serializedName": "optionalUnknown",
           "doc": "optional unknown",
           "type": {
-            "$id": "282",
+            "$id": "284",
             "kind": "unknown",
             "name": "unknown",
             "crossLanguageDefinitionId": "",
@@ -3066,23 +3083,23 @@
           "isExactName": false
         },
         {
-          "$id": "283",
+          "$id": "285",
           "kind": "property",
           "name": "requiredRecordUnknown",
           "serializedName": "requiredRecordUnknown",
           "doc": "required record of unknown",
           "type": {
-            "$id": "284",
+            "$id": "286",
             "kind": "dict",
             "keyType": {
-              "$id": "285",
+              "$id": "287",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$id": "286",
+              "$id": "288",
               "kind": "unknown",
               "name": "unknown",
               "crossLanguageDefinitionId": "",
@@ -3105,13 +3122,13 @@
           "isExactName": false
         },
         {
-          "$id": "287",
+          "$id": "289",
           "kind": "property",
           "name": "optionalRecordUnknown",
           "serializedName": "optionalRecordUnknown",
           "doc": "optional record of unknown",
           "type": {
-            "$ref": "284"
+            "$ref": "286"
           },
           "optional": true,
           "readOnly": false,
@@ -3128,13 +3145,13 @@
           "isExactName": false
         },
         {
-          "$id": "288",
+          "$id": "290",
           "kind": "property",
           "name": "readOnlyRequiredRecordUnknown",
           "serializedName": "readOnlyRequiredRecordUnknown",
           "doc": "required readonly record of unknown",
           "type": {
-            "$ref": "284"
+            "$ref": "286"
           },
           "optional": false,
           "readOnly": true,
@@ -3151,13 +3168,13 @@
           "isExactName": false
         },
         {
-          "$id": "289",
+          "$id": "291",
           "kind": "property",
           "name": "readOnlyOptionalRecordUnknown",
           "serializedName": "readOnlyOptionalRecordUnknown",
           "doc": "optional readonly record of unknown",
           "type": {
-            "$ref": "284"
+            "$ref": "286"
           },
           "optional": true,
           "readOnly": true,
@@ -3174,13 +3191,13 @@
           "isExactName": false
         },
         {
-          "$id": "290",
+          "$id": "292",
           "kind": "property",
           "name": "modelWithRequiredNullable",
           "serializedName": "modelWithRequiredNullable",
           "doc": "this is a model with required nullable properties",
           "type": {
-            "$id": "291",
+            "$id": "293",
             "kind": "model",
             "name": "ModelWithRequiredNullableProperties",
             "namespace": "BasicTypeSpec",
@@ -3196,16 +3213,16 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "292",
+                "$id": "294",
                 "kind": "property",
                 "name": "requiredNullablePrimitive",
                 "serializedName": "requiredNullablePrimitive",
                 "doc": "required nullable primitive type",
                 "type": {
-                  "$id": "293",
+                  "$id": "295",
                   "kind": "nullable",
                   "type": {
-                    "$id": "294",
+                    "$id": "296",
                     "kind": "int32",
                     "name": "int32",
                     "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -3228,13 +3245,13 @@
                 "isExactName": false
               },
               {
-                "$id": "295",
+                "$id": "297",
                 "kind": "property",
                 "name": "requiredExtensibleEnum",
                 "serializedName": "requiredExtensibleEnum",
                 "doc": "required nullable extensible enum type",
                 "type": {
-                  "$id": "296",
+                  "$id": "298",
                   "kind": "nullable",
                   "type": {
                     "$ref": "18"
@@ -3256,13 +3273,13 @@
                 "isExactName": false
               },
               {
-                "$id": "297",
+                "$id": "299",
                 "kind": "property",
                 "name": "requiredFixedEnum",
                 "serializedName": "requiredFixedEnum",
                 "doc": "required nullable fixed enum type",
                 "type": {
-                  "$id": "298",
+                  "$id": "300",
                   "kind": "nullable",
                   "type": {
                     "$ref": "13"
@@ -3300,13 +3317,13 @@
           "isExactName": false
         },
         {
-          "$id": "299",
+          "$id": "301",
           "kind": "property",
           "name": "requiredBytes",
           "serializedName": "requiredBytes",
           "doc": "Required bytes",
           "type": {
-            "$id": "300",
+            "$id": "302",
             "kind": "bytes",
             "name": "bytes",
             "encode": "base64",
@@ -3330,10 +3347,10 @@
       ]
     },
     {
-      "$ref": "291"
+      "$ref": "293"
     },
     {
-      "$id": "301",
+      "$id": "303",
       "kind": "model",
       "name": "FriendModel",
       "namespace": "BasicTypeSpec",
@@ -3349,13 +3366,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "302",
+          "$id": "304",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "name of the NotFriend",
           "type": {
-            "$id": "303",
+            "$id": "305",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3378,7 +3395,7 @@
       ]
     },
     {
-      "$id": "304",
+      "$id": "306",
       "kind": "model",
       "name": "RenamedModel",
       "namespace": "BasicTypeSpec",
@@ -3394,13 +3411,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "305",
+          "$id": "307",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "name of the ModelWithClientName",
           "type": {
-            "$id": "306",
+            "$id": "308",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3423,7 +3440,7 @@
       ]
     },
     {
-      "$id": "307",
+      "$id": "309",
       "kind": "model",
       "name": "ReturnsAnonymousModelResponse",
       "namespace": "BasicTypeSpec",
@@ -3439,7 +3456,7 @@
       "properties": []
     },
     {
-      "$id": "308",
+      "$id": "310",
       "kind": "model",
       "name": "ListWithNextLinkResponse",
       "namespace": "BasicTypeSpec",
@@ -3454,16 +3471,16 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "309",
+          "$id": "311",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$id": "310",
+            "$id": "312",
             "kind": "array",
             "name": "ArrayThingModel",
             "valueType": {
-              "$ref": "228"
+              "$ref": "230"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -3483,12 +3500,12 @@
           "isExactName": false
         },
         {
-          "$id": "311",
+          "$id": "313",
           "kind": "property",
           "name": "next",
           "serializedName": "next",
           "type": {
-            "$id": "312",
+            "$id": "314",
             "kind": "url",
             "name": "url",
             "crossLanguageDefinitionId": "TypeSpec.url",
@@ -3511,7 +3528,7 @@
       ]
     },
     {
-      "$id": "313",
+      "$id": "315",
       "kind": "model",
       "name": "ListWithStringNextLinkResponse",
       "namespace": "BasicTypeSpec",
@@ -3526,12 +3543,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "314",
+          "$id": "316",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "310"
+            "$ref": "312"
           },
           "optional": false,
           "readOnly": false,
@@ -3548,12 +3565,12 @@
           "isExactName": false
         },
         {
-          "$id": "315",
+          "$id": "317",
           "kind": "property",
           "name": "next",
           "serializedName": "next",
           "type": {
-            "$id": "316",
+            "$id": "318",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3576,7 +3593,7 @@
       ]
     },
     {
-      "$id": "317",
+      "$id": "319",
       "kind": "model",
       "name": "ListWithHeaderNextLinkResponse",
       "namespace": "",
@@ -3591,12 +3608,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "318",
+          "$id": "320",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "310"
+            "$ref": "312"
           },
           "optional": false,
           "readOnly": false,
@@ -3615,7 +3632,7 @@
       ]
     },
     {
-      "$id": "319",
+      "$id": "321",
       "kind": "model",
       "name": "ListWithHeaderNextLinkWithMaxPageResponse",
       "namespace": "",
@@ -3630,12 +3647,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "320",
+          "$id": "322",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "310"
+            "$ref": "312"
           },
           "optional": false,
           "readOnly": false,
@@ -3654,7 +3671,7 @@
       ]
     },
     {
-      "$id": "321",
+      "$id": "323",
       "kind": "model",
       "name": "ListWithContinuationTokenResponse",
       "namespace": "BasicTypeSpec",
@@ -3669,12 +3686,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "322",
+          "$id": "324",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "310"
+            "$ref": "312"
           },
           "optional": false,
           "readOnly": false,
@@ -3691,12 +3708,12 @@
           "isExactName": false
         },
         {
-          "$id": "323",
+          "$id": "325",
           "kind": "property",
           "name": "nextToken",
           "serializedName": "nextToken",
           "type": {
-            "$id": "324",
+            "$id": "326",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3719,7 +3736,7 @@
       ]
     },
     {
-      "$id": "325",
+      "$id": "327",
       "kind": "model",
       "name": "ListWithContinuationTokenWithMaxPageResponse",
       "namespace": "BasicTypeSpec",
@@ -3734,12 +3751,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "326",
+          "$id": "328",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "310"
+            "$ref": "312"
           },
           "optional": false,
           "readOnly": false,
@@ -3756,12 +3773,12 @@
           "isExactName": false
         },
         {
-          "$id": "327",
+          "$id": "329",
           "kind": "property",
           "name": "nextToken",
           "serializedName": "nextToken",
           "type": {
-            "$id": "328",
+            "$id": "330",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3784,7 +3801,7 @@
       ]
     },
     {
-      "$id": "329",
+      "$id": "331",
       "kind": "model",
       "name": "ListWithContinuationTokenHeaderResponseResponse",
       "namespace": "",
@@ -3799,12 +3816,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "330",
+          "$id": "332",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "310"
+            "$ref": "312"
           },
           "optional": false,
           "readOnly": false,
@@ -3823,7 +3840,7 @@
       ]
     },
     {
-      "$id": "331",
+      "$id": "333",
       "kind": "model",
       "name": "PageThingModel",
       "namespace": "BasicTypeSpec",
@@ -3838,12 +3855,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "332",
+          "$id": "334",
           "kind": "property",
           "name": "items",
           "serializedName": "items",
           "type": {
-            "$ref": "310"
+            "$ref": "312"
           },
           "optional": false,
           "readOnly": false,
@@ -3862,7 +3879,7 @@
       ]
     },
     {
-      "$id": "333",
+      "$id": "335",
       "kind": "model",
       "name": "MultipartRequestRequest",
       "namespace": "BasicTypeSpec",
@@ -3873,12 +3890,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "334",
+          "$id": "336",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "type": {
-            "$id": "335",
+            "$id": "337",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3907,7 +3924,7 @@
       ]
     },
     {
-      "$id": "336",
+      "$id": "338",
       "kind": "model",
       "name": "DataFactoryElementModel",
       "namespace": "BasicTypeSpec",
@@ -3923,25 +3940,25 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "337",
+          "$id": "339",
           "kind": "property",
           "name": "stringProperty",
           "serializedName": "stringProperty",
           "doc": "String property with DFE pattern",
           "type": {
-            "$id": "338",
+            "$id": "340",
             "kind": "union",
             "name": "Dfe",
             "variantTypes": [
               {
-                "$id": "339",
+                "$id": "341",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
                 "decorators": []
               },
               {
-                "$ref": "336"
+                "$ref": "338"
               }
             ],
             "namespace": "BasicTypeSpec",
@@ -3966,25 +3983,25 @@
           "isExactName": false
         },
         {
-          "$id": "340",
+          "$id": "342",
           "kind": "property",
           "name": "intProperty",
           "serializedName": "intProperty",
           "doc": "Int property with DFE pattern",
           "type": {
-            "$id": "341",
+            "$id": "343",
             "kind": "union",
             "name": "Dfe1",
             "variantTypes": [
               {
-                "$id": "342",
+                "$id": "344",
                 "kind": "int32",
                 "name": "int32",
                 "crossLanguageDefinitionId": "TypeSpec.int32",
                 "decorators": []
               },
               {
-                "$ref": "336"
+                "$ref": "338"
               }
             ],
             "namespace": "BasicTypeSpec",
@@ -4009,25 +4026,25 @@
           "isExactName": false
         },
         {
-          "$id": "343",
+          "$id": "345",
           "kind": "property",
           "name": "boolProperty",
           "serializedName": "boolProperty",
           "doc": "Bool property with DFE pattern",
           "type": {
-            "$id": "344",
+            "$id": "346",
             "kind": "union",
             "name": "Dfe2",
             "variantTypes": [
               {
-                "$id": "345",
+                "$id": "347",
                 "kind": "boolean",
                 "name": "boolean",
                 "crossLanguageDefinitionId": "TypeSpec.boolean",
                 "decorators": []
               },
               {
-                "$ref": "336"
+                "$ref": "338"
               }
             ],
             "namespace": "BasicTypeSpec",
@@ -4052,21 +4069,21 @@
           "isExactName": false
         },
         {
-          "$id": "346",
+          "$id": "348",
           "kind": "property",
           "name": "stringArrayProperty",
           "serializedName": "stringArrayProperty",
           "doc": "String array property with DFE pattern",
           "type": {
-            "$id": "347",
+            "$id": "349",
             "kind": "union",
             "name": "DfeArray",
             "variantTypes": [
               {
-                "$ref": "234"
+                "$ref": "236"
               },
               {
-                "$ref": "336"
+                "$ref": "338"
               }
             ],
             "namespace": "BasicTypeSpec",
@@ -4093,7 +4110,7 @@
       ]
     },
     {
-      "$id": "348",
+      "$id": "350",
       "kind": "model",
       "name": "XmlAdvancedModel",
       "namespace": "BasicTypeSpec",
@@ -4118,13 +4135,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "349",
+          "$id": "351",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "A simple string property",
           "type": {
-            "$id": "350",
+            "$id": "352",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4147,13 +4164,13 @@
           "isExactName": false
         },
         {
-          "$id": "351",
+          "$id": "353",
           "kind": "property",
           "name": "age",
           "serializedName": "age",
           "doc": "An integer property",
           "type": {
-            "$id": "352",
+            "$id": "354",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4176,13 +4193,13 @@
           "isExactName": false
         },
         {
-          "$id": "353",
+          "$id": "355",
           "kind": "property",
           "name": "enabled",
           "serializedName": "enabled",
           "doc": "A boolean property",
           "type": {
-            "$id": "354",
+            "$id": "356",
             "kind": "boolean",
             "name": "boolean",
             "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -4205,13 +4222,13 @@
           "isExactName": false
         },
         {
-          "$id": "355",
+          "$id": "357",
           "kind": "property",
           "name": "score",
           "serializedName": "score",
           "doc": "A float property",
           "type": {
-            "$id": "356",
+            "$id": "358",
             "kind": "float32",
             "name": "float32",
             "crossLanguageDefinitionId": "TypeSpec.float32",
@@ -4234,13 +4251,13 @@
           "isExactName": false
         },
         {
-          "$id": "357",
+          "$id": "359",
           "kind": "property",
           "name": "optionalString",
           "serializedName": "optionalString",
           "doc": "An optional string",
           "type": {
-            "$id": "358",
+            "$id": "360",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4263,13 +4280,13 @@
           "isExactName": false
         },
         {
-          "$id": "359",
+          "$id": "361",
           "kind": "property",
           "name": "optionalInt",
           "serializedName": "optionalInt",
           "doc": "An optional integer",
           "type": {
-            "$id": "360",
+            "$id": "362",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4292,16 +4309,16 @@
           "isExactName": false
         },
         {
-          "$id": "361",
+          "$id": "363",
           "kind": "property",
           "name": "nullableString",
           "serializedName": "nullableString",
           "doc": "A nullable string",
           "type": {
-            "$id": "362",
+            "$id": "364",
             "kind": "nullable",
             "type": {
-              "$id": "363",
+              "$id": "365",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4326,13 +4343,13 @@
           "isExactName": false
         },
         {
-          "$id": "364",
+          "$id": "366",
           "kind": "property",
           "name": "id",
           "serializedName": "id",
           "doc": "A string as XML attribute",
           "type": {
-            "$id": "365",
+            "$id": "367",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4360,13 +4377,13 @@
           "isExactName": false
         },
         {
-          "$id": "366",
+          "$id": "368",
           "kind": "property",
           "name": "version",
           "serializedName": "version",
           "doc": "An integer as XML attribute",
           "type": {
-            "$id": "367",
+            "$id": "369",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4394,13 +4411,13 @@
           "isExactName": false
         },
         {
-          "$id": "368",
+          "$id": "370",
           "kind": "property",
           "name": "isActive",
           "serializedName": "isActive",
           "doc": "A boolean as XML attribute",
           "type": {
-            "$id": "369",
+            "$id": "371",
             "kind": "boolean",
             "name": "boolean",
             "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -4428,13 +4445,13 @@
           "isExactName": false
         },
         {
-          "$id": "370",
+          "$id": "372",
           "kind": "property",
           "name": "originalName",
           "serializedName": "RenamedProperty",
           "doc": "A property with a custom XML element name",
           "type": {
-            "$id": "371",
+            "$id": "373",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4464,13 +4481,13 @@
           "isExactName": false
         },
         {
-          "$id": "372",
+          "$id": "374",
           "kind": "property",
           "name": "xmlIdentifier",
           "serializedName": "xml-id",
           "doc": "An attribute with a custom XML name",
           "type": {
-            "$id": "373",
+            "$id": "375",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4504,13 +4521,13 @@
           "isExactName": false
         },
         {
-          "$id": "374",
+          "$id": "376",
           "kind": "property",
           "name": "content",
           "serializedName": "content",
           "doc": "Text content in the element (unwrapped string)",
           "type": {
-            "$id": "375",
+            "$id": "377",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4538,13 +4555,13 @@
           "isExactName": false
         },
         {
-          "$id": "376",
+          "$id": "378",
           "kind": "property",
           "name": "unwrappedStrings",
           "serializedName": "unwrappedStrings",
           "doc": "An unwrapped array of strings - items appear directly without wrapper",
           "type": {
-            "$ref": "234"
+            "$ref": "236"
           },
           "optional": false,
           "readOnly": false,
@@ -4569,13 +4586,13 @@
           "isExactName": false
         },
         {
-          "$id": "377",
+          "$id": "379",
           "kind": "property",
           "name": "unwrappedCounts",
           "serializedName": "unwrappedCounts",
           "doc": "An unwrapped array of integers",
           "type": {
-            "$ref": "249"
+            "$ref": "251"
           },
           "optional": false,
           "readOnly": false,
@@ -4600,17 +4617,17 @@
           "isExactName": false
         },
         {
-          "$id": "378",
+          "$id": "380",
           "kind": "property",
           "name": "unwrappedItems",
           "serializedName": "unwrappedItems",
           "doc": "An unwrapped array of models",
           "type": {
-            "$id": "379",
+            "$id": "381",
             "kind": "array",
             "name": "ArrayXmlItem",
             "valueType": {
-              "$id": "380",
+              "$id": "382",
               "kind": "model",
               "name": "XmlItem",
               "namespace": "BasicTypeSpec",
@@ -4635,13 +4652,13 @@
               "isExactName": false,
               "properties": [
                 {
-                  "$id": "381",
+                  "$id": "383",
                   "kind": "property",
                   "name": "itemName",
                   "serializedName": "itemName",
                   "doc": "The item name",
                   "type": {
-                    "$id": "382",
+                    "$id": "384",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4664,13 +4681,13 @@
                   "isExactName": false
                 },
                 {
-                  "$id": "383",
+                  "$id": "385",
                   "kind": "property",
                   "name": "itemValue",
                   "serializedName": "itemValue",
                   "doc": "The item value",
                   "type": {
-                    "$id": "384",
+                    "$id": "386",
                     "kind": "int32",
                     "name": "int32",
                     "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4693,13 +4710,13 @@
                   "isExactName": false
                 },
                 {
-                  "$id": "385",
+                  "$id": "387",
                   "kind": "property",
                   "name": "itemId",
                   "serializedName": "itemId",
                   "doc": "Item ID as attribute",
                   "type": {
-                    "$id": "386",
+                    "$id": "388",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4754,13 +4771,13 @@
           "isExactName": false
         },
         {
-          "$id": "387",
+          "$id": "389",
           "kind": "property",
           "name": "wrappedColors",
           "serializedName": "wrappedColors",
           "doc": "A wrapped array of strings (default)",
           "type": {
-            "$ref": "234"
+            "$ref": "236"
           },
           "optional": false,
           "readOnly": false,
@@ -4780,13 +4797,13 @@
           "isExactName": false
         },
         {
-          "$id": "388",
+          "$id": "390",
           "kind": "property",
           "name": "items",
           "serializedName": "ItemCollection",
           "doc": "A wrapped array with custom wrapper name",
           "type": {
-            "$ref": "379"
+            "$ref": "381"
           },
           "optional": false,
           "readOnly": false,
@@ -4813,13 +4830,13 @@
           "isExactName": false
         },
         {
-          "$id": "389",
+          "$id": "391",
           "kind": "property",
           "name": "nestedModel",
           "serializedName": "nestedModel",
           "doc": "A nested model property",
           "type": {
-            "$id": "390",
+            "$id": "392",
             "kind": "model",
             "name": "XmlNestedModel",
             "namespace": "BasicTypeSpec",
@@ -4837,13 +4854,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "391",
+                "$id": "393",
                 "kind": "property",
                 "name": "value",
                 "serializedName": "value",
                 "doc": "The value of the nested model",
                 "type": {
-                  "$id": "392",
+                  "$id": "394",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4866,13 +4883,13 @@
                 "isExactName": false
               },
               {
-                "$id": "393",
+                "$id": "395",
                 "kind": "property",
                 "name": "nestedId",
                 "serializedName": "nestedId",
                 "doc": "An attribute on the nested model",
                 "type": {
-                  "$id": "394",
+                  "$id": "396",
                   "kind": "int32",
                   "name": "int32",
                   "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4918,13 +4935,13 @@
           "isExactName": false
         },
         {
-          "$id": "395",
+          "$id": "397",
           "kind": "property",
           "name": "optionalNestedModel",
           "serializedName": "optionalNestedModel",
           "doc": "An optional nested model",
           "type": {
-            "$ref": "390"
+            "$ref": "392"
           },
           "optional": true,
           "readOnly": false,
@@ -4943,23 +4960,23 @@
           "isExactName": false
         },
         {
-          "$id": "396",
+          "$id": "398",
           "kind": "property",
           "name": "metadata",
           "serializedName": "metadata",
           "doc": "A dictionary property",
           "type": {
-            "$id": "397",
+            "$id": "399",
             "kind": "dict",
             "keyType": {
-              "$id": "398",
+              "$id": "400",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$id": "399",
+              "$id": "401",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4984,18 +5001,18 @@
           "isExactName": false
         },
         {
-          "$id": "400",
+          "$id": "402",
           "kind": "property",
           "name": "createdAt",
           "serializedName": "createdAt",
           "doc": "A date-time property",
           "type": {
-            "$id": "401",
+            "$id": "403",
             "kind": "utcDateTime",
             "name": "utcDateTime",
             "encode": "rfc3339",
             "wireType": {
-              "$id": "402",
+              "$id": "404",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5021,18 +5038,18 @@
           "isExactName": false
         },
         {
-          "$id": "403",
+          "$id": "405",
           "kind": "property",
           "name": "duration",
           "serializedName": "duration",
           "doc": "A duration property",
           "type": {
-            "$id": "404",
+            "$id": "406",
             "kind": "duration",
             "name": "duration",
             "encode": "ISO8601",
             "wireType": {
-              "$id": "405",
+              "$id": "407",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5058,13 +5075,13 @@
           "isExactName": false
         },
         {
-          "$id": "406",
+          "$id": "408",
           "kind": "property",
           "name": "data",
           "serializedName": "data",
           "doc": "A bytes property",
           "type": {
-            "$id": "407",
+            "$id": "409",
             "kind": "bytes",
             "name": "bytes",
             "encode": "base64",
@@ -5088,13 +5105,13 @@
           "isExactName": false
         },
         {
-          "$id": "408",
+          "$id": "410",
           "kind": "property",
           "name": "optionalRecordUnknown",
           "serializedName": "optionalRecordUnknown",
           "doc": "optional record of unknown",
           "type": {
-            "$ref": "284"
+            "$ref": "286"
           },
           "optional": true,
           "readOnly": false,
@@ -5113,7 +5130,7 @@
           "isExactName": false
         },
         {
-          "$id": "409",
+          "$id": "411",
           "kind": "property",
           "name": "fixedEnum",
           "serializedName": "fixedEnum",
@@ -5138,7 +5155,7 @@
           "isExactName": false
         },
         {
-          "$id": "410",
+          "$id": "412",
           "kind": "property",
           "name": "extensibleEnum",
           "serializedName": "extensibleEnum",
@@ -5163,7 +5180,7 @@
           "isExactName": false
         },
         {
-          "$id": "411",
+          "$id": "413",
           "kind": "property",
           "name": "optionalFixedEnum",
           "serializedName": "optionalFixedEnum",
@@ -5188,7 +5205,7 @@
           "isExactName": false
         },
         {
-          "$id": "412",
+          "$id": "414",
           "kind": "property",
           "name": "optionalExtensibleEnum",
           "serializedName": "optionalExtensibleEnum",
@@ -5213,12 +5230,12 @@
           "isExactName": false
         },
         {
-          "$id": "413",
+          "$id": "415",
           "kind": "property",
           "name": "label",
           "serializedName": "label",
           "type": {
-            "$id": "414",
+            "$id": "416",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5233,14 +5250,14 @@
               "name": "TypeSpec.Xml.@ns",
               "arguments": {
                 "ns": {
-                  "$id": "415",
+                  "$id": "417",
                   "kind": "enumvalue",
                   "decorators": [],
                   "name": "ns1",
                   "isExactName": false,
                   "value": "https://example.com/ns1",
                   "enumType": {
-                    "$id": "416",
+                    "$id": "418",
                     "kind": "enum",
                     "decorators": [
                       {
@@ -5253,7 +5270,7 @@
                     "isExactName": false,
                     "namespace": "BasicTypeSpec",
                     "valueType": {
-                      "$id": "417",
+                      "$id": "419",
                       "kind": "string",
                       "decorators": [],
                       "doc": "A sequence of textual characters.",
@@ -5262,32 +5279,32 @@
                     },
                     "values": [
                       {
-                        "$id": "418",
+                        "$id": "420",
                         "kind": "enumvalue",
                         "decorators": [],
                         "name": "ns1",
                         "isExactName": false,
                         "value": "https://example.com/ns1",
                         "enumType": {
-                          "$ref": "416"
+                          "$ref": "418"
                         },
                         "valueType": {
-                          "$ref": "417"
+                          "$ref": "419"
                         },
                         "crossLanguageDefinitionId": "BasicTypeSpec.XmlNamespaces.ns1"
                       },
                       {
-                        "$id": "419",
+                        "$id": "421",
                         "kind": "enumvalue",
                         "decorators": [],
                         "name": "ns2",
                         "isExactName": false,
                         "value": "https://example.com/ns2",
                         "enumType": {
-                          "$ref": "416"
+                          "$ref": "418"
                         },
                         "valueType": {
-                          "$ref": "417"
+                          "$ref": "419"
                         },
                         "crossLanguageDefinitionId": "BasicTypeSpec.XmlNamespaces.ns2"
                       }
@@ -5305,7 +5322,7 @@
                     "__accessSet": true
                   },
                   "valueType": {
-                    "$ref": "417"
+                    "$ref": "419"
                   },
                   "crossLanguageDefinitionId": "BasicTypeSpec.XmlNamespaces.ns1"
                 }
@@ -5332,12 +5349,12 @@
           "isExactName": false
         },
         {
-          "$id": "420",
+          "$id": "422",
           "kind": "property",
           "name": "daysUsed",
           "serializedName": "daysUsed",
           "type": {
-            "$id": "421",
+            "$id": "423",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -5352,17 +5369,17 @@
               "name": "TypeSpec.Xml.@ns",
               "arguments": {
                 "ns": {
-                  "$id": "422",
+                  "$id": "424",
                   "kind": "enumvalue",
                   "decorators": [],
                   "name": "ns2",
                   "isExactName": false,
                   "value": "https://example.com/ns2",
                   "enumType": {
-                    "$ref": "416"
+                    "$ref": "418"
                   },
                   "valueType": {
-                    "$ref": "417"
+                    "$ref": "419"
                   },
                   "crossLanguageDefinitionId": "BasicTypeSpec.XmlNamespaces.ns2"
                 }
@@ -5385,12 +5402,12 @@
           "isExactName": false
         },
         {
-          "$id": "423",
+          "$id": "425",
           "kind": "property",
           "name": "fooItems",
           "serializedName": "fooItems",
           "type": {
-            "$ref": "234"
+            "$ref": "236"
           },
           "optional": false,
           "readOnly": false,
@@ -5422,12 +5439,12 @@
           "isExactName": false
         },
         {
-          "$id": "424",
+          "$id": "426",
           "kind": "property",
           "name": "anotherModel",
           "serializedName": "anotherModel",
           "type": {
-            "$ref": "390"
+            "$ref": "392"
           },
           "optional": false,
           "readOnly": false,
@@ -5458,16 +5475,16 @@
           "isExactName": false
         },
         {
-          "$id": "425",
+          "$id": "427",
           "kind": "property",
           "name": "modelsWithNamespaces",
           "serializedName": "modelsWithNamespaces",
           "type": {
-            "$id": "426",
+            "$id": "428",
             "kind": "array",
             "name": "ArrayXmlModelWithNamespace",
             "valueType": {
-              "$id": "427",
+              "$id": "429",
               "kind": "model",
               "name": "XmlModelWithNamespace",
               "namespace": "BasicTypeSpec",
@@ -5496,12 +5513,12 @@
               "isExactName": false,
               "properties": [
                 {
-                  "$id": "428",
+                  "$id": "430",
                   "kind": "property",
                   "name": "foo",
                   "serializedName": "foo",
                   "type": {
-                    "$id": "429",
+                    "$id": "431",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5550,12 +5567,12 @@
           "isExactName": false
         },
         {
-          "$id": "430",
+          "$id": "432",
           "kind": "property",
           "name": "unwrappedModelsWithNamespaces",
           "serializedName": "unwrappedModelsWithNamespaces",
           "type": {
-            "$ref": "426"
+            "$ref": "428"
           },
           "optional": false,
           "readOnly": false,
@@ -5580,16 +5597,16 @@
           "isExactName": false
         },
         {
-          "$id": "431",
+          "$id": "433",
           "kind": "property",
           "name": "listOfListFoo",
           "serializedName": "listOfListFoo",
           "type": {
-            "$id": "432",
+            "$id": "434",
             "kind": "array",
             "name": "ArrayArray",
             "valueType": {
-              "$ref": "379"
+              "$ref": "381"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -5612,22 +5629,22 @@
           "isExactName": false
         },
         {
-          "$id": "433",
+          "$id": "435",
           "kind": "property",
           "name": "dictionaryFoo",
           "serializedName": "dictionaryFoo",
           "type": {
-            "$id": "434",
+            "$id": "436",
             "kind": "dict",
             "keyType": {
-              "$id": "435",
+              "$id": "437",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "380"
+              "$ref": "382"
             },
             "decorators": []
           },
@@ -5648,22 +5665,22 @@
           "isExactName": false
         },
         {
-          "$id": "436",
+          "$id": "438",
           "kind": "property",
           "name": "dictionaryOfDictionaryFoo",
           "serializedName": "dictionaryOfDictionaryFoo",
           "type": {
-            "$id": "437",
+            "$id": "439",
             "kind": "dict",
             "keyType": {
-              "$id": "438",
+              "$id": "440",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "434"
+              "$ref": "436"
             },
             "decorators": []
           },
@@ -5684,22 +5701,22 @@
           "isExactName": false
         },
         {
-          "$id": "439",
+          "$id": "441",
           "kind": "property",
           "name": "dictionaryListFoo",
           "serializedName": "dictionaryListFoo",
           "type": {
-            "$id": "440",
+            "$id": "442",
             "kind": "dict",
             "keyType": {
-              "$id": "441",
+              "$id": "443",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "379"
+              "$ref": "381"
             },
             "decorators": []
           },
@@ -5720,16 +5737,16 @@
           "isExactName": false
         },
         {
-          "$id": "442",
+          "$id": "444",
           "kind": "property",
           "name": "listOfDictionaryFoo",
           "serializedName": "listOfDictionaryFoo",
           "type": {
-            "$id": "443",
+            "$id": "445",
             "kind": "array",
             "name": "ArrayRecord",
             "valueType": {
-              "$ref": "434"
+              "$ref": "436"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -5754,16 +5771,16 @@
       ]
     },
     {
-      "$ref": "380"
+      "$ref": "382"
     },
     {
-      "$ref": "390"
+      "$ref": "392"
     },
     {
-      "$ref": "427"
+      "$ref": "429"
     },
     {
-      "$id": "444",
+      "$id": "446",
       "kind": "model",
       "name": "Cat",
       "namespace": "BasicTypeSpec",
@@ -5774,12 +5791,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "445",
+          "$id": "447",
           "kind": "property",
           "name": "id",
           "serializedName": "id",
           "type": {
-            "$id": "446",
+            "$id": "448",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5806,12 +5823,12 @@
           "isExactName": false
         },
         {
-          "$id": "447",
+          "$id": "449",
           "kind": "property",
           "name": "boolPart",
           "serializedName": "boolPart",
           "type": {
-            "$id": "448",
+            "$id": "450",
             "kind": "boolean",
             "name": "boolean",
             "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -5838,12 +5855,12 @@
           "isExactName": false
         },
         {
-          "$id": "449",
+          "$id": "451",
           "kind": "property",
           "name": "int32Part",
           "serializedName": "int32Part",
           "type": {
-            "$id": "450",
+            "$id": "452",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -5870,12 +5887,12 @@
           "isExactName": false
         },
         {
-          "$id": "451",
+          "$id": "453",
           "kind": "property",
           "name": "int64Part",
           "serializedName": "int64Part",
           "type": {
-            "$id": "452",
+            "$id": "454",
             "kind": "int64",
             "name": "int64",
             "crossLanguageDefinitionId": "TypeSpec.int64",
@@ -5902,12 +5919,12 @@
           "isExactName": false
         },
         {
-          "$id": "453",
+          "$id": "455",
           "kind": "property",
           "name": "float32Part",
           "serializedName": "float32Part",
           "type": {
-            "$id": "454",
+            "$id": "456",
             "kind": "float32",
             "name": "float32",
             "crossLanguageDefinitionId": "TypeSpec.float32",
@@ -5934,12 +5951,12 @@
           "isExactName": false
         },
         {
-          "$id": "455",
+          "$id": "457",
           "kind": "property",
           "name": "float64Part",
           "serializedName": "float64Part",
           "type": {
-            "$id": "456",
+            "$id": "458",
             "kind": "float64",
             "name": "float64",
             "crossLanguageDefinitionId": "TypeSpec.float64",
@@ -5966,12 +5983,12 @@
           "isExactName": false
         },
         {
-          "$id": "457",
+          "$id": "459",
           "kind": "property",
           "name": "decimalPart",
           "serializedName": "decimalPart",
           "type": {
-            "$id": "458",
+            "$id": "460",
             "kind": "decimal128",
             "name": "decimal128",
             "crossLanguageDefinitionId": "TypeSpec.decimal128",
@@ -5998,12 +6015,12 @@
           "isExactName": false
         },
         {
-          "$id": "459",
+          "$id": "461",
           "kind": "property",
           "name": "int8Part",
           "serializedName": "int8Part",
           "type": {
-            "$id": "460",
+            "$id": "462",
             "kind": "int8",
             "name": "int8",
             "crossLanguageDefinitionId": "TypeSpec.int8",
@@ -6030,12 +6047,12 @@
           "isExactName": false
         },
         {
-          "$id": "461",
+          "$id": "463",
           "kind": "property",
           "name": "uint8Part",
           "serializedName": "uint8Part",
           "type": {
-            "$id": "462",
+            "$id": "464",
             "kind": "uint8",
             "name": "uint8",
             "crossLanguageDefinitionId": "TypeSpec.uint8",
@@ -6062,12 +6079,12 @@
           "isExactName": false
         },
         {
-          "$id": "463",
+          "$id": "465",
           "kind": "property",
           "name": "dictionaryPart",
           "serializedName": "dictionaryPart",
           "type": {
-            "$ref": "397"
+            "$ref": "399"
           },
           "optional": false,
           "readOnly": false,
@@ -6090,22 +6107,22 @@
           "isExactName": false
         },
         {
-          "$id": "464",
+          "$id": "466",
           "kind": "property",
           "name": "dictionaryModelPart",
           "serializedName": "dictionaryModelPart",
           "type": {
-            "$id": "465",
+            "$id": "467",
             "kind": "dict",
             "keyType": {
-              "$id": "466",
+              "$id": "468",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "228"
+              "$ref": "230"
             },
             "decorators": []
           },
@@ -6130,12 +6147,12 @@
           "isExactName": false
         },
         {
-          "$id": "467",
+          "$id": "469",
           "kind": "property",
           "name": "listPart",
           "serializedName": "listPart",
           "type": {
-            "$ref": "234"
+            "$ref": "236"
           },
           "optional": false,
           "readOnly": false,
@@ -6158,12 +6175,12 @@
           "isExactName": false
         },
         {
-          "$id": "468",
+          "$id": "470",
           "kind": "property",
           "name": "listModelPart",
           "serializedName": "listModelPart",
           "type": {
-            "$ref": "310"
+            "$ref": "312"
           },
           "optional": false,
           "readOnly": false,
@@ -6186,16 +6203,16 @@
           "isExactName": false
         },
         {
-          "$id": "469",
+          "$id": "471",
           "kind": "property",
           "name": "multipleListPart",
           "serializedName": "multipleListPart",
           "type": {
-            "$id": "470",
+            "$id": "472",
             "kind": "array",
             "name": "ArrayHttpPart",
             "valueType": {
-              "$id": "471",
+              "$id": "473",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6225,12 +6242,12 @@
           "isExactName": false
         },
         {
-          "$id": "472",
+          "$id": "474",
           "kind": "property",
           "name": "profileImage",
           "serializedName": "profileImage",
           "type": {
-            "$id": "473",
+            "$id": "475",
             "kind": "model",
             "name": "File",
             "namespace": "TypeSpec.Http",
@@ -6244,13 +6261,13 @@
             "isFileType": true,
             "properties": [
               {
-                "$id": "474",
+                "$id": "476",
                 "kind": "property",
                 "name": "contentType",
                 "summary": "The allowed media (MIME) types of the file contents.",
                 "doc": "The allowed media (MIME) types of the file contents.\n\nIn file bodies, this value comes from the `Content-Type` header of the request or response. In JSON bodies,\nthis value is serialized as a field in the response.\n\nNOTE: this is not _necessarily_ the same as the `Content-Type` header of the request or response, but\nit will be for file bodies. It may be different if the file is serialized as a JSON object. It always refers to the\n_contents_ of the file, and not necessarily the way the file itself is transmitted or serialized.",
                 "type": {
-                  "$id": "475",
+                  "$id": "477",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6267,13 +6284,13 @@
                 "isExactName": false
               },
               {
-                "$id": "476",
+                "$id": "478",
                 "kind": "property",
                 "name": "filename",
                 "summary": "The name of the file, if any.",
                 "doc": "The name of the file, if any.\n\nIn file bodies, this value comes from the `filename` parameter of the `Content-Disposition` header of the response\nor multipart payload. In JSON bodies, this value is serialized as a field in the response.\n\nNOTE: By default, `filename` cannot be sent in request payloads and can only be sent in responses and multipart\npayloads, as the `Content-Disposition` header is not valid in requests. If you want to send the `filename` in a request,\nyou must extend the `File` model and override the `filename` property with a different location defined by HTTP metadata\ndecorators.",
                 "type": {
-                  "$id": "477",
+                  "$id": "479",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6290,13 +6307,13 @@
                 "isExactName": false
               },
               {
-                "$id": "478",
+                "$id": "480",
                 "kind": "property",
                 "name": "contents",
                 "summary": "The contents of the file.",
                 "doc": "The contents of the file.\n\nIn file bodies, this value comes from the body of the request, response, or multipart payload. In JSON bodies,\nthis value is serialized as a field in the response.",
                 "type": {
-                  "$id": "479",
+                  "$id": "481",
                   "kind": "bytes",
                   "name": "bytes",
                   "encode": "base64",
@@ -6326,12 +6343,12 @@
               "isFilePart": true,
               "isMulti": false,
               "filename": {
-                "$id": "480",
+                "$id": "482",
                 "doc": "The name of the file, if any.\n\nIn file bodies, this value comes from the `filename` parameter of the `Content-Disposition` header of the response\nor multipart payload. In JSON bodies, this value is serialized as a field in the response.\n\nNOTE: By default, `filename` cannot be sent in request payloads and can only be sent in responses and multipart\npayloads, as the `Content-Disposition` header is not valid in requests. If you want to send the `filename` in a request,\nyou must extend the `File` model and override the `filename` property with a different location defined by HTTP metadata\ndecorators.",
                 "summary": "The name of the file, if any.",
                 "apiVersions": [],
                 "type": {
-                  "$id": "481",
+                  "$id": "483",
                   "kind": "string",
                   "decorators": [],
                   "doc": "A sequence of textual characters.",
@@ -6362,12 +6379,12 @@
                 "serializationOptions": {}
               },
               "contentType": {
-                "$id": "482",
+                "$id": "484",
                 "doc": "The allowed media (MIME) types of the file contents.\n\nIn file bodies, this value comes from the `Content-Type` header of the request or response. In JSON bodies,\nthis value is serialized as a field in the response.\n\nNOTE: this is not _necessarily_ the same as the `Content-Type` header of the request or response, but\nit will be for file bodies. It may be different if the file is serialized as a JSON object. It always refers to the\n_contents_ of the file, and not necessarily the way the file itself is transmitted or serialized.",
                 "summary": "The allowed media (MIME) types of the file contents.",
                 "apiVersions": [],
                 "type": {
-                  "$id": "483",
+                  "$id": "485",
                   "kind": "string",
                   "decorators": [],
                   "doc": "A sequence of textual characters.",
@@ -6408,7 +6425,7 @@
           "isExactName": false
         },
         {
-          "$id": "484",
+          "$id": "486",
           "kind": "property",
           "name": "extensibleEnumPart",
           "serializedName": "extensibleEnumPart",
@@ -6436,7 +6453,7 @@
           "isExactName": false
         },
         {
-          "$id": "485",
+          "$id": "487",
           "kind": "property",
           "name": "fixedEnumPart",
           "serializedName": "fixedEnumPart",
@@ -6464,7 +6481,7 @@
           "isExactName": false
         },
         {
-          "$id": "486",
+          "$id": "488",
           "kind": "property",
           "name": "intExtensibleEnumPart",
           "serializedName": "intExtensibleEnumPart",
@@ -6492,7 +6509,7 @@
           "isExactName": false
         },
         {
-          "$id": "487",
+          "$id": "489",
           "kind": "property",
           "name": "intFixedEnumPart",
           "serializedName": "intFixedEnumPart",
@@ -6522,7 +6539,7 @@
       ]
     },
     {
-      "$id": "488",
+      "$id": "490",
       "kind": "model",
       "name": "File",
       "namespace": "TypeSpec.Http",
@@ -6536,18 +6553,18 @@
       "isFileType": true,
       "properties": [
         {
-          "$ref": "474"
-        },
-        {
           "$ref": "476"
         },
         {
           "$ref": "478"
+        },
+        {
+          "$ref": "480"
         }
       ]
     },
     {
-      "$id": "489",
+      "$id": "491",
       "kind": "model",
       "name": "StreamingItem",
       "namespace": "BasicTypeSpec",
@@ -6558,11 +6575,11 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "490",
+          "$id": "492",
           "kind": "property",
           "name": "message",
           "type": {
-            "$id": "491",
+            "$id": "493",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6581,7 +6598,7 @@
       ]
     },
     {
-      "$id": "492",
+      "$id": "494",
       "kind": "model",
       "name": "Tree",
       "namespace": "BasicTypeSpec",
@@ -6602,7 +6619,7 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$id": "493",
+        "$id": "495",
         "kind": "model",
         "name": "Plant",
         "namespace": "BasicTypeSpec",
@@ -6622,13 +6639,13 @@
         },
         "isExactName": false,
         "discriminatorProperty": {
-          "$id": "494",
+          "$id": "496",
           "kind": "property",
           "name": "species",
           "serializedName": "species",
           "doc": "The species of plant",
           "type": {
-            "$id": "495",
+            "$id": "497",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6655,16 +6672,16 @@
         },
         "properties": [
           {
-            "$ref": "494"
+            "$ref": "496"
           },
           {
-            "$id": "496",
+            "$id": "498",
             "kind": "property",
             "name": "id",
             "serializedName": "id",
             "doc": "The unique identifier of the plant",
             "type": {
-              "$id": "497",
+              "$id": "499",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6690,13 +6707,13 @@
             "isExactName": false
           },
           {
-            "$id": "498",
+            "$id": "500",
             "kind": "property",
             "name": "height",
             "serializedName": "height",
             "doc": "The height of the plant in centimeters",
             "type": {
-              "$id": "499",
+              "$id": "501",
               "kind": "int32",
               "name": "int32",
               "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -6724,13 +6741,13 @@
         ],
         "discriminatedSubtypes": {
           "tree": {
-            "$ref": "492"
+            "$ref": "494"
           }
         }
       },
       "properties": [
         {
-          "$id": "500",
+          "$id": "502",
           "kind": "property",
           "name": "species",
           "serializedName": "species",
@@ -6757,13 +6774,13 @@
           "isExactName": false
         },
         {
-          "$id": "501",
+          "$id": "503",
           "kind": "property",
           "name": "age",
           "serializedName": "age",
           "doc": "The age of the tree in years",
           "type": {
-            "$id": "502",
+            "$id": "504",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -6791,10 +6808,10 @@
       ]
     },
     {
-      "$ref": "493"
+      "$ref": "495"
     },
     {
-      "$id": "503",
+      "$id": "505",
       "kind": "model",
       "name": "JsonlStreamStreamingItem",
       "namespace": "TypeSpec.Http.Streams",
@@ -6806,7 +6823,7 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "504",
+          "$id": "506",
           "kind": "property",
           "name": "contentType",
           "type": {
@@ -6823,11 +6840,11 @@
           "isExactName": false
         },
         {
-          "$id": "505",
+          "$id": "507",
           "kind": "property",
           "name": "body",
           "type": {
-            "$id": "506",
+            "$id": "508",
             "kind": "bytes",
             "name": "bytes",
             "crossLanguageDefinitionId": "",
@@ -6848,7 +6865,7 @@
   ],
   "clients": [
     {
-      "$id": "507",
+      "$id": "509",
       "kind": "client",
       "name": "BasicTypeSpecClient",
       "isExactName": false,
@@ -6856,7 +6873,7 @@
       "doc": "This is a sample typespec project.",
       "methods": [
         {
-          "$id": "508",
+          "$id": "510",
           "kind": "basic",
           "name": "sayHi",
           "isExactName": false,
@@ -6867,7 +6884,7 @@
           ],
           "doc": "Return hi",
           "operation": {
-            "$id": "509",
+            "$id": "511",
             "name": "sayHi",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -6875,12 +6892,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "510",
+                "$id": "512",
                 "kind": "header",
                 "name": "headParameter",
                 "serializedName": "head-parameter",
                 "type": {
-                  "$id": "511",
+                  "$id": "513",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6895,12 +6912,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.sayHi.headParameter",
                 "methodParameterSegments": [
                   {
-                    "$id": "512",
+                    "$id": "514",
                     "kind": "method",
                     "name": "headParameter",
                     "serializedName": "head-parameter",
                     "type": {
-                      "$id": "513",
+                      "$id": "515",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6920,12 +6937,12 @@
                 "isExactName": false
               },
               {
-                "$id": "514",
+                "$id": "516",
                 "kind": "query",
                 "name": "queryParameter",
                 "serializedName": "queryParameter",
                 "type": {
-                  "$id": "515",
+                  "$id": "517",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6940,12 +6957,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "516",
+                    "$id": "518",
                     "kind": "method",
                     "name": "queryParameter",
                     "serializedName": "queryParameter",
                     "type": {
-                      "$id": "517",
+                      "$id": "519",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6965,12 +6982,12 @@
                 "isExactName": false
               },
               {
-                "$id": "518",
+                "$id": "520",
                 "kind": "query",
                 "name": "optionalQuery",
                 "serializedName": "optionalQuery",
                 "type": {
-                  "$id": "519",
+                  "$id": "521",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6985,12 +7002,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "520",
+                    "$id": "522",
                     "kind": "method",
                     "name": "optionalQuery",
                     "serializedName": "optionalQuery",
                     "type": {
-                      "$id": "521",
+                      "$id": "523",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7010,7 +7027,7 @@
                 "isExactName": false
               },
               {
-                "$id": "522",
+                "$id": "524",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -7026,7 +7043,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.sayHi.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "523",
+                    "$id": "525",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7053,7 +7070,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -7079,21 +7096,21 @@
           },
           "parameters": [
             {
-              "$ref": "512"
+              "$ref": "514"
             },
             {
-              "$ref": "516"
+              "$ref": "518"
             },
             {
-              "$ref": "520"
+              "$ref": "522"
             },
             {
-              "$ref": "523"
+              "$ref": "525"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -7102,7 +7119,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.sayHi"
         },
         {
-          "$id": "524",
+          "$id": "526",
           "kind": "basic",
           "name": "helloAgain",
           "isExactName": false,
@@ -7113,7 +7130,7 @@
           ],
           "doc": "Return hi again",
           "operation": {
-            "$id": "525",
+            "$id": "527",
             "name": "helloAgain",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -7121,12 +7138,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "526",
+                "$id": "528",
                 "kind": "header",
                 "name": "p1",
                 "serializedName": "p1",
                 "type": {
-                  "$id": "527",
+                  "$id": "529",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7141,12 +7158,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloAgain.p1",
                 "methodParameterSegments": [
                   {
-                    "$id": "528",
+                    "$id": "530",
                     "kind": "method",
                     "name": "p1",
                     "serializedName": "p1",
                     "type": {
-                      "$id": "529",
+                      "$id": "531",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7166,7 +7183,7 @@
                 "isExactName": false
               },
               {
-                "$id": "530",
+                "$id": "532",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -7182,7 +7199,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloAgain.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "531",
+                    "$id": "533",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -7203,12 +7220,12 @@
                 "isExactName": false
               },
               {
-                "$id": "532",
+                "$id": "534",
                 "kind": "path",
                 "name": "p2",
                 "serializedName": "p2",
                 "type": {
-                  "$id": "533",
+                  "$id": "535",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7226,12 +7243,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloAgain.p2",
                 "methodParameterSegments": [
                   {
-                    "$id": "534",
+                    "$id": "536",
                     "kind": "method",
                     "name": "p2",
                     "serializedName": "p2",
                     "type": {
-                      "$id": "535",
+                      "$id": "537",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7251,7 +7268,7 @@
                 "isExactName": false
               },
               {
-                "$id": "536",
+                "$id": "538",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -7267,7 +7284,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloAgain.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "537",
+                    "$id": "539",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7288,12 +7305,12 @@
                 "isExactName": false
               },
               {
-                "$id": "538",
+                "$id": "540",
                 "kind": "body",
                 "name": "action",
                 "serializedName": "action",
                 "type": {
-                  "$ref": "253"
+                  "$ref": "255"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -7307,12 +7324,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloAgain.action",
                 "methodParameterSegments": [
                   {
-                    "$id": "539",
+                    "$id": "541",
                     "kind": "method",
                     "name": "action",
                     "serializedName": "action",
                     "type": {
-                      "$ref": "253"
+                      "$ref": "255"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -7335,7 +7352,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "253"
+                  "$ref": "255"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -7364,24 +7381,24 @@
           },
           "parameters": [
             {
-              "$ref": "528"
+              "$ref": "530"
+            },
+            {
+              "$ref": "541"
+            },
+            {
+              "$ref": "533"
+            },
+            {
+              "$ref": "536"
             },
             {
               "$ref": "539"
-            },
-            {
-              "$ref": "531"
-            },
-            {
-              "$ref": "534"
-            },
-            {
-              "$ref": "537"
             }
           ],
           "response": {
             "type": {
-              "$ref": "253"
+              "$ref": "255"
             }
           },
           "isOverride": false,
@@ -7390,7 +7407,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.helloAgain"
         },
         {
-          "$id": "540",
+          "$id": "542",
           "kind": "basic",
           "name": "noContentType",
           "isExactName": false,
@@ -7401,7 +7418,7 @@
           ],
           "doc": "Return hi again",
           "operation": {
-            "$id": "541",
+            "$id": "543",
             "name": "noContentType",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -7409,12 +7426,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "542",
+                "$id": "544",
                 "kind": "header",
                 "name": "p1",
                 "serializedName": "p1",
                 "type": {
-                  "$id": "543",
+                  "$id": "545",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7429,12 +7446,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.noContentType.p1",
                 "methodParameterSegments": [
                   {
-                    "$id": "544",
+                    "$id": "546",
                     "kind": "method",
                     "name": "p1",
                     "serializedName": "p1",
                     "type": {
-                      "$id": "545",
+                      "$id": "547",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7454,12 +7471,12 @@
                 "isExactName": false
               },
               {
-                "$id": "546",
+                "$id": "548",
                 "kind": "path",
                 "name": "p2",
                 "serializedName": "p2",
                 "type": {
-                  "$id": "547",
+                  "$id": "549",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7477,12 +7494,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.noContentType.p2",
                 "methodParameterSegments": [
                   {
-                    "$id": "548",
+                    "$id": "550",
                     "kind": "method",
                     "name": "p2",
                     "serializedName": "p2",
                     "type": {
-                      "$id": "549",
+                      "$id": "551",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7502,7 +7519,7 @@
                 "isExactName": false
               },
               {
-                "$id": "550",
+                "$id": "552",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -7519,7 +7536,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.noContentType.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "551",
+                    "$id": "553",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -7541,7 +7558,7 @@
                 "isExactName": false
               },
               {
-                "$id": "552",
+                "$id": "554",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -7557,7 +7574,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.noContentType.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "553",
+                    "$id": "555",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7578,12 +7595,12 @@
                 "isExactName": false
               },
               {
-                "$id": "554",
+                "$id": "556",
                 "kind": "body",
                 "name": "action",
                 "serializedName": "action",
                 "type": {
-                  "$ref": "253"
+                  "$ref": "255"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -7597,12 +7614,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.noContentType.action",
                 "methodParameterSegments": [
                   {
-                    "$id": "555",
+                    "$id": "557",
                     "kind": "method",
                     "name": "action",
                     "serializedName": "action",
                     "type": {
-                      "$ref": "253"
+                      "$ref": "255"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -7629,7 +7646,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "253"
+                  "$ref": "255"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -7658,24 +7675,24 @@
           },
           "parameters": [
             {
-              "$ref": "544"
+              "$ref": "546"
             },
             {
-              "$ref": "555"
+              "$ref": "557"
             },
             {
-              "$ref": "548"
-            },
-            {
-              "$ref": "551"
+              "$ref": "550"
             },
             {
               "$ref": "553"
+            },
+            {
+              "$ref": "555"
             }
           ],
           "response": {
             "type": {
-              "$ref": "253"
+              "$ref": "255"
             }
           },
           "isOverride": false,
@@ -7684,7 +7701,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.noContentType"
         },
         {
-          "$id": "556",
+          "$id": "558",
           "kind": "basic",
           "name": "helloDemo2",
           "isExactName": false,
@@ -7695,7 +7712,7 @@
           ],
           "doc": "Return hi in demo2",
           "operation": {
-            "$id": "557",
+            "$id": "559",
             "name": "helloDemo2",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -7703,7 +7720,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "558",
+                "$id": "560",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -7719,7 +7736,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloDemo2.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "559",
+                    "$id": "561",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7746,7 +7763,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -7772,12 +7789,12 @@
           },
           "parameters": [
             {
-              "$ref": "559"
+              "$ref": "561"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -7786,7 +7803,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.helloDemo2"
         },
         {
-          "$id": "560",
+          "$id": "562",
           "kind": "basic",
           "name": "createLiteral",
           "isExactName": false,
@@ -7797,7 +7814,7 @@
           ],
           "doc": "Create with literal value",
           "operation": {
-            "$id": "561",
+            "$id": "563",
             "name": "createLiteral",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -7805,7 +7822,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "562",
+                "$id": "564",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -7822,7 +7839,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.createLiteral.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "563",
+                    "$id": "565",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -7844,7 +7861,7 @@
                 "isExactName": false
               },
               {
-                "$id": "564",
+                "$id": "566",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -7860,7 +7877,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.createLiteral.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "565",
+                    "$id": "567",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7881,12 +7898,12 @@
                 "isExactName": false
               },
               {
-                "$id": "566",
+                "$id": "568",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -7900,12 +7917,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.createLiteral.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "567",
+                    "$id": "569",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "228"
+                      "$ref": "230"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -7932,7 +7949,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -7961,18 +7978,18 @@
           },
           "parameters": [
             {
-              "$ref": "567"
-            },
-            {
-              "$ref": "563"
+              "$ref": "569"
             },
             {
               "$ref": "565"
+            },
+            {
+              "$ref": "567"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -7981,7 +7998,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.createLiteral"
         },
         {
-          "$id": "568",
+          "$id": "570",
           "kind": "basic",
           "name": "helloLiteral",
           "isExactName": false,
@@ -7992,7 +8009,7 @@
           ],
           "doc": "Send literal parameters",
           "operation": {
-            "$id": "569",
+            "$id": "571",
             "name": "helloLiteral",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -8000,7 +8017,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "570",
+                "$id": "572",
                 "kind": "header",
                 "name": "p1",
                 "serializedName": "p1",
@@ -8016,7 +8033,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloLiteral.p1",
                 "methodParameterSegments": [
                   {
-                    "$id": "571",
+                    "$id": "573",
                     "kind": "method",
                     "name": "p1",
                     "serializedName": "p1",
@@ -8037,7 +8054,7 @@
                 "isExactName": false
               },
               {
-                "$id": "572",
+                "$id": "574",
                 "kind": "path",
                 "name": "p2",
                 "serializedName": "p2",
@@ -8056,7 +8073,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloLiteral.p2",
                 "methodParameterSegments": [
                   {
-                    "$id": "573",
+                    "$id": "575",
                     "kind": "method",
                     "name": "p2",
                     "serializedName": "p2",
@@ -8077,7 +8094,7 @@
                 "isExactName": false
               },
               {
-                "$id": "574",
+                "$id": "576",
                 "kind": "query",
                 "name": "p3",
                 "serializedName": "p3",
@@ -8093,7 +8110,7 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "575",
+                    "$id": "577",
                     "kind": "method",
                     "name": "p3",
                     "serializedName": "p3",
@@ -8114,7 +8131,7 @@
                 "isExactName": false
               },
               {
-                "$id": "576",
+                "$id": "578",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8130,7 +8147,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.helloLiteral.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "577",
+                    "$id": "579",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8157,7 +8174,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8183,9 +8200,6 @@
           },
           "parameters": [
             {
-              "$ref": "571"
-            },
-            {
               "$ref": "573"
             },
             {
@@ -8193,11 +8207,14 @@
             },
             {
               "$ref": "577"
+            },
+            {
+              "$ref": "579"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -8206,7 +8223,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.helloLiteral"
         },
         {
-          "$id": "578",
+          "$id": "580",
           "kind": "basic",
           "name": "topAction",
           "isExactName": false,
@@ -8217,7 +8234,7 @@
           ],
           "doc": "top level method",
           "operation": {
-            "$id": "579",
+            "$id": "581",
             "name": "topAction",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -8225,17 +8242,17 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "580",
+                "$id": "582",
                 "kind": "path",
                 "name": "action",
                 "serializedName": "action",
                 "type": {
-                  "$id": "581",
+                  "$id": "583",
                   "kind": "utcDateTime",
                   "name": "utcDateTime",
                   "encode": "rfc3339",
                   "wireType": {
-                    "$id": "582",
+                    "$id": "584",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8256,17 +8273,17 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.topAction.action",
                 "methodParameterSegments": [
                   {
-                    "$id": "583",
+                    "$id": "585",
                     "kind": "method",
                     "name": "action",
                     "serializedName": "action",
                     "type": {
-                      "$id": "584",
+                      "$id": "586",
                       "kind": "utcDateTime",
                       "name": "utcDateTime",
                       "encode": "rfc3339",
                       "wireType": {
-                        "$id": "585",
+                        "$id": "587",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8289,7 +8306,7 @@
                 "isExactName": false
               },
               {
-                "$id": "586",
+                "$id": "588",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8305,7 +8322,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.topAction.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "587",
+                    "$id": "589",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8332,7 +8349,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8358,15 +8375,15 @@
           },
           "parameters": [
             {
-              "$ref": "583"
+              "$ref": "585"
             },
             {
-              "$ref": "587"
+              "$ref": "589"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -8375,7 +8392,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.topAction"
         },
         {
-          "$id": "588",
+          "$id": "590",
           "kind": "basic",
           "name": "topAction2",
           "isExactName": false,
@@ -8386,7 +8403,7 @@
           ],
           "doc": "top level method2",
           "operation": {
-            "$id": "589",
+            "$id": "591",
             "name": "topAction2",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -8394,7 +8411,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "590",
+                "$id": "592",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8410,7 +8427,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.topAction2.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "591",
+                    "$id": "593",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8437,7 +8454,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8463,12 +8480,12 @@
           },
           "parameters": [
             {
-              "$ref": "591"
+              "$ref": "593"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -8477,7 +8494,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.topAction2"
         },
         {
-          "$id": "592",
+          "$id": "594",
           "kind": "basic",
           "name": "patchAction",
           "isExactName": false,
@@ -8488,7 +8505,7 @@
           ],
           "doc": "top level patch",
           "operation": {
-            "$id": "593",
+            "$id": "595",
             "name": "patchAction",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -8496,7 +8513,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "594",
+                "$id": "596",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -8513,7 +8530,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.patchAction.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "595",
+                    "$id": "597",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -8535,7 +8552,7 @@
                 "isExactName": false
               },
               {
-                "$id": "596",
+                "$id": "598",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8551,7 +8568,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.patchAction.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "597",
+                    "$id": "599",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8572,12 +8589,12 @@
                 "isExactName": false
               },
               {
-                "$id": "598",
+                "$id": "600",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -8591,12 +8608,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.patchAction.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "599",
+                    "$id": "601",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "228"
+                      "$ref": "230"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -8623,7 +8640,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8652,18 +8669,18 @@
           },
           "parameters": [
             {
-              "$ref": "599"
-            },
-            {
-              "$ref": "595"
+              "$ref": "601"
             },
             {
               "$ref": "597"
+            },
+            {
+              "$ref": "599"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -8672,7 +8689,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.patchAction"
         },
         {
-          "$id": "600",
+          "$id": "602",
           "kind": "basic",
           "name": "anonymousBody",
           "isExactName": false,
@@ -8683,7 +8700,7 @@
           ],
           "doc": "body parameter without body decorator",
           "operation": {
-            "$id": "601",
+            "$id": "603",
             "name": "anonymousBody",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -8691,7 +8708,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "602",
+                "$id": "604",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -8708,7 +8725,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.anonymousBody.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "603",
+                    "$id": "605",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -8730,7 +8747,7 @@
                 "isExactName": false
               },
               {
-                "$id": "604",
+                "$id": "606",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8746,7 +8763,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.anonymousBody.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "605",
+                    "$id": "607",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8767,12 +8784,12 @@
                 "isExactName": false
               },
               {
-                "$id": "606",
+                "$id": "608",
                 "kind": "body",
                 "name": "thingModel",
                 "serializedName": "thingModel",
                 "type": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -8786,13 +8803,13 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.anonymousBody.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "607",
+                    "$id": "609",
                     "kind": "method",
                     "name": "name",
                     "serializedName": "name",
                     "doc": "name of the ThingModel",
                     "type": {
-                      "$id": "608",
+                      "$id": "610",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8823,7 +8840,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8852,16 +8869,16 @@
           },
           "parameters": [
             {
-              "$ref": "607"
+              "$ref": "609"
             },
             {
-              "$id": "609",
+              "$id": "611",
               "kind": "method",
               "name": "requiredUnion",
               "serializedName": "requiredUnion",
               "doc": "required Union",
               "type": {
-                "$ref": "232"
+                "$ref": "234"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -8874,7 +8891,7 @@
               "isExactName": false
             },
             {
-              "$id": "610",
+              "$id": "612",
               "kind": "method",
               "name": "requiredLiteralString",
               "serializedName": "requiredLiteralString",
@@ -8893,7 +8910,7 @@
               "isExactName": false
             },
             {
-              "$id": "611",
+              "$id": "613",
               "kind": "method",
               "name": "requiredLiteralInt",
               "serializedName": "requiredLiteralInt",
@@ -8912,7 +8929,7 @@
               "isExactName": false
             },
             {
-              "$id": "612",
+              "$id": "614",
               "kind": "method",
               "name": "requiredLiteralFloat",
               "serializedName": "requiredLiteralFloat",
@@ -8931,7 +8948,7 @@
               "isExactName": false
             },
             {
-              "$id": "613",
+              "$id": "615",
               "kind": "method",
               "name": "requiredLiteralBool",
               "serializedName": "requiredLiteralBool",
@@ -8950,18 +8967,18 @@
               "isExactName": false
             },
             {
-              "$id": "614",
+              "$id": "616",
               "kind": "method",
               "name": "optionalLiteralString",
               "serializedName": "optionalLiteralString",
               "doc": "optional literal string",
               "type": {
-                "$id": "615",
+                "$id": "617",
                 "kind": "enum",
                 "name": "ThingModelOptionalLiteralString",
                 "crossLanguageDefinitionId": "",
                 "valueType": {
-                  "$id": "616",
+                  "$id": "618",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8969,12 +8986,12 @@
                 },
                 "values": [
                   {
-                    "$id": "617",
+                    "$id": "619",
                     "kind": "enumvalue",
                     "name": "reject",
                     "value": "reject",
                     "valueType": {
-                      "$id": "618",
+                      "$id": "620",
                       "kind": "string",
                       "decorators": [],
                       "doc": "A sequence of textual characters.",
@@ -8982,7 +8999,7 @@
                       "crossLanguageDefinitionId": "TypeSpec.string"
                     },
                     "enumType": {
-                      "$ref": "615"
+                      "$ref": "617"
                     },
                     "decorators": [],
                     "isExactName": false
@@ -9006,18 +9023,18 @@
               "isExactName": false
             },
             {
-              "$id": "619",
+              "$id": "621",
               "kind": "method",
               "name": "optionalLiteralInt",
               "serializedName": "optionalLiteralInt",
               "doc": "optional literal int",
               "type": {
-                "$id": "620",
+                "$id": "622",
                 "kind": "enum",
                 "name": "ThingModelOptionalLiteralInt",
                 "crossLanguageDefinitionId": "",
                 "valueType": {
-                  "$id": "621",
+                  "$id": "623",
                   "kind": "int32",
                   "name": "int32",
                   "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -9025,12 +9042,12 @@
                 },
                 "values": [
                   {
-                    "$id": "622",
+                    "$id": "624",
                     "kind": "enumvalue",
                     "name": "456",
                     "value": 456,
                     "valueType": {
-                      "$id": "623",
+                      "$id": "625",
                       "kind": "int32",
                       "decorators": [],
                       "doc": "A 32-bit integer. (`-2,147,483,648` to `2,147,483,647`)",
@@ -9038,7 +9055,7 @@
                       "crossLanguageDefinitionId": "TypeSpec.int32"
                     },
                     "enumType": {
-                      "$ref": "620"
+                      "$ref": "622"
                     },
                     "decorators": [],
                     "isExactName": false
@@ -9062,18 +9079,18 @@
               "isExactName": false
             },
             {
-              "$id": "624",
+              "$id": "626",
               "kind": "method",
               "name": "optionalLiteralFloat",
               "serializedName": "optionalLiteralFloat",
               "doc": "optional literal float",
               "type": {
-                "$id": "625",
+                "$id": "627",
                 "kind": "enum",
                 "name": "ThingModelOptionalLiteralFloat",
                 "crossLanguageDefinitionId": "",
                 "valueType": {
-                  "$id": "626",
+                  "$id": "628",
                   "kind": "float32",
                   "name": "float32",
                   "crossLanguageDefinitionId": "TypeSpec.float32",
@@ -9081,12 +9098,12 @@
                 },
                 "values": [
                   {
-                    "$id": "627",
+                    "$id": "629",
                     "kind": "enumvalue",
                     "name": "4.56",
                     "value": 4.56,
                     "valueType": {
-                      "$id": "628",
+                      "$id": "630",
                       "kind": "float32",
                       "decorators": [],
                       "doc": "A 32 bit floating point number. (`±1.5 x 10^−45` to `±3.4 x 10^38`)",
@@ -9094,7 +9111,7 @@
                       "crossLanguageDefinitionId": "TypeSpec.float32"
                     },
                     "enumType": {
-                      "$ref": "625"
+                      "$ref": "627"
                     },
                     "decorators": [],
                     "isExactName": false
@@ -9118,7 +9135,7 @@
               "isExactName": false
             },
             {
-              "$id": "629",
+              "$id": "631",
               "kind": "method",
               "name": "optionalLiteralBool",
               "serializedName": "optionalLiteralBool",
@@ -9137,13 +9154,13 @@
               "isExactName": false
             },
             {
-              "$id": "630",
+              "$id": "632",
               "kind": "method",
               "name": "requiredBadDescription",
               "serializedName": "requiredBadDescription",
               "doc": "description with xml <|endoftext|>",
               "type": {
-                "$id": "631",
+                "$id": "633",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9160,13 +9177,13 @@
               "isExactName": false
             },
             {
-              "$id": "632",
+              "$id": "634",
               "kind": "method",
               "name": "optionalNullableList",
               "serializedName": "optionalNullableList",
               "doc": "optional nullable collection",
               "type": {
-                "$ref": "248"
+                "$ref": "250"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -9179,13 +9196,13 @@
               "isExactName": false
             },
             {
-              "$id": "633",
+              "$id": "635",
               "kind": "method",
               "name": "requiredNullableList",
               "serializedName": "requiredNullableList",
               "doc": "required nullable collection",
               "type": {
-                "$ref": "252"
+                "$ref": "254"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -9198,15 +9215,15 @@
               "isExactName": false
             },
             {
-              "$ref": "603"
+              "$ref": "605"
             },
             {
-              "$ref": "605"
+              "$ref": "607"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -9215,7 +9232,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.anonymousBody"
         },
         {
-          "$id": "634",
+          "$id": "636",
           "kind": "basic",
           "name": "friendlyModel",
           "isExactName": false,
@@ -9226,7 +9243,7 @@
           ],
           "doc": "Model can have its friendly name",
           "operation": {
-            "$id": "635",
+            "$id": "637",
             "name": "friendlyModel",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -9234,7 +9251,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "636",
+                "$id": "638",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -9251,7 +9268,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.friendlyModel.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "637",
+                    "$id": "639",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -9273,7 +9290,7 @@
                 "isExactName": false
               },
               {
-                "$id": "638",
+                "$id": "640",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9289,7 +9306,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.friendlyModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "639",
+                    "$id": "641",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9310,12 +9327,12 @@
                 "isExactName": false
               },
               {
-                "$id": "640",
+                "$id": "642",
                 "kind": "body",
                 "name": "friendModel",
                 "serializedName": "friendModel",
                 "type": {
-                  "$ref": "301"
+                  "$ref": "303"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -9329,13 +9346,13 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.friendlyModel.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "641",
+                    "$id": "643",
                     "kind": "method",
                     "name": "name",
                     "serializedName": "name",
                     "doc": "name of the NotFriend",
                     "type": {
-                      "$id": "642",
+                      "$id": "644",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9366,7 +9383,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "301"
+                  "$ref": "303"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -9395,18 +9412,18 @@
           },
           "parameters": [
             {
-              "$ref": "641"
-            },
-            {
-              "$ref": "637"
+              "$ref": "643"
             },
             {
               "$ref": "639"
+            },
+            {
+              "$ref": "641"
             }
           ],
           "response": {
             "type": {
-              "$ref": "301"
+              "$ref": "303"
             }
           },
           "isOverride": false,
@@ -9415,7 +9432,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.friendlyModel"
         },
         {
-          "$id": "643",
+          "$id": "645",
           "kind": "basic",
           "name": "addTimeHeader",
           "isExactName": false,
@@ -9425,24 +9442,24 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "644",
+            "$id": "646",
             "name": "addTimeHeader",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "645",
+                "$id": "647",
                 "kind": "header",
                 "name": "repeatabilityFirstSent",
                 "serializedName": "Repeatability-First-Sent",
                 "type": {
-                  "$id": "646",
+                  "$id": "648",
                   "kind": "utcDateTime",
                   "name": "utcDateTime",
                   "encode": "rfc7231",
                   "wireType": {
-                    "$id": "647",
+                    "$id": "649",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9460,17 +9477,17 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.addTimeHeader.repeatabilityFirstSent",
                 "methodParameterSegments": [
                   {
-                    "$id": "648",
+                    "$id": "650",
                     "kind": "method",
                     "name": "repeatabilityFirstSent",
                     "serializedName": "Repeatability-First-Sent",
                     "type": {
-                      "$id": "649",
+                      "$id": "651",
                       "kind": "utcDateTime",
                       "name": "utcDateTime",
                       "encode": "rfc7231",
                       "wireType": {
-                        "$id": "650",
+                        "$id": "652",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9515,7 +9532,7 @@
           },
           "parameters": [
             {
-              "$ref": "648"
+              "$ref": "650"
             }
           ],
           "response": {},
@@ -9525,7 +9542,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.addTimeHeader"
         },
         {
-          "$id": "651",
+          "$id": "653",
           "kind": "basic",
           "name": "projectedNameModel",
           "isExactName": false,
@@ -9536,7 +9553,7 @@
           ],
           "doc": "Model can have its projected name",
           "operation": {
-            "$id": "652",
+            "$id": "654",
             "name": "projectedNameModel",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -9544,7 +9561,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "653",
+                "$id": "655",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -9561,7 +9578,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.projectedNameModel.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "654",
+                    "$id": "656",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -9583,7 +9600,7 @@
                 "isExactName": false
               },
               {
-                "$id": "655",
+                "$id": "657",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9599,7 +9616,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.projectedNameModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "656",
+                    "$id": "658",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9620,12 +9637,12 @@
                 "isExactName": false
               },
               {
-                "$id": "657",
+                "$id": "659",
                 "kind": "body",
                 "name": "renamedModel",
                 "serializedName": "renamedModel",
                 "type": {
-                  "$ref": "304"
+                  "$ref": "306"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -9639,13 +9656,13 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.projectedNameModel.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "658",
+                    "$id": "660",
                     "kind": "method",
                     "name": "name",
                     "serializedName": "name",
                     "doc": "name of the ModelWithClientName",
                     "type": {
-                      "$id": "659",
+                      "$id": "661",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9676,7 +9693,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "304"
+                  "$ref": "306"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -9705,18 +9722,18 @@
           },
           "parameters": [
             {
-              "$ref": "658"
-            },
-            {
-              "$ref": "654"
+              "$ref": "660"
             },
             {
               "$ref": "656"
+            },
+            {
+              "$ref": "658"
             }
           ],
           "response": {
             "type": {
-              "$ref": "304"
+              "$ref": "306"
             }
           },
           "isOverride": false,
@@ -9725,7 +9742,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.projectedNameModel"
         },
         {
-          "$id": "660",
+          "$id": "662",
           "kind": "basic",
           "name": "returnsAnonymousModel",
           "isExactName": false,
@@ -9736,7 +9753,7 @@
           ],
           "doc": "return anonymous model",
           "operation": {
-            "$id": "661",
+            "$id": "663",
             "name": "returnsAnonymousModel",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -9744,7 +9761,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "662",
+                "$id": "664",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9760,7 +9777,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.returnsAnonymousModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "663",
+                    "$id": "665",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9787,7 +9804,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "307"
+                  "$ref": "309"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -9813,12 +9830,12 @@
           },
           "parameters": [
             {
-              "$ref": "663"
+              "$ref": "665"
             }
           ],
           "response": {
             "type": {
-              "$ref": "307"
+              "$ref": "309"
             }
           },
           "isOverride": false,
@@ -9827,7 +9844,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.returnsAnonymousModel"
         },
         {
-          "$id": "664",
+          "$id": "666",
           "kind": "basic",
           "name": "getUnknownValue",
           "isExactName": false,
@@ -9838,7 +9855,7 @@
           ],
           "doc": "get extensible enum",
           "operation": {
-            "$id": "665",
+            "$id": "667",
             "name": "getUnknownValue",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -9846,7 +9863,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "666",
+                "$id": "668",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9862,7 +9879,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.getUnknownValue.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "667",
+                    "$id": "669",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9911,7 +9928,7 @@
           },
           "parameters": [
             {
-              "$ref": "667"
+              "$ref": "669"
             }
           ],
           "response": {
@@ -9925,7 +9942,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.getUnknownValue"
         },
         {
-          "$id": "668",
+          "$id": "670",
           "kind": "basic",
           "name": "internalProtocol",
           "isExactName": false,
@@ -9936,7 +9953,7 @@
           ],
           "doc": "When set protocol false and convenient true, then the protocol method should be internal",
           "operation": {
-            "$id": "669",
+            "$id": "671",
             "name": "internalProtocol",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -9944,7 +9961,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "670",
+                "$id": "672",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -9961,7 +9978,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.internalProtocol.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "671",
+                    "$id": "673",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -9983,7 +10000,7 @@
                 "isExactName": false
               },
               {
-                "$id": "672",
+                "$id": "674",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9999,7 +10016,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.internalProtocol.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "673",
+                    "$id": "675",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10020,12 +10037,12 @@
                 "isExactName": false
               },
               {
-                "$id": "674",
+                "$id": "676",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -10039,12 +10056,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.internalProtocol.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "675",
+                    "$id": "677",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "228"
+                      "$ref": "230"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -10071,7 +10088,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "228"
+                  "$ref": "230"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -10100,18 +10117,18 @@
           },
           "parameters": [
             {
-              "$ref": "675"
-            },
-            {
-              "$ref": "671"
+              "$ref": "677"
             },
             {
               "$ref": "673"
+            },
+            {
+              "$ref": "675"
             }
           ],
           "response": {
             "type": {
-              "$ref": "228"
+              "$ref": "230"
             }
           },
           "isOverride": false,
@@ -10120,7 +10137,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.internalProtocol"
         },
         {
-          "$id": "676",
+          "$id": "678",
           "kind": "basic",
           "name": "stillConvenient",
           "isExactName": false,
@@ -10131,7 +10148,7 @@
           ],
           "doc": "When set protocol false and convenient true, the convenient method should be generated even it has the same signature as protocol one",
           "operation": {
-            "$id": "677",
+            "$id": "679",
             "name": "stillConvenient",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -10166,7 +10183,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.stillConvenient"
         },
         {
-          "$id": "678",
+          "$id": "680",
           "kind": "basic",
           "name": "headAsBoolean",
           "isExactName": false,
@@ -10177,7 +10194,7 @@
           ],
           "doc": "head as boolean.",
           "operation": {
-            "$id": "679",
+            "$id": "681",
             "name": "headAsBoolean",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -10185,12 +10202,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "680",
+                "$id": "682",
                 "kind": "path",
                 "name": "id",
                 "serializedName": "id",
                 "type": {
-                  "$id": "681",
+                  "$id": "683",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10208,12 +10225,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.headAsBoolean.id",
                 "methodParameterSegments": [
                   {
-                    "$id": "682",
+                    "$id": "684",
                     "kind": "method",
                     "name": "id",
                     "serializedName": "id",
                     "type": {
-                      "$id": "683",
+                      "$id": "685",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10255,7 +10272,7 @@
           },
           "parameters": [
             {
-              "$ref": "682"
+              "$ref": "684"
             }
           ],
           "response": {},
@@ -10265,7 +10282,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.headAsBoolean"
         },
         {
-          "$id": "684",
+          "$id": "686",
           "kind": "paging",
           "name": "ListWithNextLink",
           "isExactName": false,
@@ -10276,7 +10293,7 @@
           ],
           "doc": "List things with nextlink",
           "operation": {
-            "$id": "685",
+            "$id": "687",
             "name": "ListWithNextLink",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -10284,7 +10301,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "686",
+                "$id": "688",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -10300,7 +10317,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ListWithNextLink.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "687",
+                    "$id": "689",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10327,7 +10344,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "308"
+                  "$ref": "310"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -10353,12 +10370,12 @@
           },
           "parameters": [
             {
-              "$ref": "687"
+              "$ref": "689"
             }
           ],
           "response": {
             "type": {
-              "$ref": "310"
+              "$ref": "312"
             },
             "resultSegments": [
               "things"
@@ -10382,7 +10399,7 @@
           }
         },
         {
-          "$id": "688",
+          "$id": "690",
           "kind": "paging",
           "name": "ListWithStringNextLink",
           "isExactName": false,
@@ -10393,7 +10410,7 @@
           ],
           "doc": "List things with nextlink",
           "operation": {
-            "$id": "689",
+            "$id": "691",
             "name": "ListWithStringNextLink",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -10401,7 +10418,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "690",
+                "$id": "692",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -10417,7 +10434,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ListWithStringNextLink.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "691",
+                    "$id": "693",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10444,7 +10461,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "313"
+                  "$ref": "315"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -10470,12 +10487,12 @@
           },
           "parameters": [
             {
-              "$ref": "691"
+              "$ref": "693"
             }
           ],
           "response": {
             "type": {
-              "$ref": "310"
+              "$ref": "312"
             },
             "resultSegments": [
               "things"
@@ -10499,7 +10516,7 @@
           }
         },
         {
-          "$id": "692",
+          "$id": "694",
           "kind": "paging",
           "name": "ListWithHeaderNextLink",
           "isExactName": false,
@@ -10510,7 +10527,7 @@
           ],
           "doc": "List things with nextlink",
           "operation": {
-            "$id": "693",
+            "$id": "695",
             "name": "ListWithHeaderNextLink",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -10518,7 +10535,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "694",
+                "$id": "696",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -10534,7 +10551,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ListWithHeaderNextLink.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "695",
+                    "$id": "697",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10561,14 +10578,14 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "317"
+                  "$ref": "319"
                 },
                 "headers": [
                   {
                     "name": "next",
                     "nameInResponse": "next",
                     "type": {
-                      "$id": "696",
+                      "$id": "698",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10599,12 +10616,12 @@
           },
           "parameters": [
             {
-              "$ref": "695"
+              "$ref": "697"
             }
           ],
           "response": {
             "type": {
-              "$ref": "310"
+              "$ref": "312"
             },
             "resultSegments": [
               "things"
@@ -10628,7 +10645,7 @@
           }
         },
         {
-          "$id": "697",
+          "$id": "699",
           "kind": "paging",
           "name": "ListWithHeaderNextLinkWithMaxPage",
           "isExactName": false,
@@ -10639,7 +10656,7 @@
           ],
           "doc": "List things with nextlink",
           "operation": {
-            "$id": "698",
+            "$id": "700",
             "name": "ListWithHeaderNextLinkWithMaxPage",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -10647,12 +10664,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "699",
+                "$id": "701",
                 "kind": "query",
                 "name": "numElements",
                 "serializedName": "numElements",
                 "type": {
-                  "$id": "700",
+                  "$id": "702",
                   "kind": "int32",
                   "name": "int32",
                   "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -10667,12 +10684,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "701",
+                    "$id": "703",
                     "kind": "method",
                     "name": "numElements",
                     "serializedName": "numElements",
                     "type": {
-                      "$id": "702",
+                      "$id": "704",
                       "kind": "int32",
                       "name": "int32",
                       "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -10692,7 +10709,7 @@
                 "isExactName": false
               },
               {
-                "$id": "703",
+                "$id": "705",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -10708,7 +10725,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ListWithHeaderNextLinkWithMaxPage.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "704",
+                    "$id": "706",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10735,14 +10752,14 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "319"
+                  "$ref": "321"
                 },
                 "headers": [
                   {
                     "name": "next",
                     "nameInResponse": "next",
                     "type": {
-                      "$id": "705",
+                      "$id": "707",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10773,15 +10790,15 @@
           },
           "parameters": [
             {
-              "$ref": "701"
+              "$ref": "703"
             },
             {
-              "$ref": "704"
+              "$ref": "706"
             }
           ],
           "response": {
             "type": {
-              "$ref": "310"
+              "$ref": "312"
             },
             "resultSegments": [
               "things"
@@ -10807,7 +10824,7 @@
           }
         },
         {
-          "$id": "706",
+          "$id": "708",
           "kind": "paging",
           "name": "ListWithContinuationToken",
           "isExactName": false,
@@ -10818,7 +10835,7 @@
           ],
           "doc": "List things with continuation token",
           "operation": {
-            "$id": "707",
+            "$id": "709",
             "name": "ListWithContinuationToken",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -10826,12 +10843,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "708",
+                "$id": "710",
                 "kind": "query",
                 "name": "token",
                 "serializedName": "token",
                 "type": {
-                  "$id": "709",
+                  "$id": "711",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10846,12 +10863,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "710",
+                    "$id": "712",
                     "kind": "method",
                     "name": "token",
                     "serializedName": "token",
                     "type": {
-                      "$id": "711",
+                      "$id": "713",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10871,7 +10888,7 @@
                 "isExactName": false
               },
               {
-                "$id": "712",
+                "$id": "714",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -10887,7 +10904,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ListWithContinuationToken.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "713",
+                    "$id": "715",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10914,7 +10931,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "321"
+                  "$ref": "323"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -10940,15 +10957,15 @@
           },
           "parameters": [
             {
-              "$ref": "710"
+              "$ref": "712"
             },
             {
-              "$ref": "713"
+              "$ref": "715"
             }
           ],
           "response": {
             "type": {
-              "$ref": "310"
+              "$ref": "312"
             },
             "resultSegments": [
               "things"
@@ -10964,7 +10981,7 @@
             ],
             "continuationToken": {
               "parameter": {
-                "$ref": "708"
+                "$ref": "710"
               },
               "responseSegments": [
                 "nextToken"
@@ -10975,7 +10992,7 @@
           }
         },
         {
-          "$id": "714",
+          "$id": "716",
           "kind": "paging",
           "name": "ListWithContinuationTokenWithMaxPage",
           "isExactName": false,
@@ -10986,7 +11003,7 @@
           ],
           "doc": "List things with continuation token",
           "operation": {
-            "$id": "715",
+            "$id": "717",
             "name": "ListWithContinuationTokenWithMaxPage",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -10994,12 +11011,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "716",
+                "$id": "718",
                 "kind": "query",
                 "name": "token",
                 "serializedName": "token",
                 "type": {
-                  "$id": "717",
+                  "$id": "719",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11014,12 +11031,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "718",
+                    "$id": "720",
                     "kind": "method",
                     "name": "token",
                     "serializedName": "token",
                     "type": {
-                      "$id": "719",
+                      "$id": "721",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11039,12 +11056,12 @@
                 "isExactName": false
               },
               {
-                "$id": "720",
+                "$id": "722",
                 "kind": "query",
                 "name": "numElements",
                 "serializedName": "numElements",
                 "type": {
-                  "$id": "721",
+                  "$id": "723",
                   "kind": "int32",
                   "name": "int32",
                   "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -11059,12 +11076,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "722",
+                    "$id": "724",
                     "kind": "method",
                     "name": "numElements",
                     "serializedName": "numElements",
                     "type": {
-                      "$id": "723",
+                      "$id": "725",
                       "kind": "int32",
                       "name": "int32",
                       "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -11084,7 +11101,7 @@
                 "isExactName": false
               },
               {
-                "$id": "724",
+                "$id": "726",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -11100,7 +11117,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ListWithContinuationTokenWithMaxPage.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "725",
+                    "$id": "727",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11127,7 +11144,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "325"
+                  "$ref": "327"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -11153,18 +11170,18 @@
           },
           "parameters": [
             {
-              "$ref": "718"
+              "$ref": "720"
             },
             {
-              "$ref": "722"
+              "$ref": "724"
             },
             {
-              "$ref": "725"
+              "$ref": "727"
             }
           ],
           "response": {
             "type": {
-              "$ref": "310"
+              "$ref": "312"
             },
             "resultSegments": [
               "things"
@@ -11180,7 +11197,7 @@
             ],
             "continuationToken": {
               "parameter": {
-                "$ref": "716"
+                "$ref": "718"
               },
               "responseSegments": [
                 "nextToken"
@@ -11193,7 +11210,7 @@
           }
         },
         {
-          "$id": "726",
+          "$id": "728",
           "kind": "paging",
           "name": "ListWithContinuationTokenHeaderResponse",
           "isExactName": false,
@@ -11204,7 +11221,7 @@
           ],
           "doc": "List things with continuation token header response",
           "operation": {
-            "$id": "727",
+            "$id": "729",
             "name": "ListWithContinuationTokenHeaderResponse",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -11212,12 +11229,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "728",
+                "$id": "730",
                 "kind": "query",
                 "name": "token",
                 "serializedName": "token",
                 "type": {
-                  "$id": "729",
+                  "$id": "731",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11232,12 +11249,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "730",
+                    "$id": "732",
                     "kind": "method",
                     "name": "token",
                     "serializedName": "token",
                     "type": {
-                      "$id": "731",
+                      "$id": "733",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11257,7 +11274,7 @@
                 "isExactName": false
               },
               {
-                "$id": "732",
+                "$id": "734",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -11273,7 +11290,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ListWithContinuationTokenHeaderResponse.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "733",
+                    "$id": "735",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11300,14 +11317,14 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "329"
+                  "$ref": "331"
                 },
                 "headers": [
                   {
                     "name": "nextToken",
                     "nameInResponse": "next-token",
                     "type": {
-                      "$id": "734",
+                      "$id": "736",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11338,15 +11355,15 @@
           },
           "parameters": [
             {
-              "$ref": "730"
+              "$ref": "732"
             },
             {
-              "$ref": "733"
+              "$ref": "735"
             }
           ],
           "response": {
             "type": {
-              "$ref": "310"
+              "$ref": "312"
             },
             "resultSegments": [
               "things"
@@ -11362,7 +11379,7 @@
             ],
             "continuationToken": {
               "parameter": {
-                "$ref": "728"
+                "$ref": "730"
               },
               "responseSegments": [
                 "next-token"
@@ -11373,7 +11390,7 @@
           }
         },
         {
-          "$id": "735",
+          "$id": "737",
           "kind": "paging",
           "name": "ListWithPaging",
           "isExactName": false,
@@ -11384,7 +11401,7 @@
           ],
           "doc": "List things with paging",
           "operation": {
-            "$id": "736",
+            "$id": "738",
             "name": "ListWithPaging",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -11392,7 +11409,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "737",
+                "$id": "739",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -11408,7 +11425,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ListWithPaging.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "738",
+                    "$id": "740",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11435,7 +11452,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "331"
+                  "$ref": "333"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -11461,12 +11478,12 @@
           },
           "parameters": [
             {
-              "$ref": "738"
+              "$ref": "740"
             }
           ],
           "response": {
             "type": {
-              "$ref": "310"
+              "$ref": "312"
             },
             "resultSegments": [
               "items"
@@ -11484,7 +11501,7 @@
           }
         },
         {
-          "$id": "739",
+          "$id": "741",
           "kind": "basic",
           "name": "ConditionalRequest",
           "isExactName": false,
@@ -11495,7 +11512,7 @@
           ],
           "doc": "A sample operation with conditional requests",
           "operation": {
-            "$id": "740",
+            "$id": "742",
             "name": "ConditionalRequest",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -11503,12 +11520,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "741",
+                "$id": "743",
                 "kind": "header",
                 "name": "ifMatch",
                 "serializedName": "If-Match",
                 "type": {
-                  "$id": "742",
+                  "$id": "744",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11523,12 +11540,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ConditionalRequest.ifMatch",
                 "methodParameterSegments": [
                   {
-                    "$id": "743",
+                    "$id": "745",
                     "kind": "method",
                     "name": "ifMatch",
                     "serializedName": "If-Match",
                     "type": {
-                      "$id": "744",
+                      "$id": "746",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11548,12 +11565,12 @@
                 "isExactName": false
               },
               {
-                "$id": "745",
+                "$id": "747",
                 "kind": "header",
                 "name": "ifNoneMatch",
                 "serializedName": "If-None-Match",
                 "type": {
-                  "$id": "746",
+                  "$id": "748",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11568,12 +11585,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ConditionalRequest.ifNoneMatch",
                 "methodParameterSegments": [
                   {
-                    "$id": "747",
+                    "$id": "749",
                     "kind": "method",
                     "name": "ifNoneMatch",
                     "serializedName": "If-None-Match",
                     "type": {
-                      "$id": "748",
+                      "$id": "750",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11615,10 +11632,10 @@
           },
           "parameters": [
             {
-              "$ref": "743"
+              "$ref": "745"
             },
             {
-              "$ref": "747"
+              "$ref": "749"
             }
           ],
           "response": {},
@@ -11628,7 +11645,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.ConditionalRequest"
         },
         {
-          "$id": "749",
+          "$id": "751",
           "kind": "basic",
           "name": "ConditionalRequestDate",
           "isExactName": false,
@@ -11639,7 +11656,7 @@
           ],
           "doc": "A sample operation with conditional requests",
           "operation": {
-            "$id": "750",
+            "$id": "752",
             "name": "ConditionalRequestDate",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -11647,12 +11664,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "751",
+                "$id": "753",
                 "kind": "header",
                 "name": "ifMatch",
                 "serializedName": "If-Match",
                 "type": {
-                  "$id": "752",
+                  "$id": "754",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11667,12 +11684,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ConditionalRequestDate.ifMatch",
                 "methodParameterSegments": [
                   {
-                    "$id": "753",
+                    "$id": "755",
                     "kind": "method",
                     "name": "ifMatch",
                     "serializedName": "If-Match",
                     "type": {
-                      "$id": "754",
+                      "$id": "756",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11692,12 +11709,12 @@
                 "isExactName": false
               },
               {
-                "$id": "755",
+                "$id": "757",
                 "kind": "header",
                 "name": "ifNoneMatch",
                 "serializedName": "If-None-Match",
                 "type": {
-                  "$id": "756",
+                  "$id": "758",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11712,12 +11729,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ConditionalRequestDate.ifNoneMatch",
                 "methodParameterSegments": [
                   {
-                    "$id": "757",
+                    "$id": "759",
                     "kind": "method",
                     "name": "ifNoneMatch",
                     "serializedName": "If-None-Match",
                     "type": {
-                      "$id": "758",
+                      "$id": "760",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11737,12 +11754,12 @@
                 "isExactName": false
               },
               {
-                "$id": "759",
+                "$id": "761",
                 "kind": "header",
                 "name": "ifModifiedSince",
                 "serializedName": "If-Modified-Since",
                 "type": {
-                  "$id": "760",
+                  "$id": "762",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11757,12 +11774,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.ConditionalRequestDate.ifModifiedSince",
                 "methodParameterSegments": [
                   {
-                    "$id": "761",
+                    "$id": "763",
                     "kind": "method",
                     "name": "ifModifiedSince",
                     "serializedName": "If-Modified-Since",
                     "type": {
-                      "$id": "762",
+                      "$id": "764",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11804,13 +11821,13 @@
           },
           "parameters": [
             {
-              "$ref": "753"
+              "$ref": "755"
             },
             {
-              "$ref": "757"
+              "$ref": "759"
             },
             {
-              "$ref": "761"
+              "$ref": "763"
             }
           ],
           "response": {},
@@ -11820,7 +11837,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.ConditionalRequestDate"
         },
         {
-          "$id": "763",
+          "$id": "765",
           "kind": "basic",
           "name": "MultipartRequest",
           "isExactName": false,
@@ -11831,7 +11848,7 @@
           ],
           "doc": "A sample operation with multipart request",
           "operation": {
-            "$id": "764",
+            "$id": "766",
             "name": "MultipartRequest",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -11839,7 +11856,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "765",
+                "$id": "767",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -11855,7 +11872,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.MultipartRequest.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "766",
+                    "$id": "768",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -11876,12 +11893,12 @@
                 "isExactName": false
               },
               {
-                "$id": "767",
+                "$id": "769",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "333"
+                  "$ref": "335"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -11895,12 +11912,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.MultipartRequest.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "768",
+                    "$id": "770",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "333"
+                      "$ref": "335"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -11942,10 +11959,10 @@
           },
           "parameters": [
             {
-              "$ref": "766"
+              "$ref": "768"
             },
             {
-              "$ref": "768"
+              "$ref": "770"
             }
           ],
           "response": {},
@@ -11955,7 +11972,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.MultipartRequest"
         },
         {
-          "$id": "769",
+          "$id": "771",
           "kind": "basic",
           "name": "CreateDataFactoryModel",
           "isExactName": false,
@@ -11966,7 +11983,7 @@
           ],
           "doc": "Create a model with DataFactoryElement properties",
           "operation": {
-            "$id": "770",
+            "$id": "772",
             "name": "CreateDataFactoryModel",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -11974,7 +11991,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "771",
+                "$id": "773",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -11991,7 +12008,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.CreateDataFactoryModel.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "772",
+                    "$id": "774",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -12013,7 +12030,7 @@
                 "isExactName": false
               },
               {
-                "$id": "773",
+                "$id": "775",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12029,7 +12046,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.CreateDataFactoryModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "774",
+                    "$id": "776",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12050,12 +12067,12 @@
                 "isExactName": false
               },
               {
-                "$id": "775",
+                "$id": "777",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "336"
+                  "$ref": "338"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -12069,12 +12086,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.CreateDataFactoryModel.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "776",
+                    "$id": "778",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "336"
+                      "$ref": "338"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -12101,7 +12118,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "336"
+                  "$ref": "338"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -12130,18 +12147,18 @@
           },
           "parameters": [
             {
-              "$ref": "776"
-            },
-            {
-              "$ref": "772"
+              "$ref": "778"
             },
             {
               "$ref": "774"
+            },
+            {
+              "$ref": "776"
             }
           ],
           "response": {
             "type": {
-              "$ref": "336"
+              "$ref": "338"
             }
           },
           "isOverride": false,
@@ -12150,7 +12167,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.CreateDataFactoryModel"
         },
         {
-          "$id": "777",
+          "$id": "779",
           "kind": "basic",
           "name": "GetDataFactoryModel",
           "isExactName": false,
@@ -12161,7 +12178,7 @@
           ],
           "doc": "Get a model with DataFactoryElement properties",
           "operation": {
-            "$id": "778",
+            "$id": "780",
             "name": "GetDataFactoryModel",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -12169,12 +12186,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "779",
+                "$id": "781",
                 "kind": "path",
                 "name": "id",
                 "serializedName": "id",
                 "type": {
-                  "$id": "780",
+                  "$id": "782",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12192,12 +12209,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.GetDataFactoryModel.id",
                 "methodParameterSegments": [
                   {
-                    "$id": "781",
+                    "$id": "783",
                     "kind": "method",
                     "name": "id",
                     "serializedName": "id",
                     "type": {
-                      "$id": "782",
+                      "$id": "784",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12217,7 +12234,7 @@
                 "isExactName": false
               },
               {
-                "$id": "783",
+                "$id": "785",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12233,7 +12250,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.GetDataFactoryModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "784",
+                    "$id": "786",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12260,7 +12277,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "336"
+                  "$ref": "338"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -12286,15 +12303,15 @@
           },
           "parameters": [
             {
-              "$ref": "781"
+              "$ref": "783"
             },
             {
-              "$ref": "784"
+              "$ref": "786"
             }
           ],
           "response": {
             "type": {
-              "$ref": "336"
+              "$ref": "338"
             }
           },
           "isOverride": false,
@@ -12303,7 +12320,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.GetDataFactoryModel"
         },
         {
-          "$id": "785",
+          "$id": "787",
           "kind": "basic",
           "name": "GetXmlAdvancedModel",
           "isExactName": false,
@@ -12314,7 +12331,7 @@
           ],
           "doc": "Get an advanced XML model with various property types",
           "operation": {
-            "$id": "786",
+            "$id": "788",
             "name": "GetXmlAdvancedModel",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -12322,7 +12339,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "787",
+                "$id": "789",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12338,7 +12355,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.GetXmlAdvancedModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "788",
+                    "$id": "790",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12365,7 +12382,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "348"
+                  "$ref": "350"
                 },
                 "headers": [
                   {
@@ -12399,12 +12416,12 @@
           },
           "parameters": [
             {
-              "$ref": "788"
+              "$ref": "790"
             }
           ],
           "response": {
             "type": {
-              "$ref": "348"
+              "$ref": "350"
             }
           },
           "isOverride": false,
@@ -12413,7 +12430,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.GetXmlAdvancedModel"
         },
         {
-          "$id": "789",
+          "$id": "791",
           "kind": "basic",
           "name": "UpdateXmlAdvancedModel",
           "isExactName": false,
@@ -12424,7 +12441,7 @@
           ],
           "doc": "Update an advanced XML model with various property types",
           "operation": {
-            "$id": "790",
+            "$id": "792",
             "name": "UpdateXmlAdvancedModel",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
@@ -12432,7 +12449,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "791",
+                "$id": "793",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -12448,7 +12465,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.UpdateXmlAdvancedModel.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "792",
+                    "$id": "794",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -12469,7 +12486,7 @@
                 "isExactName": false
               },
               {
-                "$id": "793",
+                "$id": "795",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12485,7 +12502,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.UpdateXmlAdvancedModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "794",
+                    "$id": "796",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12506,12 +12523,12 @@
                 "isExactName": false
               },
               {
-                "$id": "795",
+                "$id": "797",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "348"
+                  "$ref": "350"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -12525,12 +12542,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.UpdateXmlAdvancedModel.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "796",
+                    "$id": "798",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "348"
+                      "$ref": "350"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -12557,7 +12574,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "348"
+                  "$ref": "350"
                 },
                 "headers": [
                   {
@@ -12594,18 +12611,18 @@
           },
           "parameters": [
             {
-              "$ref": "796"
-            },
-            {
-              "$ref": "792"
+              "$ref": "798"
             },
             {
               "$ref": "794"
+            },
+            {
+              "$ref": "796"
             }
           ],
           "response": {
             "type": {
-              "$ref": "348"
+              "$ref": "350"
             }
           },
           "isOverride": false,
@@ -12614,7 +12631,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.UpdateXmlAdvancedModel"
         },
         {
-          "$id": "797",
+          "$id": "799",
           "kind": "basic",
           "name": "uploadCat",
           "isExactName": false,
@@ -12624,14 +12641,14 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "798",
+            "$id": "800",
             "name": "uploadCat",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "799",
+                "$id": "801",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -12647,7 +12664,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.uploadCat.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "800",
+                    "$id": "802",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -12668,12 +12685,12 @@
                 "isExactName": false
               },
               {
-                "$id": "801",
+                "$id": "803",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "444"
+                  "$ref": "446"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -12687,12 +12704,12 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.uploadCat.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "802",
+                    "$id": "804",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "444"
+                      "$ref": "446"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -12734,10 +12751,10 @@
           },
           "parameters": [
             {
-              "$ref": "800"
+              "$ref": "802"
             },
             {
-              "$ref": "802"
+              "$ref": "804"
             }
           ],
           "response": {},
@@ -12747,7 +12764,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.uploadCat"
         },
         {
-          "$id": "803",
+          "$id": "805",
           "kind": "basic",
           "name": "sendJsonLines",
           "isExactName": false,
@@ -12757,14 +12774,14 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "804",
+            "$id": "806",
             "name": "sendJsonLines",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "805",
+                "$id": "807",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -12780,16 +12797,16 @@
                 "crossLanguageDefinitionId": "TypeSpec.Http.Streams.JsonlStream.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "806",
+                    "$id": "808",
                     "kind": "method",
                     "name": "stream",
                     "serializedName": "stream",
                     "type": {
-                      "$id": "807",
+                      "$id": "809",
                       "kind": "streaming",
                       "name": "JsonlStreamStreamingItem",
                       "valueType": {
-                        "$ref": "489"
+                        "$ref": "491"
                       },
                       "streamKind": "jsonl",
                       "contentTypes": [
@@ -12808,7 +12825,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "808",
+                    "$id": "810",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "contentType",
@@ -12829,16 +12846,16 @@
                 "isExactName": false
               },
               {
-                "$id": "809",
+                "$id": "811",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$id": "810",
+                  "$id": "812",
                   "kind": "streaming",
                   "name": "JsonlStreamStreamingItem",
                   "valueType": {
-                    "$ref": "489"
+                    "$ref": "491"
                   },
                   "streamKind": "jsonl",
                   "contentTypes": [
@@ -12858,15 +12875,15 @@
                 "crossLanguageDefinitionId": "TypeSpec.Http.Streams.JsonlStream.body",
                 "methodParameterSegments": [
                   {
-                    "$ref": "806"
+                    "$ref": "808"
                   },
                   {
-                    "$id": "811",
+                    "$id": "813",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "506"
+                      "$ref": "508"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -12912,7 +12929,7 @@
           },
           "parameters": [
             {
-              "$ref": "806"
+              "$ref": "808"
             }
           ],
           "response": {},
@@ -12922,7 +12939,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.sendJsonLines"
         },
         {
-          "$id": "812",
+          "$id": "814",
           "kind": "basic",
           "name": "receiveJsonLines",
           "isExactName": false,
@@ -12932,14 +12949,14 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "813",
+            "$id": "815",
             "name": "receiveJsonLines",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "814",
+                "$id": "816",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12955,7 +12972,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.receiveJsonLines.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "815",
+                    "$id": "817",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12982,11 +12999,11 @@
                   200
                 ],
                 "bodyType": {
-                  "$id": "816",
+                  "$id": "818",
                   "kind": "streaming",
                   "name": "JsonlStreamStreamingItem",
                   "valueType": {
-                    "$ref": "489"
+                    "$ref": "491"
                   },
                   "streamKind": "jsonl",
                   "contentTypes": [
@@ -13026,16 +13043,16 @@
           },
           "parameters": [
             {
-              "$ref": "815"
+              "$ref": "817"
             }
           ],
           "response": {
             "type": {
-              "$id": "817",
+              "$id": "819",
               "kind": "streaming",
               "name": "JsonlStreamStreamingItem",
               "valueType": {
-                "$ref": "489"
+                "$ref": "491"
               },
               "streamKind": "jsonl",
               "contentTypes": [
@@ -13050,7 +13067,7 @@
           "crossLanguageDefinitionId": "BasicTypeSpec.receiveJsonLines"
         },
         {
-          "$id": "818",
+          "$id": "820",
           "kind": "basic",
           "name": "receiveSse",
           "isExactName": false,
@@ -13060,14 +13077,14 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "819",
+            "$id": "821",
             "name": "receiveSse",
             "isExactName": false,
             "resourceName": "BasicTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "820",
+                "$id": "822",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -13083,7 +13100,7 @@
                 "crossLanguageDefinitionId": "BasicTypeSpec.receiveSse.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "821",
+                    "$id": "823",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -13110,16 +13127,16 @@
                   200
                 ],
                 "bodyType": {
-                  "$id": "822",
+                  "$id": "824",
                   "kind": "streaming",
                   "name": "SSEStreamSampleEvents",
                   "valueType": {
-                    "$id": "823",
+                    "$id": "825",
                     "kind": "union",
                     "name": "SampleEvents",
                     "variantTypes": [
                       {
-                        "$ref": "489"
+                        "$ref": "491"
                       },
                       {
                         "$ref": "200"
@@ -13164,16 +13181,16 @@
           },
           "parameters": [
             {
-              "$ref": "821"
+              "$ref": "823"
             }
           ],
           "response": {
             "type": {
-              "$id": "824",
+              "$id": "826",
               "kind": "streaming",
               "name": "SSEStreamSampleEvents",
               "valueType": {
-                "$ref": "823"
+                "$ref": "825"
               },
               "streamKind": "sse",
               "contentTypes": [
@@ -13187,16 +13204,124 @@
           "generateConvenient": true,
           "generateProtocol": true,
           "crossLanguageDefinitionId": "BasicTypeSpec.receiveSse"
+        },
+        {
+          "$id": "827",
+          "kind": "basic",
+          "name": "getOptionalResponse",
+          "isExactName": false,
+          "accessibility": "public",
+          "apiVersions": [
+            "2024-07-16-preview",
+            "2024-08-16-preview"
+          ],
+          "operation": {
+            "$id": "828",
+            "name": "getOptionalResponse",
+            "isExactName": false,
+            "resourceName": "BasicTypeSpec",
+            "accessibility": "public",
+            "parameters": [
+              {
+                "$id": "829",
+                "kind": "header",
+                "name": "accept",
+                "serializedName": "Accept",
+                "type": {
+                  "$ref": "204"
+                },
+                "isApiVersion": false,
+                "optional": false,
+                "isContentType": false,
+                "scope": "Constant",
+                "readOnly": false,
+                "decorators": [],
+                "crossLanguageDefinitionId": "BasicTypeSpec.getOptionalResponse.accept",
+                "methodParameterSegments": [
+                  {
+                    "$id": "830",
+                    "kind": "method",
+                    "name": "accept",
+                    "serializedName": "Accept",
+                    "type": {
+                      "$ref": "204"
+                    },
+                    "location": "Header",
+                    "isApiVersion": false,
+                    "optional": false,
+                    "scope": "Constant",
+                    "crossLanguageDefinitionId": "BasicTypeSpec.getOptionalResponse.accept",
+                    "readOnly": false,
+                    "access": "public",
+                    "decorators": [],
+                    "isExactName": false
+                  }
+                ],
+                "isExactName": false
+              }
+            ],
+            "responses": [
+              {
+                "statusCodes": [
+                  200
+                ],
+                "bodyType": {
+                  "$ref": "230"
+                },
+                "headers": [],
+                "isErrorResponse": false,
+                "contentTypes": [
+                  "application/json"
+                ],
+                "serializationOptions": {
+                  "json": {
+                    "name": ""
+                  }
+                }
+              },
+              {
+                "statusCodes": [
+                  204
+                ],
+                "headers": [],
+                "isErrorResponse": false,
+                "serializationOptions": {}
+              }
+            ],
+            "httpMethod": "GET",
+            "uri": "{basicTypeSpecUrl}",
+            "path": "/optional-response",
+            "bufferResponse": true,
+            "generateProtocolMethod": true,
+            "generateConvenienceMethod": true,
+            "crossLanguageDefinitionId": "BasicTypeSpec.getOptionalResponse",
+            "decorators": [],
+            "namespace": "BasicTypeSpec"
+          },
+          "parameters": [
+            {
+              "$ref": "830"
+            }
+          ],
+          "response": {
+            "type": {
+              "$ref": "230"
+            }
+          },
+          "isOverride": false,
+          "generateConvenient": true,
+          "generateProtocol": true,
+          "crossLanguageDefinitionId": "BasicTypeSpec.getOptionalResponse"
         }
       ],
       "parameters": [
         {
-          "$id": "825",
+          "$id": "831",
           "kind": "endpoint",
           "name": "basicTypeSpecUrl",
           "serializedName": "basicTypeSpecUrl",
           "type": {
-            "$id": "826",
+            "$id": "832",
             "kind": "url",
             "name": "endpoint",
             "crossLanguageDefinitionId": "TypeSpec.url"
@@ -13221,14 +13346,14 @@
       ],
       "children": [
         {
-          "$id": "827",
+          "$id": "833",
           "kind": "client",
           "name": "PlantOperations",
           "isExactName": false,
           "namespace": "BasicTypeSpec",
           "methods": [
             {
-              "$id": "828",
+              "$id": "834",
               "kind": "basic",
               "name": "getTree",
               "isExactName": false,
@@ -13239,7 +13364,7 @@
               ],
               "doc": "Get a tree as a plant",
               "operation": {
-                "$id": "829",
+                "$id": "835",
                 "name": "getTree",
                 "isExactName": false,
                 "resourceName": "PlantOperations",
@@ -13247,12 +13372,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "830",
+                    "$id": "836",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "204"
+                      "$ref": "206"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13263,12 +13388,12 @@
                     "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.getTree.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "831",
+                        "$id": "837",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "204"
+                          "$ref": "206"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13290,14 +13415,14 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "492"
+                      "$ref": "494"
                     },
                     "headers": [
                       {
                         "name": "contentType",
                         "nameInResponse": "content-type",
                         "type": {
-                          "$ref": "206"
+                          "$ref": "208"
                         }
                       }
                     ],
@@ -13324,12 +13449,12 @@
               },
               "parameters": [
                 {
-                  "$ref": "831"
+                  "$ref": "837"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "492"
+                  "$ref": "494"
                 }
               },
               "isOverride": false,
@@ -13338,7 +13463,7 @@
               "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.getTree"
             },
             {
-              "$id": "832",
+              "$id": "838",
               "kind": "basic",
               "name": "getTreeAsJson",
               "isExactName": false,
@@ -13349,7 +13474,7 @@
               ],
               "doc": "Get a tree as a plant",
               "operation": {
-                "$id": "833",
+                "$id": "839",
                 "name": "getTreeAsJson",
                 "isExactName": false,
                 "resourceName": "PlantOperations",
@@ -13357,12 +13482,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "834",
+                    "$id": "840",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "208"
+                      "$ref": "210"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13373,12 +13498,12 @@
                     "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.getTreeAsJson.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "835",
+                        "$id": "841",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "208"
+                          "$ref": "210"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13400,14 +13525,14 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "492"
+                      "$ref": "494"
                     },
                     "headers": [
                       {
                         "name": "contentType",
                         "nameInResponse": "content-type",
                         "type": {
-                          "$ref": "210"
+                          "$ref": "212"
                         }
                       }
                     ],
@@ -13434,12 +13559,12 @@
               },
               "parameters": [
                 {
-                  "$ref": "835"
+                  "$ref": "841"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "492"
+                  "$ref": "494"
                 }
               },
               "isOverride": false,
@@ -13448,7 +13573,7 @@
               "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.getTreeAsJson"
             },
             {
-              "$id": "836",
+              "$id": "842",
               "kind": "basic",
               "name": "updateTree",
               "isExactName": false,
@@ -13459,7 +13584,7 @@
               ],
               "doc": "Update a tree as a plant",
               "operation": {
-                "$id": "837",
+                "$id": "843",
                 "name": "updateTree",
                 "isExactName": false,
                 "resourceName": "PlantOperations",
@@ -13467,12 +13592,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "838",
+                    "$id": "844",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "type": {
-                      "$ref": "212"
+                      "$ref": "214"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13483,12 +13608,12 @@
                     "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.updateTree.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "839",
+                        "$id": "845",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "type": {
-                          "$ref": "212"
+                          "$ref": "214"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13504,12 +13629,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "840",
+                    "$id": "846",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "216"
+                      "$ref": "218"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13520,12 +13645,12 @@
                     "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.updateTree.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "841",
+                        "$id": "847",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "216"
+                          "$ref": "218"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13541,12 +13666,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "842",
+                    "$id": "848",
                     "kind": "body",
                     "name": "tree",
                     "serializedName": "tree",
                     "type": {
-                      "$ref": "492"
+                      "$ref": "494"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -13560,12 +13685,12 @@
                     "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.updateTree.tree",
                     "methodParameterSegments": [
                       {
-                        "$id": "843",
+                        "$id": "849",
                         "kind": "method",
                         "name": "tree",
                         "serializedName": "tree",
                         "type": {
-                          "$ref": "492"
+                          "$ref": "494"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -13592,14 +13717,14 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "492"
+                      "$ref": "494"
                     },
                     "headers": [
                       {
                         "name": "contentType",
                         "nameInResponse": "content-type",
                         "type": {
-                          "$ref": "218"
+                          "$ref": "220"
                         }
                       }
                     ],
@@ -13629,18 +13754,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "843"
+                  "$ref": "849"
                 },
                 {
-                  "$ref": "839"
+                  "$ref": "845"
                 },
                 {
-                  "$ref": "841"
+                  "$ref": "847"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "492"
+                  "$ref": "494"
                 }
               },
               "isOverride": false,
@@ -13649,7 +13774,7 @@
               "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.updateTree"
             },
             {
-              "$id": "844",
+              "$id": "850",
               "kind": "basic",
               "name": "updateTreeAsJson",
               "isExactName": false,
@@ -13660,7 +13785,7 @@
               ],
               "doc": "Update a tree as a plant",
               "operation": {
-                "$id": "845",
+                "$id": "851",
                 "name": "updateTreeAsJson",
                 "isExactName": false,
                 "resourceName": "PlantOperations",
@@ -13668,12 +13793,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "846",
+                    "$id": "852",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "type": {
-                      "$ref": "220"
+                      "$ref": "222"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13684,12 +13809,12 @@
                     "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.updateTreeAsJson.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "847",
+                        "$id": "853",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "type": {
-                          "$ref": "220"
+                          "$ref": "222"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13705,12 +13830,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "848",
+                    "$id": "854",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "224"
+                      "$ref": "226"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13721,12 +13846,12 @@
                     "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.updateTreeAsJson.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "849",
+                        "$id": "855",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "224"
+                          "$ref": "226"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13742,12 +13867,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "850",
+                    "$id": "856",
                     "kind": "body",
                     "name": "tree",
                     "serializedName": "tree",
                     "type": {
-                      "$ref": "492"
+                      "$ref": "494"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -13761,12 +13886,12 @@
                     "crossLanguageDefinitionId": "BasicTypeSpec.PlantOperations.updateTreeAsJson.tree",
                     "methodParameterSegments": [
                       {
-                        "$id": "851",
+                        "$id": "857",
                         "kind": "method",
                         "name": "tree",
                         "serializedName": "tree",
                         "type": {
-                          "$ref": "492"
+                          "$ref": "494"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -13793,14 +13918,14 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "492"
+                      "$ref": "494"
                     },
                     "headers": [
                       {
                         "name": "contentType",
                         "nameInResponse": "content-type",
                         "type": {
-                          "$ref": "226"
+                          "$ref": "228"
                         }
                       }
                     ],
@@ -13830,18 +13955,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "851"
+                  "$ref": "857"
                 },
                 {
-                  "$ref": "847"
+                  "$ref": "853"
                 },
                 {
-                  "$ref": "849"
+                  "$ref": "855"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "492"
+                  "$ref": "494"
                 }
               },
               "isOverride": false,
@@ -13852,12 +13977,12 @@
           ],
           "parameters": [
             {
-              "$id": "852",
+              "$id": "858",
               "kind": "endpoint",
               "name": "basicTypeSpecUrl",
               "serializedName": "basicTypeSpecUrl",
               "type": {
-                "$id": "853",
+                "$id": "859",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -13881,7 +14006,7 @@
             "2024-08-16-preview"
           ],
           "parent": {
-            "$ref": "507"
+            "$ref": "509"
           },
           "isMultiServiceClient": false
         }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Azure/Versioning/PreviewVersion/V2/PreviewVersionV2Tests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Azure/Versioning/PreviewVersion/V2/PreviewVersionV2Tests.cs
@@ -53,9 +53,11 @@ namespace TestProjects.Spector.Tests.Http.Azure.Versioning.PreviewVersion.V2
         {
             var response = await new PreviewVersionClient(host, new PreviewVersionClientOptions(PreviewVersionClientOptions.ServiceVersion.V2024_12_01_Preview)).GetWidgetAsync("widget-123");
             Assert.AreEqual(200, response.GetRawResponse().Status);
-            Assert.AreEqual("widget-123", response.Value.Id);
-            Assert.AreEqual("Sample Widget", response.Value.Name);
-            Assert.AreEqual("blue", response.Value.Color);
+            Assert.IsTrue(response.HasValue);
+            var widget = response.Value!;
+            Assert.AreEqual("widget-123", widget.Id);
+            Assert.AreEqual("Sample Widget", widget.Name);
+            Assert.AreEqual("blue", widget.Color);
         });
 
         [SpectorTest]

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/versioning/previewVersion/v1/src/Generated/PreviewVersionClient.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/versioning/previewVersion/v1/src/Generated/PreviewVersionClient.cs
@@ -32,9 +32,9 @@ namespace Specs.Azure.Versioning.PreviewVersion
 
         public virtual Task<Response> GetWidgetAsync(string id, RequestContext context) => throw null;
 
-        public virtual Response<Widget> GetWidget(string id, CancellationToken cancellationToken = default) => throw null;
+        public virtual NullableResponse<Widget> GetWidget(string id, CancellationToken cancellationToken = default) => throw null;
 
-        public virtual Task<Response<Widget>> GetWidgetAsync(string id, CancellationToken cancellationToken = default) => throw null;
+        public virtual Task<NullableResponse<Widget>> GetWidgetAsync(string id, CancellationToken cancellationToken = default) => throw null;
 
         public virtual Response UpdateWidgetColor(string id, RequestContent content, RequestContext context = null) => throw null;
 

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/versioning/previewVersion/v1/src/Versioning.PreviewVersion.V1.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/versioning/previewVersion/v1/src/Versioning.PreviewVersion.V1.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)TrimmingAttribute.cs" LinkBase="Shared/Core" />
+    <Compile Include="$(AzureCoreSharedSources)NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/versioning/previewVersion/v2/src/Generated/PreviewVersionClient.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/versioning/previewVersion/v2/src/Generated/PreviewVersionClient.cs
@@ -32,9 +32,9 @@ namespace Specs.Azure.Versioning.PreviewVersion
 
         public virtual Task<Response> GetWidgetAsync(string id, RequestContext context) => throw null;
 
-        public virtual Response<Widget> GetWidget(string id, CancellationToken cancellationToken = default) => throw null;
+        public virtual NullableResponse<Widget> GetWidget(string id, CancellationToken cancellationToken = default) => throw null;
 
-        public virtual Task<Response<Widget>> GetWidgetAsync(string id, CancellationToken cancellationToken = default) => throw null;
+        public virtual Task<NullableResponse<Widget>> GetWidgetAsync(string id, CancellationToken cancellationToken = default) => throw null;
 
         public virtual Response UpdateWidgetColor(string id, RequestContent content, RequestContext context = null) => throw null;
 

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/versioning/previewVersion/v2/src/Versioning.PreviewVersion.V2.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/versioning/previewVersion/v2/src/Versioning.PreviewVersion.V2.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)TrimmingAttribute.cs" LinkBase="Shared/Core" />
+    <Compile Include="$(AzureCoreSharedSources)NoValueResponseOfT.cs" LinkBase="Shared/Core" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- map Azure convenience operations with body and no-body successes to `NullableResponse<T>`
- return `NoValueResponse<T>` for declared no-body success status codes
- include the shared no-value response implementation only when required
- add visitor and generated Basic-TypeSpec coverage for `200` with a body and `204` without one

## Testing

- `OptionalResponseBodyVisitorTests`
- `npm run prettier`
- `npm run lint`
- full `Generate.ps1` and generated Basic-TypeSpec build

The unbranded SCM implementation is intentionally deferred because nullable annotations are not currently preserved in generated libraries; exposing `ClientResult<T>` with a potentially null value would hide the optional contract.

Related to microsoft/typespec#11651 and Azure/typespec-azure#5213.