### PR TITLE
Replace equivalent model factory calls in tests

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Serialization/ResponseSnapshotTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Serialization/ResponseSnapshotTests.cs
@@ -171,7 +171,7 @@ public class ResponseSnapshotTests
         var original = new Models.ResponseObject("resp_snap7", "gpt-4o")
         {
             Status = ResponseStatus.Failed,
-            Error = ResponsesModelFactory.ResponseErrorInfo(
+            Error = new ResponseErrorInfo(
                 code: ResponseErrorCode.ServerError,
                 message: "Something went wrong"),
         };

--- a/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/DnsForwardingRulesetTests.cs
+++ b/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/DnsForwardingRulesetTests.cs
@@ -33,14 +33,14 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             //_subnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{SubnetName}";
 
             (var vnetId, var subnetId) = await CreateVirtualNetworkAsync();
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(vnetId) });
 
             _dnsResolver = (await resourceGroup.GetDnsResolvers().CreateOrUpdateAsync(WaitUntil.Completed, dnsResolverName, dnsResolverData)).Value;
             _dnsForwardingRulesetCollection = resourceGroup.GetDnsForwardingRulesets();
 
-            var outboundEndpointData = ArmDnsResolverModelFactory.DnsResolverOutboundEndpointData(
+            var outboundEndpointData = new DnsResolverOutboundEndpointData(
                 location: this.DefaultLocation,
                 subnet: new WritableSubResource { Id = new ResourceIdentifier(subnetId) });
 

--- a/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/DnsResolverPolicyLinkTests.cs
+++ b/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/DnsResolverPolicyLinkTests.cs
@@ -46,7 +46,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var dnsResolverPolicyLinkName = Recording.GenerateAssetName("dnsResolverPolicyLink-");
             await CreateDnsResolverCollection();
-            var dnsResolverPolicyLinkData = ArmDnsResolverModelFactory.DnsResolverPolicyVirtualNetworkLinkData(
+            var dnsResolverPolicyLinkData = new DnsResolverPolicyVirtualNetworkLinkData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
@@ -64,7 +64,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var dnsResolverPolicyLinkName = Recording.GenerateAssetName("dnsResolverPolicyLink-");
             await CreateDnsResolverCollection();
-            var dnsResolverPolicyLinkData = ArmDnsResolverModelFactory.DnsResolverPolicyVirtualNetworkLinkData(
+            var dnsResolverPolicyLinkData = new DnsResolverPolicyVirtualNetworkLinkData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
@@ -86,7 +86,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             var newTagKey = Recording.GenerateAlphaNumericId("tagKey");
             var newTagValue = Recording.GenerateAlphaNumericId("tagValue");
             await CreateDnsResolverCollection();
-            var dnsResolverPolicyLinkData = ArmDnsResolverModelFactory.DnsResolverPolicyVirtualNetworkLinkData(
+            var dnsResolverPolicyLinkData = new DnsResolverPolicyVirtualNetworkLinkData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
@@ -109,7 +109,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var dnsResolverPolicyLinkName = Recording.GenerateAssetName("dnsResolverPolicyLink-");
             await CreateDnsResolverCollection();
-            var dnsResolverPolicyLinkData = ArmDnsResolverModelFactory.DnsResolverPolicyVirtualNetworkLinkData(
+            var dnsResolverPolicyLinkData = new DnsResolverPolicyVirtualNetworkLinkData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 

--- a/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/DnsResolverTests.cs
+++ b/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/DnsResolverTests.cs
@@ -37,7 +37,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             await CreateDnsResolverCollectionAsync();
             await CreateVirtualNetworkAsync();
             var vnetId = DefaultVnetID;
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(vnetId) });
 
@@ -59,7 +59,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             await CreateVirtualNetworkAsync();
             var vnetId = DefaultVnetID;
             ;
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(vnetId) });
 
@@ -83,7 +83,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             await CreateDnsResolverCollectionAsync();
             await CreateVirtualNetworkAsync();
             var vnetId = DefaultVnetID;
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(vnetId) });
 
@@ -105,7 +105,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             await CreateDnsResolverCollectionAsync();
             await CreateVirtualNetworkAsync();
             var vnetId = DefaultVnetID;
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(vnetId) });
 

--- a/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/ForwardingRuleTests.cs
+++ b/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/ForwardingRuleTests.cs
@@ -35,14 +35,14 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             {
                 await CreateVirtualNetworkAsync();
             }
-            var outboundEndpointData = ArmDnsResolverModelFactory.DnsResolverOutboundEndpointData(
+            var outboundEndpointData = new DnsResolverOutboundEndpointData(
                 location: this.DefaultLocation,
                 subnet: new WritableSubResource { Id = new ResourceIdentifier(DefaultSubnetID) });
 
             //_vnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}";
             //_subnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{SubnetName}";
 
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 

--- a/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/InboundEndpointTests.cs
+++ b/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/InboundEndpointTests.cs
@@ -29,7 +29,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             //_vnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}";
             //_subnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{SubnetName}";
 
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(vnetId) });
 

--- a/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/OutboundEndpointTests.cs
+++ b/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/OutboundEndpointTests.cs
@@ -33,7 +33,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             //_vnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}";
             //_subnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{SubnetName}";
 
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
@@ -47,7 +47,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var outboundEndpointName = Recording.GenerateAssetName("outboundEndpoint-");
             await CreateDnsResolverCollection();
-            var outboundEndpointData = ArmDnsResolverModelFactory.DnsResolverOutboundEndpointData(
+            var outboundEndpointData = new DnsResolverOutboundEndpointData(
                 location: this.DefaultLocation,
                 subnet: new WritableSubResource { Id = new ResourceIdentifier(DefaultSubnetID) });
 
@@ -65,7 +65,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var outboundEndpointName = Recording.GenerateAssetName("outboundEndpoint-");
             await CreateDnsResolverCollection();
-            var outboundEndpointData = ArmDnsResolverModelFactory.DnsResolverOutboundEndpointData(
+            var outboundEndpointData = new DnsResolverOutboundEndpointData(
                 location: this.DefaultLocation,
                 subnet: new WritableSubResource { Id = new ResourceIdentifier(DefaultSubnetID) });
 
@@ -88,7 +88,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             var newTagKey = Recording.GenerateAlphaNumericId("tagKey");
             var newTagValue = Recording.GenerateAlphaNumericId("tagValue");
             await CreateDnsResolverCollection();
-            var outboundEndpointData = ArmDnsResolverModelFactory.DnsResolverOutboundEndpointData(
+            var outboundEndpointData = new DnsResolverOutboundEndpointData(
                 location: this.DefaultLocation,
                 subnet: new WritableSubResource { Id = new ResourceIdentifier(DefaultSubnetID) });
 
@@ -108,7 +108,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var outboundEndpointName = Recording.GenerateAssetName("outboundEndpoint-");
             await CreateDnsResolverCollection();
-            var outboundEndpointData = ArmDnsResolverModelFactory.DnsResolverOutboundEndpointData(
+            var outboundEndpointData = new DnsResolverOutboundEndpointData(
                 location: this.DefaultLocation,
                 subnet: new WritableSubResource { Id = new ResourceIdentifier(DefaultSubnetID) });
 

--- a/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/VirtualNetworkLinkTests.cs
+++ b/sdk/dnsresolver/Azure.ResourceManager.DnsResolver/tests/Tests/VirtualNetworkLinkTests.cs
@@ -36,14 +36,14 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             //_vnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}";
             //_subnetId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{TestEnvironment.ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{SubnetName}";
 
-            var dnsResolverData = ArmDnsResolverModelFactory.DnsResolverData(
+            var dnsResolverData = new DnsResolverData(
                 location: this.DefaultLocation,
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
             _dnsResolver = (await resourceGroup.GetDnsResolvers().CreateOrUpdateAsync(WaitUntil.Completed, dnsResolverName, dnsResolverData)).Value;
             _dnsForwardingRulesetCollection = resourceGroup.GetDnsForwardingRulesets();
 
-            var outboundEndpointData = ArmDnsResolverModelFactory.DnsResolverOutboundEndpointData(
+            var outboundEndpointData = new DnsResolverOutboundEndpointData(
                 location: this.DefaultLocation,
                 subnet: new WritableSubResource { Id = new ResourceIdentifier(DefaultSubnetID) });
 
@@ -74,7 +74,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var virtualNetworkLinkName = Recording.GenerateAssetName("virtualNetworkLink-");
             await CreateDnsResolverCollection();
-            var virtualNetworkLinkData = ArmDnsResolverModelFactory.DnsForwardingRulesetVirtualNetworkLinkData(
+            var virtualNetworkLinkData = new DnsForwardingRulesetVirtualNetworkLinkData(
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
             // ACT
@@ -91,7 +91,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var virtualNetworkLinkName = Recording.GenerateAssetName("virtualNetworkLink-");
             await CreateDnsResolverCollection();
-            var virtualNetworkLinkData = ArmDnsResolverModelFactory.DnsForwardingRulesetVirtualNetworkLinkData(
+            var virtualNetworkLinkData = new DnsForwardingRulesetVirtualNetworkLinkData(
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
             await _dnsForwardingRuleset.GetDnsForwardingRulesetVirtualNetworkLinks().CreateOrUpdateAsync(WaitUntil.Completed, virtualNetworkLinkName, virtualNetworkLinkData);
@@ -112,7 +112,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             var newTagKey = Recording.GenerateAlphaNumericId("tagKey");
             var newTagValue = Recording.GenerateAlphaNumericId("tagValue");
             await CreateDnsResolverCollection();
-            var virtualNetworkLinkData = ArmDnsResolverModelFactory.DnsForwardingRulesetVirtualNetworkLinkData(
+            var virtualNetworkLinkData = new DnsForwardingRulesetVirtualNetworkLinkData(
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
             var createdVirtualNetworkLink = await _dnsForwardingRuleset.GetDnsForwardingRulesetVirtualNetworkLinks().CreateOrUpdateAsync(WaitUntil.Completed, virtualNetworkLinkName, virtualNetworkLinkData);
@@ -134,7 +134,7 @@ namespace Azure.ResourceManager.DnsResolver.Tests
             // ARRANGE
             var virtualNetworkLinkName = Recording.GenerateAssetName("virtualNetworkLink-");
             await CreateDnsResolverCollection();
-            var virtualNetworkLinkData = ArmDnsResolverModelFactory.DnsForwardingRulesetVirtualNetworkLinkData(
+            var virtualNetworkLinkData = new DnsForwardingRulesetVirtualNetworkLinkData(
                 virtualNetwork: new WritableSubResource { Id = new ResourceIdentifier(DefaultVnetID) });
 
             var createdVirtualNetworkLink = await _dnsForwardingRuleset.GetDnsForwardingRulesetVirtualNetworkLinks().CreateOrUpdateAsync(WaitUntil.Completed, virtualNetworkLinkName, virtualNetworkLinkData);


### PR DESCRIPTION
## Purpose

Replace model factory calls in tests when the model's public constructor provides equivalent behavior.

## Changes

- Use public constructors for 24 DNS Resolver test model instances.
- Use the public `ResponseErrorInfo` constructor in an AgentServer serialization test.
- Keep model factory calls where constructors are unavailable, validate inputs differently, cannot populate the same output properties, or are themselves under test.

## Research

Full repository findings: https://gist.github.com/live1206/93741a127d0e8d3345660e73a7051ea9

## Validation

- AgentServer non-live test suite
- AgentServer API export, snippet update, snippet build, and formatting
- DNS Resolver test-project build and formatting
