### PR TITLE
[experiment] Exclude API listings from matrix-generation checkout

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -62,6 +62,8 @@ jobs:
         SparseCheckoutPaths:
           - "/*"
           - "!SessionRecords"
+          # API listings are consumed by Analyze workers, not matrix generation.
+          - "!/sdk/*/**/api/*"
         EnablePRGeneration: true
         PRMatrixSetting: ProjectNames
         PRJobBatchSize: 1
@@ -99,6 +101,8 @@ jobs:
         SparseCheckoutPaths:
           - "/*"
           - "!SessionRecords"
+          # API listings are consumed by Analyze workers, not matrix generation.
+          - "!/sdk/*/**/api/*"
         EnablePRGeneration: true
         PRMatrixSetting: ProjectNames
         PRJobBatchSize: 1
@@ -228,6 +232,8 @@ jobs:
           SparseCheckoutPaths:
             - "/*"
             - "!SessionRecords"
+            # API listings are consumed by Analyze workers, not matrix generation.
+            - "!/sdk/*/**/api/*"
           EnablePRGeneration: true
           PRMatrixSetting: ProjectNames
           PRJobBatchSize: 10
@@ -264,6 +270,8 @@ jobs:
         SparseCheckoutPaths:
           - /*
           - '!/sdk/*/**/SessionRecords/*'
+          # API listings are consumed by Analyze workers, not matrix generation.
+          - '!/sdk/*/**/api/*'
         PreGenerationSteps:
           - ${{ each config in parameters.MatrixConfigs }}:
               - template: /eng/pipelines/templates/steps/dependency.tests.yml


### PR DESCRIPTION
## Experiment

This draft PR measures checkout-time savings from excluding generated SDK public API listings from root matrix-generation sparse checkouts. **This experiment should not be merged yet.**

The exclusion is applied only to these generation jobs:
- `generate_build_matrix`
- `generate_analyze_matrix`
- `generate_target_service_test_matrix`
- `generate_target_dependencies_test_matrix`

The estimated excluded content is about **345.6 MiB raw** and **6.2 MiB as a fresh unique-blob pack** at the analyzed baseline. Build, Analyze, Test, Compliance, and fallback worker behavior remains unchanged; Analyze workers continue to consume/export API listings.

Related separate work: #61501 narrows worker test checkouts. This PR changes only matrix-generation checkouts and does not include or alter that logic.

### Local validation

- Parsed the pipeline template as YAML and confirmed exactly four exclusion entries.
- Verified a non-cone sparse worktree omits an `sdk/**/api/**` file while retaining matrix-generation files.
- Verified commit-to-commit Git diff still reports an excluded API path.
- Confirmed the matrix-generation call chain uses PR diff metadata, PackageInfo, `src/**/*.cs` LOC weighting, and MSBuild project/reference metadata without reading API listing contents.