### PR TITLE
[Storage] Improve test code coverage in Queues

### DIFF
--- a/sdk/storage/Azure.Storage.Queues/tests/ConstructorUnitTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ConstructorUnitTests.cs
@@ -1,0 +1,536 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Storage.Queues.Models;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class ConstructorUnitTests
+    {
+        #region KeyInfo
+        [Test]
+        public void KeyInfo_PublicConstructor_SetsExpiry()
+        {
+            string expiry = "2025-01-01T00:00:00Z";
+            var keyInfo = new KeyInfo(expiry);
+
+            Assert.AreEqual(expiry, keyInfo.Expiry);
+            Assert.IsNull(keyInfo.Start);
+            Assert.IsNull(keyInfo.DelegatedUserTid);
+        }
+
+        [Test]
+        public void KeyInfo_InternalConstructor_SetsAllProperties()
+        {
+            string start = "2024-01-01T00:00:00Z";
+            string expiry = "2025-01-01T00:00:00Z";
+            string delegatedUserTid = "tenant-id";
+
+            var keyInfo = new KeyInfo(start, expiry, delegatedUserTid);
+
+            Assert.AreEqual(start, keyInfo.Start);
+            Assert.AreEqual(expiry, keyInfo.Expiry);
+            Assert.AreEqual(delegatedUserTid, keyInfo.DelegatedUserTid);
+        }
+        #endregion
+
+        #region ListOfSentMessage
+        [Test]
+        public void ListOfSentMessage_IEnumerableConstructor_CopiesList()
+        {
+            IEnumerable<SendReceipt> items = new List<SendReceipt>
+            {
+                new SendReceipt("id1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(7), "pop1", DateTimeOffset.UtcNow.AddMinutes(1)),
+            };
+            var list = new ListOfSentMessage(items);
+
+            Assert.AreEqual(1, list.Items.Count);
+        }
+
+        [Test]
+        public void ListOfSentMessage_IListConstructor_AssignsList()
+        {
+            IList<SendReceipt> items = new List<SendReceipt>
+            {
+                new SendReceipt("id1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(7), "pop1", DateTimeOffset.UtcNow.AddMinutes(1)),
+            };
+            var list = new ListOfSentMessage(items);
+
+            Assert.AreSame(items, list.Items);
+        }
+        #endregion
+
+        #region ListQueuesResponse
+        [Test]
+        public void ListQueuesResponse_ShortConstructor_SetsProperties()
+        {
+            var response = new ListQueuesResponse("https://account.queue.core.windows.net/", "prefix", 10, "nextMarker");
+
+            Assert.AreEqual("https://account.queue.core.windows.net/", response.ServiceEndpoint);
+            Assert.AreEqual("prefix", response.Prefix);
+            Assert.AreEqual(10, response.MaxResults);
+            Assert.AreEqual("nextMarker", response.NextMarker);
+            Assert.IsNotNull(response.QueueItems);
+            Assert.IsNull(response.Marker);
+        }
+
+        [Test]
+        public void ListQueuesResponse_FullConstructor_SetsAllProperties()
+        {
+            var queueItems = new List<QueueItem>();
+            var response = new ListQueuesResponse("https://account.queue.core.windows.net/", "prefix", "marker", 10, queueItems, "nextMarker");
+
+            Assert.AreEqual("https://account.queue.core.windows.net/", response.ServiceEndpoint);
+            Assert.AreEqual("prefix", response.Prefix);
+            Assert.AreEqual("marker", response.Marker);
+            Assert.AreEqual(10, response.MaxResults);
+            Assert.AreSame(queueItems, response.QueueItems);
+            Assert.AreEqual("nextMarker", response.NextMarker);
+        }
+        #endregion
+
+        #region PeekedMessage
+        [Test]
+        public void PeekedMessage_InternalConstructor_SetsAllProperties()
+        {
+            var insertedOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddDays(7);
+            var message = new PeekedMessage("msgId", insertedOn, expiresOn, 3, "hello");
+
+            Assert.AreEqual("msgId", message.MessageId);
+            Assert.AreEqual(insertedOn, message.InsertedOn);
+            Assert.AreEqual(expiresOn, message.ExpiresOn);
+            Assert.AreEqual(3, message.DequeueCount);
+            Assert.AreEqual("hello", message.MessageText);
+        }
+        #endregion
+
+        #region PeekedMessages
+        [Test]
+        public void PeekedMessages_IEnumerableConstructor_CopiesList()
+        {
+            IEnumerable<PeekedMessage> items = new List<PeekedMessage>
+            {
+                new PeekedMessage("id1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(7), 1, "text"),
+            };
+            var peeked = new PeekedMessages(items);
+
+            Assert.AreEqual(1, peeked.Items.Count);
+        }
+
+        [Test]
+        public void PeekedMessages_IListConstructor_AssignsList()
+        {
+            IList<PeekedMessage> items = new List<PeekedMessage>
+            {
+                new PeekedMessage("id1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(7), 1, "text"),
+            };
+            var peeked = new PeekedMessages(items);
+
+            Assert.AreSame(items, peeked.Items);
+        }
+        #endregion
+
+        #region QueueAccessPolicy
+        [Test]
+        public void QueueAccessPolicy_PublicConstructor_DefaultValues()
+        {
+            var policy = new QueueAccessPolicy();
+
+            Assert.IsNull(policy.StartsOn);
+            Assert.IsNull(policy.ExpiresOn);
+            Assert.IsNull(policy.Permissions);
+        }
+
+        [Test]
+        public void QueueAccessPolicy_InternalConstructor_SetsAllProperties()
+        {
+            var startsOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddDays(1);
+            var policy = new QueueAccessPolicy(startsOn, expiresOn, "raup");
+
+            Assert.AreEqual(startsOn, policy.StartsOn);
+            Assert.AreEqual(expiresOn, policy.ExpiresOn);
+            Assert.AreEqual("raup", policy.Permissions);
+        }
+        #endregion
+
+        #region QueueAnalyticsLogging
+        [Test]
+        public void QueueAnalyticsLogging_InternalConstructor_SetsAllProperties()
+        {
+            var retentionPolicy = new QueueRetentionPolicy();
+            var logging = new QueueAnalyticsLogging("1.0", true, false, true, retentionPolicy);
+
+            Assert.AreEqual("1.0", logging.Version);
+            Assert.IsTrue(logging.Delete);
+            Assert.IsFalse(logging.Read);
+            Assert.IsTrue(logging.Write);
+            Assert.AreSame(retentionPolicy, logging.RetentionPolicy);
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_SkipInitialization_False_InitializesRetentionPolicy()
+        {
+            var logging = new QueueAnalyticsLogging(skipInitialization: false);
+
+            Assert.IsNotNull(logging.RetentionPolicy);
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_SkipInitialization_True_DoesNotInitialize()
+        {
+            var logging = new QueueAnalyticsLogging(skipInitialization: true);
+
+            Assert.IsNull(logging.RetentionPolicy);
+        }
+        #endregion
+
+        #region QueueCorsRule
+        [Test]
+        public void QueueCorsRule_InternalConstructor_SetsAllProperties()
+        {
+            var rule = new QueueCorsRule("*", "GET", "x-ms-*", "x-ms-request-id", 3600);
+
+            Assert.AreEqual("*", rule.AllowedOrigins);
+            Assert.AreEqual("GET", rule.AllowedMethods);
+            Assert.AreEqual("x-ms-*", rule.AllowedHeaders);
+            Assert.AreEqual("x-ms-request-id", rule.ExposedHeaders);
+            Assert.AreEqual(3600, rule.MaxAgeInSeconds);
+        }
+        #endregion
+
+        #region QueueGeoReplication
+        [Test]
+        public void QueueGeoReplication_InternalParameterizedConstructor_SetsAllProperties()
+        {
+            var lastSyncedOn = DateTimeOffset.UtcNow;
+            var geoReplication = new QueueGeoReplication(QueueGeoReplicationStatus.Live, lastSyncedOn);
+
+            Assert.AreEqual(QueueGeoReplicationStatus.Live, geoReplication.Status);
+            Assert.AreEqual(lastSyncedOn, geoReplication.LastSyncedOn);
+        }
+        #endregion
+
+        #region QueueItem
+        [Test]
+        public void QueueItem_SingleParamConstructor_SetsNameAndInitializesMetadata()
+        {
+            var item = new QueueItem("myqueue");
+
+            Assert.AreEqual("myqueue", item.Name);
+            Assert.IsNotNull(item.Metadata);
+        }
+
+        [Test]
+        public void QueueItem_FullConstructor_SetsNameAndMetadata()
+        {
+            var metadata = new Dictionary<string, string> { { "key", "value" } };
+            var item = new QueueItem("myqueue", metadata);
+
+            Assert.AreEqual("myqueue", item.Name);
+            Assert.AreSame(metadata, item.Metadata);
+        }
+        #endregion
+
+        #region QueueMessage
+        [Test]
+        public void QueueMessage_ParameterlessConstructor_CreatesInstance()
+        {
+            var message = new QueueMessage();
+
+            Assert.IsNull(message.MessageId);
+            Assert.IsNull(message.Body);
+        }
+
+        [Test]
+        public void QueueMessage_StringConstructor_SetsMessageText()
+        {
+            var message = new QueueMessage("hello");
+
+            Assert.AreEqual("hello", message.MessageText);
+        }
+        #endregion
+
+        #region QueueMetrics
+        [Test]
+        public void QueueMetrics_InternalConstructor_SetsAllProperties()
+        {
+            var retentionPolicy = new QueueRetentionPolicy();
+            var metrics = new QueueMetrics("1.0", true, true, retentionPolicy);
+
+            Assert.AreEqual("1.0", metrics.Version);
+            Assert.IsTrue(metrics.Enabled);
+            Assert.IsTrue(metrics.IncludeApis);
+            Assert.AreSame(retentionPolicy, metrics.RetentionPolicy);
+        }
+
+        [Test]
+        public void QueueMetrics_SkipInitialization_False_InitializesRetentionPolicy()
+        {
+            var metrics = new QueueMetrics(skipInitialization: false);
+
+            Assert.IsNotNull(metrics.RetentionPolicy);
+        }
+
+        [Test]
+        public void QueueMetrics_SkipInitialization_True_DoesNotInitialize()
+        {
+            var metrics = new QueueMetrics(skipInitialization: true);
+
+            Assert.IsNull(metrics.RetentionPolicy);
+        }
+        #endregion
+
+        #region QueueRetentionPolicy
+        [Test]
+        public void QueueRetentionPolicy_InternalBoolConstructor_SetsEnabled()
+        {
+            var policy = new QueueRetentionPolicy(enabled: true);
+
+            Assert.IsTrue(policy.Enabled);
+        }
+
+        [Test]
+        public void QueueRetentionPolicy_InternalFullConstructor_SetsAllProperties()
+        {
+            var policy = new QueueRetentionPolicy(enabled: true, days: 7);
+
+            Assert.IsTrue(policy.Enabled);
+            Assert.AreEqual(7, policy.Days);
+        }
+        #endregion
+
+        #region QueueServiceProperties
+        [Test]
+        public void QueueServiceProperties_InternalConstructor_SetsAllProperties()
+        {
+            var logging = new QueueAnalyticsLogging();
+            var hourMetrics = new QueueMetrics();
+            var minuteMetrics = new QueueMetrics();
+            var cors = new List<QueueCorsRule>();
+            var props = new QueueServiceProperties(logging, hourMetrics, minuteMetrics, cors);
+
+            Assert.AreSame(logging, props.Logging);
+            Assert.AreSame(hourMetrics, props.HourMetrics);
+            Assert.AreSame(minuteMetrics, props.MinuteMetrics);
+            Assert.AreSame(cors, props.Cors);
+        }
+
+        [Test]
+        public void QueueServiceProperties_SkipInitialization_False_InitializesNestedObjects()
+        {
+            var props = new QueueServiceProperties(skipInitialization: false);
+
+            Assert.IsNotNull(props.Logging);
+            Assert.IsNotNull(props.HourMetrics);
+            Assert.IsNotNull(props.MinuteMetrics);
+        }
+
+        [Test]
+        public void QueueServiceProperties_SkipInitialization_True_DoesNotInitialize()
+        {
+            var props = new QueueServiceProperties(skipInitialization: true);
+
+            Assert.IsNull(props.Logging);
+            Assert.IsNull(props.HourMetrics);
+            Assert.IsNull(props.MinuteMetrics);
+        }
+        #endregion
+
+        #region QueueServiceStatistics
+        [Test]
+        public void QueueServiceStatistics_ParameterlessConstructor_CreatesInstance()
+        {
+            var stats = new QueueServiceStatistics();
+
+            Assert.IsNull(stats.GeoReplication);
+        }
+
+        [Test]
+        public void QueueServiceStatistics_GeoReplicationConstructor_SetsProperty()
+        {
+            var geoReplication = new QueueGeoReplication(QueueGeoReplicationStatus.Live, DateTimeOffset.UtcNow);
+            var stats = new QueueServiceStatistics(geoReplication);
+
+            Assert.AreSame(geoReplication, stats.GeoReplication);
+        }
+        #endregion
+
+        #region QueueSignedIdentifier
+        [Test]
+        public void QueueSignedIdentifier_InternalConstructor_SetsIdAndAccessPolicy()
+        {
+            var accessPolicy = new QueueAccessPolicy();
+            var identifier = new QueueSignedIdentifier("myId", accessPolicy);
+
+            Assert.AreEqual("myId", identifier.Id);
+            Assert.AreSame(accessPolicy, identifier.AccessPolicy);
+        }
+
+        [Test]
+        public void QueueSignedIdentifier_SkipInitialization_False_InitializesAccessPolicy()
+        {
+            var identifier = new QueueSignedIdentifier(skipInitialization: false);
+
+            Assert.IsNotNull(identifier.AccessPolicy);
+        }
+
+        [Test]
+        public void QueueSignedIdentifier_SkipInitialization_True_DoesNotInitialize()
+        {
+            var identifier = new QueueSignedIdentifier(skipInitialization: true);
+
+            Assert.IsNull(identifier.AccessPolicy);
+        }
+        #endregion
+
+        #region QueueSignedIdentifiers
+        [Test]
+        public void QueueSignedIdentifiers_IEnumerableConstructor_CopiesList()
+        {
+            IEnumerable<QueueSignedIdentifier> items = new List<QueueSignedIdentifier>
+            {
+                new QueueSignedIdentifier(),
+            };
+            var identifiers = new QueueSignedIdentifiers(items);
+
+            Assert.AreEqual(1, identifiers.Items.Count);
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_IEnumerableConstructor_ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new QueueSignedIdentifiers((IEnumerable<QueueSignedIdentifier>)null));
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_IListConstructor_AssignsList()
+        {
+            IList<QueueSignedIdentifier> items = new List<QueueSignedIdentifier>
+            {
+                new QueueSignedIdentifier(),
+            };
+            var identifiers = new QueueSignedIdentifiers(items);
+
+            Assert.AreSame(items, identifiers.Items);
+        }
+        #endregion
+
+        #region ReceivedMessage
+        [Test]
+        public void ReceivedMessage_Constructor_SetsAllProperties()
+        {
+            var insertionTime = DateTimeOffset.UtcNow;
+            var expirationTime = DateTimeOffset.UtcNow.AddDays(7);
+            var timeNextVisible = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            var message = new ReceivedMessage("msgId", insertionTime, expirationTime, "pop1", timeNextVisible, 5, "hello");
+
+            Assert.AreEqual("msgId", message.MessageId);
+            Assert.AreEqual(insertionTime, message.InsertionTime);
+            Assert.AreEqual(expirationTime, message.ExpirationTime);
+            Assert.AreEqual("pop1", message.PopReceipt);
+            Assert.AreEqual(timeNextVisible, message.TimeNextVisible);
+            Assert.AreEqual(5, message.DequeueCount);
+            Assert.AreEqual("hello", message.MessageText);
+        }
+        #endregion
+
+        #region ReceivedMessages
+        [Test]
+        public void ReceivedMessages_IEnumerableConstructor_CopiesList()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IEnumerable<ReceivedMessage> items = new List<ReceivedMessage>
+            {
+                new ReceivedMessage("id1", now, now.AddDays(7), "pop1", now.AddMinutes(1), 1, "text"),
+            };
+            var received = new ReceivedMessages(items);
+
+            Assert.AreEqual(1, received.Items.Count);
+        }
+
+        [Test]
+        public void ReceivedMessages_IListConstructor_AssignsList()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IList<ReceivedMessage> items = new List<ReceivedMessage>
+            {
+                new ReceivedMessage("id1", now, now.AddDays(7), "pop1", now.AddMinutes(1), 1, "text"),
+            };
+            var received = new ReceivedMessages(items);
+
+            Assert.AreSame(items, received.Items);
+        }
+        #endregion
+
+        #region SendReceipt
+        [Test]
+        public void SendReceipt_ParameterlessConstructor_CreatesInstance()
+        {
+            var receipt = new SendReceipt();
+
+            Assert.IsNull(receipt.MessageId);
+            Assert.IsNull(receipt.PopReceipt);
+        }
+
+        [Test]
+        public void SendReceipt_FullConstructor_SetsAllProperties()
+        {
+            var insertionTime = DateTimeOffset.UtcNow;
+            var expirationTime = DateTimeOffset.UtcNow.AddDays(7);
+            var timeNextVisible = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            var receipt = new SendReceipt("msgId", insertionTime, expirationTime, "pop1", timeNextVisible);
+
+            Assert.AreEqual("msgId", receipt.MessageId);
+            Assert.AreEqual(insertionTime, receipt.InsertionTime);
+            Assert.AreEqual(expirationTime, receipt.ExpirationTime);
+            Assert.AreEqual("pop1", receipt.PopReceipt);
+            Assert.AreEqual(timeNextVisible, receipt.TimeNextVisible);
+        }
+        #endregion
+
+        #region UserDelegationKey
+        [Test]
+        public void UserDelegationKey_7ParamConstructor_SetsAllProperties()
+        {
+            var startsOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+
+            var key = new UserDelegationKey("oid", "tid", startsOn, expiresOn, "b", "2020-02-10", "keyValue");
+
+            Assert.AreEqual("oid", key.SignedObjectId);
+            Assert.AreEqual("tid", key.SignedTenantId);
+            Assert.AreEqual(startsOn, key.SignedStartsOn);
+            Assert.AreEqual(expiresOn, key.SignedExpiresOn);
+            Assert.AreEqual("b", key.SignedService);
+            Assert.AreEqual("2020-02-10", key.SignedVersion);
+            Assert.AreEqual("keyValue", key.Value);
+            Assert.IsNull(key.SignedDelegatedUserTenantId);
+        }
+
+        [Test]
+        public void UserDelegationKey_8ParamConstructor_SetsAllProperties()
+        {
+            var startsOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+
+            var key = new UserDelegationKey("oid", "tid", startsOn, expiresOn, "b", "2020-02-10", "delegatedTid", "keyValue");
+
+            Assert.AreEqual("oid", key.SignedObjectId);
+            Assert.AreEqual("tid", key.SignedTenantId);
+            Assert.AreEqual(startsOn, key.SignedStartsOn);
+            Assert.AreEqual(expiresOn, key.SignedExpiresOn);
+            Assert.AreEqual("b", key.SignedService);
+            Assert.AreEqual("2020-02-10", key.SignedVersion);
+            Assert.AreEqual("delegatedTid", key.SignedDelegatedUserTenantId);
+            Assert.AreEqual("keyValue", key.Value);
+        }
+        #endregion
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueAccountSasPermissionsTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueAccountSasPermissionsTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Storage.Sas;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class QueueAccountSasPermissionsTests
+    {
+        [Test]
+        public void Read_ReturnsR()
+        {
+            Assert.AreEqual("r", QueueAccountSasPermissions.Read.ToPermissionsString());
+        }
+
+        [Test]
+        public void Write_ReturnsW()
+        {
+            Assert.AreEqual("w", QueueAccountSasPermissions.Write.ToPermissionsString());
+        }
+
+        [Test]
+        public void Delete_ReturnsD()
+        {
+            Assert.AreEqual("d", QueueAccountSasPermissions.Delete.ToPermissionsString());
+        }
+
+        [Test]
+        public void List_ReturnsL()
+        {
+            Assert.AreEqual("l", QueueAccountSasPermissions.List.ToPermissionsString());
+        }
+
+        [Test]
+        public void Add_ReturnsA()
+        {
+            Assert.AreEqual("a", QueueAccountSasPermissions.Add.ToPermissionsString());
+        }
+
+        [Test]
+        public void Update_ReturnsU()
+        {
+            Assert.AreEqual("u", QueueAccountSasPermissions.Update.ToPermissionsString());
+        }
+
+        [Test]
+        public void Process_ReturnsP()
+        {
+            Assert.AreEqual("p", QueueAccountSasPermissions.Process.ToPermissionsString());
+        }
+
+        [Test]
+        public void AllCombined_ReturnsCorrectOrder()
+        {
+            var all = QueueAccountSasPermissions.Read |
+                      QueueAccountSasPermissions.Write |
+                      QueueAccountSasPermissions.Delete |
+                      QueueAccountSasPermissions.List |
+                      QueueAccountSasPermissions.Add |
+                      QueueAccountSasPermissions.Update |
+                      QueueAccountSasPermissions.Process;
+
+            Assert.AreEqual("rwdlaup", all.ToPermissionsString());
+        }
+
+        [Test]
+        public void None_ReturnsEmpty()
+        {
+            Assert.AreEqual("", ((QueueAccountSasPermissions)0).ToPermissionsString());
+        }
+
+        [Test]
+        public void ReadWrite_ReturnsRW()
+        {
+            var permissions = QueueAccountSasPermissions.Read | QueueAccountSasPermissions.Write;
+
+            Assert.AreEqual("rw", permissions.ToPermissionsString());
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientSettingsTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientSettingsTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+#pragma warning disable SCME0002 // Experimental type
+    public class QueueClientSettingsTests
+    {
+        [Test]
+        public void QueueUri_GetSet()
+        {
+            var settings = new QueueClientSettings();
+            var uri = new Uri("https://account.queue.core.windows.net/myqueue");
+
+            settings.QueueUri = uri;
+
+            Assert.AreEqual(uri, settings.QueueUri);
+        }
+
+        [Test]
+        public void ConnectionString_GetSet()
+        {
+            var settings = new QueueClientSettings();
+
+            settings.ConnectionString = "DefaultEndpointsProtocol=https;AccountName=test";
+
+            Assert.AreEqual("DefaultEndpointsProtocol=https;AccountName=test", settings.ConnectionString);
+        }
+
+        [Test]
+        public void QueueName_GetSet()
+        {
+            var settings = new QueueClientSettings();
+
+            settings.QueueName = "myqueue";
+
+            Assert.AreEqual("myqueue", settings.QueueName);
+        }
+
+        [Test]
+        public void Options_GetSet()
+        {
+            var settings = new QueueClientSettings();
+            var options = new QueueClientOptions();
+
+            settings.Options = options;
+
+            Assert.AreSame(options, settings.Options);
+        }
+    }
+#pragma warning restore SCME0002
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientSettingsTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientSettingsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
 
 namespace Azure.Storage.Queues.Tests

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientSideEncryptionOptionsTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientSideEncryptionOptionsTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Storage.Queues.Specialized;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class QueueClientSideEncryptionOptionsTests
+    {
+        [Test]
+        public void Constructor_SetsEncryptionVersion()
+        {
+            var options = new QueueClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0);
+
+            Assert.AreEqual(ClientSideEncryptionVersion.V2_0, options.EncryptionVersion);
+        }
+
+        [Test]
+        public void CloneFrom_Null_ReturnsNull()
+        {
+            var result = QueueClientSideEncryptionOptions.CloneFrom(null);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void CloneFrom_QueueOptions_CopiesDecryptionFailed()
+        {
+            var original = new QueueClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0);
+            bool handlerCalled = false;
+            original.DecryptionFailed += (sender, args) => handlerCalled = true;
+
+            var cloned = QueueClientSideEncryptionOptions.CloneFrom(original);
+
+            // Trigger event on cloned to verify handler was copied
+            cloned.OnDecryptionFailed(null, new Exception("test"));
+            Assert.IsTrue(handlerCalled);
+        }
+
+        [Test]
+        public void UsingDecryptionFailureHandler_TrueWhenSubscribed()
+        {
+            var options = new QueueClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0);
+            options.DecryptionFailed += (sender, args) => { };
+
+            Assert.IsTrue(options.UsingDecryptionFailureHandler);
+        }
+
+        [Test]
+        public void OnDecryptionFailed_InvokesHandler()
+        {
+            var options = new QueueClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0);
+            Exception receivedException = null;
+            object receivedSender = null;
+            options.DecryptionFailed += (sender, args) =>
+            {
+                receivedSender = sender;
+                receivedException = args.Exception;
+            };
+
+            var expectedException = new InvalidOperationException("decrypt failed");
+            options.OnDecryptionFailed("testMessage", expectedException);
+
+            Assert.AreEqual("testMessage", receivedSender);
+            Assert.AreSame(expectedException, receivedException);
+        }
+
+        [Test]
+        public void ClientSideDecryptionFailureEventArgs_ExposesException()
+        {
+            var options = new QueueClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0);
+            ClientSideDecryptionFailureEventArgs capturedArgs = null;
+            options.DecryptionFailed += (sender, args) => capturedArgs = args;
+
+            var exception = new InvalidOperationException("test");
+            options.OnDecryptionFailed(null, exception);
+
+            Assert.IsNotNull(capturedArgs);
+            Assert.AreSame(exception, capturedArgs.Exception);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueExtensionsTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueExtensionsTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class QueueExtensionsTests
+    {
+        [Test]
+        public void ToQueueProperties_NullResponse_ReturnsNull()
+        {
+            Response response = null;
+
+            var result = response.ToQueueProperties();
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ToUpdateReceipt_NullResponse_ReturnsNull()
+        {
+            Response response = null;
+
+            var result = response.ToUpdateReceipt();
+
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueMessageCodecTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueMessageCodecTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Storage.Queues.Models;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class QueueMessageCodecTests
+    {
+        #region EncodeMessageBody - None encoding
+        [Test]
+        public void EncodeMessageBody_None_ReturnsPlainText()
+        {
+            var body = new BinaryData("hello world");
+
+            var result = QueueMessageCodec.EncodeMessageBody(body, QueueMessageEncoding.None);
+
+            Assert.AreEqual("hello world", result);
+        }
+
+        [Test]
+        public void EncodeMessageBody_None_NullReturnsNull()
+        {
+            var result = QueueMessageCodec.EncodeMessageBody(null, QueueMessageEncoding.None);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void EncodeMessageBody_None_EmptyString()
+        {
+            var body = new BinaryData(string.Empty);
+
+            var result = QueueMessageCodec.EncodeMessageBody(body, QueueMessageEncoding.None);
+
+            Assert.AreEqual(string.Empty, result);
+        }
+        #endregion
+
+        #region EncodeMessageBody - Base64 encoding
+        [Test]
+        public void EncodeMessageBody_Base64_ReturnsBase64String()
+        {
+            var body = new BinaryData("hello world");
+
+            var result = QueueMessageCodec.EncodeMessageBody(body, QueueMessageEncoding.Base64);
+
+            Assert.AreEqual(Convert.ToBase64String(body.ToArray()), result);
+        }
+
+        [Test]
+        public void EncodeMessageBody_Base64_NullReturnsNull()
+        {
+            var result = QueueMessageCodec.EncodeMessageBody(null, QueueMessageEncoding.Base64);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void EncodeMessageBody_Base64_EmptyBytes()
+        {
+            var body = new BinaryData(Array.Empty<byte>());
+
+            var result = QueueMessageCodec.EncodeMessageBody(body, QueueMessageEncoding.Base64);
+
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [Test]
+        public void EncodeMessageBody_Base64_BinaryContent()
+        {
+            var bytes = new byte[] { 0x00, 0x01, 0xFF, 0xFE };
+            var body = new BinaryData(bytes);
+
+            var result = QueueMessageCodec.EncodeMessageBody(body, QueueMessageEncoding.Base64);
+
+            Assert.AreEqual(Convert.ToBase64String(bytes), result);
+        }
+        #endregion
+
+        #region EncodeMessageBody - Invalid encoding
+        [Test]
+        public void EncodeMessageBody_InvalidEncoding_Throws()
+        {
+            var body = new BinaryData("hello");
+
+            Assert.Throws<ArgumentException>(() =>
+                QueueMessageCodec.EncodeMessageBody(body, (QueueMessageEncoding)999));
+        }
+        #endregion
+
+        #region DecodeMessageBody - None encoding
+        [Test]
+        public void DecodeMessageBody_None_ReturnsBinaryData()
+        {
+            var result = QueueMessageCodec.DecodeMessageBody("hello world", QueueMessageEncoding.None);
+
+            Assert.AreEqual("hello world", result.ToString());
+        }
+
+        [Test]
+        public void DecodeMessageBody_None_NullReturnsEmpty()
+        {
+            var result = QueueMessageCodec.DecodeMessageBody(null, QueueMessageEncoding.None);
+
+            Assert.AreEqual(string.Empty, result.ToString());
+        }
+
+        [Test]
+        public void DecodeMessageBody_None_EmptyString()
+        {
+            var result = QueueMessageCodec.DecodeMessageBody(string.Empty, QueueMessageEncoding.None);
+
+            Assert.AreEqual(string.Empty, result.ToString());
+        }
+        #endregion
+
+        #region DecodeMessageBody - Base64 encoding
+        [Test]
+        public void DecodeMessageBody_Base64_DecodesCorrectly()
+        {
+            var originalText = "hello world";
+            var base64Text = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(originalText));
+
+            var result = QueueMessageCodec.DecodeMessageBody(base64Text, QueueMessageEncoding.Base64);
+
+            Assert.AreEqual(originalText, result.ToString());
+        }
+
+        [Test]
+        public void DecodeMessageBody_Base64_NullReturnsEmpty()
+        {
+            var result = QueueMessageCodec.DecodeMessageBody(null, QueueMessageEncoding.Base64);
+
+            Assert.AreEqual(string.Empty, result.ToString());
+        }
+
+        [Test]
+        public void DecodeMessageBody_Base64_BinaryContent()
+        {
+            var bytes = new byte[] { 0x00, 0x01, 0xFF, 0xFE };
+            var base64Text = Convert.ToBase64String(bytes);
+
+            var result = QueueMessageCodec.DecodeMessageBody(base64Text, QueueMessageEncoding.Base64);
+
+            CollectionAssert.AreEqual(bytes, result.ToArray());
+        }
+        #endregion
+
+        #region DecodeMessageBody - Invalid encoding
+        [Test]
+        public void DecodeMessageBody_InvalidEncoding_Throws()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                QueueMessageCodec.DecodeMessageBody("hello", (QueueMessageEncoding)999));
+        }
+        #endregion
+
+        #region Round-trip tests
+        [Test]
+        public void RoundTrip_None_PreservesText()
+        {
+            var original = new BinaryData("hello world");
+
+            var encoded = QueueMessageCodec.EncodeMessageBody(original, QueueMessageEncoding.None);
+            var decoded = QueueMessageCodec.DecodeMessageBody(encoded, QueueMessageEncoding.None);
+
+            Assert.AreEqual(original.ToString(), decoded.ToString());
+        }
+
+        [Test]
+        public void RoundTrip_Base64_PreservesBytes()
+        {
+            var bytes = new byte[] { 0x00, 0x01, 0x02, 0xFF };
+            var original = new BinaryData(bytes);
+
+            var encoded = QueueMessageCodec.EncodeMessageBody(original, QueueMessageEncoding.Base64);
+            var decoded = QueueMessageCodec.DecodeMessageBody(encoded, QueueMessageEncoding.Base64);
+
+            CollectionAssert.AreEqual(bytes, decoded.ToArray());
+        }
+
+        [Test]
+        public void RoundTrip_Base64_PreservesText()
+        {
+            var original = new BinaryData("hello world");
+
+            var encoded = QueueMessageCodec.EncodeMessageBody(original, QueueMessageEncoding.Base64);
+            var decoded = QueueMessageCodec.DecodeMessageBody(encoded, QueueMessageEncoding.Base64);
+
+            Assert.AreEqual(original.ToString(), decoded.ToString());
+        }
+        #endregion
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/QueuesModelFactoryTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueuesModelFactoryTests.cs
@@ -1,0 +1,477 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Storage.Queues.Models;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class QueuesModelFactoryTests
+    {
+        #region QueueServiceProperties
+        [Test]
+        public void QueueServiceProperties_WithAllParameters()
+        {
+            var logging = QueuesModelFactory.QueueAnalyticsLogging();
+            var hourMetrics = QueuesModelFactory.QueueMetrics();
+            var minuteMetrics = QueuesModelFactory.QueueMetrics();
+            var cors = new List<QueueCorsRule> { QueuesModelFactory.QueueCorsRule() };
+
+            var result = QueuesModelFactory.QueueServiceProperties(logging, hourMetrics, minuteMetrics, cors);
+
+            Assert.AreSame(logging, result.Logging);
+            Assert.AreSame(hourMetrics, result.HourMetrics);
+            Assert.AreSame(minuteMetrics, result.MinuteMetrics);
+            Assert.AreEqual(1, result.Cors.Count);
+        }
+
+        [Test]
+        public void QueueServiceProperties_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueServiceProperties();
+
+            Assert.IsNull(result.Logging);
+            Assert.IsNull(result.HourMetrics);
+            Assert.IsNull(result.MinuteMetrics);
+            Assert.IsNotNull(result.Cors);
+        }
+        #endregion
+
+        #region QueueAnalyticsLogging
+        [Test]
+        public void QueueAnalyticsLogging_WithAllParameters()
+        {
+            var retentionPolicy = QueuesModelFactory.QueueRetentionPolicy(true, 7);
+
+            var result = QueuesModelFactory.QueueAnalyticsLogging("1.0", true, false, true, retentionPolicy);
+
+            Assert.AreEqual("1.0", result.Version);
+            Assert.IsTrue(result.Delete);
+            Assert.IsFalse(result.Read);
+            Assert.IsTrue(result.Write);
+            Assert.AreSame(retentionPolicy, result.RetentionPolicy);
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueAnalyticsLogging();
+
+            Assert.IsNull(result.Version);
+            Assert.IsFalse(result.Delete);
+            Assert.IsFalse(result.Read);
+            Assert.IsFalse(result.Write);
+            Assert.IsNull(result.RetentionPolicy);
+        }
+        #endregion
+
+        #region QueueRetentionPolicy
+        [Test]
+        public void QueueRetentionPolicy_WithAllParameters()
+        {
+            var result = QueuesModelFactory.QueueRetentionPolicy(true, 7);
+
+            Assert.IsTrue(result.Enabled);
+            Assert.AreEqual(7, result.Days);
+        }
+
+        [Test]
+        public void QueueRetentionPolicy_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueRetentionPolicy();
+
+            Assert.IsFalse(result.Enabled);
+            Assert.IsNull(result.Days);
+        }
+        #endregion
+
+        #region QueueMetrics
+        [Test]
+        public void QueueMetrics_WithAllParameters()
+        {
+            var retentionPolicy = QueuesModelFactory.QueueRetentionPolicy(true, 7);
+
+            var result = QueuesModelFactory.QueueMetrics("1.0", true, true, retentionPolicy);
+
+            Assert.AreEqual("1.0", result.Version);
+            Assert.IsTrue(result.Enabled);
+            Assert.IsTrue(result.IncludeApis);
+            Assert.AreSame(retentionPolicy, result.RetentionPolicy);
+        }
+
+        [Test]
+        public void QueueMetrics_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueMetrics();
+
+            Assert.IsNull(result.Version);
+            Assert.IsFalse(result.Enabled);
+            Assert.IsNull(result.IncludeApis);
+            Assert.IsNull(result.RetentionPolicy);
+        }
+        #endregion
+
+        #region QueueCorsRule
+        [Test]
+        public void QueueCorsRule_WithAllParameters()
+        {
+            var result = QueuesModelFactory.QueueCorsRule("*", "GET", "x-ms-*", "x-ms-request-id", 3600);
+
+            Assert.AreEqual("*", result.AllowedOrigins);
+            Assert.AreEqual("GET", result.AllowedMethods);
+            Assert.AreEqual("x-ms-*", result.AllowedHeaders);
+            Assert.AreEqual("x-ms-request-id", result.ExposedHeaders);
+            Assert.AreEqual(3600, result.MaxAgeInSeconds);
+        }
+
+        [Test]
+        public void QueueCorsRule_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueCorsRule();
+
+            Assert.IsNull(result.AllowedOrigins);
+            Assert.IsNull(result.AllowedMethods);
+            Assert.IsNull(result.AllowedHeaders);
+            Assert.IsNull(result.ExposedHeaders);
+            Assert.AreEqual(0, result.MaxAgeInSeconds);
+        }
+        #endregion
+
+        #region QueueAccessPolicy
+        [Test]
+        public void QueueAccessPolicy_WithAllParameters()
+        {
+            var startsOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddDays(1);
+
+            var result = QueuesModelFactory.QueueAccessPolicy(startsOn, expiresOn, "raup");
+
+            Assert.AreEqual(startsOn, result.StartsOn);
+            Assert.AreEqual(expiresOn, result.ExpiresOn);
+            Assert.AreEqual("raup", result.Permissions);
+        }
+
+        [Test]
+        public void QueueAccessPolicy_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueAccessPolicy();
+
+            Assert.IsNull(result.StartsOn);
+            Assert.IsNull(result.ExpiresOn);
+            Assert.IsNull(result.Permissions);
+        }
+        #endregion
+
+        #region QueueMessage (string overload)
+        [Test]
+        public void QueueMessage_StringOverload_WithAllParameters()
+        {
+            var nextVisibleOn = DateTimeOffset.UtcNow.AddMinutes(1);
+            var insertedOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddDays(7);
+
+            var result = QueuesModelFactory.QueueMessage("msgId", "popReceipt", "hello", 3, nextVisibleOn, insertedOn, expiresOn);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.AreEqual("popReceipt", result.PopReceipt);
+            Assert.AreEqual("hello", result.Body.ToString());
+            Assert.AreEqual(3, result.DequeueCount);
+            Assert.AreEqual(nextVisibleOn, result.NextVisibleOn);
+            Assert.AreEqual(insertedOn, result.InsertedOn);
+            Assert.AreEqual(expiresOn, result.ExpiresOn);
+        }
+
+        [Test]
+        public void QueueMessage_StringOverload_WithRequiredOnly()
+        {
+            var result = QueuesModelFactory.QueueMessage("msgId", "popReceipt", "hello", 0);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.AreEqual("popReceipt", result.PopReceipt);
+            Assert.AreEqual("hello", result.Body.ToString());
+            Assert.AreEqual(0, result.DequeueCount);
+            Assert.IsNull(result.NextVisibleOn);
+            Assert.IsNull(result.InsertedOn);
+            Assert.IsNull(result.ExpiresOn);
+        }
+        #endregion
+
+        #region QueueMessage (BinaryData overload)
+        [Test]
+        public void QueueMessage_BinaryDataOverload_WithAllParameters()
+        {
+            var body = new BinaryData("hello");
+            var nextVisibleOn = DateTimeOffset.UtcNow.AddMinutes(1);
+            var insertedOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddDays(7);
+
+            var result = QueuesModelFactory.QueueMessage("msgId", "popReceipt", body, 3, nextVisibleOn, insertedOn, expiresOn);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.AreEqual("popReceipt", result.PopReceipt);
+            Assert.AreSame(body, result.Body);
+            Assert.AreEqual(3, result.DequeueCount);
+            Assert.AreEqual(nextVisibleOn, result.NextVisibleOn);
+            Assert.AreEqual(insertedOn, result.InsertedOn);
+            Assert.AreEqual(expiresOn, result.ExpiresOn);
+        }
+
+        [Test]
+        public void QueueMessage_BinaryDataOverload_WithRequiredOnly()
+        {
+            var body = new BinaryData("hello");
+
+            var result = QueuesModelFactory.QueueMessage("msgId", "popReceipt", body, 0);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.IsNull(result.NextVisibleOn);
+        }
+        #endregion
+
+        #region PeekedMessage (string overload)
+        [Test]
+        public void PeekedMessage_StringOverload_WithAllParameters()
+        {
+            var insertedOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddDays(7);
+
+            var result = QueuesModelFactory.PeekedMessage("msgId", "hello", 3, insertedOn, expiresOn);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.AreEqual("hello", result.Body.ToString());
+            Assert.AreEqual(3, result.DequeueCount);
+            Assert.AreEqual(insertedOn, result.InsertedOn);
+            Assert.AreEqual(expiresOn, result.ExpiresOn);
+        }
+
+        [Test]
+        public void PeekedMessage_StringOverload_WithRequiredOnly()
+        {
+            var result = QueuesModelFactory.PeekedMessage("msgId", "hello", 0);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.IsNull(result.InsertedOn);
+            Assert.IsNull(result.ExpiresOn);
+        }
+        #endregion
+
+        #region PeekedMessage (BinaryData overload)
+        [Test]
+        public void PeekedMessage_BinaryDataOverload_WithAllParameters()
+        {
+            var body = new BinaryData("hello");
+            var insertedOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddDays(7);
+
+            var result = QueuesModelFactory.PeekedMessage("msgId", body, 3, insertedOn, expiresOn);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.AreSame(body, result.Body);
+            Assert.AreEqual(3, result.DequeueCount);
+            Assert.AreEqual(insertedOn, result.InsertedOn);
+            Assert.AreEqual(expiresOn, result.ExpiresOn);
+        }
+
+        [Test]
+        public void PeekedMessage_BinaryDataOverload_WithRequiredOnly()
+        {
+            var body = new BinaryData("hello");
+
+            var result = QueuesModelFactory.PeekedMessage("msgId", body, 0);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.IsNull(result.InsertedOn);
+            Assert.IsNull(result.ExpiresOn);
+        }
+        #endregion
+
+        #region QueueItem
+        [Test]
+        public void QueueItem_WithAllParameters()
+        {
+            var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+            var result = QueuesModelFactory.QueueItem("myqueue", metadata);
+
+            Assert.AreEqual("myqueue", result.Name);
+            Assert.AreSame(metadata, result.Metadata);
+        }
+
+        [Test]
+        public void QueueItem_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueItem("myqueue");
+
+            Assert.AreEqual("myqueue", result.Name);
+            Assert.IsNull(result.Metadata);
+        }
+        #endregion
+
+        #region QueueProperties (int overload)
+        [Test]
+        public void QueueProperties_IntOverload_SetsProperties()
+        {
+            var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+            var result = QueuesModelFactory.QueueProperties(metadata, 42);
+
+            Assert.AreSame(metadata, result.Metadata);
+            Assert.AreEqual(42, result.ApproximateMessagesCount);
+        }
+        #endregion
+
+        #region QueueProperties (long overload)
+        [Test]
+        public void QueueProperties_LongOverload_SetsProperties()
+        {
+            var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+            var result = QueuesModelFactory.QueueProperties(metadata, 100L);
+
+            Assert.AreSame(metadata, result.Metadata);
+            Assert.AreEqual(100L, result.ApproximateMessagesCountLong);
+        }
+        #endregion
+
+        #region QueueServiceStatistics
+        [Test]
+        public void QueueServiceStatistics_WithGeoReplication()
+        {
+            var geoReplication = QueuesModelFactory.QueueGeoReplication(QueueGeoReplicationStatus.Live, DateTimeOffset.UtcNow);
+
+            var result = QueuesModelFactory.QueueServiceStatistics(geoReplication);
+
+            Assert.AreSame(geoReplication, result.GeoReplication);
+        }
+
+        [Test]
+        public void QueueServiceStatistics_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueServiceStatistics();
+
+            Assert.IsNull(result.GeoReplication);
+        }
+        #endregion
+
+        #region UpdateReceipt
+        [Test]
+        public void UpdateReceipt_SetsProperties()
+        {
+            var nextVisibleOn = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            var result = QueuesModelFactory.UpdateReceipt("popReceipt", nextVisibleOn);
+
+            Assert.AreEqual("popReceipt", result.PopReceipt);
+            Assert.AreEqual(nextVisibleOn, result.NextVisibleOn);
+        }
+        #endregion
+
+        #region SendReceipt
+        [Test]
+        public void SendReceipt_SetsProperties()
+        {
+            var insertionTime = DateTimeOffset.UtcNow;
+            var expirationTime = DateTimeOffset.UtcNow.AddDays(7);
+            var timeNextVisible = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            var result = QueuesModelFactory.SendReceipt("msgId", insertionTime, expirationTime, "popReceipt", timeNextVisible);
+
+            Assert.AreEqual("msgId", result.MessageId);
+            Assert.AreEqual(insertionTime, result.InsertionTime);
+            Assert.AreEqual(expirationTime, result.ExpirationTime);
+            Assert.AreEqual("popReceipt", result.PopReceipt);
+            Assert.AreEqual(timeNextVisible, result.TimeNextVisible);
+        }
+        #endregion
+
+        #region QueueGeoReplication
+        [Test]
+        public void QueueGeoReplication_WithAllParameters()
+        {
+            var lastSyncedOn = DateTimeOffset.UtcNow;
+
+            var result = QueuesModelFactory.QueueGeoReplication(QueueGeoReplicationStatus.Live, lastSyncedOn);
+
+            Assert.AreEqual(QueueGeoReplicationStatus.Live, result.Status);
+            Assert.AreEqual(lastSyncedOn, result.LastSyncedOn);
+        }
+
+        [Test]
+        public void QueueGeoReplication_WithDefaults()
+        {
+            var result = QueuesModelFactory.QueueGeoReplication(QueueGeoReplicationStatus.Bootstrap);
+
+            Assert.AreEqual(QueueGeoReplicationStatus.Bootstrap, result.Status);
+            Assert.IsNull(result.LastSyncedOn);
+        }
+        #endregion
+
+        #region UserDelegationKey (8-param overload)
+        [Test]
+        public void UserDelegationKey_8Param_WithAllParameters()
+        {
+            var startsOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+
+            var result = QueuesModelFactory.UserDelegationKey("oid", "tid", startsOn, expiresOn, "b", "2020-02-10", "delegatedTid", "keyValue");
+
+            Assert.AreEqual("oid", result.SignedObjectId);
+            Assert.AreEqual("tid", result.SignedTenantId);
+            Assert.AreEqual(startsOn, result.SignedStartsOn);
+            Assert.AreEqual(expiresOn, result.SignedExpiresOn);
+            Assert.AreEqual("b", result.SignedService);
+            Assert.AreEqual("2020-02-10", result.SignedVersion);
+            Assert.AreEqual("delegatedTid", result.SignedDelegatedUserTenantId);
+            Assert.AreEqual("keyValue", result.Value);
+        }
+
+        [Test]
+        public void UserDelegationKey_8Param_WithDefaults()
+        {
+            var result = QueuesModelFactory.UserDelegationKey();
+
+            Assert.IsNull(result.SignedObjectId);
+            Assert.IsNull(result.SignedDelegatedUserTenantId);
+            Assert.IsNull(result.Value);
+        }
+        #endregion
+
+        #region UserDelegationKey (7-param overload)
+        [Test]
+        public void UserDelegationKey_7Param_SetsProperties()
+        {
+            var startsOn = DateTimeOffset.UtcNow;
+            var expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+
+            var result = QueuesModelFactory.UserDelegationKey("oid", "tid", startsOn, expiresOn, "b", "2020-02-10", "keyValue");
+
+            Assert.AreEqual("oid", result.SignedObjectId);
+            Assert.AreEqual("tid", result.SignedTenantId);
+            Assert.AreEqual(startsOn, result.SignedStartsOn);
+            Assert.AreEqual(expiresOn, result.SignedExpiresOn);
+            Assert.AreEqual("b", result.SignedService);
+            Assert.AreEqual("2020-02-10", result.SignedVersion);
+            Assert.AreEqual("keyValue", result.Value);
+        }
+        #endregion
+
+        #region QueueSignedIdentifier
+        [Test]
+        public void QueueSignedIdentifier_SetsProperties()
+        {
+            var accessPolicy = QueuesModelFactory.QueueAccessPolicy(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1), "r");
+
+            var result = new QueueSignedIdentifier()
+            {
+                Id = "myPolicy",
+                AccessPolicy = accessPolicy,
+            };
+
+            Assert.AreEqual("myPolicy", result.Id);
+            Assert.AreSame(accessPolicy, result.AccessPolicy);
+        }
+        #endregion
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SerializationUnitTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/SerializationUnitTests.cs
@@ -1,0 +1,1583 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+using Azure.Core;
+using Azure.Storage.Queues.Models;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class SerializationUnitTests
+    {
+        private static readonly ModelReaderWriterOptions XmlOptions = new ModelReaderWriterOptions("X");
+        private static readonly ModelReaderWriterOptions InvalidOptions = new ModelReaderWriterOptions("J");
+
+        #region QueueGeoReplicationStatus
+        private static object[] QueueGeoReplicationStatusCases =
+        {
+            new object[] { QueueGeoReplicationStatus.Live, "live" },
+            new object[] { QueueGeoReplicationStatus.Bootstrap, "bootstrap" },
+            new object[] { QueueGeoReplicationStatus.Unavailable, "unavailable" },
+        };
+
+        [TestCaseSource(nameof(QueueGeoReplicationStatusCases))]
+        public void QueueGeoReplicationStatus_SerializesCorrectly(QueueGeoReplicationStatus enumValue, string expected)
+        {
+            Assert.AreEqual(expected, enumValue.ToSerialString());
+        }
+
+        [TestCaseSource(nameof(QueueGeoReplicationStatusCases))]
+        public void QueueGeoReplicationStatus_DeserializesCorrectly(QueueGeoReplicationStatus expected, string serialValue)
+        {
+            Assert.AreEqual(expected, serialValue.ToQueueGeoReplicationStatus());
+        }
+
+        [TestCaseSource(nameof(QueueGeoReplicationStatusCases))]
+        public void QueueGeoReplicationStatus_RoundTrips(QueueGeoReplicationStatus enumValue, string _)
+        {
+            Assert.AreEqual(enumValue, enumValue.ToSerialString().ToQueueGeoReplicationStatus());
+        }
+
+        [Test]
+        public void QueueGeoReplicationStatus_ToSerialString_ThrowsForInvalid()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => ((QueueGeoReplicationStatus)999).ToSerialString());
+        }
+
+        [Test]
+        public void QueueGeoReplicationStatus_ToQueueGeoReplicationStatus_ThrowsForUnknown()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => "unknown".ToQueueGeoReplicationStatus());
+        }
+        #endregion
+
+        #region PeekedMessage Serialization
+        [Test]
+        public void PeekedMessage_WriteAndCreate_RoundTrips()
+        {
+            var original = new PeekedMessage("msg1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(7), 3, "hello");
+            IPersistableModel<PeekedMessage> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            PeekedMessage deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.MessageId, deserialized.MessageId);
+            Assert.AreEqual(original.DequeueCount, deserialized.DequeueCount);
+            Assert.AreEqual(original.MessageText, deserialized.MessageText);
+        }
+
+        [Test]
+        public void PeekedMessage_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<PeekedMessage> persistable = new PeekedMessage("id", null, null, 0, "text");
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void PeekedMessage_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<PeekedMessage> persistable = new PeekedMessage("id", null, null, 0, "text");
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void PeekedMessage_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<PeekedMessage> persistable = new PeekedMessage("id", null, null, 0, "text");
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<QueueMessage/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void PeekedMessage_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var message = new PeekedMessage("id", null, null, 0, "text");
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => message.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void PeekedMessage_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(PeekedMessage.DeserializePeekedMessage(null, XmlOptions));
+        }
+
+        [Test]
+        public void PeekedMessage_IXmlSerializable_Write()
+        {
+            var message = new PeekedMessage("id", null, null, 0, "text");
+            IXmlSerializable serializable = message;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "QueueMessage");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("QueueMessage", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueAccessPolicy Serialization
+        [Test]
+        public void QueueAccessPolicy_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueAccessPolicy(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1), "raup");
+            IPersistableModel<QueueAccessPolicy> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueAccessPolicy deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.Permissions, deserialized.Permissions);
+        }
+
+        [Test]
+        public void QueueAccessPolicy_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueAccessPolicy> persistable = new QueueAccessPolicy();
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueAccessPolicy_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueAccessPolicy> persistable = new QueueAccessPolicy();
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueAccessPolicy_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueAccessPolicy> persistable = new QueueAccessPolicy();
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<AccessPolicy/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueAccessPolicy_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var policy = new QueueAccessPolicy();
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => policy.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueAccessPolicy_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueAccessPolicy.DeserializeQueueAccessPolicy(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueAccessPolicy_IXmlSerializable_Write()
+        {
+            var policy = new QueueAccessPolicy();
+            IXmlSerializable serializable = policy;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "AccessPolicy");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("AccessPolicy", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueAnalyticsLogging Serialization
+        [Test]
+        public void QueueAnalyticsLogging_WriteAndCreate_RoundTrips()
+        {
+            var retentionPolicy = new QueueRetentionPolicy(true, 7);
+            var original = new QueueAnalyticsLogging("1.0", true, false, true, retentionPolicy);
+            IPersistableModel<QueueAnalyticsLogging> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueAnalyticsLogging deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.Version, deserialized.Version);
+            Assert.AreEqual(original.Delete, deserialized.Delete);
+            Assert.AreEqual(original.Read, deserialized.Read);
+            Assert.AreEqual(original.Write, deserialized.Write);
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueAnalyticsLogging> persistable = new QueueAnalyticsLogging();
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueAnalyticsLogging> persistable = new QueueAnalyticsLogging();
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueAnalyticsLogging> persistable = new QueueAnalyticsLogging();
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<Logging/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var logging = new QueueAnalyticsLogging();
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => logging.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueAnalyticsLogging.DeserializeQueueAnalyticsLogging(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueAnalyticsLogging_IXmlSerializable_Write()
+        {
+            var logging = new QueueAnalyticsLogging();
+            IXmlSerializable serializable = logging;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "Logging");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("Logging", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueCorsRule Serialization
+        [Test]
+        public void QueueCorsRule_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueCorsRule("*", "GET", "x-ms-*", "x-ms-request-id", 3600);
+            IPersistableModel<QueueCorsRule> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueCorsRule deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.AllowedOrigins, deserialized.AllowedOrigins);
+            Assert.AreEqual(original.AllowedMethods, deserialized.AllowedMethods);
+            Assert.AreEqual(original.MaxAgeInSeconds, deserialized.MaxAgeInSeconds);
+        }
+
+        [Test]
+        public void QueueCorsRule_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueCorsRule> persistable = new QueueCorsRule();
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueCorsRule_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueCorsRule> persistable = new QueueCorsRule();
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueCorsRule_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueCorsRule> persistable = new QueueCorsRule();
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<CorsRule/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueCorsRule_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var rule = new QueueCorsRule();
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => rule.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueCorsRule_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueCorsRule.DeserializeQueueCorsRule(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueCorsRule_IXmlSerializable_Write()
+        {
+            var rule = new QueueCorsRule();
+            IXmlSerializable serializable = rule;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "CorsRule");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("CorsRule", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueGeoReplication Serialization
+        [Test]
+        public void QueueGeoReplication_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueGeoReplication(QueueGeoReplicationStatus.Live, DateTimeOffset.UtcNow);
+            IPersistableModel<QueueGeoReplication> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueGeoReplication deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.Status, deserialized.Status);
+        }
+
+        [Test]
+        public void QueueGeoReplication_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueGeoReplication> persistable = new QueueGeoReplication(QueueGeoReplicationStatus.Live, null);
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueGeoReplication_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueGeoReplication> persistable = new QueueGeoReplication(QueueGeoReplicationStatus.Live, null);
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueGeoReplication_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueGeoReplication> persistable = new QueueGeoReplication(QueueGeoReplicationStatus.Live, null);
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<GeoReplication/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueGeoReplication_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var geo = new QueueGeoReplication(QueueGeoReplicationStatus.Live, null);
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => geo.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueGeoReplication_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueGeoReplication.DeserializeQueueGeoReplication(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueGeoReplication_IXmlSerializable_Write()
+        {
+            var geo = new QueueGeoReplication(QueueGeoReplicationStatus.Live, null);
+            IXmlSerializable serializable = geo;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "GeoReplication");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("GeoReplication", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueItem Serialization
+        [Test]
+        public void QueueItem_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueItem("myqueue");
+            IPersistableModel<QueueItem> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueItem deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.Name, deserialized.Name);
+        }
+
+        [Test]
+        public void QueueItem_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueItem> persistable = new QueueItem("q");
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueItem_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueItem> persistable = new QueueItem("q");
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueItem_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueItem> persistable = new QueueItem("q");
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<Queue/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueItem_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var item = new QueueItem("q");
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => item.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueItem_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueItem.DeserializeQueueItem(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueItem_IXmlSerializable_Write()
+        {
+            var item = new QueueItem("q");
+            IXmlSerializable serializable = item;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "Queue");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("Queue", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueMessage Serialization
+        [Test]
+        public void QueueMessage_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueMessage("hello");
+            IPersistableModel<QueueMessage> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueMessage deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.MessageText, deserialized.MessageText);
+        }
+
+        [Test]
+        public void QueueMessage_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueMessage> persistable = new QueueMessage("text");
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueMessage_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueMessage> persistable = new QueueMessage("text");
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueMessage_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueMessage> persistable = new QueueMessage("text");
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<QueueMessage/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueMessage_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var message = new QueueMessage("text");
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => message.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueMessage_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueMessage.DeserializeQueueMessage(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueMessage_IXmlSerializable_Write()
+        {
+            var message = new QueueMessage("text");
+            IXmlSerializable serializable = message;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "QueueMessage");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("QueueMessage", doc.Root.Name.LocalName);
+        }
+
+        [Test]
+        public void QueueMessage_ImplicitOperatorRequestContent_ReturnsContent()
+        {
+            var message = new QueueMessage("text");
+            RequestContent content = message;
+            Assert.IsNotNull(content);
+        }
+
+        [Test]
+        public void QueueMessage_ImplicitOperatorRequestContent_NullReturnsNull()
+        {
+            QueueMessage message = null;
+            RequestContent content = message;
+            Assert.IsNull(content);
+        }
+        #endregion
+
+        #region QueueMetrics Serialization
+        [Test]
+        public void QueueMetrics_WriteAndCreate_RoundTrips()
+        {
+            var retentionPolicy = new QueueRetentionPolicy(true, 7);
+            var original = new QueueMetrics("1.0", true, true, retentionPolicy);
+            IPersistableModel<QueueMetrics> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueMetrics deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.Version, deserialized.Version);
+            Assert.AreEqual(original.Enabled, deserialized.Enabled);
+            Assert.AreEqual(original.IncludeApis, deserialized.IncludeApis);
+        }
+
+        [Test]
+        public void QueueMetrics_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueMetrics> persistable = new QueueMetrics();
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueMetrics_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueMetrics> persistable = new QueueMetrics();
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueMetrics_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueMetrics> persistable = new QueueMetrics();
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<Metrics/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueMetrics_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var metrics = new QueueMetrics();
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => metrics.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueMetrics_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueMetrics.DeserializeQueueMetrics(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueMetrics_IXmlSerializable_Write()
+        {
+            var metrics = new QueueMetrics();
+            IXmlSerializable serializable = metrics;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "Metrics");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("Metrics", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueRetentionPolicy Serialization
+        [Test]
+        public void QueueRetentionPolicy_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueRetentionPolicy(true, 7);
+            IPersistableModel<QueueRetentionPolicy> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueRetentionPolicy deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.Enabled, deserialized.Enabled);
+            Assert.AreEqual(original.Days, deserialized.Days);
+        }
+
+        [Test]
+        public void QueueRetentionPolicy_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueRetentionPolicy> persistable = new QueueRetentionPolicy();
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueRetentionPolicy_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueRetentionPolicy> persistable = new QueueRetentionPolicy();
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueRetentionPolicy_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueRetentionPolicy> persistable = new QueueRetentionPolicy();
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<RetentionPolicy/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueRetentionPolicy_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var policy = new QueueRetentionPolicy();
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => policy.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueRetentionPolicy_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueRetentionPolicy.DeserializeQueueRetentionPolicy(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueRetentionPolicy_IXmlSerializable_Write()
+        {
+            var policy = new QueueRetentionPolicy();
+            IXmlSerializable serializable = policy;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "RetentionPolicy");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("RetentionPolicy", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueServiceProperties Serialization
+        [Test]
+        public void QueueServiceProperties_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueServiceProperties();
+            original.Cors = new System.Collections.Generic.List<QueueCorsRule>();
+            IPersistableModel<QueueServiceProperties> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueServiceProperties deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.IsNotNull(deserialized);
+        }
+
+        [Test]
+        public void QueueServiceProperties_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueServiceProperties> persistable = new QueueServiceProperties();
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueServiceProperties_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueServiceProperties> persistable = new QueueServiceProperties();
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueServiceProperties_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueServiceProperties> persistable = new QueueServiceProperties();
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<StorageServiceProperties/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueServiceProperties_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var props = new QueueServiceProperties();
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => props.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueServiceProperties_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueServiceProperties.DeserializeQueueServiceProperties(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueServiceProperties_IXmlSerializable_Write()
+        {
+            var props = new QueueServiceProperties();
+            props.Cors = new System.Collections.Generic.List<QueueCorsRule>();
+            IXmlSerializable serializable = props;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "StorageServiceProperties");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("StorageServiceProperties", doc.Root.Name.LocalName);
+        }
+
+        [Test]
+        public void QueueServiceProperties_ImplicitOperatorRequestContent_ReturnsContent()
+        {
+            var props = new QueueServiceProperties();
+            props.Cors = new System.Collections.Generic.List<QueueCorsRule>();
+            RequestContent content = props;
+            Assert.IsNotNull(content);
+        }
+
+        [Test]
+        public void QueueServiceProperties_ImplicitOperatorRequestContent_NullReturnsNull()
+        {
+            QueueServiceProperties props = null;
+            RequestContent content = props;
+            Assert.IsNull(content);
+        }
+        #endregion
+
+        #region QueueServiceStatistics Serialization
+        [Test]
+        public void QueueServiceStatistics_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueServiceStatistics(new QueueGeoReplication(QueueGeoReplicationStatus.Live, DateTimeOffset.UtcNow));
+            IPersistableModel<QueueServiceStatistics> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueServiceStatistics deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.IsNotNull(deserialized.GeoReplication);
+            Assert.AreEqual(original.GeoReplication.Status, deserialized.GeoReplication.Status);
+        }
+
+        [Test]
+        public void QueueServiceStatistics_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueServiceStatistics> persistable = new QueueServiceStatistics();
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueServiceStatistics_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueServiceStatistics> persistable = new QueueServiceStatistics();
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueServiceStatistics_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueServiceStatistics> persistable = new QueueServiceStatistics();
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<StorageServiceStats/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueServiceStatistics_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var stats = new QueueServiceStatistics();
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => stats.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueServiceStatistics_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueServiceStatistics.DeserializeQueueServiceStatistics(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueServiceStatistics_IXmlSerializable_Write()
+        {
+            var stats = new QueueServiceStatistics();
+            IXmlSerializable serializable = stats;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "StorageServiceStats");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("StorageServiceStats", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueSignedIdentifier Serialization
+        [Test]
+        public void QueueSignedIdentifier_WriteAndCreate_RoundTrips()
+        {
+            var original = new QueueSignedIdentifier("myId", new QueueAccessPolicy());
+            IPersistableModel<QueueSignedIdentifier> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueSignedIdentifier deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.Id, deserialized.Id);
+        }
+
+        [Test]
+        public void QueueSignedIdentifier_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<QueueSignedIdentifier> persistable = new QueueSignedIdentifier();
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifier_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueSignedIdentifier> persistable = new QueueSignedIdentifier();
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifier_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueSignedIdentifier> persistable = new QueueSignedIdentifier();
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<SignedIdentifier/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifier_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var id = new QueueSignedIdentifier();
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => id.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifier_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueSignedIdentifier.DeserializeQueueSignedIdentifier(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifier_IXmlSerializable_Write()
+        {
+            var id = new QueueSignedIdentifier();
+            IXmlSerializable serializable = id;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "SignedIdentifier");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("SignedIdentifier", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region SendReceipt Serialization
+        [Test]
+        public void SendReceipt_WriteAndCreate_RoundTrips()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var original = new SendReceipt("msg1", now, now.AddDays(7), "pop1", now.AddMinutes(1));
+            IPersistableModel<SendReceipt> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            SendReceipt deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.MessageId, deserialized.MessageId);
+            Assert.AreEqual(original.PopReceipt, deserialized.PopReceipt);
+        }
+
+        [Test]
+        public void SendReceipt_GetFormatFromOptions_ReturnsX()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<SendReceipt> persistable = new SendReceipt("id", now, now, "pop", now);
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void SendReceipt_Write_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<SendReceipt> persistable = new SendReceipt("id", now, now, "pop", now);
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void SendReceipt_Create_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<SendReceipt> persistable = new SendReceipt("id", now, now, "pop", now);
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<QueueMessage/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void SendReceipt_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var receipt = new SendReceipt("id", now, now, "pop", now);
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => receipt.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void SendReceipt_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(SendReceipt.DeserializeSendReceipt(null, XmlOptions));
+        }
+
+        [Test]
+        public void SendReceipt_IXmlSerializable_Write()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var receipt = new SendReceipt("id", now, now, "pop", now);
+            IXmlSerializable serializable = receipt;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "QueueMessage");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("QueueMessage", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region UserDelegationKey Serialization
+        [Test]
+        public void UserDelegationKey_WriteAndCreate_RoundTrips()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var original = new UserDelegationKey("oid", "tid", now, now.AddHours(1), "b", "2020-02-10", "keyValue");
+            IPersistableModel<UserDelegationKey> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            UserDelegationKey deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.SignedObjectId, deserialized.SignedObjectId);
+            Assert.AreEqual(original.SignedTenantId, deserialized.SignedTenantId);
+            Assert.AreEqual(original.Value, deserialized.Value);
+        }
+
+        [Test]
+        public void UserDelegationKey_GetFormatFromOptions_ReturnsX()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<UserDelegationKey> persistable = new UserDelegationKey("oid", "tid", now, now, "b", "v", "key");
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void UserDelegationKey_Write_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<UserDelegationKey> persistable = new UserDelegationKey("oid", "tid", now, now, "b", "v", "key");
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void UserDelegationKey_Create_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<UserDelegationKey> persistable = new UserDelegationKey("oid", "tid", now, now, "b", "v", "key");
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<UserDelegationKey/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void UserDelegationKey_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var key = new UserDelegationKey("oid", "tid", now, now, "b", "v", "key");
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => key.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void UserDelegationKey_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(UserDelegationKey.DeserializeUserDelegationKey(null, XmlOptions));
+        }
+
+        [Test]
+        public void UserDelegationKey_IXmlSerializable_Write()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var key = new UserDelegationKey("oid", "tid", now, now, "b", "v", "key");
+            IXmlSerializable serializable = key;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "UserDelegationKey");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("UserDelegationKey", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region KeyInfo Serialization
+        [Test]
+        public void KeyInfo_WriteAndCreate_RoundTrips()
+        {
+            var original = new KeyInfo("start", "2025-01-01", "tenantId");
+            IPersistableModel<KeyInfo> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            KeyInfo deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.Start, deserialized.Start);
+            Assert.AreEqual(original.Expiry, deserialized.Expiry);
+        }
+
+        [Test]
+        public void KeyInfo_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<KeyInfo> persistable = new KeyInfo("2025-01-01");
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void KeyInfo_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<KeyInfo> persistable = new KeyInfo("2025-01-01");
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void KeyInfo_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<KeyInfo> persistable = new KeyInfo("2025-01-01");
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<KeyInfo/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void KeyInfo_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var keyInfo = new KeyInfo("2025-01-01");
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => keyInfo.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void KeyInfo_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(KeyInfo.DeserializeKeyInfo(null, XmlOptions));
+        }
+
+        [Test]
+        public void KeyInfo_IXmlSerializable_Write()
+        {
+            var keyInfo = new KeyInfo("2025-01-01");
+            IXmlSerializable serializable = keyInfo;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "KeyInfo");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("KeyInfo", doc.Root.Name.LocalName);
+        }
+
+        [Test]
+        public void KeyInfo_ImplicitOperatorRequestContent_ReturnsContent()
+        {
+            var keyInfo = new KeyInfo("2025-01-01");
+            RequestContent content = keyInfo;
+            Assert.IsNotNull(content);
+        }
+
+        [Test]
+        public void KeyInfo_ImplicitOperatorRequestContent_NullReturnsNull()
+        {
+            KeyInfo keyInfo = null;
+            RequestContent content = keyInfo;
+            Assert.IsNull(content);
+        }
+        #endregion
+
+        #region ListOfSentMessage Serialization
+        [Test]
+        public void ListOfSentMessage_WriteAndCreate_RoundTrips()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var items = new[] { new SendReceipt("id", now, now.AddDays(7), "pop", now.AddMinutes(1)) };
+            var original = new ListOfSentMessage(items);
+            IPersistableModel<ListOfSentMessage> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            ListOfSentMessage deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(1, deserialized.Items.Count);
+            Assert.AreEqual("id", deserialized.Items[0].MessageId);
+        }
+
+        [Test]
+        public void ListOfSentMessage_GetFormatFromOptions_ReturnsX()
+        {
+            var original = new ListOfSentMessage(new SendReceipt[0]);
+            IPersistableModel<ListOfSentMessage> persistable = original;
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void ListOfSentMessage_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<ListOfSentMessage> persistable = new ListOfSentMessage(new SendReceipt[0]);
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void ListOfSentMessage_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<ListOfSentMessage> persistable = new ListOfSentMessage(new SendReceipt[0]);
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<QueueMessagesList/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void ListOfSentMessage_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var list = new ListOfSentMessage(new SendReceipt[0]);
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => list.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void ListOfSentMessage_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(ListOfSentMessage.DeserializeListOfSentMessage(null, XmlOptions));
+        }
+
+        [Test]
+        public void ListOfSentMessage_IXmlSerializable_Write()
+        {
+            var list = new ListOfSentMessage(new SendReceipt[0]);
+            IXmlSerializable serializable = list;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "QueueMessagesList");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("QueueMessagesList", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region ListQueuesResponse Serialization
+        [Test]
+        public void ListQueuesResponse_WriteAndCreate_RoundTrips()
+        {
+            var original = new ListQueuesResponse("https://account.queue.core.windows.net/", "prefix", 10, "nextMarker");
+            IPersistableModel<ListQueuesResponse> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            ListQueuesResponse deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.ServiceEndpoint, deserialized.ServiceEndpoint);
+            Assert.AreEqual(original.Prefix, deserialized.Prefix);
+        }
+
+        [Test]
+        public void ListQueuesResponse_GetFormatFromOptions_ReturnsX()
+        {
+            var original = new ListQueuesResponse("https://account.queue.core.windows.net/", "", 10, "");
+            IPersistableModel<ListQueuesResponse> persistable = original;
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void ListQueuesResponse_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<ListQueuesResponse> persistable = new ListQueuesResponse("https://account.queue.core.windows.net/", "", 10, "");
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void ListQueuesResponse_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<ListQueuesResponse> persistable = new ListQueuesResponse("https://account.queue.core.windows.net/", "", 10, "");
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<EnumerationResults/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void ListQueuesResponse_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var response = new ListQueuesResponse("https://account.queue.core.windows.net/", "", 10, "");
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => response.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void ListQueuesResponse_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(ListQueuesResponse.DeserializeListQueuesResponse(null, XmlOptions));
+        }
+
+        [Test]
+        public void ListQueuesResponse_IXmlSerializable_Write()
+        {
+            var response = new ListQueuesResponse("https://account.queue.core.windows.net/", "", 10, "");
+            IXmlSerializable serializable = response;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "EnumerationResults");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("EnumerationResults", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region PeekedMessages Serialization
+        [Test]
+        public void PeekedMessages_WriteAndCreate_RoundTrips()
+        {
+            var items = new[] { new PeekedMessage("id", null, null, 0, "text") };
+            var original = new PeekedMessages(items);
+            IPersistableModel<PeekedMessages> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            PeekedMessages deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(1, deserialized.Items.Count);
+        }
+
+        [Test]
+        public void PeekedMessages_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<PeekedMessages> persistable = new PeekedMessages(new PeekedMessage[0]);
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void PeekedMessages_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<PeekedMessages> persistable = new PeekedMessages(new PeekedMessage[0]);
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void PeekedMessages_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<PeekedMessages> persistable = new PeekedMessages(new PeekedMessage[0]);
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<QueueMessagesList/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void PeekedMessages_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var messages = new PeekedMessages(new PeekedMessage[0]);
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => messages.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void PeekedMessages_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(PeekedMessages.DeserializePeekedMessages(null, XmlOptions));
+        }
+
+        [Test]
+        public void PeekedMessages_IXmlSerializable_Write()
+        {
+            var messages = new PeekedMessages(new PeekedMessage[0]);
+            IXmlSerializable serializable = messages;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "QueueMessagesList");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("QueueMessagesList", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region QueueSignedIdentifiers Serialization
+        [Test]
+        public void QueueSignedIdentifiers_WriteAndCreate_RoundTrips()
+        {
+            var items = new[] { new QueueSignedIdentifier("myId", new QueueAccessPolicy()) };
+            var original = new QueueSignedIdentifiers(items);
+            IPersistableModel<QueueSignedIdentifiers> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            QueueSignedIdentifiers deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(1, deserialized.Items.Count);
+            Assert.AreEqual("myId", deserialized.Items[0].Id);
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_GetFormatFromOptions_ReturnsX()
+        {
+            var original = new QueueSignedIdentifiers(new QueueSignedIdentifier[0]);
+            IPersistableModel<QueueSignedIdentifiers> persistable = original;
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueSignedIdentifiers> persistable = new QueueSignedIdentifiers(new QueueSignedIdentifier[0]);
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<QueueSignedIdentifiers> persistable = new QueueSignedIdentifiers(new QueueSignedIdentifier[0]);
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<SignedIdentifiers/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var ids = new QueueSignedIdentifiers(new QueueSignedIdentifier[0]);
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => ids.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(QueueSignedIdentifiers.DeserializeQueueSignedIdentifiers(null, XmlOptions));
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_IXmlSerializable_Write()
+        {
+            var ids = new QueueSignedIdentifiers(new QueueSignedIdentifier[0]);
+            IXmlSerializable serializable = ids;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "SignedIdentifiers");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("SignedIdentifiers", doc.Root.Name.LocalName);
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_ImplicitOperatorRequestContent_ReturnsContent()
+        {
+            var ids = new QueueSignedIdentifiers(new QueueSignedIdentifier[0]);
+            RequestContent content = ids;
+            Assert.IsNotNull(content);
+        }
+
+        [Test]
+        public void QueueSignedIdentifiers_ImplicitOperatorRequestContent_NullReturnsNull()
+        {
+            QueueSignedIdentifiers ids = null;
+            RequestContent content = ids;
+            Assert.IsNull(content);
+        }
+        #endregion
+
+        #region ReceivedMessage Serialization
+        [Test]
+        public void ReceivedMessage_WriteAndCreate_RoundTrips()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var original = new ReceivedMessage("msg1", now, now.AddDays(7), "pop1", now.AddMinutes(1), 5, "hello");
+            IPersistableModel<ReceivedMessage> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            ReceivedMessage deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(original.MessageId, deserialized.MessageId);
+            Assert.AreEqual(original.PopReceipt, deserialized.PopReceipt);
+            Assert.AreEqual(original.DequeueCount, deserialized.DequeueCount);
+            Assert.AreEqual(original.MessageText, deserialized.MessageText);
+        }
+
+        [Test]
+        public void ReceivedMessage_GetFormatFromOptions_ReturnsX()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<ReceivedMessage> persistable = new ReceivedMessage("id", now, now, "pop", now, 0, "text");
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void ReceivedMessage_Write_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<ReceivedMessage> persistable = new ReceivedMessage("id", now, now, "pop", now, 0, "text");
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void ReceivedMessage_Create_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            IPersistableModel<ReceivedMessage> persistable = new ReceivedMessage("id", now, now, "pop", now, 0, "text");
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<QueueMessage/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void ReceivedMessage_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var message = new ReceivedMessage("id", now, now, "pop", now, 0, "text");
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => message.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void ReceivedMessage_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(ReceivedMessage.DeserializeReceivedMessage(null, XmlOptions));
+        }
+
+        [Test]
+        public void ReceivedMessage_IXmlSerializable_Write()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var message = new ReceivedMessage("id", now, now, "pop", now, 0, "text");
+            IXmlSerializable serializable = message;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "QueueMessage");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("QueueMessage", doc.Root.Name.LocalName);
+        }
+        #endregion
+
+        #region ReceivedMessages Serialization
+        [Test]
+        public void ReceivedMessages_WriteAndCreate_RoundTrips()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var items = new[] { new ReceivedMessage("id", now, now.AddDays(7), "pop", now.AddMinutes(1), 1, "text") };
+            var original = new ReceivedMessages(items);
+            IPersistableModel<ReceivedMessages> persistable = original;
+
+            BinaryData data = persistable.Write(XmlOptions);
+            ReceivedMessages deserialized = persistable.Create(data, XmlOptions);
+
+            Assert.AreEqual(1, deserialized.Items.Count);
+        }
+
+        [Test]
+        public void ReceivedMessages_GetFormatFromOptions_ReturnsX()
+        {
+            IPersistableModel<ReceivedMessages> persistable = new ReceivedMessages(new ReceivedMessage[0]);
+            Assert.AreEqual("X", persistable.GetFormatFromOptions(XmlOptions));
+        }
+
+        [Test]
+        public void ReceivedMessages_Write_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<ReceivedMessages> persistable = new ReceivedMessages(new ReceivedMessage[0]);
+            Assert.Throws<FormatException>(() => persistable.Write(InvalidOptions));
+        }
+
+        [Test]
+        public void ReceivedMessages_Create_ThrowsForInvalidFormat()
+        {
+            IPersistableModel<ReceivedMessages> persistable = new ReceivedMessages(new ReceivedMessage[0]);
+            Assert.Throws<FormatException>(() => persistable.Create(BinaryData.FromString("<QueueMessagesList/>"), InvalidOptions));
+        }
+
+        [Test]
+        public void ReceivedMessages_XmlModelWriteCore_ThrowsForInvalidFormat()
+        {
+            var messages = new ReceivedMessages(new ReceivedMessage[0]);
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            Assert.Throws<FormatException>(() => messages.XmlModelWriteCore(writer, InvalidOptions));
+        }
+
+        [Test]
+        public void ReceivedMessages_Deserialize_ReturnsNullForNullElement()
+        {
+            Assert.IsNull(ReceivedMessages.DeserializeReceivedMessages(null, XmlOptions));
+        }
+
+        [Test]
+        public void ReceivedMessages_IXmlSerializable_Write()
+        {
+            var messages = new ReceivedMessages(new ReceivedMessage[0]);
+            IXmlSerializable serializable = messages;
+
+            using var stream = new MemoryStream();
+            using var writer = XmlWriter.Create(stream);
+            writer.WriteStartDocument();
+            serializable.Write(writer, "QueueMessagesList");
+            writer.Flush();
+
+            stream.Position = 0;
+            var doc = XDocument.Load(stream);
+            Assert.AreEqual("QueueMessagesList", doc.Root.Name.LocalName);
+        }
+        #endregion
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SpecializedQueueClientOptionsTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/SpecializedQueueClientOptionsTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Storage.Queues.Specialized;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class SpecializedQueueClientOptionsTests
+    {
+        [Test]
+        public void SpecializedQueueClientOptions_DefaultConstructor()
+        {
+            var options = new SpecializedQueueClientOptions();
+
+            Assert.IsNull(options.ClientSideEncryption);
+        }
+
+        [Test]
+        public void SpecializedQueueClientOptions_WithVersion()
+        {
+            var options = new SpecializedQueueClientOptions(QueueClientOptions.ServiceVersion.V2024_11_04);
+
+            Assert.IsNull(options.ClientSideEncryption);
+        }
+
+        [Test]
+        public void SpecializedQueueClientOptions_SetClientSideEncryption()
+        {
+            var options = new SpecializedQueueClientOptions();
+            var encryptionOptions = new QueueClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0);
+
+            options.ClientSideEncryption = encryptionOptions;
+
+            Assert.AreSame(encryptionOptions, options.ClientSideEncryption);
+        }
+
+        [Test]
+        public void SpecializedQueueClientOptions_SetClientSideEncryption_Null()
+        {
+            var options = new SpecializedQueueClientOptions();
+            options.ClientSideEncryption = null;
+
+            Assert.IsNull(options.ClientSideEncryption);
+        }
+    }
+}


### PR DESCRIPTION
Tests where code coverage was missing
- Generated Serialization methods
- Queue Encryptor/Dencryptor
- Model Factory
- Extensions, settings 