### PR TITLE
Match the full blob path pattern when scaling Blob Trigger from zero

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed a bug where Blob Trigger scaling from zero only matched the container name, so writes that did not match the trigger's blob name pattern (for example `container/{name}.txt`) could still scale the function out. The scale decision now applies the same path matching used by the Blob Trigger listener.
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
@@ -77,8 +77,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             return blobs;
         }
 
-        public async Task<StorageAnalyticsLogEntry> GetFirstLogEntryWithWritesAsync(string containerName, CancellationToken cancellationToken, int hoursWindow = DefaultScanHoursWindow)
+        public async Task<StorageAnalyticsLogEntry> GetFirstLogEntryWithWritesAsync(IBlobPathSource pathSource, CancellationToken cancellationToken, int hoursWindow = DefaultScanHoursWindow)
         {
+            if (pathSource == null)
+            {
+                throw new ArgumentNullException(nameof(pathSource));
+            }
+
             if (hoursWindow <= 0)
             {
                 return null;
@@ -121,8 +126,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                                     if (entry != null && entry.IsBlobWrite)
                                     {
                                         var path = entry.ToBlobPath();
-                                        if (path != null &&
-                                            string.Equals(path.ContainerName, containerName, StringComparison.OrdinalIgnoreCase))
+
+                                        // A null binding data means the blob does not match the trigger's path pattern.
+                                        if (path != null && pathSource.CreateBindingData(path) != null)
                                         {
                                             // If we found a valid write entry, we can stop searching.
                                             return entry;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
@@ -126,9 +126,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                                     if (entry != null && entry.IsBlobWrite)
                                     {
                                         var path = entry.ToBlobPath();
-
-                                        // A null binding data means the blob does not match the trigger's path pattern.
-                                        if (path != null && pathSource.CreateBindingData(path) != null)
+                                        if (path != null && MatchesTriggerPath(pathSource, path))
                                         {
                                             // If we found a valid write entry, we can stop searching.
                                             return entry;
@@ -153,6 +151,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                                                     select entry.ToBlobPath();
 
             return parsedBlobPaths.Where(p => p != null);
+        }
+
+        // ToBlobPath unescapes the absolute-URL form of RequestedObjectKey but not the '/account/container/blob'
+        // form, so a logged blob name can still be percent-encoded while the trigger pattern is not. Unlike the
+        // listener, scaling has no container-scan fallback, so accept either form rather than never scale from zero.
+        private static bool MatchesTriggerPath(IBlobPathSource pathSource, BlobPath path)
+        {
+            if (pathSource.CreateBindingData(path) != null)
+            {
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(path.BlobName) || path.BlobName.IndexOf('%') < 0)
+            {
+                return false;
+            }
+
+            var unescapedPath = new BlobPath(path.ContainerName, Uri.UnescapeDataString(path.BlobName));
+
+            return pathSource.CreateBindingData(unescapedPath) != null;
         }
 
         // Return a search prefix for the given start,end time.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobLogListener.cs
@@ -126,7 +126,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                                     if (entry != null && entry.IsBlobWrite)
                                     {
                                         var path = entry.ToBlobPath();
-                                        if (path != null && MatchesTriggerPath(pathSource, path))
+
+                                        // A null binding data means the blob does not match the trigger's path pattern.
+                                        if (path != null && pathSource.CreateBindingData(path) != null)
                                         {
                                             // If we found a valid write entry, we can stop searching.
                                             return entry;
@@ -151,26 +153,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                                                     select entry.ToBlobPath();
 
             return parsedBlobPaths.Where(p => p != null);
-        }
-
-        // ToBlobPath unescapes the absolute-URL form of RequestedObjectKey but not the '/account/container/blob'
-        // form, so a logged blob name can still be percent-encoded while the trigger pattern is not. Unlike the
-        // listener, scaling has no container-scan fallback, so accept either form rather than never scale from zero.
-        private static bool MatchesTriggerPath(IBlobPathSource pathSource, BlobPath path)
-        {
-            if (pathSource.CreateBindingData(path) != null)
-            {
-                return true;
-            }
-
-            if (string.IsNullOrEmpty(path.BlobName) || path.BlobName.IndexOf('%') < 0)
-            {
-                return false;
-            }
-
-            var unescapedPath = new BlobPath(path.ContainerName, Uri.UnescapeDataString(path.BlobName));
-
-            return pathSource.CreateBindingData(unescapedPath) != null;
         }
 
         // Return a search prefix for the given start,end time.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ZeroToOneTargetScalerProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ZeroToOneTargetScalerProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             private readonly TargetScalerDescriptor _targetScalerDescriptor;
             private readonly Lazy<Task<BlobLogListener>> _blobLogListener;
             private readonly ILogger _logger;
-            private readonly string _containerName;
+            private readonly IBlobPathSource _pathSource;
             private StorageAnalyticsLogEntry _lastIdentifiedLogEntryWithWrites = null;
 
             public ZeroToOneTargetScaler(string functionId, BlobServiceClient blobServiceClient, string blobPath, ILoggerFactory loggerFactory)
@@ -63,12 +63,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                     CancellationToken.None));
                 _logger = loggerFactory.CreateLogger<ZeroToOneTargetScaler>();
 
-                _containerName = blobPath;
-                int separatorIndex = blobPath.IndexOf("/", StringComparison.OrdinalIgnoreCase);
-                if (separatorIndex > 0)
-                {
-                    _containerName = blobPath.Substring(0, separatorIndex);
-                }
+                // Matching on the full path pattern keeps scale decisions consistent with BlobTriggerExecutor.
+                _pathSource = CreatePathSource(blobPath, _logger);
             }
 
             public TargetScalerDescriptor TargetScalerDescriptor => _targetScalerDescriptor;
@@ -85,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 }
 
                 var blobLogListener = await _blobLogListener.Value.ConfigureAwait(false);
-                _lastIdentifiedLogEntryWithWrites = await blobLogListener.GetFirstLogEntryWithWritesAsync(_containerName, CancellationToken.None).ConfigureAwait(false);
+                _lastIdentifiedLogEntryWithWrites = await blobLogListener.GetFirstLogEntryWithWritesAsync(_pathSource, CancellationToken.None).ConfigureAwait(false);
                 if (_lastIdentifiedLogEntryWithWrites != null)
                 {
                     _logger.LogInformation($"Recent writes were detected for '{_targetScalerDescriptor.FunctionId}' (requestedObjectKey='{_lastIdentifiedLogEntryWithWrites.RequestedObjectKey}', requestStartTime='{_lastIdentifiedLogEntryWithWrites.RequestStartTime:O}').");
@@ -97,6 +93,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 }
 
                 return new TargetScalerResult() { TargetWorkerCount = 0 };
+            }
+
+            private static IBlobPathSource CreatePathSource(string blobPath, ILogger logger)
+            {
+                try
+                {
+                    return BlobPathSource.Create(blobPath);
+                }
+                catch (FormatException ex) when (!string.IsNullOrEmpty(blobPath))
+                {
+                    // Degrade to container-only matching rather than failing scaling for the whole function.
+                    int separatorIndex = blobPath.IndexOf('/');
+                    string containerName = separatorIndex > 0 ? blobPath.Substring(0, separatorIndex) : blobPath;
+                    logger.LogWarning($"Unable to parse blob path '{blobPath}'. Falling back to container-only matching on '{containerName}'. Exception: {ex.Message}");
+
+                    return new FixedBlobPathSource(new BlobPath(containerName, string.Empty));
+                }
             }
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ZeroToOneTargetScalerProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ZeroToOneTargetScalerProvider.cs
@@ -101,12 +101,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 {
                     return BlobPathSource.Create(blobPath);
                 }
-                catch (FormatException ex) when (!string.IsNullOrEmpty(blobPath))
+                catch (FormatException ex)
                 {
-                    // Degrade to container-only matching rather than failing scaling for the whole function.
-                    int separatorIndex = blobPath.IndexOf('/');
-                    string containerName = separatorIndex > 0 ? blobPath.Substring(0, separatorIndex) : blobPath;
-                    logger.LogWarning($"Unable to parse blob path '{blobPath}'. Falling back to container-only matching on '{containerName}'. Exception: {ex.Message}");
+                    // Degrade rather than failing scaling for the whole function. An empty container name matches
+                    // nothing, which is the safe default when the path is unusable.
+                    int separatorIndex = blobPath?.IndexOf('/') ?? -1;
+                    string containerName = separatorIndex > 0 ? blobPath.Substring(0, separatorIndex) : blobPath ?? string.Empty;
+
+                    logger.LogWarning(ex, "Unable to parse blob trigger path '{BlobPath}'. Falling back to container-only matching on '{ContainerName}'.", blobPath, containerName);
 
                     return new FixedBlobPathSource(new BlobPath(containerName, string.Empty));
                 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
@@ -20,18 +20,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.Listeners
 {
     public class ZeroToOneTargetScalerTests
     {
+        // A single PutBlob entry for 'test-blobs/basic/test.txt'. 'Timestamp=' is replaced by each test case.
+        private const string PutBlobLogContent = "1.0;Timestamp='';PutBlob;Success;201;6;6;authenticated;teststorage;teststorage;blob;\"https://teststorage.blob.core.windows.net:443/test-blobs/basic%5Ctest.txt\";\"/teststorage/test-blobs/basic/test.txt\";612fc70e-e01e-008e-507f-3defe5000000;0;172.185.1.166:36700;2025-01-05;545;9;337;0;9;;\"HlAhCgICSX+3m8OLat5sNA==\";\"&quot;0x8DE0B970756F5CF&quot;\";Wednesday, 15-Oct-25 03:00:42 GMT;\"If-None-Match=*\";\"azsdk-net-Storage.Blobs/12.23.0 (.NET 8.0.21; Microsoft Windows 10.0.17763)\";;\"0ec36b75-69d3-453f-afd3-a329e0970962\"\r\n1.0;";
+
         public ZeroToOneTargetScalerTests()
         {
         }
 
         [Test]
         [TestCase("Sample log content", 10, "sc-test-blobs/basic", 0, 0)]
-        [TestCase("1.0;Timestamp='';PutBlob;Success;201;6;6;authenticated;teststorage;teststorage;blob;\"https://teststorage.blob.core.windows.net:443/test-blobs/basic%5Ctest.txt\";\"/teststorage/test-blobs/basic/test.txt\";612fc70e-e01e-008e-507f-3defe5000000;0;172.185.1.166:36700;2025-01-05;545;9;337;0;9;;\"HlAhCgICSX+3m8OLat5sNA==\";\"&quot;0x8DE0B970756F5CF&quot;\";Wednesday, 15-Oct-25 03:00:42 GMT;\"If-None-Match=*\";\"azsdk-net-Storage.Blobs/12.23.0 (.NET 8.0.21; Microsoft Windows 10.0.17763)\";;\"0ec36b75-69d3-453f-afd3-a329e0970962\"\r\n1.0;",
-            10, "test-blobs/basic", 1, 1)]
-        [TestCase("1.0;Timestamp='';PutBlob;Success;201;6;6;authenticated;teststorage;teststorage;blob;\"https://teststorage.blob.core.windows.net:443/test-blobs/basic%5Ctest.txt\";\"/teststorage/test-blobs/basic/test.txt\";612fc70e-e01e-008e-507f-3defe5000000;0;172.185.1.166:36700;2025-01-05;545;9;337;0;9;;\"HlAhCgICSX+3m8OLat5sNA==\";\"&quot;0x8DE0B970756F5CF&quot;\";Wednesday, 15-Oct-25 03:00:42 GMT;\"If-None-Match=*\";\"azsdk-net-Storage.Blobs/12.23.0 (.NET 8.0.21; Microsoft Windows 10.0.17763)\";;\"0ec36b75-69d3-453f-afd3-a329e0970962\"\r\n1.0;",
-            180, "test-blobs/basic", 1, 0)]
-        [TestCase("1.0;Timestamp='';PutBlob;Success;201;6;6;authenticated;teststorage;teststorage;blob;\"https://teststorage.blob.core.windows.net:443/test-blobs/basic%5Ctest.txt\";\"/teststorage/test-blobs/basic/test.txt\";612fc70e-e01e-008e-507f-3defe5000000;0;172.185.1.166:36700;2025-01-05;545;9;337;0;9;;\"HlAhCgICSX+3m8OLat5sNA==\";\"&quot;0x8DE0B970756F5CF&quot;\";Wednesday, 15-Oct-25 03:00:42 GMT;\"If-None-Match=*\";\"azsdk-net-Storage.Blobs/12.23.0 (.NET 8.0.21; Microsoft Windows 10.0.17763)\";;\"0ec36b75-69d3-453f-afd3-a329e0970962\"\r\n1.0;",
-            10, "test-blobs1/basic", 0, 0)]
+        [TestCase(PutBlobLogContent, 10, "test-blobs/basic/test.txt", 1, 1)]
+        [TestCase(PutBlobLogContent, 180, "test-blobs/basic/test.txt", 1, 0)]
+        [TestCase(PutBlobLogContent, 10, "test-blobs1/basic", 0, 0)]
+        // Container-only pattern matches any write in the container.
+        [TestCase(PutBlobLogContent, 10, "test-blobs", 1, 1)]
+        // Binding parameters are matched against the whole path, and '{name}' spans '/'.
+        [TestCase(PutBlobLogContent, 10, "test-blobs/{name}.txt", 1, 1)]
+        [TestCase(PutBlobLogContent, 10, "test-blobs/basic/{name}", 1, 1)]
+        [TestCase(PutBlobLogContent, 10, "test-blobs/{name}.json", 0, 0)]
+        [TestCase(PutBlobLogContent, 10, "test-blobs/other/{name}", 0, 0)]
+        [TestCase(PutBlobLogContent, 10, "test-blobs/basic", 0, 0)]
+        // An unparsable path degrades to container-only matching.
+        [TestCase(PutBlobLogContent, 10, "test-blobs/", 1, 1)]
         public async Task GetScaleResultAsync_WorkAsExpected(string logBlobContent, int offsetInMinutes, string blobPath, int expectedTargetWorkerCount, int excpectedChachReads)
         {
             string timeStamp = $"{DateTime.UtcNow.AddMinutes(-offsetInMinutes):o}";

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
@@ -68,14 +68,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.Listeners
 
         // The scaler only ever sees $logs entries, so a blob must resolve to the same path the host's
         // BlobTriggerExecutor would match. StorageAnalyticsLogEntry.ToBlobPath decodes the absolute-URL form
-        // of RequestedObjectKey but not the '/account/container/blob' form, so special characters can differ.
+        // of RequestedObjectKey but not the '/account/container/blob' form, so both must be handled.
         [Test]
         [TestCase("/teststorage/test-blobs/basic/test.txt", "test-blobs/{name}.txt", 1)]
         [TestCase("/teststorage/test-blobs/my%20folder/test.txt", "test-blobs/{name}", 1)]
         [TestCase("/teststorage/test-blobs/my%20folder/test.txt", "test-blobs/my folder/{name}", 1)]
         [TestCase("/teststorage/test-blobs/caf%C3%A9/test.txt", "test-blobs/café/{name}", 1)]
         [TestCase("/teststorage/test-blobs/report%2450.txt", "test-blobs/report$50.txt", 1)]
+        [TestCase("/teststorage/test-blobs/100%25.txt", "test-blobs/100%.txt", 1)]
         [TestCase("https://teststorage.blob.core.windows.net:443/test-blobs/my%20folder/test.txt", "test-blobs/my folder/{name}", 1)]
+        [TestCase("/teststorage/test-blobs/my%20folder/test.txt", "test-blobs/other folder/{name}", 0)]
+        [TestCase("/teststorage/test-blobs/caf%C3%A9/test.txt", "test-blobs/cafe/{name}", 0)]
         public async Task GetScaleResultAsync_MatchesBlobNamesWithSpecialCharacters(string requestedObjectKey, string blobPath, int expectedTargetWorkerCount)
         {
             var scaler = CreateScaler(BuildPutBlobLogContent(requestedObjectKey), blobPath, out _);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.Listeners
         [TestCase(PutBlobLogContent, 10, "test-blobs/basic", 0, 0)]
         // An unparsable path degrades to container-only matching.
         [TestCase(PutBlobLogContent, 10, "test-blobs/", 1, 1)]
-        public async Task GetScaleResultAsync_WorkAsExpected(string logBlobContent, int offsetInMinutes, string blobPath, int expectedTargetWorkerCount, int excpectedChachReads)
+        // A path with no usable container name never scales out.
+        [TestCase(PutBlobLogContent, 10, "", 0, 0)]
+        [TestCase(PutBlobLogContent, 10, null, 0, 0)]
+        public async Task GetScaleResultAsync_WorkAsExpected(string logBlobContent, int offsetInMinutes, string blobPath, int expectedTargetWorkerCount, int expectedCacheReads)
         {
             string timeStamp = $"{DateTime.UtcNow.AddMinutes(-offsetInMinutes):o}";
             logBlobContent = logBlobContent.Replace("Timestamp=''", timeStamp);
@@ -87,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.Listeners
             result = await scaler.GetScaleResultAsync(new TargetScalerContext());
 
             var cacheReads = loggerProvider.GetAllLogMessages().Where(x => x.FormattedMessage.Contains("Recent writes were detected from cache for ")).Count();
-            Assert.AreEqual(excpectedChachReads, cacheReads);
+            Assert.AreEqual(expectedCacheReads, cacheReads);
 
             Assert.NotNull(result);
             Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
@@ -50,6 +50,55 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.Listeners
             string timeStamp = $"{DateTime.UtcNow.AddMinutes(-offsetInMinutes):o}";
             logBlobContent = logBlobContent.Replace("Timestamp=''", timeStamp);
 
+            var scaler = CreateScaler(logBlobContent, blobPath, out var loggerProvider);
+
+            var result = await scaler.GetScaleResultAsync(new TargetScalerContext());
+
+            Assert.NotNull(result);
+            Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);
+
+            result = await scaler.GetScaleResultAsync(new TargetScalerContext());
+
+            var cacheReads = loggerProvider.GetAllLogMessages().Where(x => x.FormattedMessage.Contains("Recent writes were detected from cache for ")).Count();
+            Assert.AreEqual(expectedCacheReads, cacheReads);
+
+            Assert.NotNull(result);
+            Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);
+        }
+
+        // The scaler only ever sees $logs entries, so a blob must resolve to the same path the host's
+        // BlobTriggerExecutor would match. StorageAnalyticsLogEntry.ToBlobPath decodes the absolute-URL form
+        // of RequestedObjectKey but not the '/account/container/blob' form, so special characters can differ.
+        [Test]
+        [TestCase("/teststorage/test-blobs/basic/test.txt", "test-blobs/{name}.txt", 1)]
+        [TestCase("/teststorage/test-blobs/my%20folder/test.txt", "test-blobs/{name}", 1)]
+        [TestCase("/teststorage/test-blobs/my%20folder/test.txt", "test-blobs/my folder/{name}", 1)]
+        [TestCase("/teststorage/test-blobs/caf%C3%A9/test.txt", "test-blobs/café/{name}", 1)]
+        [TestCase("/teststorage/test-blobs/report%2450.txt", "test-blobs/report$50.txt", 1)]
+        [TestCase("https://teststorage.blob.core.windows.net:443/test-blobs/my%20folder/test.txt", "test-blobs/my folder/{name}", 1)]
+        public async Task GetScaleResultAsync_MatchesBlobNamesWithSpecialCharacters(string requestedObjectKey, string blobPath, int expectedTargetWorkerCount)
+        {
+            var scaler = CreateScaler(BuildPutBlobLogContent(requestedObjectKey), blobPath, out _);
+
+            var result = await scaler.GetScaleResultAsync(new TargetScalerContext());
+
+            Assert.NotNull(result);
+            Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);
+        }
+
+        private static string BuildPutBlobLogContent(string requestedObjectKey)
+        {
+            string timeStamp = $"{DateTime.UtcNow.AddMinutes(-10):o}";
+
+            return $"1.0;{timeStamp};PutBlob;Success;201;6;6;authenticated;teststorage;teststorage;blob;" +
+                $"\"https://teststorage.blob.core.windows.net:443/test-blobs/basic%5Ctest.txt\";\"{requestedObjectKey}\";" +
+                "612fc70e-e01e-008e-507f-3defe5000000;0;172.185.1.166:36700;2025-01-05;545;9;337;0;9;;" +
+                "\"HlAhCgICSX+3m8OLat5sNA==\";\"&quot;0x8DE0B970756F5CF&quot;\";Wednesday, 15-Oct-25 03:00:42 GMT;\"If-None-Match=*\";" +
+                "\"azsdk-net-Storage.Blobs/12.23.0 (.NET 8.0.21; Microsoft Windows 10.0.17763)\";;\"0ec36b75-69d3-453f-afd3-a329e0970962\"";
+        }
+
+        private ZeroToOneTargetScaler CreateScaler(string logBlobContent, string blobPath, out TestLoggerProvider loggerProvider)
+        {
             var mockBlobContainerClient = new Mock<BlobContainerClient>();
             var page = Page<BlobItem>.FromValues(
                 values: new BlobItem[] { CreateBlobItem() },
@@ -76,24 +125,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.Listeners
             mockBlobServiceClient.Setup(b => b.GetBlobContainerClient(It.IsAny<string>()))
                 .Returns(mockBlobContainerClient.Object);
 
-            var loggerProvider = new TestLoggerProvider();
+            loggerProvider = new TestLoggerProvider();
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
 
-            var scaler = new ZeroToOneTargetScaler("TestFunction", mockBlobServiceClient.Object, blobPath, loggerFactory);
-
-            var result = await scaler.GetScaleResultAsync(new TargetScalerContext());
-
-            Assert.NotNull(result);
-            Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);
-
-            result = await scaler.GetScaleResultAsync(new TargetScalerContext());
-
-            var cacheReads = loggerProvider.GetAllLogMessages().Where(x => x.FormattedMessage.Contains("Recent writes were detected from cache for ")).Count();
-            Assert.AreEqual(expectedCacheReads, cacheReads);
-
-            Assert.NotNull(result);
-            Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);
+            return new ZeroToOneTargetScaler("TestFunction", mockBlobServiceClient.Object, blobPath, loggerFactory);
         }
 
         private BlobItem CreateBlobItem()

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/ZeroToOneTargetScalerTests.cs
@@ -66,19 +66,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.Listeners
             Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);
         }
 
-        // The scaler only ever sees $logs entries, so a blob must resolve to the same path the host's
-        // BlobTriggerExecutor would match. StorageAnalyticsLogEntry.ToBlobPath decodes the absolute-URL form
-        // of RequestedObjectKey but not the '/account/container/blob' form, so both must be handled.
+        // Storage Analytics records RequestedObjectKey as a raw, unencoded path, verified against a live account:
+        // a blob named 'my folder/x.txt' is logged as '/account/container/my folder/x.txt'. Patterns containing
+        // such characters must still match, since the scaler has no container-scan fallback to catch a miss.
         [Test]
         [TestCase("/teststorage/test-blobs/basic/test.txt", "test-blobs/{name}.txt", 1)]
-        [TestCase("/teststorage/test-blobs/my%20folder/test.txt", "test-blobs/{name}", 1)]
-        [TestCase("/teststorage/test-blobs/my%20folder/test.txt", "test-blobs/my folder/{name}", 1)]
-        [TestCase("/teststorage/test-blobs/caf%C3%A9/test.txt", "test-blobs/café/{name}", 1)]
-        [TestCase("/teststorage/test-blobs/report%2450.txt", "test-blobs/report$50.txt", 1)]
-        [TestCase("/teststorage/test-blobs/100%25.txt", "test-blobs/100%.txt", 1)]
+        [TestCase("/teststorage/test-blobs/my folder/test.txt", "test-blobs/my folder/{name}", 1)]
+        [TestCase("/teststorage/test-blobs/my folder/test.txt", "test-blobs/{name}", 1)]
+        [TestCase("/teststorage/test-blobs/café/test.txt", "test-blobs/café/{name}", 1)]
+        [TestCase("/teststorage/test-blobs/report$50.txt", "test-blobs/report$50.txt", 1)]
+        [TestCase("/teststorage/test-blobs/100%.txt", "test-blobs/100%.txt", 1)]
+        [TestCase("/teststorage/test-blobs/a+b/test.txt", "test-blobs/a+b/{name}", 1)]
         [TestCase("https://teststorage.blob.core.windows.net:443/test-blobs/my%20folder/test.txt", "test-blobs/my folder/{name}", 1)]
-        [TestCase("/teststorage/test-blobs/my%20folder/test.txt", "test-blobs/other folder/{name}", 0)]
-        [TestCase("/teststorage/test-blobs/caf%C3%A9/test.txt", "test-blobs/cafe/{name}", 0)]
+        [TestCase("/teststorage/test-blobs/my folder/test.txt", "test-blobs/other folder/{name}", 0)]
+        [TestCase("/teststorage/test-blobs/café/test.txt", "test-blobs/cafe/{name}", 0)]
         public async Task GetScaleResultAsync_MatchesBlobNamesWithSpecialCharacters(string requestedObjectKey, string blobPath, int expectedTargetWorkerCount)
         {
             var scaler = CreateScaler(BuildPutBlobLogContent(requestedObjectKey), blobPath, out _);


### PR DESCRIPTION
## Summary

The zero-to-one Blob Trigger scaler only compared the **container name** when scanning `$logs`, so a write to *any* blob in the container scaled the function out — even when the blob did not match the trigger's path pattern.

For a trigger bound to `mycontainer/{name}.txt`, a write to `mycontainer/foo.json` produced `TargetWorkerCount = 1`. The bogus result was then cached in `_lastIdentifiedLogEntryWithWrites` and reused for the remainder of the cache window, so a single non-matching write kept the app scaled out.

This is the second half of the issue partially addressed by #53263. That PR added container-level filtering (writes to unrelated containers no longer scale out); this PR adds the blob name pattern matching.

## Change

`ZeroToOneTargetScaler` now builds an `IBlobPathSource` from the resolved trigger path and passes it to `BlobLogListener.GetFirstLogEntryWithWritesAsync`, which matches each parsed log entry with `pathSource.CreateBindingData(path) != null`.

That is the exact check `BlobTriggerExecutor` performs on the host side, so the scale decision and the runtime listener cannot drift apart. It also replaces the ad-hoc container parsing:

```csharp
// before
_containerName = blobPath;
int separatorIndex = blobPath.IndexOf("/", StringComparison.OrdinalIgnoreCase);
if (separatorIndex > 0)
{
    _containerName = blobPath.Substring(0, separatorIndex);
}

// after
_pathSource = CreatePathSource(blobPath, _logger);
```

`BlobPathSource.Create` is called once in the constructor rather than per poll, since it compiles a `Regex` with `RegexOptions.Compiled`. `ParameterizedBlobPathSource.CreateBindingData` already short-circuits on a container-name comparison before running the regex, so entries from unrelated containers stay on the cheap path.

`$logs` prefix scanning is unaffected — that prefix is time-based (`blob/YYYY/MM/DD/HH00`) and never used the container name.

## Behavior notes

- **Semantics are inherited from the host, by design.** `{name}` compiles to `(?<name>.*)` anchored `^...$`, so it spans `/` — `mycontainer/{name}.txt` matches `mycontainer/a/b/c.txt`. Matching is case-sensitive on the blob name and case-insensitive on the container, exactly as in `BlobTriggerExecutor`.
- **Caching gets strictly better.** A cached entry is now guaranteed to satisfy the trigger, so the cache no longer amplifies false positives.
- **Malformed paths degrade instead of failing.** If `BlobPathSource.Create` throws `FormatException`, the scaler logs a warning and falls back to container-only matching; a null or empty path falls back to an empty container name, which matches nothing. Crashing scale evaluation for a function because of one bad path value would be a worse failure mode than an over-eager scale-out.
- **Early exit is slightly weaker.** Previously the scan returned on the first write to the container. A container with heavy non-matching write traffic will now read further into the log blobs before returning `null`. This is still bounded by the ~12 log blobs in the 2-hour window, and matches what the pre-#53263 code did unconditionally.

## Test changes reviewers should look at

Two **pre-existing** cases in `ZeroToOneTargetScalerTests` used `blobPath = "test-blobs/basic"` and expected `TargetWorkerCount = 1`. Those expectations encoded the bug: `test-blobs/basic` denotes the literal blob named `basic`, while the log entry under test is for `basic/test.txt`. They are updated to `test-blobs/basic/test.txt`, and `test-blobs/basic` is added back as an explicit negative case.

New coverage against the same log entry (`test-blobs/basic/test.txt`):

| Trigger path | Expected workers |
|---|---|
| `test-blobs` (container only) | 1 |
| `test-blobs/{name}.txt` | 1 |
| `test-blobs/basic/{name}` | 1 |
| `test-blobs/{name}.json` | 0 |
| `test-blobs/other/{name}` | 0 |
| `test-blobs/basic` | 0 |
| `test-blobs/` (unparsable, falls back to container-only) | 1 |
| `""` / `null` (no usable container name) | 0 |

Plus `GetScaleResultAsync_MatchesBlobNamesWithSpecialCharacters`, covering names containing a space, non-ASCII, `$`, `%`, and `+`, in both `RequestedObjectKey` forms, with negative cases so the matching cannot pass by accepting everything.

## Verification

**Unit tests (CI).** The suite runs across 9 platform legs (Windows/Ubuntu/macOS, net8.0/9.0/10.0).

**End-to-end against a live storage account.** A harness was built that reproduces the Scale Controller's own registration path — real `blobTrigger` JSON → `TriggerMetadata` → `AddAzureStorageBlobsScaleForTrigger` → `ITargetScalerProvider` → `GetScaleResultAsync` — reading real Storage Analytics logs, with nothing mocked. Three blobs were written to a live account (`match.txt`, `nomatch.json`, `my folder/spaced.txt`) and the scaler was asked for a decision per trigger pattern:

| Trigger path | Expected | Actual |
|---|---|---|
| `test-blobs/{name}.txt` | 1 | 1 |
| `test-blobs/{name}.json` | 1 | 1 |
| `test-blobs/match.txt` | 1 | 1 |
| `test-blobs/my folder/{name}` | 1 | 1 |
| `test-blobs/{name}.zip` | 0 | 0 |
| `test-blobs/other folder/{name}` | 0 | 0 |
| `other-container/{name}.txt` | 0 | 0 |

All 7 correct. The negative cases are meaningful because the positives return 1 in the same run — the scaler is discriminating, not simply returning 0. Under the previous container-only logic every one of these would have returned 1.

**Log format.** Two separate live accounts confirmed that Storage Analytics writes `RequestedObjectKey` as a raw, unencoded path (`/account/container/my folder/spaced.txt`), which is why no URL decoding is needed in the matching path.

**Not covered here:** the scaler running inside the Scale Controller process itself, and real worker allocation. Those are exercised by the Scale Controller release validation rather than by this repo.
