### PR TITLE
Update http-client-csharp 20260814.4 SDKs (part 1/4)

### DIFF
--- a/eng/azure-typespec-http-client-csharp-emitter-package-lock.json
+++ b/eng/azure-typespec-http-client-csharp-emitter-package-lock.json
@@ -5,25 +5,25 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260813.3"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260814.4"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "0.70.0",
-        "@azure-tools/typespec-azure-core": "0.70.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.70.0",
-        "@azure-tools/typespec-azure-rulesets": "0.70.0",
-        "@azure-tools/typespec-client-generator-core": "0.70.0",
-        "@typespec/compiler": "1.14.0",
-        "@typespec/http": "1.14.0",
-        "@typespec/openapi": "1.14.0",
-        "@typespec/rest": "0.84.0",
-        "@typespec/versioning": "0.84.0"
+        "@azure-tools/typespec-autorest": "0.71.0",
+        "@azure-tools/typespec-azure-core": "0.71.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.71.0",
+        "@azure-tools/typespec-azure-rulesets": "0.71.0",
+        "@azure-tools/typespec-client-generator-core": "0.71.1",
+        "@typespec/compiler": "1.15.0",
+        "@typespec/http": "1.15.0",
+        "@typespec/openapi": "1.15.0",
+        "@typespec/rest": "0.85.0",
+        "@typespec/versioning": "0.85.0"
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.70.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-autorest/-/typespec-autorest-0.70.0.tgz",
-      "integrity": "sha1-hxXdmTz6UUqpPXEGLwyRUHHNt38=",
+      "version": "0.71.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-autorest/-/typespec-autorest-0.71.0.tgz",
+      "integrity": "sha1-RFb9WR9/0pZaHjt7hxCTvDo3Rlc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -33,15 +33,15 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
-        "@azure-tools/typespec-client-generator-core": "^0.70.0",
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/http": "^1.14.0",
-        "@typespec/openapi": "^1.14.0",
-        "@typespec/rest": "^0.84.0",
-        "@typespec/versioning": "^0.84.0",
-        "@typespec/xml": "^0.84.0"
+        "@azure-tools/typespec-azure-core": "^0.71.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.71.0",
+        "@azure-tools/typespec-client-generator-core": "^0.71.0",
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/http": "^1.15.0",
+        "@typespec/openapi": "^1.15.0",
+        "@typespec/rest": "^0.85.0",
+        "@typespec/versioning": "^0.85.0",
+        "@typespec/xml": "^0.85.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -50,23 +50,23 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.70.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.70.0.tgz",
-      "integrity": "sha1-k3VYRkt7yNAA1kiBElz71YbZH7A=",
+      "version": "0.71.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.71.0.tgz",
+      "integrity": "sha1-OndNkxsckNGPmzgPEgcZW+SG6K4=",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/http": "^1.14.0",
-        "@typespec/rest": "^0.84.0"
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/http": "^1.15.0",
+        "@typespec/rest": "^0.85.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.70.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.70.0.tgz",
-      "integrity": "sha1-+Skz0cnW1LADE60g/JnqYk0nixg=",
+      "version": "0.71.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.71.0.tgz",
+      "integrity": "sha1-yIlakkA/ScZ83103yBZb1NS0vG4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -77,34 +77,34 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/http": "^1.14.0",
-        "@typespec/openapi": "^1.14.0",
-        "@typespec/rest": "^0.84.0",
-        "@typespec/versioning": "^0.84.0"
+        "@azure-tools/typespec-azure-core": "^0.71.0",
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/http": "^1.15.0",
+        "@typespec/openapi": "^1.15.0",
+        "@typespec/rest": "^0.85.0",
+        "@typespec/versioning": "^0.85.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.70.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.70.0.tgz",
-      "integrity": "sha1-/iCKSwMs+gWfYYd9UTZFo/AXjrQ=",
+      "version": "0.71.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.71.0.tgz",
+      "integrity": "sha1-om2dE6CDZXh48GWtwV7PMDhWGlg=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
-        "@azure-tools/typespec-client-generator-core": "^0.70.0",
-        "@typespec/compiler": "^1.14.0"
+        "@azure-tools/typespec-azure-core": "^0.71.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.71.0",
+        "@azure-tools/typespec-client-generator-core": "^0.71.0",
+        "@typespec/compiler": "^1.15.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.70.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.70.0.tgz",
-      "integrity": "sha1-k7nEgErM8Vd5PRVdaR8rfSPFpic=",
+      "version": "0.71.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.71.1.tgz",
+      "integrity": "sha1-/uAZ0Q9Cyn1XTZ38gQsfoBbjFNM=",
       "license": "MIT",
       "dependencies": {
         "change-case": "^5.4.4",
@@ -115,25 +115,25 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/events": "^0.84.0",
-        "@typespec/http": "^1.14.0",
-        "@typespec/openapi": "^1.14.0",
-        "@typespec/rest": "^0.84.0",
-        "@typespec/sse": "^0.84.0",
-        "@typespec/streams": "^0.84.0",
-        "@typespec/versioning": "^0.84.0",
-        "@typespec/xml": "^0.84.0"
+        "@azure-tools/typespec-azure-core": "^0.71.0",
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/events": "^0.85.0",
+        "@typespec/http": "^1.15.0",
+        "@typespec/openapi": "^1.15.0",
+        "@typespec/rest": "^0.85.0",
+        "@typespec/sse": "^0.85.0",
+        "@typespec/streams": "^0.85.0",
+        "@typespec/versioning": "^0.85.0",
+        "@typespec/xml": "^0.85.0"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260813.3",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260813.3.tgz",
-      "integrity": "sha1-PLDVXa0Kyxkcwq1Q3BmNL3eieHA=",
+      "version": "1.0.0-alpha.20260814.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260814.4.tgz",
+      "integrity": "sha1-Id9SuykjzVRspGyeoPD523iDBI8=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260812.5"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260814.8"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.14.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/compiler/-/compiler-1.14.0.tgz",
-      "integrity": "sha1-2FXCBu7K+j54eOf0JVthKC8FP0Y=",
+      "version": "1.15.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/compiler/-/compiler-1.15.0.tgz",
+      "integrity": "sha1-3BWfZoiYvTkU/OnXjF9I5MHn3ec=",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -670,9 +670,9 @@
         "is-unicode-supported": "^2.1.0",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
-        "prettier": "^3.8.1",
+        "prettier": "^3.9.5",
         "semver": "^7.7.4",
-        "tar": "^7.5.13",
+        "tar": "^7.5.21",
         "temporal-polyfill": "^1.0.1",
         "vscode-languageserver": "^10.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
@@ -688,29 +688,29 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.84.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/events/-/events-0.84.0.tgz",
-      "integrity": "sha1-U6JW0cqeb0+n5fCjTbaW3DlOYPk=",
+      "version": "0.85.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/events/-/events-0.85.0.tgz",
+      "integrity": "sha1-TZtGfQwTcbcldDGg/rTUpzz2Was=",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0"
+        "@typespec/compiler": "^1.15.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.14.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http/-/http-1.14.0.tgz",
-      "integrity": "sha1-La9yB2Ny8FhnXSBbst9wYQBiOq4=",
+      "version": "1.15.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http/-/http-1.15.0.tgz",
+      "integrity": "sha1-OqvPNx2dM+UE2rk3fC+/t8tER04=",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/streams": "^0.84.0"
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/streams": "^0.85.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -719,79 +719,79 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260812.5",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260812.5.tgz",
-      "integrity": "sha1-wXgvU1ccqHd4RjDL0rJ+UHxLMBo=",
+      "version": "1.0.0-alpha.20260814.8",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260814.8.tgz",
+      "integrity": "sha1-CSjfhnypJqHq/SZTFq3RTNzPMP4=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.70.0 <0.71.0 || ~0.71.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.70.0 <0.71.0 || ~0.71.0-0",
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/events": ">=0.84.0 <0.85.0 || ~0.85.0-0",
-        "@typespec/http": "^1.14.0",
-        "@typespec/openapi": "^1.14.0",
-        "@typespec/rest": ">=0.84.0 <0.85.0 || ~0.85.0-0",
-        "@typespec/sse": ">=0.84.0 <0.85.0 || ~0.85.0-0",
-        "@typespec/streams": ">=0.84.0 <0.85.0 || ~0.85.0-0",
-        "@typespec/versioning": ">=0.84.0 <0.85.0 || ~0.85.0-0"
+        "@azure-tools/typespec-azure-core": ">=0.71.0 <0.72.0 || ~0.72.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.71.1 <0.72.0 || ~0.72.0-0",
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/events": ">=0.85.0 <0.86.0 || ~0.86.0-0",
+        "@typespec/http": "^1.15.0",
+        "@typespec/openapi": "^1.15.0",
+        "@typespec/rest": ">=0.85.0 <0.86.0 || ~0.86.0-0",
+        "@typespec/sse": ">=0.85.0 <0.86.0 || ~0.86.0-0",
+        "@typespec/streams": ">=0.85.0 <0.86.0 || ~0.86.0-0",
+        "@typespec/versioning": ">=0.85.0 <0.86.0 || ~0.86.0-0"
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.14.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/openapi/-/openapi-1.14.0.tgz",
-      "integrity": "sha1-uwjWOV3VwWP59UXlR2xVUuzyCGc=",
+      "version": "1.15.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/openapi/-/openapi-1.15.0.tgz",
+      "integrity": "sha1-f7jb9Zwx/8+LWYZ9miF2ANsE1H4=",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/http": "^1.14.0"
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/http": "^1.15.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.84.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/rest/-/rest-0.84.0.tgz",
-      "integrity": "sha1-kMLB39G8geZbiA3EEdQBaqteuuA=",
+      "version": "0.85.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/rest/-/rest-0.85.0.tgz",
+      "integrity": "sha1-MpezFelVNp3C8V7zqiIGkCmOSig=",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/http": "^1.14.0"
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/http": "^1.15.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.84.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/sse/-/sse-0.84.0.tgz",
-      "integrity": "sha1-dkP/3P+tvI4Q2SV3oRz/F2JMVXo=",
+      "version": "0.85.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/sse/-/sse-0.85.0.tgz",
+      "integrity": "sha1-7Z+nl1EmgQOzVw0M7Kyt9BI62ME=",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0",
-        "@typespec/events": "^0.84.0",
-        "@typespec/http": "^1.14.0",
-        "@typespec/streams": "^0.84.0"
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/events": "^0.85.0",
+        "@typespec/http": "^1.15.0",
+        "@typespec/streams": "^0.85.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.84.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/streams/-/streams-0.84.0.tgz",
-      "integrity": "sha1-Bm3D76chBKlcou2jj913xFfTBI4=",
+      "version": "0.85.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/streams/-/streams-0.85.0.tgz",
+      "integrity": "sha1-kpy9k/VI78G2x7vEPYBBaTSAJ5k=",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0"
+        "@typespec/compiler": "^1.15.0"
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
@@ -809,28 +809,28 @@
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.84.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/versioning/-/versioning-0.84.0.tgz",
-      "integrity": "sha1-YS06C7uMMWXKp7vwuy8qV8kjr38=",
+      "version": "0.85.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/versioning/-/versioning-0.85.0.tgz",
+      "integrity": "sha1-QKPYE3Ekp2N3BF1WHYklWdQd/Rg=",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0"
+        "@typespec/compiler": "^1.15.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.84.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/xml/-/xml-0.84.0.tgz",
-      "integrity": "sha1-aP99jZ3+wHS7f9mMJbEUT4Py7+g=",
+      "version": "0.85.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/xml/-/xml-0.85.0.tgz",
+      "integrity": "sha1-uwCwqUDM38WdUrmj+nxFC1A4Bw4=",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.14.0"
+        "@typespec/compiler": "^1.15.0"
       }
     },
     "node_modules/agent-base": {

--- a/eng/azure-typespec-http-client-csharp-emitter-package.json
+++ b/eng/azure-typespec-http-client-csharp-emitter-package.json
@@ -1,18 +1,18 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260813.3"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260814.4"
   },
   "devDependencies": {
-    "@azure-tools/typespec-azure-core": "0.70.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.70.0",
-    "@azure-tools/typespec-azure-rulesets": "0.70.0",
-    "@azure-tools/typespec-client-generator-core": "0.70.0",
-    "@azure-tools/typespec-autorest": "0.70.0",
-    "@typespec/compiler": "1.14.0",
-    "@typespec/http": "1.14.0",
-    "@typespec/openapi": "1.14.0",
-    "@typespec/rest": "0.84.0",
-    "@typespec/versioning": "0.84.0"
+    "@azure-tools/typespec-azure-core": "0.71.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.71.0",
+    "@azure-tools/typespec-azure-rulesets": "0.71.0",
+    "@azure-tools/typespec-client-generator-core": "0.71.1",
+    "@azure-tools/typespec-autorest": "0.71.0",
+    "@typespec/compiler": "1.15.0",
+    "@typespec/http": "1.15.0",
+    "@typespec/openapi": "1.15.0",
+    "@typespec/rest": "0.85.0",
+    "@typespec/versioning": "0.85.0"
   }
 }

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/AgentsPersistentModelFactory.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/AgentsPersistentModelFactory.cs
@@ -699,7 +699,7 @@ namespace Azure.AI.Agents.Persistent
         /// <returns> A new <see cref="Persistent.MessageInputImageUriBlock"/> instance for mocking. </returns>
         public static MessageInputImageUriBlock MessageInputImageUriBlock(MessageImageUriParam imageUrl = default)
         {
-            return new MessageInputImageUriBlock(MessageBlockType.ImageUrl, additionalBinaryDataProperties: null, imageUrl);
+            return new MessageInputImageUriBlock(MessageBlockType.ImageUri, additionalBinaryDataProperties: null, imageUrl);
         }
 
         /// <summary> Defines how an external image URL is referenced when creating an image-URL block. </summary>

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.AI.Agents.Persistent
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/Models/MessageBlockType.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/Models/MessageBlockType.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.Agents.Persistent
         /// <summary> Indicates a block referencing an internally uploaded image file. </summary>
         private const string ImageFileValue = "image_file";
         /// <summary> Indicates a block referencing an external image URL. </summary>
-        private const string ImageUrlValue = "image_url";
+        private const string ImageUriValue = "image_url";
 
         /// <summary> Initializes a new instance of <see cref="MessageBlockType"/>. </summary>
         /// <param name="value"> The value. </param>
@@ -38,7 +38,7 @@ namespace Azure.AI.Agents.Persistent
         public static MessageBlockType ImageFile { get; } = new MessageBlockType(ImageFileValue);
 
         /// <summary> Indicates a block referencing an external image URL. </summary>
-        public static MessageBlockType ImageUrl { get; } = new MessageBlockType(ImageUrlValue);
+        public static MessageBlockType ImageUri { get; } = new MessageBlockType(ImageUriValue);
 
         /// <summary> Determines if two <see cref="MessageBlockType"/> values are the same. </summary>
         /// <param name="left"> The left value to compare. </param>

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/Models/MessageInputImageUriBlock.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Generated/Models/MessageInputImageUriBlock.cs
@@ -16,7 +16,7 @@ namespace Azure.AI.Agents.Persistent
         /// <summary> Initializes a new instance of <see cref="MessageInputImageUriBlock"/>. </summary>
         /// <param name="imageUrl"> Information about the external image URL, including the URL and optional detail level. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="imageUrl"/> is null. </exception>
-        public MessageInputImageUriBlock(MessageImageUriParam imageUrl) : base(MessageBlockType.ImageUrl)
+        public MessageInputImageUriBlock(MessageImageUriParam imageUrl) : base(MessageBlockType.ImageUri)
         {
             Argument.AssertNotNull(imageUrl, nameof(imageUrl));
 

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.AI.AnomalyDetector
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.Data.AppConfiguration
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/batch/Azure.Compute.Batch/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/batch/Azure.Compute.Batch/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.Compute.Batch
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations.Authoring/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations.Authoring/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.AI.Language.Conversations.Authoring
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.AI.Language.Conversations
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/api/Azure.AI.Language.QuestionAnswering.Authoring.net10.0.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/api/Azure.AI.Language.QuestionAnswering.Authoring.net10.0.cs
@@ -627,7 +627,7 @@ namespace Azure.AI.Language.QuestionAnswering.Authoring
         private readonly int _dummyPrimitive;
         public SourceKind(string value) { throw null; }
         public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind File { get { throw null; } }
-        public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind Url { get { throw null; } }
+        public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind Uri { get { throw null; } }
         public bool Equals(Azure.AI.Language.QuestionAnswering.Authoring.SourceKind other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/api/Azure.AI.Language.QuestionAnswering.Authoring.net8.0.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/api/Azure.AI.Language.QuestionAnswering.Authoring.net8.0.cs
@@ -627,7 +627,7 @@ namespace Azure.AI.Language.QuestionAnswering.Authoring
         private readonly int _dummyPrimitive;
         public SourceKind(string value) { throw null; }
         public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind File { get { throw null; } }
-        public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind Url { get { throw null; } }
+        public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind Uri { get { throw null; } }
         public bool Equals(Azure.AI.Language.QuestionAnswering.Authoring.SourceKind other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/api/Azure.AI.Language.QuestionAnswering.Authoring.netstandard2.0.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/api/Azure.AI.Language.QuestionAnswering.Authoring.netstandard2.0.cs
@@ -619,7 +619,7 @@ namespace Azure.AI.Language.QuestionAnswering.Authoring
         private readonly int _dummyPrimitive;
         public SourceKind(string value) { throw null; }
         public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind File { get { throw null; } }
-        public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind Url { get { throw null; } }
+        public static Azure.AI.Language.QuestionAnswering.Authoring.SourceKind Uri { get { throw null; } }
         public bool Equals(Azure.AI.Language.QuestionAnswering.Authoring.SourceKind other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.AI.Language.QuestionAnswering.Authoring
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/src/Generated/Models/SourceKind.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Authoring/src/Generated/Models/SourceKind.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.Language.QuestionAnswering.Authoring
         /// <summary> File Source. </summary>
         private const string FileValue = "file";
         /// <summary> URI Source. </summary>
-        private const string UrlValue = "url";
+        private const string UriValue = "url";
 
         /// <summary> Initializes a new instance of <see cref="SourceKind"/>. </summary>
         /// <param name="value"> The value. </param>
@@ -33,7 +33,7 @@ namespace Azure.AI.Language.QuestionAnswering.Authoring
         public static SourceKind File { get; } = new SourceKind(FileValue);
 
         /// <summary> URI Source. </summary>
-        public static SourceKind Url { get; } = new SourceKind(UrlValue);
+        public static SourceKind Uri { get; } = new SourceKind(UriValue);
 
         /// <summary> Determines if two <see cref="SourceKind"/> values are the same. </summary>
         /// <param name="left"> The left value to compare. </param>

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Inference/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering.Inference/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.AI.Language.QuestionAnswering.Inference
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text.Authoring/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.AI.Language.Text.Authoring
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/cognitivelanguage/Azure.AI.Language.Text/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Text/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.AI.Language.Text
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/communication/Azure.Communication.JobRouter/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.Communication.JobRouter
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/communication/Azure.Communication.Messages/src/Generated/CommunicationMessagesModelFactory.cs
+++ b/sdk/communication/Azure.Communication.Messages/src/Generated/CommunicationMessagesModelFactory.cs
@@ -138,7 +138,7 @@ namespace Azure.Communication.Messages
         /// <returns> A new <see cref="Messages.LinkContent"/> instance for mocking. </returns>
         public static LinkContent LinkContent(string title = default, Uri uri = default)
         {
-            return new LinkContent(MessageContentKind.Url, additionalBinaryDataProperties: null, title, uri);
+            return new LinkContent(MessageContentKind.Uri, additionalBinaryDataProperties: null, title, uri);
         }
 
         /// <summary> The action content of type ActionGroup. </summary>

--- a/sdk/communication/Azure.Communication.Messages/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/communication/Azure.Communication.Messages/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.Communication.Messages
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/communication/Azure.Communication.Messages/src/Generated/Models/LinkContent.cs
+++ b/sdk/communication/Azure.Communication.Messages/src/Generated/Models/LinkContent.cs
@@ -17,7 +17,7 @@ namespace Azure.Communication.Messages
         /// <param name="title"> Title of the url content. </param>
         /// <param name="uri"> The url in the content. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="title"/> or <paramref name="uri"/> is null. </exception>
-        public LinkContent(string title, Uri uri) : base(MessageContentKind.Url)
+        public LinkContent(string title, Uri uri) : base(MessageContentKind.Uri)
         {
             Argument.AssertNotNull(title, nameof(title));
             Argument.AssertNotNull(uri, nameof(uri));

--- a/sdk/communication/Azure.Communication.Messages/src/Generated/Models/MessageContentKind.cs
+++ b/sdk/communication/Azure.Communication.Messages/src/Generated/Models/MessageContentKind.cs
@@ -27,7 +27,7 @@ namespace Azure.Communication.Messages
         /// <summary> The ButtonSet content type. </summary>
         private const string ButtonSetValue = "buttonSet";
         /// <summary> The Url content type. </summary>
-        private const string UrlValue = "url";
+        private const string UriValue = "url";
 
         /// <summary> Initializes a new instance of <see cref="MessageContentKind"/>. </summary>
         /// <param name="value"> The value. </param>
@@ -58,7 +58,7 @@ namespace Azure.Communication.Messages
         public static MessageContentKind ButtonSet { get; } = new MessageContentKind(ButtonSetValue);
 
         /// <summary> The Url content type. </summary>
-        public static MessageContentKind Url { get; } = new MessageContentKind(UrlValue);
+        public static MessageContentKind Uri { get; } = new MessageContentKind(UriValue);
 
         /// <summary> Determines if two <see cref="MessageContentKind"/> values are the same. </summary>
         /// <param name="left"> The left value to compare. </param>

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.Security.CodeTransparency
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.Security.ConfidentialLedger
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)

--- a/sdk/template/Azure.Template/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/template/Azure.Template/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -159,6 +161,59 @@ namespace Azure.Template
                 default:
                     throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
             }
+        }
+
+        public static void WriteBase64StringValue(this Utf8JsonWriter writer, BinaryData value, string format)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            switch (format)
+            {
+                case "U":
+                    writer.WriteBase64UrlStringValue(value.ToMemory().Span);
+                    break;
+                case "D":
+                    writer.WriteBase64StringValue(value.ToMemory().Span);
+                    break;
+                default:
+                    throw new ArgumentException($"Format is not supported: '{format}'", nameof(format));
+            }
+        }
+
+        public static void WriteBase64UrlStringValue(this Utf8JsonWriter writer, ReadOnlySpan<byte> source)
+        {
+            byte[] encoded = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
+            OperationStatus status = Base64.EncodeToUtf8(source, encoded, out int bytesConsumed, out int bytesWritten);
+            if (status != OperationStatus.Done || bytesConsumed != source.Length)
+            {
+                throw new InvalidOperationException("Base64Url encoding did not complete.");
+            }
+            for (int index = 0; index < bytesWritten; index++)
+            {
+                if (encoded[index] == (byte)'+')
+                {
+                    encoded[index] = (byte)'-';
+                }
+                else
+                {
+                    if (encoded[index] == (byte)'/')
+                    {
+                        encoded[index] = (byte)'_';
+                    }
+                    else
+                    {
+                        if (encoded[index] == (byte)'=')
+                        {
+                            bytesWritten = index;
+                            break;
+                        }
+                    }
+                }
+            }
+            writer.WriteStringValue(encoded.AsSpan(0, bytesWritten));
         }
 
         public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)


### PR DESCRIPTION
Generated by branded - http-client-csharp build [20260814.4](https://dev.azure.com/azure-sdk//internal/_build/results?buildId=6706444).

Split into four PRs because the combined pull-request CI matrix exceeded the Azure Pipelines YAML size limit. All changes were copied exactly from #62123; no code was manually edited, regenerated, or formatted.

| Part | PR | Service range | Packages |
|---|---|---|---:|
| 1 | #62148 | `ai`–`confidentialledger`, plus `Azure.Template` | 15 |
| 2 | #62147 | `contentsafety`–`keyvault`, plus `Azure.Template` | 14 |
| 3 | #62146 | `loadtestservice`–`search`, plus `Azure.Template` | 11 |
| 4 | #62145 | `storage`–`voicelive` | 10 |

Each SDK service directory appears in exactly one PR except `Azure.Template`, which is intentionally included in all four parts. The two emitter package metadata files are also intentionally shared by all four PRs, and compatibility baselines remain with their corresponding service ranges. Merge the PRs in part order.