### PR TITLE
Prepare Microsoft.Extensions.Azure 1.14.1 release

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Release History
 
-## 1.15.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.14.1 (2026-09-08)
 
 ### Other Changes
+
+- Updated dependency `Azure.Core` to version `1.61.0`.
+- Updated dependency `Microsoft.Extensions.Configuration.Binder` to version `10.0.10`.
+- Updated dependency `Microsoft.Extensions.Logging` to version `10.0.10`.
 
 ## 1.14.0 (2026-04-22)
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Azure Client SDK integration with Microsoft.Extensions libraries</Description>
     <AssemblyTitle>Azure Client SDK integration Microsoft.Extensions</AssemblyTitle>
-    <Version>1.15.0-beta.1</Version>
+    <Version>1.14.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.14.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline AspNetCore Extensions</PackageTags>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Prepares the dependency-only `Microsoft.Extensions.Azure` 1.14.1 patch release. This updates the package version and documents the dependency-floor changes from 1.14.0: Azure.Core 1.53.0 to 1.61.0, Microsoft.Extensions.Configuration.Binder 10.0.3 to 10.0.10, and Microsoft.Extensions.Logging 10.0.3 to 10.0.10.

There are no product source or public API changes. The package continues to target netstandard2.0, net8.0, and net10.0. `MicrosoftExtensionsAzureVersion` intentionally remains at 1.14.0 until this package is published and downstream extension packages are prepared in a follow-up change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR - N/A, no REST spec changes.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes. N/A, this is package metadata only; the package build, API compatibility check, pack, and dependency graph comparison completed successfully.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above. N/A, no SDK regeneration.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. N/A, no generator or specification changes.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. The package csproj is updated; AssemblyInfo.cs is intentionally unchanged because this release has no source or API changes.