### PR TITLE
Fix JSON converter generation for dynamic models

### DIFF
--- a/eng/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/eng/packages/http-client-csharp/emitter/src/emitter.ts
@@ -56,7 +56,8 @@ export async function emitAzureCodeModel(
   context.options["sdk-context-options"].additionalDecorators = [
     ...(Array.isArray(existingDecorators) ? existingDecorators : []),
     // https://github.com/Azure/typespec-azure/blob/main/packages/typespec-client-generator-core/README.md#usesystemtextjsonconverter
-    "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter"
+    "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter",
+    "TypeSpec\\.HttpClient\\.CSharp\\.@dynamicModel"
   ];
 
   // warn if use-model-namespaces is true, but namespace is not set

--- a/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
+++ b/eng/packages/http-client-csharp/emitter/test/Unit/options.test.ts
@@ -93,7 +93,10 @@ describe("Configuration tests", async () => {
       strictEqual(program.diagnostics.length, 0);
       deepStrictEqual(
         context.options["sdk-context-options"]?.additionalDecorators,
-        ["Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter"]
+        [
+          "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter",
+          "TypeSpec\\.HttpClient\\.CSharp\\.@dynamicModel"
+        ]
       );
     });
 
@@ -107,7 +110,10 @@ describe("Configuration tests", async () => {
       strictEqual(program.diagnostics.length, 0);
       deepStrictEqual(
         context.options["sdk-context-options"]?.additionalDecorators,
-        ["Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter"]
+        [
+          "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter",
+          "TypeSpec\\.HttpClient\\.CSharp\\.@dynamicModel"
+        ]
       );
     });
 
@@ -123,7 +129,10 @@ describe("Configuration tests", async () => {
       strictEqual(program.diagnostics.length, 0);
       deepStrictEqual(
         context.options["sdk-context-options"]?.additionalDecorators,
-        ["Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter"]
+        [
+          "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter",
+          "TypeSpec\\.HttpClient\\.CSharp\\.@dynamicModel"
+        ]
       );
     });
 
@@ -145,7 +154,8 @@ describe("Configuration tests", async () => {
         [
           "Existing.Decorator.One",
           "Existing.Decorator.Two",
-          "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter"
+          "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter",
+          "TypeSpec\\.HttpClient\\.CSharp\\.@dynamicModel"
         ]
       );
     });
@@ -162,7 +172,10 @@ describe("Configuration tests", async () => {
       strictEqual(program.diagnostics.length, 0);
       deepStrictEqual(
         context.options["sdk-context-options"]?.additionalDecorators,
-        ["Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter"]
+        [
+          "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter",
+          "TypeSpec\\.HttpClient\\.CSharp\\.@dynamicModel"
+        ]
       );
     });
     it("preserves existing properties in sdk-context-options", async () => {
@@ -185,7 +198,8 @@ describe("Configuration tests", async () => {
         context.options["sdk-context-options"]?.additionalDecorators,
         [
           "Existing.Decorator",
-          "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter"
+          "Azure\\.ClientGenerator\\.Core\\.@useSystemTextJsonConverter",
+          "TypeSpec\\.HttpClient\\.CSharp\\.@dynamicModel"
         ]
       );
     });

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/SystemTextJsonConverterVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/SystemTextJsonConverterVisitor.cs
@@ -111,7 +111,7 @@ namespace Azure.Generator.Visitors
                                     $"Deserialize{_serializationProvider.Name}",
                                     [
                                         documentVariable.Property(nameof(JsonDocument.RootElement)),
-                                        documentVariable.Property(nameof(JsonDocument.RootElement)).Invoke("GetUtf8Bytes"),
+                                        documentVariable.Property(nameof(JsonDocument.RootElement)).As<JsonElement>().GetUtf8Bytes(),
                                         WireOptions
                                     ])
                                 : Static().Invoke(

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/SystemTextJsonConverterVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/SystemTextJsonConverterVisitor.cs
@@ -31,7 +31,7 @@ namespace Azure.Generator.Visitors
             {
                 AzureClientGenerator.Instance.AddTypeToKeep(type);
                 var serializationProvider = type.SerializationProviders[0];
-                var converter = new ConverterTypeProvider(serializationProvider);
+                var converter = new ConverterTypeProvider(serializationProvider, model.IsDynamicModel);
                 serializationProvider.Update(
                     attributes: [..serializationProvider.Attributes, new AttributeStatement(typeof(JsonConverter), TypeOf(converter.Type))],
                     nestedTypes: [..serializationProvider.NestedTypes, converter]);
@@ -43,10 +43,12 @@ namespace Azure.Generator.Visitors
         private class ConverterTypeProvider : TypeProvider
         {
             private readonly TypeProvider _serializationProvider;
+            private readonly bool _isDynamicModel;
 
-            public ConverterTypeProvider(TypeProvider serializationProvider)
+            public ConverterTypeProvider(TypeProvider serializationProvider, bool isDynamicModel)
             {
                 _serializationProvider = serializationProvider;
+                _isDynamicModel = isDynamicModel;
             }
 
             protected override string BuildRelativeFilePath() => _serializationProvider.RelativeFilePath;
@@ -104,10 +106,18 @@ namespace Azure.Generator.Visitors
                         new[]
                         {
                             UsingDeclare("document", typeof(JsonDocument), Static<JsonDocument>().Invoke(nameof(JsonDocument.ParseValue), readerParameter.AsArgument()), out var documentVariable),
-                            Return(Static().Invoke(
-                                $"Deserialize{_serializationProvider.Name}",
-                                documentVariable.Property(nameof(JsonDocument.RootElement)),
-                                WireOptions))
+                            Return(_isDynamicModel
+                                ? Static().Invoke(
+                                    $"Deserialize{_serializationProvider.Name}",
+                                    [
+                                        documentVariable.Property(nameof(JsonDocument.RootElement)),
+                                        documentVariable.Property(nameof(JsonDocument.RootElement)).Invoke("GetUtf8Bytes"),
+                                        WireOptions
+                                    ])
+                                : Static().Invoke(
+                                    $"Deserialize{_serializationProvider.Name}",
+                                    documentVariable.Property(nameof(JsonDocument.RootElement)),
+                                    WireOptions))
                         },
                     this);
             }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/SystemTextJsonConverterVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/SystemTextJsonConverterVisitorTests.cs
@@ -156,6 +156,28 @@ namespace Azure.Generator.Tests.Visitors
         }
 
         [Test]
+        public void DynamicModelReadConverterPreservesRawData()
+        {
+            var visitor = new TestSystemTextJsonConverterVisitor();
+            var decorator = new InputDecoratorInfo("Azure.ClientGenerator.Core.@useSystemTextJsonConverter", null);
+            var inputModel = InputFactory.Model("TestModel", decorators: [decorator], isDynamicModel: true);
+            MockHelpers.LoadMockGenerator(inputModels: () => [inputModel]);
+
+            var modelProvider = AzureClientGenerator.Instance.TypeFactory.CreateModel(inputModel);
+            Assert.IsNotNull(modelProvider);
+
+            var updatedModel = visitor.InvokePreVisitModel(inputModel, modelProvider);
+            var converterType = updatedModel!.SerializationProviders[0].NestedTypes
+                .First(t => t.Name.EndsWith("Converter"));
+            var readMethod = converterType.Methods.First(m => m.Signature.Name == "Read");
+            var readMethodBody = readMethod.BodyStatements!.ToDisplayString();
+
+            Assert.That(
+                readMethodBody,
+                Does.Contain("DeserializeTestModel(document.RootElement, document.RootElement.GetUtf8Bytes(), global::Samples.ModelSerializationExtensions.WireOptions)"));
+        }
+
+        [Test]
         public void WriteConverterMethodHasCorrectBody()
         {
             // Arrange

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/Basic-TypeSpec.tsp
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/Basic-TypeSpec.tsp
@@ -6,6 +6,7 @@ import "@typespec/events";
 import "@typespec/xml";
 import "@azure-tools/typespec-client-generator-core";
 import "@azure-tools/typespec-azure-core";
+import "@typespec/http-client-csharp";
 
 @versioned(Versions)
 @service(#{
@@ -177,6 +178,7 @@ model ModelWithClientName {
 
 @doc("this is a roundtrip model")
 @useSystemTextJsonConverter()
+@TypeSpec.HttpClient.CSharp.dynamicModel
 model RoundTripModel {
   @doc("Required string, illustrating a reference type property.")
   requiredString: string;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecModelFactory.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecModelFactory.cs
@@ -47,7 +47,7 @@ namespace BasicTypeSpec
                 requiredBadDescription,
                 optionalNullableList.ToList(),
                 requiredNullableList.ToList(),
-                additionalBinaryDataProperties: null);
+                default);
         }
 
         /// <summary> this is a roundtrip model. </summary>
@@ -114,7 +114,7 @@ namespace BasicTypeSpec
                 readOnlyOptionalRecordUnknown,
                 modelWithRequiredNullable,
                 requiredBytes,
-                additionalBinaryDataProperties: null);
+                default);
         }
 
         /// <summary> A model with a few required nullable properties. </summary>
@@ -124,7 +124,7 @@ namespace BasicTypeSpec
         /// <returns> A new <see cref="BasicTypeSpec.ModelWithRequiredNullableProperties"/> instance for mocking. </returns>
         public static ModelWithRequiredNullableProperties ModelWithRequiredNullableProperties(int? requiredNullablePrimitive = default, StringExtensibleEnum? requiredExtensibleEnum = default, StringFixedEnum? requiredFixedEnum = default)
         {
-            return new ModelWithRequiredNullableProperties(requiredNullablePrimitive, requiredExtensibleEnum, requiredFixedEnum, additionalBinaryDataProperties: null);
+            return new ModelWithRequiredNullableProperties(requiredNullablePrimitive, requiredExtensibleEnum, requiredFixedEnum, default);
         }
 
         /// <summary> this is not a friendly model but with a friendly name. </summary>

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -337,6 +337,86 @@ namespace BasicTypeSpec
 #endif
         }
 
+        public static ReadOnlySpan<byte> SliceToStartOfPropertyName(this ReadOnlySpan<byte> jsonPath)
+        {
+            ReadOnlySpan<byte> local = jsonPath;
+            if (local.Length < 3)
+            {
+                return ReadOnlySpan<byte>.Empty;
+            }
+            if (local[0] != '$')
+            {
+                return ReadOnlySpan<byte>.Empty;
+            }
+            if (local[1] == '.')
+            {
+                return local.Slice(2);
+            }
+            return local.Length >= 4 && local[1] == '[' && (local[2] == '\'' || local[2] == '"') ? local.Slice(3) : ReadOnlySpan<byte>.Empty;
+        }
+
+        public static string GetFirstPropertyName(this ReadOnlySpan<byte> jsonPath, out int bytesConsumed)
+        {
+            ReadOnlySpan<byte> local = jsonPath;
+            for (bytesConsumed = 0; bytesConsumed < local.Length; bytesConsumed++)
+            {
+                byte current = local[bytesConsumed];
+                if (current == '.')
+                {
+                    break;
+                }
+                else
+                {
+                    if (current == '\'' || current == '"')
+                    {
+                        if (bytesConsumed + 1 < local.Length && local[bytesConsumed + 1] == ']')
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            string key;
+#if NET6_0_OR_GREATER
+            key = global::System.Text.Encoding.UTF8.GetString(local.Slice(0, bytesConsumed));
+#else
+            key = Encoding.UTF8.GetString(local.Slice(0, bytesConsumed).ToArray());
+#endif
+            bytesConsumed += jsonPath.Length - local.Length;
+            return key;
+        }
+
+        public static bool TryGetIndex(this ReadOnlySpan<byte> indexSlice, out int index, out int bytesConsumed)
+        {
+            index = -1;
+            bytesConsumed = 0;
+
+            if (indexSlice.IsEmpty || indexSlice[0] != '[')
+            {
+                return false;
+            }
+
+            indexSlice = indexSlice.Slice(1);
+            if (indexSlice.IsEmpty || indexSlice[0] == '-')
+            {
+                return false;
+            }
+
+            int indexEnd = indexSlice.Slice(1).IndexOf((byte)']');
+            if (indexEnd < 0)
+            {
+                return false;
+            }
+
+            return Utf8Parser.TryParse(indexSlice.Slice(0, indexEnd + 1), out index, out bytesConsumed);
+        }
+
+        public static ReadOnlySpan<byte> GetRemainder(this ReadOnlySpan<byte> jsonPath, int index)
+        {
+            return index >= jsonPath.Length ? ReadOnlySpan<byte>.Empty : jsonPath[index] == '.' ? jsonPath.Slice(index) : jsonPath.Slice(index + 2);
+        }
+
         public static DateTimeOffset GetDateTimeOffset(this XElement element, string format) => format switch
         {
             "U" => DateTimeOffset.FromUnixTimeSeconds((long)element),

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithContinuationTokenHeaderResponseResponse.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithContinuationTokenHeaderResponseResponse.Serialization.cs
@@ -144,7 +144,7 @@ namespace BasicTypeSpec
                     List<ThingModel> array = new List<ThingModel>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        array.Add(ThingModel.DeserializeThingModel(item, options));
+                        array.Add(ThingModel.DeserializeThingModel(item, item.GetUtf8Bytes(), options));
                     }
                     things = array;
                     continue;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithContinuationTokenResponse.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithContinuationTokenResponse.Serialization.cs
@@ -150,7 +150,7 @@ namespace BasicTypeSpec
                     List<ThingModel> array = new List<ThingModel>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        array.Add(ThingModel.DeserializeThingModel(item, options));
+                        array.Add(ThingModel.DeserializeThingModel(item, item.GetUtf8Bytes(), options));
                     }
                     things = array;
                     continue;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithContinuationTokenWithMaxPageResponse.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithContinuationTokenWithMaxPageResponse.Serialization.cs
@@ -150,7 +150,7 @@ namespace BasicTypeSpec
                     List<ThingModel> array = new List<ThingModel>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        array.Add(ThingModel.DeserializeThingModel(item, options));
+                        array.Add(ThingModel.DeserializeThingModel(item, item.GetUtf8Bytes(), options));
                     }
                     things = array;
                     continue;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithHeaderNextLinkResponse.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithHeaderNextLinkResponse.Serialization.cs
@@ -144,7 +144,7 @@ namespace BasicTypeSpec
                     List<ThingModel> array = new List<ThingModel>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        array.Add(ThingModel.DeserializeThingModel(item, options));
+                        array.Add(ThingModel.DeserializeThingModel(item, item.GetUtf8Bytes(), options));
                     }
                     things = array;
                     continue;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithHeaderNextLinkWithMaxPageResponse.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithHeaderNextLinkWithMaxPageResponse.Serialization.cs
@@ -144,7 +144,7 @@ namespace BasicTypeSpec
                     List<ThingModel> array = new List<ThingModel>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        array.Add(ThingModel.DeserializeThingModel(item, options));
+                        array.Add(ThingModel.DeserializeThingModel(item, item.GetUtf8Bytes(), options));
                     }
                     things = array;
                     continue;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithNextLinkResponse.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithNextLinkResponse.Serialization.cs
@@ -150,7 +150,7 @@ namespace BasicTypeSpec
                     List<ThingModel> array = new List<ThingModel>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        array.Add(ThingModel.DeserializeThingModel(item, options));
+                        array.Add(ThingModel.DeserializeThingModel(item, item.GetUtf8Bytes(), options));
                     }
                     things = array;
                     continue;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithStringNextLinkResponse.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ListWithStringNextLinkResponse.Serialization.cs
@@ -150,7 +150,7 @@ namespace BasicTypeSpec
                     List<ThingModel> array = new List<ThingModel>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        array.Add(ThingModel.DeserializeThingModel(item, options));
+                        array.Add(ThingModel.DeserializeThingModel(item, item.GetUtf8Bytes(), options));
                     }
                     things = array;
                     continue;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ModelWithRequiredNullableProperties.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ModelWithRequiredNullableProperties.Serialization.cs
@@ -7,7 +7,7 @@
 
 using System;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 
 namespace BasicTypeSpec
@@ -30,7 +30,7 @@ namespace BasicTypeSpec
                 case "J":
                     using (JsonDocument document = JsonDocument.Parse(data, ModelSerializationExtensions.JsonDocumentOptions))
                     {
-                        return DeserializeModelWithRequiredNullableProperties(document.RootElement, options);
+                        return DeserializeModelWithRequiredNullableProperties(document.RootElement, data, options);
                     }
                 default:
                     throw new FormatException($"The model {nameof(ModelWithRequiredNullableProperties)} does not support reading '{options.Format}' format.");
@@ -64,6 +64,14 @@ namespace BasicTypeSpec
         /// <param name="options"> The client options for reading and writing models. </param>
         void IJsonModel<ModelWithRequiredNullableProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            if (Patch.Contains("$"u8))
+            {
+                writer.WriteRawValue(Patch.GetJson("$"u8));
+                return;
+            }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
             writer.WriteStartObject();
             JsonModelWriteCore(writer, options);
             writer.WriteEndObject();
@@ -78,48 +86,37 @@ namespace BasicTypeSpec
             {
                 throw new FormatException($"The model {nameof(ModelWithRequiredNullableProperties)} does not support writing '{format}' format.");
             }
-            if (Optional.IsDefined(RequiredNullablePrimitive))
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            if (Optional.IsDefined(RequiredNullablePrimitive) && !Patch.Contains("$.requiredNullablePrimitive"u8))
             {
                 writer.WritePropertyName("requiredNullablePrimitive"u8);
                 writer.WriteNumberValue(RequiredNullablePrimitive.Value);
             }
-            else
+            else if (!Patch.Contains("$.requiredNullablePrimitive"u8))
             {
                 writer.WriteNull("requiredNullablePrimitive"u8);
             }
-            if (Optional.IsDefined(RequiredExtensibleEnum))
+            if (Optional.IsDefined(RequiredExtensibleEnum) && !Patch.Contains("$.requiredExtensibleEnum"u8))
             {
                 writer.WritePropertyName("requiredExtensibleEnum"u8);
                 writer.WriteStringValue(RequiredExtensibleEnum.Value.ToString());
             }
-            else
+            else if (!Patch.Contains("$.requiredExtensibleEnum"u8))
             {
                 writer.WriteNull("requiredExtensibleEnum"u8);
             }
-            if (Optional.IsDefined(RequiredFixedEnum))
+            if (Optional.IsDefined(RequiredFixedEnum) && !Patch.Contains("$.requiredFixedEnum"u8))
             {
                 writer.WritePropertyName("requiredFixedEnum"u8);
                 writer.WriteStringValue(RequiredFixedEnum.Value.ToSerialString());
             }
-            else
+            else if (!Patch.Contains("$.requiredFixedEnum"u8))
             {
                 writer.WriteNull("requiredFixedEnum"u8);
             }
-            if (options.Format != "W" && _additionalBinaryDataProperties != null)
-            {
-                foreach (var item in _additionalBinaryDataProperties)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-                    writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
+
+            Patch.WriteTo(writer);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         }
 
         /// <param name="reader"> The JSON reader. </param>
@@ -136,12 +133,13 @@ namespace BasicTypeSpec
                 throw new FormatException($"The model {nameof(ModelWithRequiredNullableProperties)} does not support reading '{format}' format.");
             }
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
-            return DeserializeModelWithRequiredNullableProperties(document.RootElement, options);
+            return DeserializeModelWithRequiredNullableProperties(document.RootElement, null, options);
         }
 
         /// <param name="element"> The JSON element to deserialize. </param>
+        /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        internal static ModelWithRequiredNullableProperties DeserializeModelWithRequiredNullableProperties(JsonElement element, ModelReaderWriterOptions options)
+        internal static ModelWithRequiredNullableProperties DeserializeModelWithRequiredNullableProperties(JsonElement element, BinaryData data, ModelReaderWriterOptions options)
         {
             if (element.ValueKind == JsonValueKind.Null)
             {
@@ -150,7 +148,9 @@ namespace BasicTypeSpec
             int? requiredNullablePrimitive = default;
             StringExtensibleEnum? requiredExtensibleEnum = default;
             StringFixedEnum? requiredFixedEnum = default;
-            IDictionary<string, BinaryData> additionalBinaryDataProperties = new ChangeTrackingDictionary<string, BinaryData>();
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            JsonPatch patch = new JsonPatch(data is null ? ReadOnlyMemory<byte>.Empty : data.ToMemory());
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
             foreach (var prop in element.EnumerateObject())
             {
                 if (prop.NameEquals("requiredNullablePrimitive"u8))
@@ -183,12 +183,9 @@ namespace BasicTypeSpec
                     requiredFixedEnum = prop.Value.GetString().ToStringFixedEnum();
                     continue;
                 }
-                if (options.Format != "W")
-                {
-                    additionalBinaryDataProperties.Add(prop.Name, BinaryData.FromString(prop.Value.GetRawText()));
-                }
+                patch.Set([.. "$."u8, .. Encoding.UTF8.GetBytes(prop.Name)], prop.Value.GetUtf8Bytes());
             }
-            return new ModelWithRequiredNullableProperties(requiredNullablePrimitive, requiredExtensibleEnum, requiredFixedEnum, additionalBinaryDataProperties);
+            return new ModelWithRequiredNullableProperties(requiredNullablePrimitive, requiredExtensibleEnum, requiredFixedEnum, patch);
         }
     }
 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ModelWithRequiredNullableProperties.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ModelWithRequiredNullableProperties.cs
@@ -5,16 +5,18 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
+using System.ClientModel.Primitives;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace BasicTypeSpec
 {
     /// <summary> A model with a few required nullable properties. </summary>
     public partial class ModelWithRequiredNullableProperties
     {
-        /// <summary> Keeps track of any properties unknown to the library. </summary>
-        private protected readonly IDictionary<string, BinaryData> _additionalBinaryDataProperties;
+        [Experimental("SCME0001")]
+        private JsonPatch _patch;
 
         /// <summary> Initializes a new instance of <see cref="ModelWithRequiredNullableProperties"/>. </summary>
         /// <param name="requiredNullablePrimitive"> required nullable primitive type. </param>
@@ -31,14 +33,22 @@ namespace BasicTypeSpec
         /// <param name="requiredNullablePrimitive"> required nullable primitive type. </param>
         /// <param name="requiredExtensibleEnum"> required nullable extensible enum type. </param>
         /// <param name="requiredFixedEnum"> required nullable fixed enum type. </param>
-        /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
-        internal ModelWithRequiredNullableProperties(int? requiredNullablePrimitive, StringExtensibleEnum? requiredExtensibleEnum, StringFixedEnum? requiredFixedEnum, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        /// <param name="patch"></param>
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        internal ModelWithRequiredNullableProperties(int? requiredNullablePrimitive, StringExtensibleEnum? requiredExtensibleEnum, StringFixedEnum? requiredFixedEnum, in JsonPatch patch)
         {
             RequiredNullablePrimitive = requiredNullablePrimitive;
             RequiredExtensibleEnum = requiredExtensibleEnum;
             RequiredFixedEnum = requiredFixedEnum;
-            _additionalBinaryDataProperties = additionalBinaryDataProperties;
+            _patch = patch;
         }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+        /// <summary> Gets the Patch. </summary>
+        [JsonIgnore]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Experimental("SCME0001")]
+        public ref JsonPatch Patch => ref _patch;
 
         /// <summary> required nullable primitive type. </summary>
         public int? RequiredNullablePrimitive { get; set; }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/PageThingModel.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/PageThingModel.Serialization.cs
@@ -144,7 +144,7 @@ namespace BasicTypeSpec
                     List<ThingModel> array = new List<ThingModel>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        array.Add(ThingModel.DeserializeThingModel(item, options));
+                        array.Add(ThingModel.DeserializeThingModel(item, item.GetUtf8Bytes(), options));
                     }
                     items = array;
                     continue;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/RoundTripModel.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/RoundTripModel.Serialization.cs
@@ -8,6 +8,7 @@
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Azure;
@@ -34,7 +35,7 @@ namespace BasicTypeSpec
                 case "J":
                     using (JsonDocument document = JsonDocument.Parse(data, ModelSerializationExtensions.JsonDocumentOptions))
                     {
-                        return DeserializeRoundTripModel(document.RootElement, options);
+                        return DeserializeRoundTripModel(document.RootElement, data, options);
                     }
                 default:
                     throw new FormatException($"The model {nameof(RoundTripModel)} does not support reading '{options.Format}' format.");
@@ -77,14 +78,23 @@ namespace BasicTypeSpec
         /// <param name="response"> The <see cref="Response"/> to deserialize the <see cref="RoundTripModel"/> from. </param>
         public static explicit operator RoundTripModel(Response response)
         {
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeRoundTripModel(document.RootElement, ModelSerializationExtensions.WireOptions);
+            BinaryData data = response.Content;
+            using JsonDocument document = JsonDocument.Parse(data, ModelSerializationExtensions.JsonDocumentOptions);
+            return DeserializeRoundTripModel(document.RootElement, data, ModelSerializationExtensions.WireOptions);
         }
 
         /// <param name="writer"> The JSON writer. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
         void IJsonModel<RoundTripModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            if (Patch.Contains("$"u8))
+            {
+                writer.WriteRawValue(Patch.GetJson("$"u8));
+                return;
+            }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
             writer.WriteStartObject();
             JsonModelWriteCore(writer, options);
             writer.WriteEndObject();
@@ -99,112 +109,210 @@ namespace BasicTypeSpec
             {
                 throw new FormatException($"The model {nameof(RoundTripModel)} does not support writing '{format}' format.");
             }
-            writer.WritePropertyName("requiredString"u8);
-            writer.WriteStringValue(RequiredString);
-            writer.WritePropertyName("requiredInt"u8);
-            writer.WriteNumberValue(RequiredInt);
-            writer.WritePropertyName("requiredCollection"u8);
-            writer.WriteStartArray();
-            foreach (StringFixedEnum item in RequiredCollection)
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            if (!Patch.Contains("$.requiredString"u8))
             {
-                writer.WriteStringValue(item.ToSerialString());
+                writer.WritePropertyName("requiredString"u8);
+                writer.WriteStringValue(RequiredString);
             }
-            writer.WriteEndArray();
-            writer.WritePropertyName("requiredDictionary"u8);
-            writer.WriteStartObject();
-            foreach (var item in RequiredDictionary)
+            if (!Patch.Contains("$.requiredInt"u8))
             {
-                writer.WritePropertyName(item.Key);
-                writer.WriteStringValue(item.Value.ToString());
+                writer.WritePropertyName("requiredInt"u8);
+                writer.WriteNumberValue(RequiredInt);
             }
-            writer.WriteEndObject();
-            writer.WritePropertyName("requiredModel"u8);
-            writer.WriteObjectValue(RequiredModel, options);
-            if (Optional.IsDefined(IntExtensibleEnum))
+            if (Patch.Contains("$.requiredCollection"u8))
+            {
+                if (!Patch.IsRemoved("$.requiredCollection"u8))
+                {
+                    writer.WritePropertyName("requiredCollection"u8);
+                    Patch.WriteTo(writer, "$.requiredCollection"u8);
+                }
+            }
+            else
+            {
+                writer.WritePropertyName("requiredCollection"u8);
+                writer.WriteStartArray();
+                for (int i = 0; i < RequiredCollection.Count; i++)
+                {
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.requiredCollection[{i}]")))
+                    {
+                        continue;
+                    }
+                    writer.WriteStringValue(RequiredCollection[i].ToSerialString());
+                }
+                Patch.WriteTo(writer, "$.requiredCollection"u8);
+                writer.WriteEndArray();
+            }
+            if (!Patch.Contains("$.requiredDictionary"u8))
+            {
+                writer.WritePropertyName("requiredDictionary"u8);
+                writer.WriteStartObject();
+#if NET8_0_OR_GREATER
+                global::System.Span<byte> buffer = stackalloc byte[256];
+#endif
+                foreach (var item in RequiredDictionary)
+                {
+#if NET8_0_OR_GREATER
+                    int bytesWritten = global::System.Text.Encoding.UTF8.GetBytes(item.Key.AsSpan(), buffer);
+                    bool patchContains = (bytesWritten == 256) ? Patch.Contains("$.requiredDictionary"u8, global::System.Text.Encoding.UTF8.GetBytes(item.Key)) : Patch.Contains("$.requiredDictionary"u8, buffer.Slice(0, bytesWritten));
+#else
+                    bool patchContains = Patch.Contains("$.requiredDictionary"u8, Encoding.UTF8.GetBytes(item.Key));
+#endif
+                    if (!patchContains)
+                    {
+                        writer.WritePropertyName(item.Key);
+                        writer.WriteStringValue(item.Value.ToString());
+                    }
+                }
+
+                Patch.WriteTo(writer, "$.requiredDictionary"u8);
+                writer.WriteEndObject();
+            }
+            if (!Patch.Contains("$.requiredModel"u8))
+            {
+                writer.WritePropertyName("requiredModel"u8);
+                writer.WriteObjectValue(RequiredModel, options);
+            }
+            if (Optional.IsDefined(IntExtensibleEnum) && !Patch.Contains("$.intExtensibleEnum"u8))
             {
                 writer.WritePropertyName("intExtensibleEnum"u8);
                 writer.WriteNumberValue(IntExtensibleEnum.Value.ToSerialInt32());
             }
-            if (Optional.IsCollectionDefined(IntExtensibleEnumCollection))
+            if (Patch.Contains("$.intExtensibleEnumCollection"u8))
+            {
+                if (!Patch.IsRemoved("$.intExtensibleEnumCollection"u8))
+                {
+                    writer.WritePropertyName("intExtensibleEnumCollection"u8);
+                    Patch.WriteTo(writer, "$.intExtensibleEnumCollection"u8);
+                }
+            }
+            else if (Optional.IsCollectionDefined(IntExtensibleEnumCollection))
             {
                 writer.WritePropertyName("intExtensibleEnumCollection"u8);
                 writer.WriteStartArray();
-                foreach (IntExtensibleEnum item in IntExtensibleEnumCollection)
+                for (int i = 0; i < IntExtensibleEnumCollection.Count; i++)
                 {
-                    writer.WriteNumberValue(item.ToSerialInt32());
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.intExtensibleEnumCollection[{i}]")))
+                    {
+                        continue;
+                    }
+                    writer.WriteNumberValue(IntExtensibleEnumCollection[i].ToSerialInt32());
                 }
+                Patch.WriteTo(writer, "$.intExtensibleEnumCollection"u8);
                 writer.WriteEndArray();
             }
-            if (Optional.IsDefined(FloatExtensibleEnum))
+            if (Optional.IsDefined(FloatExtensibleEnum) && !Patch.Contains("$.floatExtensibleEnum"u8))
             {
                 writer.WritePropertyName("floatExtensibleEnum"u8);
                 writer.WriteNumberValue(FloatExtensibleEnum.Value.ToSerialSingle());
             }
-            if (Optional.IsDefined(FloatExtensibleEnumWithIntValue))
+            if (Optional.IsDefined(FloatExtensibleEnumWithIntValue) && !Patch.Contains("$.floatExtensibleEnumWithIntValue"u8))
             {
                 writer.WritePropertyName("floatExtensibleEnumWithIntValue"u8);
                 writer.WriteNumberValue(FloatExtensibleEnumWithIntValue.Value.ToSerialSingle());
             }
-            if (Optional.IsCollectionDefined(FloatExtensibleEnumCollection))
+            if (Patch.Contains("$.floatExtensibleEnumCollection"u8))
+            {
+                if (!Patch.IsRemoved("$.floatExtensibleEnumCollection"u8))
+                {
+                    writer.WritePropertyName("floatExtensibleEnumCollection"u8);
+                    Patch.WriteTo(writer, "$.floatExtensibleEnumCollection"u8);
+                }
+            }
+            else if (Optional.IsCollectionDefined(FloatExtensibleEnumCollection))
             {
                 writer.WritePropertyName("floatExtensibleEnumCollection"u8);
                 writer.WriteStartArray();
-                foreach (FloatExtensibleEnum item in FloatExtensibleEnumCollection)
+                for (int i = 0; i < FloatExtensibleEnumCollection.Count; i++)
                 {
-                    writer.WriteNumberValue(item.ToSerialSingle());
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.floatExtensibleEnumCollection[{i}]")))
+                    {
+                        continue;
+                    }
+                    writer.WriteNumberValue(FloatExtensibleEnumCollection[i].ToSerialSingle());
                 }
+                Patch.WriteTo(writer, "$.floatExtensibleEnumCollection"u8);
                 writer.WriteEndArray();
             }
-            if (Optional.IsDefined(FloatFixedEnum))
+            if (Optional.IsDefined(FloatFixedEnum) && !Patch.Contains("$.floatFixedEnum"u8))
             {
                 writer.WritePropertyName("floatFixedEnum"u8);
                 writer.WriteNumberValue(FloatFixedEnum.Value.ToSerialSingle());
             }
-            if (Optional.IsDefined(FloatFixedEnumWithIntValue))
+            if (Optional.IsDefined(FloatFixedEnumWithIntValue) && !Patch.Contains("$.floatFixedEnumWithIntValue"u8))
             {
                 writer.WritePropertyName("floatFixedEnumWithIntValue"u8);
                 writer.WriteNumberValue((int)FloatFixedEnumWithIntValue.Value);
             }
-            if (Optional.IsCollectionDefined(FloatFixedEnumCollection))
+            if (Patch.Contains("$.floatFixedEnumCollection"u8))
+            {
+                if (!Patch.IsRemoved("$.floatFixedEnumCollection"u8))
+                {
+                    writer.WritePropertyName("floatFixedEnumCollection"u8);
+                    Patch.WriteTo(writer, "$.floatFixedEnumCollection"u8);
+                }
+            }
+            else if (Optional.IsCollectionDefined(FloatFixedEnumCollection))
             {
                 writer.WritePropertyName("floatFixedEnumCollection"u8);
                 writer.WriteStartArray();
-                foreach (FloatFixedEnum item in FloatFixedEnumCollection)
+                for (int i = 0; i < FloatFixedEnumCollection.Count; i++)
                 {
-                    writer.WriteNumberValue(item.ToSerialSingle());
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.floatFixedEnumCollection[{i}]")))
+                    {
+                        continue;
+                    }
+                    writer.WriteNumberValue(FloatFixedEnumCollection[i].ToSerialSingle());
                 }
+                Patch.WriteTo(writer, "$.floatFixedEnumCollection"u8);
                 writer.WriteEndArray();
             }
-            if (Optional.IsDefined(IntFixedEnum))
+            if (Optional.IsDefined(IntFixedEnum) && !Patch.Contains("$.intFixedEnum"u8))
             {
                 writer.WritePropertyName("intFixedEnum"u8);
                 writer.WriteNumberValue((int)IntFixedEnum.Value);
             }
-            if (Optional.IsCollectionDefined(IntFixedEnumCollection))
+            if (Patch.Contains("$.intFixedEnumCollection"u8))
+            {
+                if (!Patch.IsRemoved("$.intFixedEnumCollection"u8))
+                {
+                    writer.WritePropertyName("intFixedEnumCollection"u8);
+                    Patch.WriteTo(writer, "$.intFixedEnumCollection"u8);
+                }
+            }
+            else if (Optional.IsCollectionDefined(IntFixedEnumCollection))
             {
                 writer.WritePropertyName("intFixedEnumCollection"u8);
                 writer.WriteStartArray();
-                foreach (IntFixedEnum item in IntFixedEnumCollection)
+                for (int i = 0; i < IntFixedEnumCollection.Count; i++)
                 {
-                    writer.WriteNumberValue((int)item);
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.intFixedEnumCollection[{i}]")))
+                    {
+                        continue;
+                    }
+                    writer.WriteNumberValue((int)IntFixedEnumCollection[i]);
                 }
+                Patch.WriteTo(writer, "$.intFixedEnumCollection"u8);
                 writer.WriteEndArray();
             }
-            if (Optional.IsDefined(StringFixedEnum))
+            if (Optional.IsDefined(StringFixedEnum) && !Patch.Contains("$.stringFixedEnum"u8))
             {
                 writer.WritePropertyName("stringFixedEnum"u8);
                 writer.WriteStringValue(StringFixedEnum.Value.ToSerialString());
             }
-            writer.WritePropertyName("requiredUnknown"u8);
-#if NET6_0_OR_GREATER
-            writer.WriteRawValue(RequiredUnknown);
-#else
-            using (JsonDocument document = JsonDocument.Parse(RequiredUnknown))
+            if (!Patch.Contains("$.requiredUnknown"u8))
             {
-                JsonSerializer.Serialize(writer, document.RootElement);
-            }
+                writer.WritePropertyName("requiredUnknown"u8);
+#if NET6_0_OR_GREATER
+                writer.WriteRawValue(RequiredUnknown);
+#else
+                using (JsonDocument document = JsonDocument.Parse(RequiredUnknown))
+                {
+                    JsonSerializer.Serialize(writer, document.RootElement);
+                }
 #endif
-            if (Optional.IsDefined(OptionalUnknown))
+            }
+            if (Optional.IsDefined(OptionalUnknown) && !Patch.Contains("$.optionalUnknown"u8))
             {
                 writer.WritePropertyName("optionalUnknown"u8);
 #if NET6_0_OR_GREATER
@@ -216,114 +324,167 @@ namespace BasicTypeSpec
                 }
 #endif
             }
-            writer.WritePropertyName("requiredRecordUnknown"u8);
-            writer.WriteStartObject();
-            foreach (var item in RequiredRecordUnknown)
+            if (!Patch.Contains("$.requiredRecordUnknown"u8))
             {
-                writer.WritePropertyName(item.Key);
-                if (item.Value == null)
-                {
-                    writer.WriteNullValue();
-                    continue;
-                }
-#if NET6_0_OR_GREATER
-                writer.WriteRawValue(item.Value);
-#else
-                using (JsonDocument document = JsonDocument.Parse(item.Value))
-                {
-                    JsonSerializer.Serialize(writer, document.RootElement);
-                }
+                writer.WritePropertyName("requiredRecordUnknown"u8);
+                writer.WriteStartObject();
+#if NET8_0_OR_GREATER
+                global::System.Span<byte> buffer = stackalloc byte[256];
 #endif
+                foreach (var item in RequiredRecordUnknown)
+                {
+#if NET8_0_OR_GREATER
+                    int bytesWritten = global::System.Text.Encoding.UTF8.GetBytes(item.Key.AsSpan(), buffer);
+                    bool patchContains = (bytesWritten == 256) ? Patch.Contains("$.requiredRecordUnknown"u8, global::System.Text.Encoding.UTF8.GetBytes(item.Key)) : Patch.Contains("$.requiredRecordUnknown"u8, buffer.Slice(0, bytesWritten));
+#else
+                    bool patchContains = Patch.Contains("$.requiredRecordUnknown"u8, Encoding.UTF8.GetBytes(item.Key));
+#endif
+                    if (!patchContains)
+                    {
+                        writer.WritePropertyName(item.Key);
+                        if (item.Value == null)
+                        {
+                            writer.WriteNullValue();
+                            continue;
+                        }
+#if NET6_0_OR_GREATER
+                        writer.WriteRawValue(item.Value);
+#else
+                        using (JsonDocument document = JsonDocument.Parse(item.Value))
+                        {
+                            JsonSerializer.Serialize(writer, document.RootElement);
+                        }
+#endif
+                    }
+                }
+
+                Patch.WriteTo(writer, "$.requiredRecordUnknown"u8);
+                writer.WriteEndObject();
             }
-            writer.WriteEndObject();
-            if (Optional.IsCollectionDefined(OptionalRecordUnknown))
+            if (Optional.IsCollectionDefined(OptionalRecordUnknown) && !Patch.Contains("$.optionalRecordUnknown"u8))
             {
                 writer.WritePropertyName("optionalRecordUnknown"u8);
                 writer.WriteStartObject();
+#if NET8_0_OR_GREATER
+                global::System.Span<byte> buffer = stackalloc byte[256];
+#endif
                 foreach (var item in OptionalRecordUnknown)
                 {
-                    writer.WritePropertyName(item.Key);
-                    if (item.Value == null)
-                    {
-                        writer.WriteNullValue();
-                        continue;
-                    }
-#if NET6_0_OR_GREATER
-                    writer.WriteRawValue(item.Value);
+#if NET8_0_OR_GREATER
+                    int bytesWritten = global::System.Text.Encoding.UTF8.GetBytes(item.Key.AsSpan(), buffer);
+                    bool patchContains = (bytesWritten == 256) ? Patch.Contains("$.optionalRecordUnknown"u8, global::System.Text.Encoding.UTF8.GetBytes(item.Key)) : Patch.Contains("$.optionalRecordUnknown"u8, buffer.Slice(0, bytesWritten));
 #else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
+                    bool patchContains = Patch.Contains("$.optionalRecordUnknown"u8, Encoding.UTF8.GetBytes(item.Key));
 #endif
+                    if (!patchContains)
+                    {
+                        writer.WritePropertyName(item.Key);
+                        if (item.Value == null)
+                        {
+                            writer.WriteNullValue();
+                            continue;
+                        }
+#if NET6_0_OR_GREATER
+                        writer.WriteRawValue(item.Value);
+#else
+                        using (JsonDocument document = JsonDocument.Parse(item.Value))
+                        {
+                            JsonSerializer.Serialize(writer, document.RootElement);
+                        }
+#endif
+                    }
                 }
+
+                Patch.WriteTo(writer, "$.optionalRecordUnknown"u8);
                 writer.WriteEndObject();
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && !Patch.Contains("$.readOnlyRequiredRecordUnknown"u8))
             {
                 writer.WritePropertyName("readOnlyRequiredRecordUnknown"u8);
                 writer.WriteStartObject();
+#if NET8_0_OR_GREATER
+                global::System.Span<byte> buffer = stackalloc byte[256];
+#endif
                 foreach (var item in ReadOnlyRequiredRecordUnknown)
                 {
-                    writer.WritePropertyName(item.Key);
-                    if (item.Value == null)
-                    {
-                        writer.WriteNullValue();
-                        continue;
-                    }
-#if NET6_0_OR_GREATER
-                    writer.WriteRawValue(item.Value);
+#if NET8_0_OR_GREATER
+                    int bytesWritten = global::System.Text.Encoding.UTF8.GetBytes(item.Key.AsSpan(), buffer);
+                    bool patchContains = (bytesWritten == 256) ? Patch.Contains("$.readOnlyRequiredRecordUnknown"u8, global::System.Text.Encoding.UTF8.GetBytes(item.Key)) : Patch.Contains("$.readOnlyRequiredRecordUnknown"u8, buffer.Slice(0, bytesWritten));
 #else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
+                    bool patchContains = Patch.Contains("$.readOnlyRequiredRecordUnknown"u8, Encoding.UTF8.GetBytes(item.Key));
 #endif
+                    if (!patchContains)
+                    {
+                        writer.WritePropertyName(item.Key);
+                        if (item.Value == null)
+                        {
+                            writer.WriteNullValue();
+                            continue;
+                        }
+#if NET6_0_OR_GREATER
+                        writer.WriteRawValue(item.Value);
+#else
+                        using (JsonDocument document = JsonDocument.Parse(item.Value))
+                        {
+                            JsonSerializer.Serialize(writer, document.RootElement);
+                        }
+#endif
+                    }
                 }
+
+                Patch.WriteTo(writer, "$.readOnlyRequiredRecordUnknown"u8);
                 writer.WriteEndObject();
             }
-            if (options.Format != "W" && Optional.IsCollectionDefined(ReadOnlyOptionalRecordUnknown))
+            if (options.Format != "W" && Optional.IsCollectionDefined(ReadOnlyOptionalRecordUnknown) && !Patch.Contains("$.readOnlyOptionalRecordUnknown"u8))
             {
                 writer.WritePropertyName("readOnlyOptionalRecordUnknown"u8);
                 writer.WriteStartObject();
+#if NET8_0_OR_GREATER
+                global::System.Span<byte> buffer = stackalloc byte[256];
+#endif
                 foreach (var item in ReadOnlyOptionalRecordUnknown)
                 {
-                    writer.WritePropertyName(item.Key);
-                    if (item.Value == null)
-                    {
-                        writer.WriteNullValue();
-                        continue;
-                    }
-#if NET6_0_OR_GREATER
-                    writer.WriteRawValue(item.Value);
+#if NET8_0_OR_GREATER
+                    int bytesWritten = global::System.Text.Encoding.UTF8.GetBytes(item.Key.AsSpan(), buffer);
+                    bool patchContains = (bytesWritten == 256) ? Patch.Contains("$.readOnlyOptionalRecordUnknown"u8, global::System.Text.Encoding.UTF8.GetBytes(item.Key)) : Patch.Contains("$.readOnlyOptionalRecordUnknown"u8, buffer.Slice(0, bytesWritten));
 #else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
+                    bool patchContains = Patch.Contains("$.readOnlyOptionalRecordUnknown"u8, Encoding.UTF8.GetBytes(item.Key));
 #endif
+                    if (!patchContains)
+                    {
+                        writer.WritePropertyName(item.Key);
+                        if (item.Value == null)
+                        {
+                            writer.WriteNullValue();
+                            continue;
+                        }
+#if NET6_0_OR_GREATER
+                        writer.WriteRawValue(item.Value);
+#else
+                        using (JsonDocument document = JsonDocument.Parse(item.Value))
+                        {
+                            JsonSerializer.Serialize(writer, document.RootElement);
+                        }
+#endif
+                    }
                 }
+
+                Patch.WriteTo(writer, "$.readOnlyOptionalRecordUnknown"u8);
                 writer.WriteEndObject();
             }
-            writer.WritePropertyName("modelWithRequiredNullable"u8);
-            writer.WriteObjectValue(ModelWithRequiredNullable, options);
-            writer.WritePropertyName("requiredBytes"u8);
-            writer.WriteBase64StringValue(RequiredBytes, "D");
-            if (options.Format != "W" && _additionalBinaryDataProperties != null)
+            if (!Patch.Contains("$.modelWithRequiredNullable"u8))
             {
-                foreach (var item in _additionalBinaryDataProperties)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-                    writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
+                writer.WritePropertyName("modelWithRequiredNullable"u8);
+                writer.WriteObjectValue(ModelWithRequiredNullable, options);
             }
+            if (!Patch.Contains("$.requiredBytes"u8))
+            {
+                writer.WritePropertyName("requiredBytes"u8);
+                writer.WriteBase64StringValue(RequiredBytes, "D");
+            }
+
+            Patch.WriteTo(writer);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         }
 
         /// <param name="reader"> The JSON reader. </param>
@@ -340,12 +501,13 @@ namespace BasicTypeSpec
                 throw new FormatException($"The model {nameof(RoundTripModel)} does not support reading '{format}' format.");
             }
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
-            return DeserializeRoundTripModel(document.RootElement, options);
+            return DeserializeRoundTripModel(document.RootElement, null, options);
         }
 
         /// <param name="element"> The JSON element to deserialize. </param>
+        /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        internal static RoundTripModel DeserializeRoundTripModel(JsonElement element, ModelReaderWriterOptions options)
+        internal static RoundTripModel DeserializeRoundTripModel(JsonElement element, BinaryData data, ModelReaderWriterOptions options)
         {
             if (element.ValueKind == JsonValueKind.Null)
             {
@@ -375,7 +537,9 @@ namespace BasicTypeSpec
             IReadOnlyDictionary<string, BinaryData> readOnlyOptionalRecordUnknown = default;
             ModelWithRequiredNullableProperties modelWithRequiredNullable = default;
             BinaryData requiredBytes = default;
-            IDictionary<string, BinaryData> additionalBinaryDataProperties = new ChangeTrackingDictionary<string, BinaryData>();
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            JsonPatch patch = new JsonPatch(data is null ? ReadOnlyMemory<byte>.Empty : data.ToMemory());
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
             foreach (var prop in element.EnumerateObject())
             {
                 if (prop.NameEquals("requiredString"u8))
@@ -410,7 +574,7 @@ namespace BasicTypeSpec
                 }
                 if (prop.NameEquals("requiredModel"u8))
                 {
-                    requiredModel = ThingModel.DeserializeThingModel(prop.Value, options);
+                    requiredModel = ThingModel.DeserializeThingModel(prop.Value, prop.Value.GetUtf8Bytes(), options);
                     continue;
                 }
                 if (prop.NameEquals("intExtensibleEnum"u8))
@@ -624,7 +788,7 @@ namespace BasicTypeSpec
                 }
                 if (prop.NameEquals("modelWithRequiredNullable"u8))
                 {
-                    modelWithRequiredNullable = ModelWithRequiredNullableProperties.DeserializeModelWithRequiredNullableProperties(prop.Value, options);
+                    modelWithRequiredNullable = ModelWithRequiredNullableProperties.DeserializeModelWithRequiredNullableProperties(prop.Value, prop.Value.GetUtf8Bytes(), options);
                     continue;
                 }
                 if (prop.NameEquals("requiredBytes"u8))
@@ -632,10 +796,7 @@ namespace BasicTypeSpec
                     requiredBytes = BinaryData.FromBytes(prop.Value.GetBytesFromBase64("D"));
                     continue;
                 }
-                if (options.Format != "W")
-                {
-                    additionalBinaryDataProperties.Add(prop.Name, BinaryData.FromString(prop.Value.GetRawText()));
-                }
+                patch.Set([.. "$."u8, .. Encoding.UTF8.GetBytes(prop.Name)], prop.Value.GetUtf8Bytes());
             }
             return new RoundTripModel(
                 requiredString,
@@ -662,8 +823,53 @@ namespace BasicTypeSpec
                 readOnlyOptionalRecordUnknown ?? new ChangeTrackingDictionary<string, BinaryData>(),
                 modelWithRequiredNullable,
                 requiredBytes,
-                additionalBinaryDataProperties);
+                patch);
         }
+
+        /// <summary></summary>
+        /// <param name="jsonPath"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        private bool PropagateGet(ReadOnlySpan<byte> jsonPath, out JsonPatch.EncodedValue value)
+        {
+            ReadOnlySpan<byte> local = jsonPath.SliceToStartOfPropertyName();
+            value = default;
+
+            if (local.StartsWith("requiredModel"u8))
+            {
+                return RequiredModel.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("requiredModel"u8.Length)], out value);
+            }
+            if (local.StartsWith("modelWithRequiredNullable"u8))
+            {
+                return ModelWithRequiredNullable.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("modelWithRequiredNullable"u8.Length)], out value);
+            }
+            return false;
+        }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+        /// <summary></summary>
+        /// <param name="jsonPath"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        private bool PropagateSet(ReadOnlySpan<byte> jsonPath, JsonPatch.EncodedValue value)
+        {
+            ReadOnlySpan<byte> local = jsonPath.SliceToStartOfPropertyName();
+
+            if (local.StartsWith("requiredModel"u8))
+            {
+                RequiredModel.Patch.Set([.. "$"u8, .. local.Slice("requiredModel"u8.Length)], value);
+                return true;
+            }
+            if (local.StartsWith("modelWithRequiredNullable"u8))
+            {
+                ModelWithRequiredNullable.Patch.Set([.. "$"u8, .. local.Slice("modelWithRequiredNullable"u8.Length)], value);
+                return true;
+            }
+            return false;
+        }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
         internal partial class RoundTripModelConverter : JsonConverter<RoundTripModel>
         {
@@ -683,7 +889,7 @@ namespace BasicTypeSpec
             public override RoundTripModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 using JsonDocument document = JsonDocument.ParseValue(ref reader);
-                return DeserializeRoundTripModel(document.RootElement, ModelSerializationExtensions.WireOptions);
+                return DeserializeRoundTripModel(document.RootElement, document.RootElement.GetUtf8Bytes(), ModelSerializationExtensions.WireOptions);
             }
         }
     }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/RoundTripModel.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/RoundTripModel.cs
@@ -6,17 +6,21 @@
 #nullable disable
 
 using System;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace BasicTypeSpec
 {
     /// <summary> this is a roundtrip model. </summary>
     public partial class RoundTripModel
     {
-        /// <summary> Keeps track of any properties unknown to the library. </summary>
-        private protected readonly IDictionary<string, BinaryData> _additionalBinaryDataProperties;
+        [Experimental("SCME0001")]
+        private JsonPatch _patch;
 
         /// <summary> Initializes a new instance of <see cref="RoundTripModel"/>. </summary>
         /// <param name="requiredString"> Required string, illustrating a reference type property. </param>
@@ -29,6 +33,7 @@ namespace BasicTypeSpec
         /// <param name="modelWithRequiredNullable"> this is a model with required nullable properties. </param>
         /// <param name="requiredBytes"> Required bytes. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="requiredString"/>, <paramref name="requiredCollection"/>, <paramref name="requiredDictionary"/>, <paramref name="requiredModel"/>, <paramref name="requiredUnknown"/>, <paramref name="requiredRecordUnknown"/>, <paramref name="modelWithRequiredNullable"/> or <paramref name="requiredBytes"/> is null. </exception>
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         public RoundTripModel(string requiredString, int requiredInt, IEnumerable<StringFixedEnum> requiredCollection, IDictionary<string, StringExtensibleEnum> requiredDictionary, ThingModel requiredModel, BinaryData requiredUnknown, IDictionary<string, BinaryData> requiredRecordUnknown, ModelWithRequiredNullableProperties modelWithRequiredNullable, BinaryData requiredBytes)
         {
             Argument.AssertNotNull(requiredString, nameof(requiredString));
@@ -56,7 +61,9 @@ namespace BasicTypeSpec
             ReadOnlyOptionalRecordUnknown = new ChangeTrackingDictionary<string, BinaryData>();
             ModelWithRequiredNullable = modelWithRequiredNullable;
             RequiredBytes = requiredBytes;
+            _patch.SetPropagators(PropagateSet, PropagateGet);
         }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
         /// <summary> Initializes a new instance of <see cref="RoundTripModel"/>. </summary>
         /// <param name="requiredString"> Required string, illustrating a reference type property. </param>
@@ -83,8 +90,9 @@ namespace BasicTypeSpec
         /// <param name="readOnlyOptionalRecordUnknown"> optional readonly record of unknown. </param>
         /// <param name="modelWithRequiredNullable"> this is a model with required nullable properties. </param>
         /// <param name="requiredBytes"> Required bytes. </param>
-        /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
-        internal RoundTripModel(string requiredString, int requiredInt, IList<StringFixedEnum> requiredCollection, IDictionary<string, StringExtensibleEnum> requiredDictionary, ThingModel requiredModel, IntExtensibleEnum? intExtensibleEnum, IList<IntExtensibleEnum> intExtensibleEnumCollection, FloatExtensibleEnum? floatExtensibleEnum, FloatExtensibleEnumWithIntValue? floatExtensibleEnumWithIntValue, IList<FloatExtensibleEnum> floatExtensibleEnumCollection, FloatFixedEnum? floatFixedEnum, FloatFixedEnumWithIntValue? floatFixedEnumWithIntValue, IList<FloatFixedEnum> floatFixedEnumCollection, IntFixedEnum? intFixedEnum, IList<IntFixedEnum> intFixedEnumCollection, StringFixedEnum? stringFixedEnum, BinaryData requiredUnknown, BinaryData optionalUnknown, IDictionary<string, BinaryData> requiredRecordUnknown, IDictionary<string, BinaryData> optionalRecordUnknown, IReadOnlyDictionary<string, BinaryData> readOnlyRequiredRecordUnknown, IReadOnlyDictionary<string, BinaryData> readOnlyOptionalRecordUnknown, ModelWithRequiredNullableProperties modelWithRequiredNullable, BinaryData requiredBytes, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        /// <param name="patch"></param>
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        internal RoundTripModel(string requiredString, int requiredInt, IList<StringFixedEnum> requiredCollection, IDictionary<string, StringExtensibleEnum> requiredDictionary, ThingModel requiredModel, IntExtensibleEnum? intExtensibleEnum, IList<IntExtensibleEnum> intExtensibleEnumCollection, FloatExtensibleEnum? floatExtensibleEnum, FloatExtensibleEnumWithIntValue? floatExtensibleEnumWithIntValue, IList<FloatExtensibleEnum> floatExtensibleEnumCollection, FloatFixedEnum? floatFixedEnum, FloatFixedEnumWithIntValue? floatFixedEnumWithIntValue, IList<FloatFixedEnum> floatFixedEnumCollection, IntFixedEnum? intFixedEnum, IList<IntFixedEnum> intFixedEnumCollection, StringFixedEnum? stringFixedEnum, BinaryData requiredUnknown, BinaryData optionalUnknown, IDictionary<string, BinaryData> requiredRecordUnknown, IDictionary<string, BinaryData> optionalRecordUnknown, IReadOnlyDictionary<string, BinaryData> readOnlyRequiredRecordUnknown, IReadOnlyDictionary<string, BinaryData> readOnlyOptionalRecordUnknown, ModelWithRequiredNullableProperties modelWithRequiredNullable, BinaryData requiredBytes, in JsonPatch patch)
         {
             RequiredString = requiredString;
             RequiredInt = requiredInt;
@@ -110,8 +118,16 @@ namespace BasicTypeSpec
             ReadOnlyOptionalRecordUnknown = readOnlyOptionalRecordUnknown;
             ModelWithRequiredNullable = modelWithRequiredNullable;
             RequiredBytes = requiredBytes;
-            _additionalBinaryDataProperties = additionalBinaryDataProperties;
+            _patch = patch;
+            _patch.SetPropagators(PropagateSet, PropagateGet);
         }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+        /// <summary> Gets the Patch. </summary>
+        [JsonIgnore]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Experimental("SCME0001")]
+        public ref JsonPatch Patch => ref _patch;
 
         /// <summary> Required string, illustrating a reference type property. </summary>
         public string RequiredString { get; set; }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ThingModel.Serialization.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ThingModel.Serialization.cs
@@ -8,6 +8,7 @@
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using Azure;
 using Azure.Core;
@@ -32,7 +33,7 @@ namespace BasicTypeSpec
                 case "J":
                     using (JsonDocument document = JsonDocument.Parse(data, ModelSerializationExtensions.JsonDocumentOptions))
                     {
-                        return DeserializeThingModel(document.RootElement, options);
+                        return DeserializeThingModel(document.RootElement, data, options);
                     }
                 default:
                     throw new FormatException($"The model {nameof(ThingModel)} does not support reading '{options.Format}' format.");
@@ -75,14 +76,23 @@ namespace BasicTypeSpec
         /// <param name="response"> The <see cref="Response"/> to deserialize the <see cref="ThingModel"/> from. </param>
         public static explicit operator ThingModel(Response response)
         {
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeThingModel(document.RootElement, ModelSerializationExtensions.WireOptions);
+            BinaryData data = response.Content;
+            using JsonDocument document = JsonDocument.Parse(data, ModelSerializationExtensions.JsonDocumentOptions);
+            return DeserializeThingModel(document.RootElement, data, ModelSerializationExtensions.WireOptions);
         }
 
         /// <param name="writer"> The JSON writer. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
         void IJsonModel<ThingModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            if (Patch.Contains("$"u8))
+            {
+                writer.WriteRawValue(Patch.GetJson("$"u8));
+                return;
+            }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
             writer.WriteStartObject();
             JsonModelWriteCore(writer, options);
             writer.WriteEndObject();
@@ -97,86 +107,122 @@ namespace BasicTypeSpec
             {
                 throw new FormatException($"The model {nameof(ThingModel)} does not support writing '{format}' format.");
             }
-            writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(Name);
-            writer.WritePropertyName("requiredUnion"u8);
-#if NET6_0_OR_GREATER
-            writer.WriteRawValue(RequiredUnion);
-#else
-            using (JsonDocument document = JsonDocument.Parse(RequiredUnion))
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            if (!Patch.Contains("$.name"u8))
             {
-                JsonSerializer.Serialize(writer, document.RootElement);
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name);
             }
+            if (!Patch.Contains("$.requiredUnion"u8))
+            {
+                writer.WritePropertyName("requiredUnion"u8);
+#if NET6_0_OR_GREATER
+                writer.WriteRawValue(RequiredUnion);
+#else
+                using (JsonDocument document = JsonDocument.Parse(RequiredUnion))
+                {
+                    JsonSerializer.Serialize(writer, document.RootElement);
+                }
 #endif
-            writer.WritePropertyName("requiredLiteralString"u8);
-            writer.WriteStringValue(RequiredLiteralString);
-            writer.WritePropertyName("requiredLiteralInt"u8);
-            writer.WriteNumberValue(RequiredLiteralInt);
-            writer.WritePropertyName("requiredLiteralFloat"u8);
-            writer.WriteNumberValue(RequiredLiteralFloat);
-            writer.WritePropertyName("requiredLiteralBool"u8);
-            writer.WriteBooleanValue(RequiredLiteralBool);
-            if (Optional.IsDefined(OptionalLiteralString))
+            }
+            if (!Patch.Contains("$.requiredLiteralString"u8))
+            {
+                writer.WritePropertyName("requiredLiteralString"u8);
+                writer.WriteStringValue(RequiredLiteralString);
+            }
+            if (!Patch.Contains("$.requiredLiteralInt"u8))
+            {
+                writer.WritePropertyName("requiredLiteralInt"u8);
+                writer.WriteNumberValue(RequiredLiteralInt);
+            }
+            if (!Patch.Contains("$.requiredLiteralFloat"u8))
+            {
+                writer.WritePropertyName("requiredLiteralFloat"u8);
+                writer.WriteNumberValue(RequiredLiteralFloat);
+            }
+            if (!Patch.Contains("$.requiredLiteralBool"u8))
+            {
+                writer.WritePropertyName("requiredLiteralBool"u8);
+                writer.WriteBooleanValue(RequiredLiteralBool);
+            }
+            if (Optional.IsDefined(OptionalLiteralString) && !Patch.Contains("$.optionalLiteralString"u8))
             {
                 writer.WritePropertyName("optionalLiteralString"u8);
                 writer.WriteStringValue(OptionalLiteralString.Value.ToString());
             }
-            if (Optional.IsDefined(OptionalLiteralInt))
+            if (Optional.IsDefined(OptionalLiteralInt) && !Patch.Contains("$.optionalLiteralInt"u8))
             {
                 writer.WritePropertyName("optionalLiteralInt"u8);
                 writer.WriteNumberValue(OptionalLiteralInt.Value.ToSerialInt32());
             }
-            if (Optional.IsDefined(OptionalLiteralFloat))
+            if (Optional.IsDefined(OptionalLiteralFloat) && !Patch.Contains("$.optionalLiteralFloat"u8))
             {
                 writer.WritePropertyName("optionalLiteralFloat"u8);
                 writer.WriteNumberValue(OptionalLiteralFloat.Value.ToSerialSingle());
             }
-            if (Optional.IsDefined(OptionalLiteralBool))
+            if (Optional.IsDefined(OptionalLiteralBool) && !Patch.Contains("$.optionalLiteralBool"u8))
             {
                 writer.WritePropertyName("optionalLiteralBool"u8);
                 writer.WriteBooleanValue(OptionalLiteralBool.Value);
             }
-            writer.WritePropertyName("requiredBadDescription"u8);
-            writer.WriteStringValue(RequiredBadDescription);
-            if (Optional.IsCollectionDefined(OptionalNullableList))
+            if (!Patch.Contains("$.requiredBadDescription"u8))
+            {
+                writer.WritePropertyName("requiredBadDescription"u8);
+                writer.WriteStringValue(RequiredBadDescription);
+            }
+            if (Patch.Contains("$.optionalNullableList"u8))
+            {
+                if (!Patch.IsRemoved("$.optionalNullableList"u8))
+                {
+                    writer.WritePropertyName("optionalNullableList"u8);
+                    Patch.WriteTo(writer, "$.optionalNullableList"u8);
+                }
+            }
+            else if (Optional.IsCollectionDefined(OptionalNullableList))
             {
                 writer.WritePropertyName("optionalNullableList"u8);
                 writer.WriteStartArray();
-                foreach (int item in OptionalNullableList)
+                for (int i = 0; i < OptionalNullableList.Count; i++)
                 {
-                    writer.WriteNumberValue(item);
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.optionalNullableList[{i}]")))
+                    {
+                        continue;
+                    }
+                    writer.WriteNumberValue(OptionalNullableList[i]);
                 }
+                Patch.WriteTo(writer, "$.optionalNullableList"u8);
                 writer.WriteEndArray();
             }
-            if (Optional.IsCollectionDefined(RequiredNullableList))
+            if (Patch.Contains("$.requiredNullableList"u8))
+            {
+                if (!Patch.IsRemoved("$.requiredNullableList"u8))
+                {
+                    writer.WritePropertyName("requiredNullableList"u8);
+                    Patch.WriteTo(writer, "$.requiredNullableList"u8);
+                }
+            }
+            else if (Optional.IsCollectionDefined(RequiredNullableList))
             {
                 writer.WritePropertyName("requiredNullableList"u8);
                 writer.WriteStartArray();
-                foreach (int item in RequiredNullableList)
+                for (int i = 0; i < RequiredNullableList.Count; i++)
                 {
-                    writer.WriteNumberValue(item);
+                    if (Patch.IsRemoved(Encoding.UTF8.GetBytes($"$.requiredNullableList[{i}]")))
+                    {
+                        continue;
+                    }
+                    writer.WriteNumberValue(RequiredNullableList[i]);
                 }
+                Patch.WriteTo(writer, "$.requiredNullableList"u8);
                 writer.WriteEndArray();
             }
             else
             {
                 writer.WriteNull("requiredNullableList"u8);
             }
-            if (options.Format != "W" && _additionalBinaryDataProperties != null)
-            {
-                foreach (var item in _additionalBinaryDataProperties)
-                {
-                    writer.WritePropertyName(item.Key);
-#if NET6_0_OR_GREATER
-                    writer.WriteRawValue(item.Value);
-#else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
-                }
-            }
+
+            Patch.WriteTo(writer);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         }
 
         /// <param name="reader"> The JSON reader. </param>
@@ -193,12 +239,13 @@ namespace BasicTypeSpec
                 throw new FormatException($"The model {nameof(ThingModel)} does not support reading '{format}' format.");
             }
             using JsonDocument document = JsonDocument.ParseValue(ref reader);
-            return DeserializeThingModel(document.RootElement, options);
+            return DeserializeThingModel(document.RootElement, null, options);
         }
 
         /// <param name="element"> The JSON element to deserialize. </param>
+        /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        internal static ThingModel DeserializeThingModel(JsonElement element, ModelReaderWriterOptions options)
+        internal static ThingModel DeserializeThingModel(JsonElement element, BinaryData data, ModelReaderWriterOptions options)
         {
             if (element.ValueKind == JsonValueKind.Null)
             {
@@ -217,7 +264,9 @@ namespace BasicTypeSpec
             string requiredBadDescription = default;
             IList<int> optionalNullableList = default;
             IList<int> requiredNullableList = default;
-            IDictionary<string, BinaryData> additionalBinaryDataProperties = new ChangeTrackingDictionary<string, BinaryData>();
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            JsonPatch patch = new JsonPatch(data is null ? ReadOnlyMemory<byte>.Empty : data.ToMemory());
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
             foreach (var prop in element.EnumerateObject())
             {
                 if (prop.NameEquals("name"u8))
@@ -320,10 +369,7 @@ namespace BasicTypeSpec
                     requiredNullableList = array;
                     continue;
                 }
-                if (options.Format != "W")
-                {
-                    additionalBinaryDataProperties.Add(prop.Name, BinaryData.FromString(prop.Value.GetRawText()));
-                }
+                patch.Set([.. "$."u8, .. Encoding.UTF8.GetBytes(prop.Name)], prop.Value.GetUtf8Bytes());
             }
             return new ThingModel(
                 name,
@@ -339,7 +385,7 @@ namespace BasicTypeSpec
                 requiredBadDescription,
                 optionalNullableList ?? new ChangeTrackingList<int>(),
                 requiredNullableList,
-                additionalBinaryDataProperties);
+                patch);
         }
     }
 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ThingModel.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Models/ThingModel.cs
@@ -6,17 +6,21 @@
 #nullable disable
 
 using System;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace BasicTypeSpec
 {
     /// <summary> A model with a few properties of literal types. </summary>
     public partial class ThingModel
     {
-        /// <summary> Keeps track of any properties unknown to the library. </summary>
-        private protected readonly IDictionary<string, BinaryData> _additionalBinaryDataProperties;
+        [Experimental("SCME0001")]
+        private JsonPatch _patch;
 
         /// <summary> Initializes a new instance of <see cref="ThingModel"/>. </summary>
         /// <param name="name"> name of the ThingModel. </param>
@@ -51,8 +55,9 @@ namespace BasicTypeSpec
         /// <param name="requiredBadDescription"> description with xml &lt;|endoftext|&gt;. </param>
         /// <param name="optionalNullableList"> optional nullable collection. </param>
         /// <param name="requiredNullableList"> required nullable collection. </param>
-        /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
-        internal ThingModel(string name, BinaryData requiredUnion, string requiredLiteralString, int requiredLiteralInt, float requiredLiteralFloat, bool requiredLiteralBool, ThingModelOptionalLiteralString? optionalLiteralString, ThingModelOptionalLiteralInt? optionalLiteralInt, ThingModelOptionalLiteralFloat? optionalLiteralFloat, bool? optionalLiteralBool, string requiredBadDescription, IList<int> optionalNullableList, IList<int> requiredNullableList, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        /// <param name="patch"></param>
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        internal ThingModel(string name, BinaryData requiredUnion, string requiredLiteralString, int requiredLiteralInt, float requiredLiteralFloat, bool requiredLiteralBool, ThingModelOptionalLiteralString? optionalLiteralString, ThingModelOptionalLiteralInt? optionalLiteralInt, ThingModelOptionalLiteralFloat? optionalLiteralFloat, bool? optionalLiteralBool, string requiredBadDescription, IList<int> optionalNullableList, IList<int> requiredNullableList, in JsonPatch patch)
         {
             Name = name;
             RequiredUnion = requiredUnion;
@@ -67,8 +72,15 @@ namespace BasicTypeSpec
             RequiredBadDescription = requiredBadDescription;
             OptionalNullableList = optionalNullableList;
             RequiredNullableList = requiredNullableList;
-            _additionalBinaryDataProperties = additionalBinaryDataProperties;
+            _patch = patch;
         }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+        /// <summary> Gets the Patch. </summary>
+        [JsonIgnore]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Experimental("SCME0001")]
+        public ref JsonPatch Patch => ref _patch;
 
         /// <summary> name of the ThingModel. </summary>
         public string Name { get; set; }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/tspCodeModel.json
@@ -2594,6 +2594,10 @@
       "doc": "this is a roundtrip model",
       "decorators": [
         {
+          "name": "TypeSpec.HttpClient.CSharp.@dynamicModel",
+          "arguments": {}
+        },
+        {
           "name": "Azure.ClientGenerator.Core.@useSystemTextJsonConverter",
           "arguments": {}
         }


### PR DESCRIPTION
## Summary
- preserve the C# `dynamicModel` decorator in the Azure data-plane emitter
- detect dynamic models when generating `System.Text.Json` converters
- pass the original JSON payload to dynamic-model deserializers
- mark the local `RoundTripModel` sample dynamic and regenerate its output
- add focused emitter and generator regression coverage

Fixes #62234
