### PR TITLE
Remove obsolete provisioning resource reset workaround

### DIFF
--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,24 +1,24 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-13 03:41:32 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-13 09:46:07 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Latest Published Version Chain
 
 ```
 @typespec/http-client-csharp (alpha.20260812.9)
-  └─ @azure-typespec/http-client-csharp (alpha.20260812.4)
-       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260812.1)
-            └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260810.4)
+  └─ @azure-typespec/http-client-csharp (alpha.20260813.1)
+       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260812.4)
+            └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260813.1)
 ```
 
 ## Emitter Versions
 
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
-| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260812.5](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260812.5) | [1.0.0-alpha.20260812.9](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260812.9) | [6d4a250](https://github.com/microsoft/typespec/commit/6d4a250c4bf683e81616d29c1777de8e4f6dc0bd) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260812.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260812.4) | [1.0.0-alpha.20260812.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260812.4) | [100eace](https://github.com/Azure/azure-sdk-for-net/commit/100eaceb37db1fce20f5db3a34aca2d8ec7de7d7) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260812.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260812.1) | [1.0.0-alpha.20260812.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260812.1) | [ad23c92](https://github.com/Azure/azure-sdk-for-net/commit/ad23c928f50a12ca01629266a2d8d4ad3798dcad) |
+| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | 1.0.0-alpha.20260812.5 | 1.0.0-alpha.20260812.9 | [4b15488](https://github.com/microsoft/typespec/commit/4b1548899c8c42cda2b78970519337dd4f387d27) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | 1.0.0-alpha.20260812.4 | 1.0.0-alpha.20260813.1 | [100eace](https://github.com/Azure/azure-sdk-for-net/commit/100eaceb37db1fce20f5db3a34aca2d8ec7de7d7) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | 1.0.0-alpha.20260812.4 | 1.0.0-alpha.20260812.4 | [ad23c92](https://github.com/Azure/azure-sdk-for-net/commit/ad23c928f50a12ca01629266a2d8d4ad3798dcad) |
 
 ## Source Files
 

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,24 +1,24 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-13 09:46:07 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-13 03:41:32 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Latest Published Version Chain
 
 ```
 @typespec/http-client-csharp (alpha.20260812.9)
-  └─ @azure-typespec/http-client-csharp (alpha.20260813.1)
-       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260812.4)
-            └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260813.1)
+  └─ @azure-typespec/http-client-csharp (alpha.20260812.4)
+       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260812.1)
+            └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260810.4)
 ```
 
 ## Emitter Versions
 
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
-| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | 1.0.0-alpha.20260812.5 | 1.0.0-alpha.20260812.9 | [4b15488](https://github.com/microsoft/typespec/commit/4b1548899c8c42cda2b78970519337dd4f387d27) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | 1.0.0-alpha.20260812.4 | 1.0.0-alpha.20260813.1 | [100eace](https://github.com/Azure/azure-sdk-for-net/commit/100eaceb37db1fce20f5db3a34aca2d8ec7de7d7) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | 1.0.0-alpha.20260812.4 | 1.0.0-alpha.20260812.4 | [ad23c92](https://github.com/Azure/azure-sdk-for-net/commit/ad23c928f50a12ca01629266a2d8d4ad3798dcad) |
+| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260812.5](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260812.5) | [1.0.0-alpha.20260812.9](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260812.9) | [6d4a250](https://github.com/microsoft/typespec/commit/6d4a250c4bf683e81616d29c1777de8e4f6dc0bd) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260812.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260812.4) | [1.0.0-alpha.20260812.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260812.4) | [100eace](https://github.com/Azure/azure-sdk-for-net/commit/100eaceb37db1fce20f5db3a34aca2d8ec7de7d7) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260812.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260812.1) | [1.0.0-alpha.20260812.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260812.1) | [ad23c92](https://github.com/Azure/azure-sdk-for-net/commit/ad23c928f50a12ca01629266a2d8d4ad3798dcad) |
 
 ## Source Files
 

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260812.5</UnbrandedGeneratorVersion>
-    <AzureGeneratorVersion>1.0.0-alpha.20260813.1</AzureGeneratorVersion>
-    <AzureManagementGeneratorVersion>1.0.0-alpha.20260812.4</AzureManagementGeneratorVersion>
+    <AzureGeneratorVersion>1.0.0-alpha.20260812.4</AzureGeneratorVersion>
+    <AzureManagementGeneratorVersion>1.0.0-alpha.20260812.1</AzureManagementGeneratorVersion>
   </PropertyGroup>
 
   <!-- Packages used by the TypeSpec generators -->

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260812.5</UnbrandedGeneratorVersion>
-    <AzureGeneratorVersion>1.0.0-alpha.20260812.4</AzureGeneratorVersion>
-    <AzureManagementGeneratorVersion>1.0.0-alpha.20260812.1</AzureManagementGeneratorVersion>
+    <AzureGeneratorVersion>1.0.0-alpha.20260813.1</AzureGeneratorVersion>
+    <AzureManagementGeneratorVersion>1.0.0-alpha.20260812.4</AzureManagementGeneratorVersion>
   </PropertyGroup>
 
   <!-- Packages used by the TypeSpec generators -->

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -141,14 +141,6 @@ namespace Azure.Generator.Provisioning.Providers
         {
             _inputModel = projection.ResourceModel;
             _resourceProjection = projection;
-            // ModelProvider may materialize and cache Type while matching custom partial classes
-            // in its constructor. At that point this derived constructor has not assigned
-            // _resourceProjection, so BuildName() falls back to the shared input-model name.
-            // When one model backs multiple ARM projections (for example, CommitmentPlan and
-            // CognitiveServicesCommitmentPlan), every provider would retain that same cached name,
-            // causing later projections to overwrite earlier generated files. Clear the base
-            // caches after assigning the projection so BuildName() uses its ResourceName.
-            base.Reset();
             _defaultApiVersion = projection.ApiVersions.Count > 0
                 ? projection.ApiVersions.Last()
                 : null;

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260810.7",
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260812.1",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260810.10"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260812.4",
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260812.4",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.70.1",
@@ -156,22 +156,22 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260810.7",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260810.7.tgz",
-      "integrity": "sha1-jnPJHhp176xDEVz2896VuKsKOk4=",
+      "version": "1.0.0-alpha.20260812.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260812.4.tgz",
+      "integrity": "sha1-cnY04VN8a8UMqwJLDCaGtIZAipQ=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260810.10"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260812.1",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260812.1.tgz",
-      "integrity": "sha1-CQZxkzEWDfbWStpwU1LX+rerZrc=",
+      "version": "1.0.0-alpha.20260812.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260812.4.tgz",
+      "integrity": "sha1-S33eaBuuzpRfnmaampuCHLyA8uA=",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260810.7",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260810.10"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260812.4",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -298,33 +298,33 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.17.1",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
-      "integrity": "sha1-EozjSq27IGyUDpnKXgzxldEsbfw=",
+      "version": "5.18.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
+      "integrity": "sha1-RGubQmeKIgQZ70MFT9/BOFWhLC4=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.11.2"
+        "@azure/msal-common": "16.12.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.11.2",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-common/-/msal-common-16.11.2.tgz",
-      "integrity": "sha1-bLo7L5utC9sH7o37+nLv9Lo2nDA=",
+      "version": "16.12.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-common/-/msal-common-16.12.0.tgz",
+      "integrity": "sha1-XL1Y25GUj5I4LoxijzSlf0adOnQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.4.1",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-node/-/msal-node-5.4.1.tgz",
-      "integrity": "sha1-PWogGDnMfAogM9lqLW7pEXYcrMs=",
+      "version": "5.5.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-node/-/msal-node-5.5.0.tgz",
+      "integrity": "sha1-1JivIxqllWZkKJve00fAVrX357M=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.11.2",
+        "@azure/msal-common": "16.12.0",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -1677,9 +1677,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260810.10",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260810.10.tgz",
-      "integrity": "sha1-4am8Au3ahLoxBSpqbGAr965u3IQ=",
+      "version": "1.0.0-alpha.20260812.5",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260812.5.tgz",
+      "integrity": "sha1-wXgvU1ccqHd4RjDL0rJ+UHxLMBo=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"
@@ -1751,9 +1751,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.7",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
-      "integrity": "sha1-mrJ1NYmDu9MLyJUM9NxX5kcGcPM=",
+      "version": "0.3.8",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha1-tN7lpeeXGu3HCVO7fS2/V4P0LTg=",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260812.4",
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260812.4",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260810.7",
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260812.1",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260810.10"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.70.1",
@@ -156,22 +156,22 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260812.4",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260812.4.tgz",
-      "integrity": "sha1-cnY04VN8a8UMqwJLDCaGtIZAipQ=",
+      "version": "1.0.0-alpha.20260810.7",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260810.7.tgz",
+      "integrity": "sha1-jnPJHhp176xDEVz2896VuKsKOk4=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260810.10"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260812.4",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260812.4.tgz",
-      "integrity": "sha1-S33eaBuuzpRfnmaampuCHLyA8uA=",
+      "version": "1.0.0-alpha.20260812.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260812.1.tgz",
+      "integrity": "sha1-CQZxkzEWDfbWStpwU1LX+rerZrc=",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260812.4",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260810.7",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260810.10"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -298,33 +298,33 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.18.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
-      "integrity": "sha1-RGubQmeKIgQZ70MFT9/BOFWhLC4=",
+      "version": "5.17.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
+      "integrity": "sha1-EozjSq27IGyUDpnKXgzxldEsbfw=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.12.0"
+        "@azure/msal-common": "16.11.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.12.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-common/-/msal-common-16.12.0.tgz",
-      "integrity": "sha1-XL1Y25GUj5I4LoxijzSlf0adOnQ=",
+      "version": "16.11.2",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-common/-/msal-common-16.11.2.tgz",
+      "integrity": "sha1-bLo7L5utC9sH7o37+nLv9Lo2nDA=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.5.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-node/-/msal-node-5.5.0.tgz",
-      "integrity": "sha1-1JivIxqllWZkKJve00fAVrX357M=",
+      "version": "5.4.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure/msal-node/-/msal-node-5.4.1.tgz",
+      "integrity": "sha1-PWogGDnMfAogM9lqLW7pEXYcrMs=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.12.0",
+        "@azure/msal-common": "16.11.2",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -1677,9 +1677,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260812.5",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260812.5.tgz",
-      "integrity": "sha1-wXgvU1ccqHd4RjDL0rJ+UHxLMBo=",
+      "version": "1.0.0-alpha.20260810.10",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260810.10.tgz",
+      "integrity": "sha1-4am8Au3ahLoxBSpqbGAr965u3IQ=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"
@@ -1751,9 +1751,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.8",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
-      "integrity": "sha1-tN7lpeeXGu3HCVO7fS2/V4P0LTg=",
+      "version": "0.3.7",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
+      "integrity": "sha1-mrJ1NYmDu9MLyJUM9NxX5kcGcPM=",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -36,9 +36,9 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260812.4",
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260812.4",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260810.7",
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260812.1",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260810.10"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.70.1",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -36,9 +36,9 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260810.7",
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260812.1",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260810.10"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260812.4",
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260812.4",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.70.1",


### PR DESCRIPTION
# Summary
- Removes the `ProvisioningResourceProvider` `base.Reset()` workaround now that the current base generator no longer caches the derived `BuildName()` result during construction.
- Keeps all provisioning emitter and generator dependencies at their existing `main` versions.

# Validation
- `npm install`
- `npm run build`
- `SharedResourceModelUsesModelSettableUsage` passes and verifies distinct `Profile` and `ProfileRevision` provider names without the workaround.

Related discussion: https://github.com/Azure/azure-sdk-for-net/pull/60970#discussion_r3679517460