### PR TITLE
[Identity] Remove KeyAttestation dependency from Azure.Identity.Broker

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -190,7 +190,6 @@
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.84.2" />
-    <PackageVersion Include="Microsoft.Identity.Client.KeyAttestation" Version="4.84.2" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.15.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### Other Changes
 
-- Removed the unused direct dependency on `Microsoft.Identity.Client.KeyAttestation`.
-
 ## 1.8.0-beta.1 (2026-06-09)
 
 ### Features Added

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Removed the unused direct dependency on `Microsoft.Identity.Client.KeyAttestation`.
+
 ## 1.8.0-beta.1 (2026-06-09)
 
 ### Features Added

--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -13,6 +13,5 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" />
-    <PackageReference Include="Microsoft.Identity.Client.KeyAttestation" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

- Remove the unused direct `Microsoft.Identity.Client.KeyAttestation` reference from `Azure.Identity.Broker`.
- Remove the now-unused central package version entry.
- Preserve Azure.Core's optional runtime-resolved attestation integration.
- Document the dependency cleanup in the unreleased Broker changelog.

## Validation

- `dotnet format sdk\identity\Azure.Identity.Broker\src\Azure.Identity.Broker.csproj`
- `dotnet test sdk\identity\Azure.Identity.Broker\tests\Azure.Identity.Broker.Tests.csproj -f net10.0 --filter "TestCategory!=Live"` (172 passed, 12 skipped)
- Packed all supported target frameworks and confirmed the package metadata has no direct KeyAttestation dependency.