### PR TITLE
[experiment] Baseline matrix-generation checkout timing

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -59,6 +59,7 @@ jobs:
           Path: eng/pipelines/templates/stages/build-matrix.json
           Selection: sparse
           GenerateVMJobs: true
+        # Experiment baseline: retain API listings in root build, analyze, and test matrix sparse checkouts.
         SparseCheckoutPaths:
           - "/*"
           - "!SessionRecords"


### PR DESCRIPTION
## Purpose

This draft PR is a no-op baseline for CI checkout timing comparison and should not be merged. It intentionally retains the current sparse checkout behavior, including API listings, for the root PR matrix-generation pipelines.

The resulting timings will be compared against the API-exclusion experiment.

## Validation

- Parsed `eng/pipelines/templates/jobs/ci.yml` as YAML
- Ran `git diff --check`

> **Experiment only:** Do not merge.