### PR TITLE
[DO NOT MERGE] Diagnose Analytics pipeline identity

### DIFF
--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -95,8 +95,7 @@ steps:
         $directPackageCount = @($packageInfos | Where-Object { $_.IncludedForValidation -eq $false }).Count
         $indirectPackageCount = @($packageInfos | Where-Object { $_.IncludedForValidation -eq $true }).Count
         if ($directPackageCount -le 1 -and $indirectPackageCount -le 1) {
-          Write-Host "Runtime-weighted batching is unnecessary for $directPackageCount direct and $indirectPackageCount indirect package(s). Using count-based batching."
-          return
+          Write-Host "Runtime-weighted batching is unnecessary for $directPackageCount direct and $indirectPackageCount indirect package(s), but this diagnostic run will query Analytics."
         }
 
         try {

--- a/eng/pipelines/templates/steps/pr-matrix-presteps.yml
+++ b/eng/pipelines/templates/steps/pr-matrix-presteps.yml
@@ -116,6 +116,24 @@ steps:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - pwsh: |
+        $connection = Invoke-RestMethod `
+          -Uri "$(System.CollectionUri)_apis/connectionData?connectOptions=1&lastChangeId=-1&lastChangeId64=-1&api-version=7.1-preview.1" `
+          -Headers @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+
+        $identity = $connection.authenticatedUser
+        Write-Host "System.AccessToken identity: $($identity.providerDisplayName)"
+        Write-Host "Identity ID: $($identity.id)"
+        Write-Host "Subject descriptor: $($identity.subjectDescriptor)"
+        Write-Host "Project: $(System.TeamProject) ($(System.TeamProjectId))"
+        Write-Host "Pipeline: $(Build.DefinitionName) ($(System.DefinitionId))"
+        Write-Host "##vso[task.logissue type=error]Intentionally failing after logging the System.AccessToken identity."
+        exit 1
+      displayName: Identify System.AccessToken caller and fail
+      condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+    - pwsh: |
         $weightsFile = "$(Build.ArtifactStagingDirectory)/test-weights.json"
         if (Test-Path $weightsFile) {
           eng/scripts/Apply-WeightedBatching.ps1 `

--- a/eng/scripts/Get-TestAssemblyWeights.ps1
+++ b/eng/scripts/Get-TestAssemblyWeights.ps1
@@ -194,10 +194,40 @@ function Invoke-TestResultsQueries {
       }
     }
     catch {
+      $errorDetails = [System.Collections.Generic.List[string]]@($_.Exception.Message)
+      $response = $_.Exception.Response
+      if ($response) {
+        $errorDetails.Add("HTTP status: $([int]$response.StatusCode) $($response.ReasonPhrase)")
+
+        foreach ($headerName in @("X-TFS-Session", "X-VSS-E2EID", "ActivityId")) {
+          if ($response.Headers.Contains($headerName)) {
+            $headerValue = ($response.Headers.GetValues($headerName) -join ",")
+            $errorDetails.Add("${headerName}: $headerValue")
+          }
+        }
+
+        $responseBody = $_.ErrorDetails.Message
+        if ([string]::IsNullOrWhiteSpace($responseBody) -and $response.Content) {
+          try {
+            $responseBody = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+          }
+          catch {
+            $errorDetails.Add("Response body could not be read: $($_.Exception.Message)")
+          }
+        }
+        if (-not [string]::IsNullOrWhiteSpace($responseBody)) {
+          $responseBody = $responseBody -replace "\s+", " "
+          if ($responseBody.Length -gt 2000) {
+            $responseBody = $responseBody.Substring(0, 2000) + "..."
+          }
+          $errorDetails.Add("Response body: $responseBody")
+        }
+      }
+
       [PSCustomObject]@{
         Batch = $query.Batch
         Rows  = @()
-        Error = $_.Exception.Message
+        Error = $errorDetails -join "; "
       }
     }
   } -ThrottleLimit $ThrottleLimit)

--- a/eng/scripts/tests/Get-TestAssemblyWeights.Tests.ps1
+++ b/eng/scripts/tests/Get-TestAssemblyWeights.Tests.ps1
@@ -115,6 +115,62 @@ Describe "Get-TestAssemblyWeights" {
     $parameters.Keys | Should -Contain "RetryBaseDelaySeconds"
   }
 
+  It "includes HTTP response diagnostics when an Analytics query fails" {
+    $socket = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $socket.Start()
+    $port = ([System.Net.IPEndPoint]$socket.LocalEndpoint).Port
+    $socket.Stop()
+
+    $readyFile = Join-Path $TestDrive "listener-ready"
+    $server = Start-ThreadJob -ArgumentList $port, $readyFile -ScriptBlock {
+      param($Port, $ReadyFile)
+
+      $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $Port)
+      $listener.Start()
+      Set-Content -Path $ReadyFile -Value "ready"
+
+      try {
+        $body = '{"message":"Analytics access denied"}'
+        $response = "HTTP/1.1 403 Forbidden`r`n" +
+          "X-TFS-Session: test-session`r`n" +
+          "Content-Type: application/json`r`n" +
+          "Content-Length: $([System.Text.Encoding]::UTF8.GetByteCount($body))`r`n" +
+          "Connection: close`r`n`r`n$body"
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($response)
+        1..2 | ForEach-Object {
+          $client = $listener.AcceptTcpClient()
+          $stream = $client.GetStream()
+          $stream.Write($bytes, 0, $bytes.Length)
+          $stream.Dispose()
+          $client.Dispose()
+        }
+      }
+      finally {
+        $listener.Stop()
+      }
+    }
+
+    try {
+      while (-not (Test-Path $readyFile)) {
+        Start-Sleep -Milliseconds 25
+      }
+
+      {
+        Invoke-TestResultsQueries `
+          -Queries @([PSCustomObject]@{ Batch = 1; Url = "http://127.0.0.1:$port/" }) `
+          -AccessToken "token" `
+          -ThrottleLimit 1 `
+          -WindowLabel "test" `
+          -MaxRetryAttempts 1 `
+          -RetryBaseDelaySeconds 1
+      } | Should -Throw "*HTTP status: 403 Forbidden*X-TFS-Session: test-session*Analytics access denied*"
+    }
+    finally {
+      Stop-Job $server -ErrorAction SilentlyContinue
+      Remove-Job $server -Force -ErrorAction SilentlyContinue
+    }
+  }
+
   It "requires one observation for a low assembly count" {
     $durations = @{
       "assembly-1.dll" = [System.Collections.Generic.List[int]]@(10)


### PR DESCRIPTION
## Purpose

Diagnostic-only PR to verify which Azure DevOps identity backs `System.AccessToken` in the .NET pull-request pipeline and capture the complete Analytics authorization failure.

## Changes

- After the test assembly runtime query, call Azure DevOps `connectionData` and log the authenticated identity ID, display name, and subject descriptor.
- Intentionally fail that pipeline job after logging the identity.
- Include HTTP status, Azure DevOps correlation headers, and a bounded response body when an Analytics query fails.
- Add a focused test covering a retried HTTP 403 response.

## Expected CI result

The `generate_target_service_test_matrix` job should fail intentionally at **Identify System.AccessToken caller and fail**. Its preceding Analytics query should include the expanded 403 diagnostics.

**Do not merge this PR.** It intentionally breaks PR validation and exists only to collect diagnostic output.
