### PR TITLE
Simple prototype on using checkout task with configuration instead of sparse-checkout

### DIFF
--- a/eng/packages/plugins/client/Client.Plugin/ci.yml
+++ b/eng/packages/plugins/client/Client.Plugin/ci.yml
@@ -35,11 +35,9 @@ extends:
       jobs:
       - job: Build
         steps:
-        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-          parameters:
-            Paths:
-              - "/sdk"
-              - "/common"
+        - checkout: self
+          fetchDepth: 1
+          fetchTags: false
         - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
         - template: /eng/pipelines/templates/steps/install-dotnet.yml
         - pwsh: |

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -83,21 +83,9 @@ jobs:
     steps:
       - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
       
-      - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
-        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-          parameters:
-            # we only need to checkout all sdk directories for All PR builds OR the
-            # deprecating AdditionalDependency leg of the core/resource builds. ProjectListOverrideFilePropertyName will be set in the latter case.
-            ${{ if and(ne(parameters.ServiceDirectory, 'auto'), eq(parameters.ProjectListOverrideFilePropertyName, '')) }}:
-              Paths:
-                - "/*"
-                - "!SessionRecords"
-                - "/sdk/${{ parameters.ServiceDirectory }}/**/SessionRecords/*"
-            ${{ else }}:
-              Paths:
-                - "/*"
-                - "!SessionRecords"
-                - "/sdk/*/**/SessionRecords/*"
+      - checkout: self
+        fetchDepth: 1
+        fetchTags: false
 
       - ${{ if ne(parameters.ProjectListOverrideFilePropertyName, '') }}:
         - task: DownloadPipelineArtifact@2

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -59,9 +59,7 @@ jobs:
           Path: eng/pipelines/templates/stages/build-matrix.json
           Selection: sparse
           GenerateVMJobs: true
-        SparseCheckoutPaths:
-          - "/*"
-          - "!SessionRecords"
+        SparseCheckout: false
         EnablePRGeneration: true
         PRMatrixSetting: ProjectNames
         PRJobBatchSize: 1
@@ -72,6 +70,9 @@ jobs:
           SDKType: ${{ parameters.SDKType }}
           BuildSnippets: ${{ parameters.BuildSnippets }}
         PreGenerationSteps:
+          - checkout: self
+            fetchDepth: 1
+            fetchTags: false
           - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
             parameters:
               ServiceDirectory: ${{ parameters.ServiceDirectory }}
@@ -96,9 +97,7 @@ jobs:
           Path: eng/pipelines/templates/stages/build-matrix.json
           Selection: sparse
           GenerateVMJobs: true
-        SparseCheckoutPaths:
-          - "/*"
-          - "!SessionRecords"
+        SparseCheckout: false
         EnablePRGeneration: true
         PRMatrixSetting: ProjectNames
         PRJobBatchSize: 1
@@ -109,6 +108,9 @@ jobs:
           BuildSnippets: ${{ parameters.BuildSnippets }}
           ArtifactName: AnalyzePackageInfoArtifact
         PreGenerationSteps:
+          - checkout: self
+            fetchDepth: 1
+            fetchTags: false
           - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
             parameters:
               ServiceDirectory: ${{ parameters.ServiceDirectory }}
@@ -176,6 +178,7 @@ jobs:
         os: windows
       steps:
         - checkout: self
+          fetchDepth: 1
           fetchFilter: tree:0
           fetchTags: false
 
@@ -214,9 +217,7 @@ jobs:
         CloudConfig:
           Cloud: public
         ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-          SparseCheckoutPaths:
-            - "/*"
-            - "!SessionRecords"
+          SparseCheckout: false
           EnablePRGeneration: true
           PRMatrixSetting: ProjectNames
           PRJobBatchSize: 10
@@ -224,6 +225,9 @@ jobs:
             - 'AdditionalTestArguments=.*true'
             - 'Pool=.*LinuxPool$'
           PreGenerationSteps:
+            - checkout: self
+              fetchDepth: 1
+              fetchTags: false
             - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
               parameters:
                 ServiceDirectory: ${{ parameters.ServiceDirectory }}
@@ -250,10 +254,11 @@ jobs:
               - ${{ matrixReplace }}
         CloudConfig:
           Cloud: public
-        SparseCheckoutPaths:
-          - /*
-          - '!/sdk/*/**/SessionRecords/*'
+        SparseCheckout: false
         PreGenerationSteps:
+          - checkout: self
+            fetchDepth: 1
+            fetchTags: false
           - ${{ each config in parameters.MatrixConfigs }}:
               - template: /eng/pipelines/templates/steps/dependency.tests.yml
                 parameters:

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -97,12 +97,9 @@ jobs:
       container: $[ variables['Container'] ]
 
     steps:
-      - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
-        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-          parameters:
-              Paths:
-                - "/*"
-                - "!SessionRecords"
+      - checkout: self
+        fetchDepth: 1
+        fetchTags: false
 
       - ${{ parameters.PreSteps }}
 

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -16,12 +16,9 @@ parameters:
     default: BuildPackagesArtifact
 
 steps:
-  - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
-    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-      parameters:
-          Paths:
-            - "/*"
-            - "!SessionRecords"
+  - checkout: self
+    fetchDepth: 1
+    fetchTags: false
 
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
 

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -16,12 +16,9 @@ parameters:
     default: true
 
 steps:
-  - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
-    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-      parameters:
-        Paths:
-          - "/*"
-          - "!SessionRecords"
+  - checkout: self
+    fetchDepth: 1
+    fetchTags: false
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
   - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
     parameters:


### PR DESCRIPTION
Simple prototype PR replacing custom `sparse-checkout` template usage with built-in `checkout` task with configurations on fetch depth and inclusion of tags when `sparse-checkout` is performing a sizeable checkout (based on included paths). Our custom `sparse-checkout` has a lot of complexity and injects large amounts of inline PowerShell code into YAML, making maintenance on it costly and liable to cause YAML too big issues with Azure DevOps.