### PR TITLE
Default archived collection fallback to false

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 2.0.0-beta.3 (Unreleased)
-
-### Features Added
+## 2.0.0-beta.3 (2026-08-17)
 
 ### Breaking Changes
 
-### Bugs Fixed
-
-### Other Changes
+- Changed `ConfidentialLedgerClientOptions.EnableArchivedCollectionFallback` to default to `false`. Callers that require `GetCurrentLedgerEntry` and `GetCurrentLedgerEntryAsync` to search ledger history after a collection-specific 404 must now explicitly opt in by setting the option to `true`.
 
 ## 2.0.0-beta.2 (2026-08-13)
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
@@ -123,7 +123,15 @@ var ledgerClient = new ConfidentialLedgerClient(ledgerEndpoint, credential, opti
 
 `GetLedgerEntry` automatically re-polls a successful response whose state is `Loading`. The configured `Retry.MaxRetries` bounds the additional loading polls and `Retry.Delay` controls their spacing.
 
-Collection pruning can remove the live value while retaining its history. Archived fallback is enabled by default, so `GetCurrentLedgerEntry` handles a collection-specific 404 by querying history and returning the latest retained entry, including tags, without additional caller logic or configuration. A missing collection still surfaces the original 404 when history contains no entry. Set `EnableArchivedCollectionFallback = false` only to restore the legacy 404 behavior for pruned collections.
+Collection pruning can remove the live value while retaining its history. Archived fallback is disabled by default because the service returns the same 404 for a pruned collection and a collection that never existed, and searching ledger history can be expensive on a ledger with a long transaction history. To transparently query history and return the latest retained entry, including tags, explicitly set `EnableArchivedCollectionFallback = true`. A missing collection still surfaces the original 404 when history contains no entry.
+
+```C#
+var options = new ConfidentialLedgerClientOptions
+{
+    EnableArchivedCollectionFallback = true,
+};
+var ledgerClient = new ConfidentialLedgerClient(ledgerEndpoint, credential, options);
+```
 
 Each endpoint uses its own transport pipeline and the TLS identity certificate returned by the independently validated Identity Service is pinned specifically to that endpoint's ledger id. A certificate trusted for one ledger is not accepted for another ledger, including during concurrent failover. Custom transports remain in use; their TLS behavior remains the custom transport owner's responsibility. Do not disable `VerifyConnection` in production.
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClientOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClientOptions.cs
@@ -46,15 +46,17 @@ namespace Azure.Security.ConfidentialLedger
 
         /// <summary>
         /// Controls whether a current-entry read transparently falls back to ledger history when a
-        /// collection's live entry has been archived by collection pruning. Defaults to <c>true</c>.
+        /// collection's live entry has been archived by collection pruning. Defaults to <c>false</c>.
         /// </summary>
         /// <remarks>
         /// This mirrors the service-side collection pruning feature: when a ledger is configured to prune (archive) old collections, the
         /// <c>GetCurrentLedgerEntry</c> endpoint returns <c>404 Not Found</c> for a pruned collection. With this option enabled the client
-        /// transparently performs a historical query for the collection and returns its latest committed entry. Defaults to <c>true</c>.
-        /// Set this option to <c>false</c> only when the caller requires the legacy behavior where a pruned collection returns 404.
+        /// transparently performs a historical query for the collection and returns its latest committed entry. Defaults to <c>false</c>
+        /// because the service returns the same 404 for a pruned collection and a collection that never existed, and a historical query
+        /// can be expensive on a ledger with a long transaction history. Set this option to <c>true</c> only when transparent access to
+        /// archived collections is required.
         /// </remarks>
-        public bool EnableArchivedCollectionFallback { get; set; } = true;
+        public bool EnableArchivedCollectionFallback { get; set; }
 
         /// <summary>
         /// Controls the order in which a read request is retried against the ledger's failover endpoints

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerPruningLiveTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerPruningLiveTests.cs
@@ -73,7 +73,8 @@ namespace Azure.Security.ConfidentialLedger.Tests
             var options = InstrumentClientOptions(
                 new ConfidentialLedgerClientOptions(ServiceVersion.V2024_12_09_Preview)
                 {
-                    CertificateEndpoint = TestEnvironment.ConfidentialLedgerPruningIdentityUrl
+                    CertificateEndpoint = TestEnvironment.ConfidentialLedgerPruningIdentityUrl,
+                    EnableArchivedCollectionFallback = true,
                 });
 
             TokenCredential credential = TestEnvironment.Credential;

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerPruningTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerPruningTests.cs
@@ -59,11 +59,11 @@ namespace Azure.Security.ConfidentialLedger.Tests
         }
 
         [Test]
-        public void ArchivedCollectionFallback_IsEnabledByDefault()
+        public void ArchivedCollectionFallback_IsDisabledByDefault()
         {
             var options = new ConfidentialLedgerClientOptions();
 
-            Assert.IsTrue(options.EnableArchivedCollectionFallback);
+            Assert.IsFalse(options.EnableArchivedCollectionFallback);
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- change `ConfidentialLedgerClientOptions.EnableArchivedCollectionFallback` to default to `false`
- require callers to explicitly opt in to historical fallback for pruned collections
- update unit/live tests and README guidance for the new beta.3 behavior

## Validation
- `dotnet format` for source and test projects
- focused pruning tests: 232 passed across net462, net8.0, net9.0, and net10.0
- full test project: 1,336 total, 834 passed, 502 intentionally skipped, 0 failed
- Release package build/pack succeeded
- `git diff --check` passed
