### PR TITLE
Enable nullable analysis for AzurePipelineResponse

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/AzurePipelineResponse.cs
+++ b/sdk/core/Azure.Core/src/Shared/AzurePipelineResponse.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;


### PR DESCRIPTION
## Summary
- enable nullable reference type analysis for AzurePipelineResponse

## Testing
- dotnet format sdk/core/Azure.Core/src/Azure.Core.csproj
- dotnet build sdk/core/Azure.Core/src/Azure.Core.csproj --no-restore