### PR TITLE
Update Azure.ClientSdk.Analyzers

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -233,7 +233,7 @@
   <!--                  package dependencies                          -->
   <!-- ============================================================== -->
   <ItemGroup>
-    <PackageVersion Include="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20260723.1" PrivateAssets="All" />
+    <PackageVersion Include="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20260819.1" PrivateAssets="All" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20251023.1" PrivateAssets="All" />
 


### PR DESCRIPTION
Updates `Azure.ClientSdk.Analyzers` to `0.1.1-dev.20260819.1`, which contains the removal of the legacy AZC0004 implementation from Azure/azure-sdk-tools#16775.

The replacement AZC0004 implementation, including the async streaming exemption, was added in #62270.