### PR TITLE
Handle casing-only deserializer argument changes

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
@@ -529,7 +529,7 @@ namespace Azure.Generator.Management.Visitors
             }
 
             var constructorParameters = modelProvider.FullConstructor.Signature.Parameters;
-            var argumentsByName = new Dictionary<string, ValueExpression>(StringComparer.Ordinal);
+            var argumentsByName = new Dictionary<string, ValueExpression>(StringComparer.OrdinalIgnoreCase);
             foreach (var argument in newInstanceExpression.Parameters)
             {
                 if (!TryGetArgumentName(argument, out var argumentName))

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
@@ -529,7 +529,7 @@ namespace Azure.Generator.Management.Visitors
             }
 
             var constructorParameters = modelProvider.FullConstructor.Signature.Parameters;
-            var argumentsByName = new Dictionary<string, ValueExpression>(StringComparer.OrdinalIgnoreCase);
+            var argumentsByName = new Dictionary<string, ValueExpression>(StringComparer.Ordinal);
             foreach (var argument in newInstanceExpression.Parameters)
             {
                 if (!TryGetArgumentName(argument, out var argumentName))
@@ -547,7 +547,7 @@ namespace Azure.Generator.Management.Visitors
             var changed = constructorParameters.Count != newInstanceExpression.Parameters.Count;
             foreach (var constructorParameter in constructorParameters)
             {
-                if (argumentsByName.TryGetValue(constructorParameter.Name, out var argument))
+                if (TryGetArgumentByName(argumentsByName, constructorParameter.Name, out var argument))
                 {
                     arguments.Add(argument);
                     usedArguments.Add(argument);
@@ -567,6 +567,36 @@ namespace Azure.Generator.Management.Visitors
             unusedArguments = newInstanceExpression.Parameters.Where(argument => !usedArguments.Contains(argument)).ToArray();
             updatedArguments = changed ? arguments : null;
             return changed;
+        }
+
+        private static bool TryGetArgumentByName(
+            IReadOnlyDictionary<string, ValueExpression> argumentsByName,
+            string parameterName,
+            [NotNullWhen(true)] out ValueExpression? argument)
+        {
+            if (argumentsByName.TryGetValue(parameterName, out argument))
+            {
+                return true;
+            }
+
+            argument = null;
+            foreach (var candidate in argumentsByName)
+            {
+                if (!string.Equals(candidate.Key, parameterName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (argument is not null)
+                {
+                    argument = null;
+                    return false;
+                }
+
+                argument = candidate.Value;
+            }
+
+            return argument is not null;
         }
 
         private static bool TryGetArgumentName(ValueExpression argument, [NotNullWhen(true)] out string? name)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -299,6 +299,40 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(rendered, Does.Contain("return new global::Samples.Models.TestModel(id, name, ((global::System.Collections.Generic.IDictionary<string, global::System.BinaryData>)default));"));
         }
 
+        [Test]
+        public void RebuildsDeserializeConstructorCallWithCasingOnlyDifference()
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("vmwareId", InputPrimitiveType.String),
+                ]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
+            var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+            model.FullConstructor.Signature.Parameters[0].Update(name: "vMwareId");
+            var vmwareId = new VariableExpression(typeof(string), "vmwareId");
+            var method = new MethodProvider(
+                new MethodSignature(
+                    "DeserializeTestModel",
+                    null,
+                    MethodSignatureModifiers.Internal | MethodSignatureModifiers.Static,
+                    model.Type,
+                    null,
+                    []),
+                Return(new NewInstanceExpression(model.Type, [vmwareId])),
+                modelFactory);
+            modelFactory.Update(methods: [method]);
+
+            Management.Visitors.ModelFactoryBackwardCompatHelper.FixConstructorCalls(modelFactory.Methods);
+
+            var rendered = new TypeProviderWriter(modelFactory).Write().Content;
+            Assert.That(rendered, Does.Contain("return new global::Samples.Models.TestModel(vmwareId, ((global::System.Collections.Generic.IDictionary<string, global::System.BinaryData>)default));"));
+        }
+
         private static void SetLastContractView(TypeProvider typeProvider, TypeProvider lastContractView)
         {
             typeof(TypeProvider).GetField(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -333,6 +333,41 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(rendered, Does.Contain("return new global::Samples.Models.TestModel(vmwareId, ((global::System.Collections.Generic.IDictionary<string, global::System.BinaryData>)default));"));
         }
 
+        [Test]
+        public void RebuildsDeserializeConstructorCallPrefersExactCasing()
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("vmwareId", InputPrimitiveType.String),
+                ]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
+            var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+            var legacyVmwareId = new VariableExpression(typeof(string), "vMwareId");
+            var vmwareId = new VariableExpression(typeof(string), "vmwareId");
+            var method = new MethodProvider(
+                new MethodSignature(
+                    "DeserializeTestModel",
+                    null,
+                    MethodSignatureModifiers.Internal | MethodSignatureModifiers.Static,
+                    model.Type,
+                    null,
+                    []),
+                Return(new NewInstanceExpression(model.Type, [legacyVmwareId, vmwareId])),
+                modelFactory);
+            modelFactory.Update(methods: [method]);
+
+            Management.Visitors.ModelFactoryBackwardCompatHelper.FixConstructorCalls(modelFactory.Methods);
+
+            var rendered = new TypeProviderWriter(modelFactory).Write().Content;
+            Assert.That(rendered, Does.Contain("return new global::Samples.Models.TestModel(vmwareId, ((global::System.Collections.Generic.IDictionary<string, global::System.BinaryData>)default));"));
+            Assert.That(rendered, Does.Not.Contain("TestModel(vMwareId"));
+        }
+
         private static void SetLastContractView(TypeProvider typeProvider, TypeProvider lastContractView)
         {
             typeof(TypeProvider).GetField(


### PR DESCRIPTION
## Description

Use case-insensitive matching when the management generator repairs deserializer constructor calls. This preserves the generated local value when a constructor parameter differs only by historical acronym casing instead of replacing it with `default` and removing the declaration.

This was exposed while validating microsoft/typespec#11719 against all management libraries. Recovery Services Site Recovery contains `vMware*` serialization locals that normalize to `vmware*`; without this fix, the repair step emitted an undeclared assignment and discarded the deserialized value.

## Validation

- Azure.Generator.Management tests: 270 passed
- Management regeneration with TypeSpec PR #11719: 218/218 passed
- Management library builds with ApiCompat: 218/218 passed