### PR TITLE
Bump http-client-csharp version for mgmt

### DIFF
--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,14 +1,14 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-19 04:12:09 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-19 08:56:52 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Latest Published Version Chain
 
 ```
 @typespec/http-client-csharp (alpha.20260818.17)
-  └─ @azure-typespec/http-client-csharp (alpha.20260818.4)
-       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260818.5)
+  └─ @azure-typespec/http-client-csharp (alpha.20260818.5)
+       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260818.4)
             └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260818.1)
 ```
 
@@ -16,9 +16,9 @@
 
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
-| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | 1.0.0-alpha.20260818.17 | 1.0.0-alpha.20260818.17 | [0da67d5](https://github.com/microsoft/typespec/commit/0da67d590e0c8af0500af2603214b3cf62e549f7) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | 1.0.0-alpha.20260817.5 | 1.0.0-alpha.20260818.4 | [e90d659](https://github.com/Azure/azure-sdk-for-net/commit/e90d659517b79c16ffbcc613f7980adafe003c22) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | 1.0.0-alpha.20260812.1 | 1.0.0-alpha.20260818.5 | [ad23c92](https://github.com/Azure/azure-sdk-for-net/commit/ad23c928f50a12ca01629266a2d8d4ad3798dcad) |
+| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260818.17](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260818.17) | [1.0.0-alpha.20260818.17](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260818.17) | [a849fcf](https://github.com/microsoft/typespec/commit/a849fcfc965b6dc0cb8dffcb32132e71655a6b4a) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260818.5](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260818.5) | [1.0.0-alpha.20260818.5](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260818.5) | [bd494a4](https://github.com/Azure/azure-sdk-for-net/commit/bd494a4011d982eb0db5c1e8cda6b5e679149a91) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260812.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260812.1) | [1.0.0-alpha.20260818.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260818.4) | [ad23c92](https://github.com/Azure/azure-sdk-for-net/commit/ad23c928f50a12ca01629266a2d8d4ad3798dcad) |
 
 ## Source Files
 

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260818.17</UnbrandedGeneratorVersion>
-    <AzureGeneratorVersion>1.0.0-alpha.20260817.5</AzureGeneratorVersion>
+    <AzureGeneratorVersion>1.0.0-alpha.20260818.5</AzureGeneratorVersion>
     <AzureManagementGeneratorVersion>1.0.0-alpha.20260812.1</AzureManagementGeneratorVersion>
   </PropertyGroup>
 

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260817.5",
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260818.5",
         "@typespec/http-client-csharp": "1.0.0-alpha.20260817.7"
       },
       "devDependencies": {
@@ -271,12 +271,33 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260817.5",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260817.5.tgz",
-      "integrity": "sha1-yL0riAqhAOKK6iYj98u4tdd1F6A=",
+      "version": "1.0.0-alpha.20260818.5",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260818.5.tgz",
+      "integrity": "sha1-nG6/qFtT/jW04mLKGbGkrmHscq4=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260817.7"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260818.17"
+      }
+    },
+    "node_modules/@azure-typespec/http-client-csharp/node_modules/@typespec/http-client-csharp": {
+      "version": "1.0.0-alpha.20260818.17",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260818.17.tgz",
+      "integrity": "sha512-DiKrQD/iBaLqKjo72oR1z2ZA87HU2EYfhCrmpACqOPW/Aky1InYbNKWFwiahPxxssqGQxNFmMkuDRrKZ+OOM0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.13.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": ">=0.71.0 <0.72.0 || ~0.72.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.71.1 <0.72.0 || ~0.72.0-0",
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/events": ">=0.85.0 <0.86.0 || ~0.86.0-0",
+        "@typespec/http": "^1.15.0",
+        "@typespec/openapi": "^1.15.0",
+        "@typespec/rest": ">=0.85.0 <0.86.0 || ~0.86.0-0",
+        "@typespec/sse": ">=0.85.0 <0.86.0 || ~0.86.0-0",
+        "@typespec/streams": ">=0.85.0 <0.86.0 || ~0.86.0-0",
+        "@typespec/versioning": ">=0.85.0 <0.86.0 || ~0.86.0-0"
       }
     },
     "node_modules/@azure/abort-controller": {

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260818.5",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260817.7"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260818.17"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.44",
@@ -277,27 +277,6 @@
       "license": "MIT",
       "dependencies": {
         "@typespec/http-client-csharp": "1.0.0-alpha.20260818.17"
-      }
-    },
-    "node_modules/@azure-typespec/http-client-csharp/node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260818.17",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260818.17.tgz",
-      "integrity": "sha512-DiKrQD/iBaLqKjo72oR1z2ZA87HU2EYfhCrmpACqOPW/Aky1InYbNKWFwiahPxxssqGQxNFmMkuDRrKZ+OOM0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/identity": "^4.13.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.71.0 <0.72.0 || ~0.72.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.71.1 <0.72.0 || ~0.72.0-0",
-        "@typespec/compiler": "^1.15.0",
-        "@typespec/events": ">=0.85.0 <0.86.0 || ~0.86.0-0",
-        "@typespec/http": "^1.15.0",
-        "@typespec/openapi": "^1.15.0",
-        "@typespec/rest": ">=0.85.0 <0.86.0 || ~0.86.0-0",
-        "@typespec/sse": ">=0.85.0 <0.86.0 || ~0.86.0-0",
-        "@typespec/streams": ">=0.85.0 <0.86.0 || ~0.86.0-0",
-        "@typespec/versioning": ">=0.85.0 <0.86.0 || ~0.86.0-0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2222,9 +2201,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260817.7",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260817.7.tgz",
-      "integrity": "sha512-c8Ag1vGAuC8cs/+uUNoA1JC+b0XkOoSTRR34WcQVC0dkQWNzshl0zyzRBfVyHUmVUTMfalwmISttadgsFJ2j6g==",
+      "version": "1.0.0-alpha.20260818.17",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260818.17.tgz",
+      "integrity": "sha512-DiKrQD/iBaLqKjo72oR1z2ZA87HU2EYfhCrmpACqOPW/Aky1InYbNKWFwiahPxxssqGQxNFmMkuDRrKZ+OOM0w==",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260818.5",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260817.7"
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260818.17"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.44",

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -38,7 +38,7 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260817.5",
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260818.5",
     "@typespec/http-client-csharp": "1.0.0-alpha.20260817.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Bump the management-plane generator dependencies:

- `@azure-typespec/http-client-csharp` and `Azure.Generator` from `1.0.0-alpha.20260817.5` to `1.0.0-alpha.20260818.5`.
- Direct `@typespec/http-client-csharp` from `1.0.0-alpha.20260817.7` to `1.0.0-alpha.20260818.17`, matching the version used by the updated Azure package and existing unbranded NuGet generator version.

This also refreshes the npm lockfile and emitter version dashboard. Regenerating the management test projects produced no source changes.

## Validation

- `pwsh eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1`
