### PR TITLE
[Azure.Data.Tables] Prepare 12.12.0 release

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Release History
 
-## 12.12.0-beta.1 (Unreleased)
+## 12.12.0 (2026-08-20)
 
 ### Acknowledgments
 
 Thank you to our developer community members who helped to make Azure Tables better with their contributions to this release:
 
 - Marco Studerus _([GitHub](https://github.com/e-i-n-s))_
-
-### Features Added
-
-### Breaking Changes
 
 ### Bugs Fixed
 - Fixed an error handling issue where `GetEntityAsync` and `GetEntityIfExistsAsync` could throw an
@@ -23,6 +19,7 @@ Thank you to our developer community members who helped to make Azure Tables bet
 - Fixed duplicated diagnostic scopes in `TableClient.Query` and `TableServiceClient.Query` (A community contribution, courtesy of _[e-i-n-s](https://github.com/e-i-n-s)_)
 
 ### Other Changes
+- Updated the minimum `Azure.Core` dependency to 1.61.0 and added .NET 10 target framework support. ([#62244](https://github.com/Azure/azure-sdk-for-net/issues/62244))
 - Use precedence rules to reduce the parenthesis nesting in OData filters generated from LINQ expressions.
  
 ## 12.11.0 (2025-05-06)

--- a/sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj
+++ b/sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This client library enables working with the Microsoft Azure Table service</Description>
     <AssemblyTitle>Microsoft Azure.Data.Tables client library</AssemblyTitle>
-    <Version>12.12.0-beta.1</Version>
+    <Version>12.12.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>12.11.0</ApiCompatVersion>
     <DefineConstants>TableSDK;$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
## Summary
- prepare Azure.Data.Tables 12.12.0 for release on August 20, 2026
- document the updated Azure.Core dependency and .NET 10 target framework support

Fixes #62244

## Testing
- `dotnet format sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj`
- `dotnet build sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj --no-restore`