### PR TITLE
Fix Confidential Ledger changelog release entry

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.2 (Unreleased)
+## 2.0.0-beta.2 (2026-08-13)
 
 ### Features Added
 - Added support to route retryable HTTP responses and retryable transport failures to failover ledgers for `GetLedgerEntry`, `GetLedgerEntryAsync`, `GetCurrentLedgerEntry`, and `GetCurrentLedgerEntryAsync`. No other reads or writes fail over. The primary and every failover endpoint receive independent normal retry budgets; caller cancellation never initiates failover, and the original primary failure is preserved if discovery or all failovers fail.
@@ -20,8 +20,6 @@
 - Failover requests are now validated by endpoint-specific transports against that ledger's own identity TLS certificate, fetched from the independently validated Identity Service. A certificate trusted for one ledger cannot authenticate another ledger. Custom transports remain supported.
 - `PostLedgerEntryOperation` now treats transient `406 NotAcceptable` responses from the status endpoint as `Pending` and tolerates exactly 3 consecutive `404 NotFound` HTTP responses while a transaction is replicated. The operation-specific 404 tolerance no longer multiplies with pipeline retries; normal 404 retry behavior remains unchanged for other operations.
 - Archived-collection fallback responses now preserve the complete historical ledger entry payload, including optional tags.
-
-### Other Changes
 
 ## 2.0.0-beta.1 (2026-08-05)
 


### PR DESCRIPTION
## Summary

- set the `2.0.0-beta.2` changelog release date to `2026-08-13`
- remove the empty `Other Changes` section

These changes address the release changelog validation failures for `Azure.Security.ConfidentialLedger`.

## Testing

- Not run locally: the environment does not have the required .NET SDK, so the changelog validator could not initialize package metadata and `dotnet format` was unavailable.
- The change is limited to the two changelog conditions reported by CI.