### PR TITLE
Update Tables code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,7 +87,6 @@
 
 /sdk/ai/Azure.AI.Projects.Agents/    @rhurey
 
-/sdk/tables/Azure.Data.Tables/    @jorgerangel-msft @jsquire
 
 # PRLabel: %AI Agents
 /sdk/agentserver/    @ankitbko @RaviPidaparthi @Shivakishore14 @vangarp
@@ -514,7 +513,7 @@
 # ServiceOwners: @wanyang7
 
 # PRLabel: %Tables
-/sdk/tables/    @jorgerangel-msft
+/sdk/tables/    @jorgerangel-msft @jsquire
 
 # AzureSdkOwners: @jorgerangel-msft
 # ServiceLabel: %Tables


### PR DESCRIPTION
The package-specific `/sdk/tables/Azure.Data.Tables/` record was shadowed by the later, broader `/sdk/tables/` rule, so it was not the effective ownership rule.

This change moves `@jsquire` onto the effective Tables rule and removes the redundant generated package-specific record.