### PR TITLE
Prepare ASP.NET Core extensions patch releases

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.5.2 (2026-09-08)
 
 ### Other Changes
+
+- Updated `Azure.Core` dependency from 1.54.0 to 1.61.0.
+- Updated `Azure.Security.KeyVault.Secrets` dependency from 4.10.0 to 4.11.0.
+- Updated `Microsoft.Extensions.Configuration` dependency from 10.0.3 to the serviced 10.0.10 release.
 
 ## 1.5.1 (2026-04-29)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Azure Key Vault configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
     <PackageTags>$(PackageTags);azure;keyvault</PackageTags>
-    <Version>1.6.0-beta.1</Version>
+    <Version>1.5.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.1</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.5.4 (2026-09-08)
 
 ### Other Changes
+
+- Updated `Azure.Core` dependency from 1.55.0 to 1.61.0.
+- Updated `Microsoft.AspNetCore.DataProtection` to patched versions that resolve `System.Security.Cryptography.Xml` advisories GHSA-g8r8-53c2-pm3f, GHSA-8q5v-6pqq-x66h, GHSA-23rf-6693-g89p, GHSA-cvvh-rhrc-wg4q, and GHSA-mmjf-rqrv-855v: from 8.0.26 to 8.0.29 for `net8.0`, and from 10.0.7 to 10.0.10 for all other target frameworks.
 
 ## 1.5.3 (2026-05-08)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Blob storage support as key store (https://docs.microsoft.com/aspnet/core/security/data-protection/implementation/key-storage-providers).</Description>
     <PackageTags>aspnetcore;dataprotection;azure;blob;key store</PackageTags>
-    <Version>1.6.0-beta.1</Version>
+    <Version>1.5.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.3</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.7.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.6.4 (2026-09-08)
 
 ### Other Changes
+
+- Updated `Azure.Core` dependency from 1.55.0 to 1.61.0.
+- Updated `Microsoft.AspNetCore.DataProtection` to patched versions that resolve `System.Security.Cryptography.Xml` advisories GHSA-g8r8-53c2-pm3f, GHSA-8q5v-6pqq-x66h, GHSA-23rf-6693-g89p, GHSA-cvvh-rhrc-wg4q, and GHSA-mmjf-rqrv-855v: from 8.0.26 to 8.0.29 for `net8.0`, and from 10.0.7 to 10.0.10 for all other target frameworks.
 
 ## 1.6.3 (2026-05-08)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Key Vault key encryption support.</Description>
     <PackageTags>aspnetcore;dataprotection;azure;keyvault</PackageTags>
-    <Version>1.7.0-beta.1</Version>
+    <Version>1.6.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.6.3</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Prepares stable patch releases for exactly these packages:

| Package | Version |
| --- | --- |
| `Azure.Extensions.AspNetCore.Configuration.Secrets` | `1.5.2` |
| `Azure.Extensions.AspNetCore.DataProtection.Blobs` | `1.5.4` |
| `Azure.Extensions.AspNetCore.DataProtection.Keys` | `1.6.4` |

Each package's project version and changelog were updated. There are no product source, public API, generated-code, or implementation changes. This work is independent of #62160 and includes no files or commits from that release PR.

### Effective direct dependency floor changes

Compared with tags `Azure.Extensions.AspNetCore.Configuration.Secrets_1.5.1`, `Azure.Extensions.AspNetCore.DataProtection.Blobs_1.5.3`, and `Azure.Extensions.AspNetCore.DataProtection.Keys_1.6.3`:

| Package | Dependency | Previous floor | New floor |
| --- | --- | --- | --- |
| Configuration.Secrets | `Azure.Core` | `1.54.0` | `1.61.0` |
| Configuration.Secrets | `Azure.Security.KeyVault.Secrets` | `4.10.0` | `4.11.0` |
| Configuration.Secrets | `Microsoft.Extensions.Configuration` | `10.0.3` | `10.0.10` |
| DataProtection.Blobs | `Azure.Core` | `1.55.0` | `1.61.0` |
| DataProtection.Blobs | `Microsoft.AspNetCore.DataProtection` (`net8.0`) | `8.0.26` | `8.0.29` |
| DataProtection.Blobs | `Microsoft.AspNetCore.DataProtection` (`net10.0`, `netstandard2.0`) | `10.0.7` | `10.0.10` |
| DataProtection.Keys | `Azure.Core` | `1.55.0` | `1.61.0` |
| DataProtection.Keys | `Microsoft.AspNetCore.DataProtection` (`net8.0`) | `8.0.26` | `8.0.29` |
| DataProtection.Keys | `Microsoft.AspNetCore.DataProtection` (`net10.0`, `netstandard2.0`) | `10.0.7` | `10.0.10` |

The DataProtection servicing floors come from #61774 and pull patched `System.Security.Cryptography.Xml` versions that resolve GHSA-g8r8-53c2-pm3f, GHSA-8q5v-6pqq-x66h, GHSA-23rf-6693-g89p, GHSA-cvvh-rhrc-wg4q, and GHSA-mmjf-rqrv-855v.

### Packed dependency groups

| Package | Framework group | Direct dependency floors |
| --- | --- | --- |
| Configuration.Secrets | `net8.0`, `net10.0`, `netstandard2.0` | `Azure.Core` 1.61.0; `Azure.Security.KeyVault.Secrets` 4.11.0; `Microsoft.Extensions.Configuration` 10.0.10 |
| DataProtection.Blobs | `net8.0` | `Azure.Core` 1.61.0; `Azure.Storage.Blobs` 12.26.0; `Microsoft.AspNetCore.DataProtection` 8.0.29 |
| DataProtection.Blobs | `net10.0`, `netstandard2.0` | `Azure.Core` 1.61.0; `Azure.Storage.Blobs` 12.26.0; `Microsoft.AspNetCore.DataProtection` 10.0.10 |
| DataProtection.Keys | `net8.0` | `Azure.Core` 1.61.0; `Azure.Security.KeyVault.Keys` 4.10.0; `Microsoft.AspNetCore.DataProtection` 8.0.29 |
| DataProtection.Keys | `net10.0`, `netstandard2.0` | `Azure.Core` 1.61.0; `Azure.Security.KeyVault.Keys` 4.10.0; `Microsoft.AspNetCore.DataProtection` 10.0.10 |

### Validation

- Ran `Prepare-Release.ps1` separately for all three packages with the requested stable versions.
- Ran the package-specific pre-commit `dotnet format` checks.
- Built all three packages in Release configuration with 0 warnings and 0 errors. The standard builds ran ApiCompat against 1.5.1, 1.5.3, and 1.6.3 respectively.
- Packed exact stable-version nupkgs and inspected each nuspec against its prior stable package/tag. All three contain only `net8.0`, `net10.0`, and `netstandard2.0` dependency groups with the floors above.
- Resolved and compared the complete prior/new transitive dependency graphs for every target framework.
- Verified `System.Security.Cryptography.Xml` resolves identically for each DataProtection package:

| Framework | `Microsoft.AspNetCore.DataProtection` | `System.Security.Cryptography.Xml` |
| --- | --- | --- |
| `net8.0` | `8.0.29` | `8.0.4` |
| `net10.0` | `10.0.10` | `10.0.10` |
| `netstandard2.0` | `10.0.10` | `10.0.10` |

- Built combined temporary consumers for `net8.0`, `net10.0`, and `netstandard2.0` against all three packed extension packages plus `Azure.Core` 1.61.0 and `Azure.Identity` 1.21.0. The consumers compile `DefaultAzureCredential`, `AddAzureKeyVault`, `PersistKeysToAzureBlobStorage`, and `ProtectKeysWithAzureKeyVault` together with 0 warnings and 0 errors, guarding the dependency/type-collision scenarios from #58822 and #58901.
- Confirmed the diff contains no `.cs` or API listing changes.

Validation nupkgs and consumer projects were created outside the repository and are not committed. No packages were published and no release pipeline was triggered.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] REST spec PR link is not applicable to these extension package releases.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There is one focused commit with an informative message.

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Release builds, ApiCompat, exact package inspection, dependency graph comparison, and representative consumer builds cover these metadata-only changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] SDK regeneration and REST spec links are not applicable.
- [x] The three package project versions were updated to the requested stable patch versions.
