### PR TITLE
[Service Bus] Add list sessions samples

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
@@ -33,6 +33,7 @@ description: Samples for the Azure.Messaging.ServiceBus client library
 - [Distributed tracing and monitoring](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md)
 - [Performance patterns](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample20_PerformancePatterns.md)
 - [Auto-forwarding into a session-enabled queue](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_AutoForwardIntoSession.md)
+- [List message sessions](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample22_GetMessageSessions.md)
 
 ## Application samples
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample22_GetMessageSessions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample22_GetMessageSessions.md
@@ -1,0 +1,46 @@
+# List message sessions
+
+This sample demonstrates how to list session IDs for a session-enabled queue or subscription using `ServiceBusClient.GetMessageSessionsAsync`.
+Without a filter, listing returns sessions with active messages or stored session state and excludes sessions with neither.
+
+## Queue
+
+```C# Snippet:ServiceBusGetMessageSessionsFromQueue
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+string queueName = "<queue_name>";
+
+await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
+
+await foreach (string sessionId in client.GetMessageSessionsAsync(queueName))
+{
+    Console.WriteLine(sessionId);
+}
+```
+
+## Topic subscription
+
+```C# Snippet:ServiceBusGetMessageSessionsFromSubscription
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+string topicName = "<topic_name>";
+string subscriptionName = "<subscription_name>";
+
+await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
+
+await foreach (string sessionId in client.GetMessageSessionsAsync(topicName, subscriptionName))
+{
+    Console.WriteLine(sessionId);
+}
+```
+
+## Sessions with recently updated state
+
+Pass a real cutoff to list only sessions whose stored session state was set or updated after that time:
+
+```C# Snippet:ServiceBusGetMessageSessionsUpdatedAfter
+DateTimeOffset stateUpdatedAfter = DateTimeOffset.UtcNow.AddDays(-7);
+
+await foreach (string sessionId in client.GetMessageSessionsAsync(queueName, stateUpdatedAfter))
+{
+    Console.WriteLine(sessionId);
+}
+```

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample22_GetMessageSessions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample22_GetMessageSessions.md
@@ -37,6 +37,11 @@ await foreach (string sessionId in client.GetMessageSessionsAsync(topicName, sub
 Pass a real cutoff to list only sessions whose stored session state was set or updated after that time:
 
 ```C# Snippet:ServiceBusGetMessageSessionsUpdatedAfter
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+string queueName = "<queue_name>";
+
+await using ServiceBusClient client = new(fullyQualifiedNamespace, new DefaultAzureCredential());
+
 DateTimeOffset stateUpdatedAfter = DateTimeOffset.UtcNow.AddDays(-7);
 
 await foreach (string sessionId in client.GetMessageSessionsAsync(queueName, stateUpdatedAfter))


### PR DESCRIPTION
## Summary

Adds discoverable samples for `ServiceBusClient.GetMessageSessionsAsync` covering both supported modes:

- Default listing: sessions with active messages or stored session state.
- Filtered listing: sessions whose stored state was set or updated after a cutoff.

No runtime behavior or public API changes.

## Testing

- Verified queue and subscription overload signatures in `ServiceBusClient`.
- Verified sample links and `git diff --check`.

Related implementation: Azure/azure-sdk-for-net#58761
