### PR TITLE
CSEv2 support Python/Java nonce patterns

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -190,7 +190,6 @@ namespace Azure.Storage.Cryptography
             if (!CompatSwitches.CseV2AllowMisorderedAuthRegions)
             {
                 Argument.AssertInRange(initialAuthRegion, 0, long.MaxValue, nameof(initialAuthRegion));
-                // regions are 0-indexed, but nonce values are 1-indexed
                 transform = new ForceSequentialNonceAuthenticatedCryptographicTransform(transform, initialAuthRegion);
             }
             return new AuthenticatedRegionCryptoStream(

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideDecryptor.cs
@@ -191,7 +191,7 @@ namespace Azure.Storage.Cryptography
             {
                 Argument.AssertInRange(initialAuthRegion, 0, long.MaxValue, nameof(initialAuthRegion));
                 // regions are 0-indexed, but nonce values are 1-indexed
-                transform = new ForceSequentialNonceAuthenticatedCryptographicTransform(transform, initialAuthRegion + 1);
+                transform = new ForceSequentialNonceAuthenticatedCryptographicTransform(transform, initialAuthRegion);
             }
             return new AuthenticatedRegionCryptoStream(
                 contentStream,

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ForceSequentialNonceAuthenticatedCryptographicTransform.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ForceSequentialNonceAuthenticatedCryptographicTransform.cs
@@ -121,7 +121,7 @@ internal class ForceSequentialNonceAuthenticatedCryptographicTransform : IAuthen
             {
                 1 => matches[0],
                 0 => throw new CryptographicException($"Encountered out-of-order nonce in region {_nextRegion}."),
-                _ => default,
+                _ => null,
             };
         }
         _nextRegion += 1;

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ForceSequentialNonceAuthenticatedCryptographicTransform.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ForceSequentialNonceAuthenticatedCryptographicTransform.cs
@@ -95,6 +95,10 @@ internal class ForceSequentialNonceAuthenticatedCryptographicTransform : IAuthen
             using IDisposable _2 = ArrayPool<byte>.Shared.RentAsSpanDisposable(NonceLength, out Span<byte> zeroBigLead8);
             using IDisposable _3 = ArrayPool<byte>.Shared.RentAsSpanDisposable(NonceLength, out Span<byte> oneLittleTrailing8);
 
+            zeroBig12.Clear();
+            zeroBigLead8.Clear();
+            oneLittleTrailing8.Clear();
+
             BinaryPrimitives.WriteInt64BigEndian(zeroBig12.Slice(NonceLength - longLength), _nextRegion);
             BinaryPrimitives.WriteInt64BigEndian(zeroBigLead8.Slice(0, longLength), _nextRegion);
             BinaryPrimitives.WriteInt64LittleEndian(oneLittleTrailing8.Slice(NonceLength - longLength), _nextRegion + 1);

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ForceSequentialNonceAuthenticatedCryptographicTransform.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ForceSequentialNonceAuthenticatedCryptographicTransform.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using Azure.Storage.Common;
 using Azure.Storage.Cryptography.Models;
@@ -11,8 +13,30 @@ namespace Azure.Storage.Cryptography;
 
 internal class ForceSequentialNonceAuthenticatedCryptographicTransform : IAuthenticatedCryptographicTransform
 {
+    private enum AcceptedNoncePatterns
+    {
+        /// <summary>
+        /// A full 12-byte integer, big endian.
+        /// The first value is 0.
+        /// </summary>
+        ZeroIndexBigEndian12,
+
+        /// <summary>
+        /// An eight byte integer followed by four zeroes, big endian.
+        /// The first value is 0.
+        /// </summary>
+        ZeroIndexBigEndianLeading8,
+
+        /// <summary>
+        /// Four zeroes followed by an eight byte integer, little endian.
+        /// The first value is 1.
+        /// </summary>
+        OneIndexLittleEndianTrailing8,
+    }
+
     private readonly IAuthenticatedCryptographicTransform _inner;
-    private long _next;
+    private long _nextRegion;
+    private AcceptedNoncePatterns? _noncePattern;
 
     public TransformMode TransformMode => _inner.TransformMode;
 
@@ -22,7 +46,7 @@ internal class ForceSequentialNonceAuthenticatedCryptographicTransform : IAuthen
 
     public ForceSequentialNonceAuthenticatedCryptographicTransform(
         IAuthenticatedCryptographicTransform inner,
-        long countStart)
+        long initialRegion)
     {
         Argument.AssertNotNull(inner, nameof(inner));
         if (inner.TransformMode != TransformMode.Decrypt)
@@ -31,7 +55,7 @@ internal class ForceSequentialNonceAuthenticatedCryptographicTransform : IAuthen
         }
         Argument.AssertInRange(inner.NonceLength, sizeof(long), int.MaxValue, nameof(inner.NonceLength));
         _inner = inner;
-        _next = countStart;
+        _nextRegion = initialRegion;
     }
 
     public void Dispose() => _inner.Dispose();
@@ -42,28 +66,60 @@ internal class ForceSequentialNonceAuthenticatedCryptographicTransform : IAuthen
         return _inner.TransformAuthenticationBlock(input, output);
     }
 
-    private void AssertNonceAndIncrement(ReadOnlySpan<byte> actual)
+    private void AssertNonceAndIncrement(ReadOnlySpan<byte> actualBytes)
     {
-        var array = ArrayPool<byte>.Shared.Rent(NonceLength);
-        Array.Clear(array, 0, array.Length);
-        try
+        const int longLength = 8;
+        if (_noncePattern.HasValue)
         {
-            Span<byte> expected = new(array, 0, NonceLength);
-            const int longBytes = 8;
-            BitConverter.GetBytes(_next).CopyTo(expected.Slice(NonceLength - longBytes));
-            if (!expected.SequenceEqual(actual))
+            long actual = _noncePattern.Value switch
             {
-                string nonceToString(ReadOnlySpan<byte> span)
-                {
-                    return BitConverter.ToInt64(span.Slice(NonceLength - longBytes).ToArray(), 0).ToString();
-                }
-                throw new CryptographicException($"Encountered out-of-order authenticated region. Expected {nonceToString(expected)}, got {nonceToString(actual)}.");
+                // we will never exceed 8 bytes. we can cast to a long just fine.
+                AcceptedNoncePatterns.ZeroIndexBigEndian12 => BinaryPrimitives.ReadInt64BigEndian(actualBytes.Slice(NonceLength - longLength)),// we will never exceed 8 bytes. we can cast to a long just fine.
+                AcceptedNoncePatterns.ZeroIndexBigEndianLeading8 => BinaryPrimitives.ReadInt64BigEndian(actualBytes.Slice(0, longLength)),
+                AcceptedNoncePatterns.OneIndexLittleEndianTrailing8 => BinaryPrimitives.ReadInt64LittleEndian(actualBytes.Slice(NonceLength - longLength)),
+                _ => throw new Exception(),
+            };
+            long expected = _noncePattern.Value switch
+            {
+                AcceptedNoncePatterns.OneIndexLittleEndianTrailing8 => _nextRegion + 1,
+                _ => _nextRegion,
+            };
+            if (expected != actual)
+            {
+                throw new CryptographicException($"Encountered out-of-order nonce in region {_nextRegion}.");
             }
-            _next += 1;
         }
-        finally
+        else
         {
-            ArrayPool<byte>.Shared.Return(array);
+            using IDisposable _1 = ArrayPool<byte>.Shared.RentAsSpanDisposable(NonceLength, out Span<byte> zeroBig12);
+            using IDisposable _2 = ArrayPool<byte>.Shared.RentAsSpanDisposable(NonceLength, out Span<byte> zeroBigLead8);
+            using IDisposable _3 = ArrayPool<byte>.Shared.RentAsSpanDisposable(NonceLength, out Span<byte> oneLittleTrailing8);
+
+            BinaryPrimitives.WriteInt64BigEndian(zeroBig12.Slice(NonceLength - longLength), _nextRegion);
+            BinaryPrimitives.WriteInt64BigEndian(zeroBigLead8.Slice(0, longLength), _nextRegion);
+            BinaryPrimitives.WriteInt64LittleEndian(oneLittleTrailing8.Slice(NonceLength - longLength), _nextRegion + 1);
+
+            List<AcceptedNoncePatterns> matches = new(3);
+            if (actualBytes.SequenceEqual(zeroBig12))
+            {
+                matches.Add(AcceptedNoncePatterns.ZeroIndexBigEndian12);
+            }
+            if (actualBytes.SequenceEqual(zeroBigLead8))
+            {
+                matches.Add(AcceptedNoncePatterns.ZeroIndexBigEndianLeading8);
+            }
+            if (actualBytes.SequenceEqual(oneLittleTrailing8))
+            {
+                matches.Add(AcceptedNoncePatterns.OneIndexLittleEndianTrailing8);
+            }
+
+            _noncePattern = matches.Count switch
+            {
+                1 => matches[0],
+                0 => throw new CryptographicException($"Encountered out-of-order nonce in region {_nextRegion}."),
+                _ => default,
+            };
         }
+        _nextRegion += 1;
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ForceSequentialNonceAuthenticatedCryptographicTransform.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ForceSequentialNonceAuthenticatedCryptographicTransform.cs
@@ -77,7 +77,7 @@ internal class ForceSequentialNonceAuthenticatedCryptographicTransform : IAuthen
                 AcceptedNoncePatterns.ZeroIndexBigEndian12 => BinaryPrimitives.ReadInt64BigEndian(actualBytes.Slice(NonceLength - longLength)),// we will never exceed 8 bytes. we can cast to a long just fine.
                 AcceptedNoncePatterns.ZeroIndexBigEndianLeading8 => BinaryPrimitives.ReadInt64BigEndian(actualBytes.Slice(0, longLength)),
                 AcceptedNoncePatterns.OneIndexLittleEndianTrailing8 => BinaryPrimitives.ReadInt64LittleEndian(actualBytes.Slice(NonceLength - longLength)),
-                _ => throw new Exception(),
+                _ => throw new Exception("Missing switch case. Please report."),
             };
             long expected = _noncePattern.Value switch
             {

--- a/sdk/storage/Azure.Storage.Common/tests/AuthenticatedRegionCryptoStreamTest.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/AuthenticatedRegionCryptoStreamTest.cs
@@ -470,7 +470,7 @@ namespace Azure.Storage.Test
             IAuthenticatedCryptographicTransform transform = new GcmAuthenticatedCryptographicTransform(cek, TransformMode.Decrypt);
             if (detectReorder)
             {
-                transform = new ForceSequentialNonceAuthenticatedCryptographicTransform(transform, 1);
+                transform = new ForceSequentialNonceAuthenticatedCryptographicTransform(transform, 0);
             }
             destStream = new MemoryStream();
             writeStream = new AuthenticatedRegionCryptoStream(
@@ -515,7 +515,7 @@ namespace Azure.Storage.Test
             IAuthenticatedCryptographicTransform transform = new GcmAuthenticatedCryptographicTransform(cek, TransformMode.Decrypt);
             if (detectReorder)
             {
-                transform = new ForceSequentialNonceAuthenticatedCryptographicTransform(transform, 1);
+                transform = new ForceSequentialNonceAuthenticatedCryptographicTransform(transform, 0);
             }
             destStream = new MemoryStream();
             readStream = new AuthenticatedRegionCryptoStream(

--- a/sdk/storage/Azure.Storage.Queues/src/Azure.Storage.Queues.csproj
+++ b/sdk/storage/Azure.Storage.Queues/src/Azure.Storage.Queues.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(AzureStorageSharedSources)Argument.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)BufferExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\*.cs" LinkBase="Shared\ClientsideEncryption" />
     <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\Models\*.cs" LinkBase="Shared\ClientsideEncryption\Models" />
     <Compile Include="$(AzureStorageSharedSources)Constants.cs" LinkBase="Shared" />


### PR DESCRIPTION
#61713 added a detection mechanism for reordered auth regions, but it assumed all CSE implementations across languages used the same nonce pattern. There are three different patterns in official circulation. This expands support to all three.