### PR TITLE
[Service Bus] Prepare Azure.Messaging.ServiceBus 7.21.0-beta.1 release

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 7.21.0-beta.1 (Unreleased)
+## 7.21.0-beta.1 (2026-08-21)
 
 ### Features Added
 
@@ -8,10 +8,6 @@
 - Added `ServiceBusAdministrationClientOptions.ServiceVersion.V2024_05` and made it the default service version. The topic filter counts above are served by the `2024-05` service API version, so the administration client now sends `api-version=2024-05` by default.
 - Added `GetMessageSessionsAsync` overloads on `ServiceBusClient` for queues and subscriptions. The no-filter overload returns the IDs of sessions that have active messages or session state, and the `sessionStateUpdatedAfter` overload returns session IDs whose session state was updated after the specified timestamp. Implements the `com.microsoft:get-message-sessions` AMQP management operation. ([#58761](https://github.com/Azure/azure-sdk-for-net/pull/58761))
 - Added opt-in support for non-exclusive session locking on `ServiceBusSessionReceiver`, allowing a session to be cooperatively taken over by another receiver. Set `ServiceBusSessionReceiverOptions.EnableNonExclusiveSession` to accept a session non-exclusively, then read the token from `ServiceBusSessionReceiver.SessionLockToken` and pass it as `ServiceBusSessionReceiverOptions.SessionLockToken = Guid.Parse(token)` to take that session over. `ServiceBusSessionReceiver.IsSessionExclusive` reports the mode the session was established under. Dispositions for a non-exclusive session are routed over the management link so that settlement keeps working across a takeover, which lowers settlement throughput compared to an exclusive session. This applies to `ServiceBusSessionReceiver` only; `ServiceBusSessionProcessor` continues to lock sessions exclusively. Accepting a session with `EnableNonExclusiveSession` set throws `NotSupportedException` when the endpoint declines it, either by refusing the request outright or by accepting it without assigning a lock token, which is how a caller detects whether the feature is available for a namespace. An endpoint that declines in some other way surfaces the exception its own error maps to. ([#60060](https://github.com/Azure/azure-sdk-for-net/pull/60060))
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 


### PR DESCRIPTION
## Summary

Prepares `Azure.Messaging.ServiceBus` `7.21.0-beta.1` for the planned
August 21, 2026 release.

## Changes

- `sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md`

No additional package changes.

## Cross-SDK release set

| SDK | Package | Version | PR |
|-----|---------|---------|----|
| .NET | `Azure.Messaging.ServiceBus` | `7.21.0-beta.1` | [#62282](https://github.com/Azure/azure-sdk-for-net/pull/62282) |
| Java | `azure-messaging-servicebus` | `7.18.0-beta.3` | [#50198](https://github.com/Azure/azure-sdk-for-java/pull/50198) |
| JavaScript | `@azure/service-bus` | `7.10.0-beta.5` | [#39672](https://github.com/Azure/azure-sdk-for-js/pull/39672) |
| Go | `sdk/messaging/azservicebus` | `1.11.0-beta.1` | [#27420](https://github.com/Azure/azure-sdk-for-go/pull/27420) |
| Python | `azure-servicebus` | `7.15.0b2` | [#48649](https://github.com/Azure/azure-sdk-for-python/pull/48649) |

## Validation

- `./eng/common/scripts/Prepare-Release.ps1 -PackageName Azure.Messaging.ServiceBus -ServiceDirectory servicebus -ReleaseDate '08/21/2026'`
- `git diff --check`
- Metadata-only change; no product tests required.

## Release controls

- Release tracking: [27586 - .NET - Service Bus - 7.21](https://dev.azure.com/azure-sdk/Release/_workitems/edit/27586/)
- Release pipeline: Not queued by this PR.
