### PR TITLE
Bump management emitter dependencies

### DIFF
--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,13 +1,13 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-19 23:07:08 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-20 04:41:48 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Latest Published Version Chain
 
 ```
 @typespec/http-client-csharp (alpha.20260819.14)
-  └─ @azure-typespec/http-client-csharp (alpha.20260819.2)
+  └─ @azure-typespec/http-client-csharp (alpha.20260819.3)
        └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260819.3)
             └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260818.1)
 ```
@@ -17,8 +17,8 @@
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
 | `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | 1.0.0-alpha.20260819.14 | 1.0.0-alpha.20260819.14 | [365ec52](https://github.com/microsoft/typespec/commit/365ec52b50b82cd9e1e037de4c6fcd5de7e32e90) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | 1.0.0-alpha.20260817.5 | 1.0.0-alpha.20260819.2 | [e90d659](https://github.com/Azure/azure-sdk-for-net/commit/e90d659517b79c16ffbcc613f7980adafe003c22) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | 1.0.0-alpha.20260812.1 | 1.0.0-alpha.20260819.3 | [ad23c92](https://github.com/Azure/azure-sdk-for-net/commit/ad23c928f50a12ca01629266a2d8d4ad3798dcad) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260819.3](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260819.3) | [1.0.0-alpha.20260819.3](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260819.3) | [b77d431](https://github.com/Azure/azure-sdk-for-net/commit/b77d43115c7ebe317d6e736c77cd81ae9a735ee1) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260812.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260812.1) | [1.0.0-alpha.20260819.3](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260819.3) | [ad23c92](https://github.com/Azure/azure-sdk-for-net/commit/ad23c928f50a12ca01629266a2d8d4ad3798dcad) |
 
 ## Source Files
 

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260819.14</UnbrandedGeneratorVersion>
-    <AzureGeneratorVersion>1.0.0-alpha.20260817.5</AzureGeneratorVersion>
+    <AzureGeneratorVersion>1.0.0-alpha.20260819.3</AzureGeneratorVersion>
     <AzureManagementGeneratorVersion>1.0.0-alpha.20260812.1</AzureManagementGeneratorVersion>
   </PropertyGroup>
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -432,8 +432,7 @@ function convertResolvedResourceToMetadata(
 
   // Convert resource scope
   const resourceScopeValue = convertScopeToResourceScope(
-    resolvedResource.scope,
-    resourceIdPattern
+    resolvedResource.scope
   );
 
   // Build resource type string
@@ -525,15 +524,11 @@ function getMethodIdFromOperation(
  * Convert scope string/object to ResourceScopeKind enum
  */
 function convertScopeToResourceScope(
-  scope: string | ResolvedResource | undefined,
-  resourceIdPattern: string
+  scope: string | ResolvedResource | undefined
 ): ResourceScopeKind {
-  const pathScope = resourceIdPattern
-    ? new RequestPath(resourceIdPattern).operationScope
-    : ResourceScopeKind.ResourceGroup;
-
   if (!scope) {
-    return pathScope;
+    // TODO: does it make sense that we have something without scope??
+    return ResourceScopeKind.ResourceGroup; // Default
   }
 
   if (typeof scope === "string") {
@@ -550,7 +545,7 @@ function convertScopeToResourceScope(
       case "ExternalResource":
         return ResourceScopeKind.Extension;
       default:
-        return pathScope;
+        return ResourceScopeKind.ResourceGroup;
     }
   }
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -432,7 +432,8 @@ function convertResolvedResourceToMetadata(
 
   // Convert resource scope
   const resourceScopeValue = convertScopeToResourceScope(
-    resolvedResource.scope
+    resolvedResource.scope,
+    resourceIdPattern
   );
 
   // Build resource type string
@@ -524,11 +525,15 @@ function getMethodIdFromOperation(
  * Convert scope string/object to ResourceScopeKind enum
  */
 function convertScopeToResourceScope(
-  scope: string | ResolvedResource | undefined
+  scope: string | ResolvedResource | undefined,
+  resourceIdPattern: string
 ): ResourceScopeKind {
+  const pathScope = resourceIdPattern
+    ? new RequestPath(resourceIdPattern).operationScope
+    : ResourceScopeKind.ResourceGroup;
+
   if (!scope) {
-    // TODO: does it make sense that we have something without scope??
-    return ResourceScopeKind.ResourceGroup; // Default
+    return pathScope;
   }
 
   if (typeof scope === "string") {
@@ -545,7 +550,7 @@ function convertScopeToResourceScope(
       case "ExternalResource":
         return ResourceScopeKind.Extension;
       default:
-        return ResourceScopeKind.ResourceGroup;
+        return pathScope;
     }
   }
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -527,11 +527,11 @@ function assignRemainingOperations(
       const scope = buildScopeInfoFromPath(operationPath);
       const isCollectionAction = isResourceCollectionAction(sdkMethod);
       const target = isCollectionAction
-        ? findCollectionActionTargetResource(
+        ? (findCollectionActionTargetResource(
             resources,
             operationPath,
             actionTarget
-          ) ?? actionTarget
+          ) ?? actionTarget)
         : actionTarget;
       target.metadata.methods.push({
         methodId,

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -527,11 +527,11 @@ function assignRemainingOperations(
       const scope = buildScopeInfoFromPath(operationPath);
       const isCollectionAction = isResourceCollectionAction(sdkMethod);
       const target = isCollectionAction
-        ? (findCollectionActionTargetResource(
+        ? findCollectionActionTargetResource(
             resources,
             operationPath,
             actionTarget
-          ) ?? actionTarget)
+          ) ?? actionTarget
         : actionTarget;
       target.metadata.methods.push({
         methodId,

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
@@ -9,10 +9,7 @@ import {
   SdkHttpOperation,
   SdkMethod
 } from "@azure-tools/typespec-client-generator-core";
-import type {
-  CodeModel,
-  CSharpEmitterContext
-} from "./code-model-types.js";
+import type { CodeModel, CSharpEmitterContext } from "./code-model-types.js";
 import { getAllSdkClients } from "./sdk-client-utils.js";
 
 // https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-resource-manager/README.md#armprovidernamespace

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
@@ -9,7 +9,10 @@ import {
   SdkHttpOperation,
   SdkMethod
 } from "@azure-tools/typespec-client-generator-core";
-import type { CodeModel, CSharpEmitterContext } from "./code-model-types.js";
+import type {
+  CodeModel,
+  CSharpEmitterContext
+} from "./code-model-types.js";
 import { getAllSdkClients } from "./sdk-client-utils.js";
 
 // https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-resource-manager/README.md#armprovidernamespace

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -12,10 +12,7 @@ import { createModel } from "@typespec/http-client-csharp";
 import { buildArmProviderSchema } from "../src/resource-detection.js";
 import { resolveArmResources } from "../src/resolve-arm-resources-converter.js";
 import { ok, strictEqual, deepStrictEqual } from "assert";
-import {
-  ArmResourceSchema,
-  ResourceScopeKind
-} from "../src/resource-metadata.js";
+import { ResourceScopeKind } from "../src/resource-metadata.js";
 
 describe("Resource Detection", () => {
   let runner: TestHost;
@@ -2198,37 +2195,29 @@ interface SitesByServiceGroup extends SiteOps<ServiceGroup> {}
     const resolvedSchema = resolveArmResources(program, sdkContext);
     ok(resolvedSchema);
 
-    // Compare the entire schemas using deep equality
-    // Note: The two APIs have a known difference in how they classify ServiceGroup scope:
-    // - Legacy detection (buildArmProviderSchema): uses Tenant scope
-    // - resolveArmResources: uses Extension scope
-    // We normalize ResourceScopeKind and operationScope only for the ServiceGroup-scoped resource
-    const serviceGroupResourcePattern =
-      "/providers/Microsoft.Management/serviceGroups/{servicegroupName}/providers/Microsoft.ContosoProviderHub/sites/{siteName}";
-    const normalizeServiceGroupScopes = (resource: ArmResourceSchema) => {
-      const resourceIdPattern = (
-        resource.metadata as {
-          resourceIdPattern: string | { path: string };
-        }
-      ).resourceIdPattern;
-      const resourceIdPath =
-        typeof resourceIdPattern === "string"
-          ? resourceIdPattern
-          : resourceIdPattern.path;
-      if (resourceIdPath === serviceGroupResourcePattern) {
-        (resource.metadata as { scope: { kind: unknown } }).scope.kind =
-          "<normalized>";
-        for (const method of resource.metadata.methods) {
-          (method as { scope: { kind: unknown } }).scope.kind = "<normalized>";
-        }
-      }
-    };
+    const resolvedSiteResources = resolvedSchema.resources.filter(
+      (r) => r.resourceModelId === siteModelId
+    );
+    const getResolvedScope = (resourceIdPattern: string) =>
+      resolvedSiteResources.find(
+        (r) => r.metadata.resourceIdPattern.path === resourceIdPattern
+      )?.metadata.scope.kind;
+    strictEqual(
+      getResolvedScope(rgSite.metadata.resourceIdPattern.path),
+      ResourceScopeKind.ResourceGroup
+    );
+    strictEqual(
+      getResolvedScope(subSite.metadata.resourceIdPattern.path),
+      ResourceScopeKind.Subscription
+    );
+    strictEqual(
+      getResolvedScope(sgSite.metadata.resourceIdPattern.path),
+      ResourceScopeKind.Extension
+    );
+
     deepStrictEqual(
-      normalizeSchemaForComparison(resolvedSchema, normalizeServiceGroupScopes),
-      normalizeSchemaForComparison(
-        armProviderSchema,
-        normalizeServiceGroupScopes
-      )
+      normalizeSchemaForComparison(resolvedSchema),
+      normalizeSchemaForComparison(armProviderSchema)
     );
   });
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -12,7 +12,10 @@ import { createModel } from "@typespec/http-client-csharp";
 import { buildArmProviderSchema } from "../src/resource-detection.js";
 import { resolveArmResources } from "../src/resolve-arm-resources-converter.js";
 import { ok, strictEqual, deepStrictEqual } from "assert";
-import { ResourceScopeKind } from "../src/resource-metadata.js";
+import {
+  ArmResourceSchema,
+  ResourceScopeKind
+} from "../src/resource-metadata.js";
 
 describe("Resource Detection", () => {
   let runner: TestHost;
@@ -2195,29 +2198,37 @@ interface SitesByServiceGroup extends SiteOps<ServiceGroup> {}
     const resolvedSchema = resolveArmResources(program, sdkContext);
     ok(resolvedSchema);
 
-    const resolvedSiteResources = resolvedSchema.resources.filter(
-      (r) => r.resourceModelId === siteModelId
-    );
-    const getResolvedScope = (resourceIdPattern: string) =>
-      resolvedSiteResources.find(
-        (r) => r.metadata.resourceIdPattern.path === resourceIdPattern
-      )?.metadata.scope.kind;
-    strictEqual(
-      getResolvedScope(rgSite.metadata.resourceIdPattern.path),
-      ResourceScopeKind.ResourceGroup
-    );
-    strictEqual(
-      getResolvedScope(subSite.metadata.resourceIdPattern.path),
-      ResourceScopeKind.Subscription
-    );
-    strictEqual(
-      getResolvedScope(sgSite.metadata.resourceIdPattern.path),
-      ResourceScopeKind.Extension
-    );
-
+    // Compare the entire schemas using deep equality
+    // Note: The two APIs have a known difference in how they classify ServiceGroup scope:
+    // - Legacy detection (buildArmProviderSchema): uses Tenant scope
+    // - resolveArmResources: uses Extension scope
+    // We normalize ResourceScopeKind and operationScope only for the ServiceGroup-scoped resource
+    const serviceGroupResourcePattern =
+      "/providers/Microsoft.Management/serviceGroups/{servicegroupName}/providers/Microsoft.ContosoProviderHub/sites/{siteName}";
+    const normalizeServiceGroupScopes = (resource: ArmResourceSchema) => {
+      const resourceIdPattern = (
+        resource.metadata as {
+          resourceIdPattern: string | { path: string };
+        }
+      ).resourceIdPattern;
+      const resourceIdPath =
+        typeof resourceIdPattern === "string"
+          ? resourceIdPattern
+          : resourceIdPattern.path;
+      if (resourceIdPath === serviceGroupResourcePattern) {
+        (resource.metadata as { scope: { kind: unknown } }).scope.kind =
+          "<normalized>";
+        for (const method of resource.metadata.methods) {
+          (method as { scope: { kind: unknown } }).scope.kind = "<normalized>";
+        }
+      }
+    };
     deepStrictEqual(
-      normalizeSchemaForComparison(resolvedSchema),
-      normalizeSchemaForComparison(armProviderSchema)
+      normalizeSchemaForComparison(resolvedSchema, normalizeServiceGroupScopes),
+      normalizeSchemaForComparison(
+        armProviderSchema,
+        normalizeServiceGroupScopes
+      )
     );
   });
 

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -2202,8 +2202,8 @@
     },
     "node_modules/@typespec/http-client-csharp": {
       "version": "1.0.0-alpha.20260819.14",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260819.14.tgz",
-      "integrity": "sha1-nSpS+PpMK69feOMR8yPicGBLgsw=",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260819.14.tgz",
+      "integrity": "sha512-FlHV1gfF6IhdHTqI3HOAdCpaxFZ7GKCwepKtBtHWcYHrbpGX1a5dkWj1i+EmxLN9JbxoylFs/e6NsEcFyizDCQ==",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260817.5",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260817.7"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260819.3",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260819.14"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.44",
@@ -271,12 +271,12 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260817.5",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260817.5.tgz",
-      "integrity": "sha1-yL0riAqhAOKK6iYj98u4tdd1F6A=",
+      "version": "1.0.0-alpha.20260819.3",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260819.3.tgz",
+      "integrity": "sha1-Ptb19vgE2CO1y0qtk9vG2VPknMY=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260817.7"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260819.14"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2201,9 +2201,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260817.7",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260817.7.tgz",
-      "integrity": "sha512-c8Ag1vGAuC8cs/+uUNoA1JC+b0XkOoSTRR34WcQVC0dkQWNzshl0zyzRBfVyHUmVUTMfalwmISttadgsFJ2j6g==",
+      "version": "1.0.0-alpha.20260819.14",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260819.14.tgz",
+      "integrity": "sha1-nSpS+PpMK69feOMR8yPicGBLgsw=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -38,8 +38,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260817.5",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260817.7"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260819.3",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260819.14"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.44",


### PR DESCRIPTION
## Description

Bump the management-plane generator dependencies:

- `@azure-typespec/http-client-csharp` and `Azure.Generator` to `1.0.0-alpha.20260819.3`.
- Direct `@typespec/http-client-csharp` to `1.0.0-alpha.20260819.14`, matching the version used by the updated Azure package and the existing unbranded NuGet generator version.

This also refreshes the npm lockfile and emitter version dashboard. Regenerating the management test projects produced no source changes.

## Validation

- `npm run build:emitter`
- `npm run build:generator`
- `npm run lint`
- `npm run prettier`
- `npm test`
- `pwsh eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1`
