### PR TITLE
[WebJobs.Extensions.ServiceBus] Fix ServiceBusClient disposal on scale-only host

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed a memory leak on the scale-only host path where `MessagingProvider` and its cached `ServiceBusClient`s were never disposed on host teardown. `AddServiceBusScaleForTrigger` now forces construction of `CleanupService`, which the DI container then disposes automatically, tearing down the cached clients and releasing their AMQP connections, CBS-refresh timers, and heartbeat timers. Previously these stayed registered on the process-wide static `TimerQueue` for the life of the process, because a scale-only host (`ConfigureWebJobsScale`) does not initialize `IExtensionConfigProvider`s — the binding path's normal route into `CleanupService`.
 - Wait for 2 secs before scaling out for ScaleMonitor to avoid aggressive scaling (matches with ScaleControlelr V2) - AB#32302750
 
 ### Other Changes

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -142,6 +142,12 @@ namespace Microsoft.Extensions.Hosting
             // Since there can be more than one instance of ServiceBusScalerProvider, we have to store a reference to the created instance to filter it out later.
             ServiceBusScalerProvider serviceBusScalerProvider = null;
             builder.Services.AddSingleton(serviceProvider => {
+                // Force construction of CleanupService so MS.DI disposes it on host teardown;
+                // CleanupService.Dispose() then calls MessagingProvider.DisposeAsync(). Scale-only
+                // hosts don't build any IExtensionConfigProvider, which is the binding path's only
+                // route into CleanupService.
+                serviceProvider.GetRequiredService<CleanupService>();
+
                 serviceBusScalerProvider = new ServiceBusScalerProvider(serviceProvider, triggerMetadata);
                 return serviceBusScalerProvider;
             });

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -6,12 +6,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.ServiceBus.Config;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -23,6 +27,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
     public class ServiceBusHostBuilderExtensionsTests
     {
         private const string ExtensionPath = "AzureWebJobs:Extensions:ServiceBus";
+        private const string FakeConnectionString =
+            "Endpoint=sb://default.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123=";
 
         [Test]
         public void ConfigureOptions_AppliesValuesCorrectly_BackCompat()
@@ -286,6 +292,53 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
 
             // verify that the service bus config provider was registered
             var serviceBusExtensionConfig = configProviders.OfType<ServiceBusExtensionConfigProvider>().Single();
+        }
+
+        [Test]
+        public async Task AddServiceBusScaleForTrigger_DisposesCachedClient_OnHostDispose()
+        {
+            string triggerJson = @"{
+                ""name"": ""myQueueItem"",
+                ""type"": ""serviceBusTrigger"",
+                ""direction"": ""in"",
+                ""queueName"": ""testqueue"",
+                ""functionName"": ""FakeFunction""
+            }";
+
+            TriggerMetadata metadata = new TriggerMetadata(JObject.Parse(triggerJson));
+
+            IHost host = new HostBuilder()
+                .ConfigureAppConfiguration(config =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        { "AzureWebJobsServiceBus", FakeConnectionString }
+                    });
+                })
+                .ConfigureServices(services => services.AddAzureClientsCore())
+                .ConfigureWebJobsScale((_, builder) =>
+                {
+                    builder.AddServiceBus();
+                    builder.AddServiceBusScaleForTrigger(metadata);
+                },
+                _ => { })
+                .Build();
+
+            // Resolving the scale monitor provider runs the singleton factory registered by
+            // AddServiceBusScaleForTrigger, which is where CleanupService must be resolved for
+            // MS.DI to include it in the container disposal chain.
+            _ = host.Services.GetRequiredService<IScaleMonitorProvider>();
+
+            MessagingProvider provider = host.Services.GetRequiredService<MessagingProvider>();
+            Assert.AreEqual(1, provider.ClientCache.Count);
+
+            ServiceBusClient cachedClient = provider.ClientCache.Values.Single();
+            Assert.IsFalse(cachedClient.IsClosed);
+
+            await ((IAsyncDisposable)host).DisposeAsync();
+
+            Assert.IsTrue(cachedClient.IsClosed);
+            Assert.AreEqual(0, provider.ClientCache.Count);
         }
     }
 }


### PR DESCRIPTION
# Fix `ServiceBusClient` disposal on the scale-only host path

### Summary

`AddServiceBusScaleForTrigger` now resolves `CleanupService` inside its scaler-provider factory. This forces MS.DI to construct `CleanupService` and add it to the container's disposal chain, so `MessagingProvider.DisposeAsync()` runs on host teardown and tears down every cached `ServiceBusClient` (releasing its AMQP connection, CBS-refresh timers, and heartbeat timer).

Without this, the scale-only host built via `ConfigureWebJobsScale` leaks every `ServiceBusClient` created via `MessagingProvider` for the life of the process. Each leaked client keeps a live AMQP connection and multiple `System.Threading.Timer`s on the process-wide static `TimerQueue`, pinning any object reachable from the timer callback (including customer credential state and site metadata).

### Root cause

- `MessagingProvider` deliberately does **not** implement `IAsyncDisposable` (`Primitives/MessagingProvider.cs:224-225` — explicit SDK-owner comment says implementing it "could break existing user code"). The only route into `MessagingProvider.DisposeAsync()` is `CleanupService.Dispose()` / `DisposeAsync()`.
- MS.DI adds a singleton to its disposal chain **only after it has constructed it**. A registered-but-never-resolved singleton is never on the list.
- The only consumer that resolves `CleanupService` today is `ServiceBusExtensionConfigProvider`, which takes it as an unused constructor parameter (`Config/ServiceBusExtensionConfigProvider.cs:52`) purely to pin its lifetime.
- On the **binding** path (`ConfigureWebJobs` → `AddWebJobs`), `IExtensionRegistry` is registered, its factory walks `IEnumerable<IExtensionConfigProvider>`, and `ServiceBusExtensionConfigProvider` is constructed. That transitively constructs `CleanupService`. Disposal is free.
- On the **scale-only** path (`ConfigureWebJobsScale` → `AddWebJobsScale`), `IExtensionRegistry` is not registered, no `IExtensionConfigProvider` is instantiated, `CleanupService` is registered but never resolved, and `MessagingProvider.DisposeAsync()` never runs. Every `ServiceBusClient` cached in `MessagingProvider.ClientCache` (and its `AmqpConnectionScope` with per-link CBS-refresh timers + heartbeat timer) stays alive for the life of the process.

### Fix

Inside the singleton factory registered by `AddServiceBusScaleForTrigger`, resolve `CleanupService` once. That forces construction and adds it to the container's disposal chain. `ServiceBusScalerProvider` construction is unchanged.

```csharp
builder.Services.AddSingleton(serviceProvider => {
    // Force MessagingProvider disposal to run on host teardown. ...
    serviceProvider.GetRequiredService<CleanupService>();

    serviceBusScalerProvider = new ServiceBusScalerProvider(serviceProvider, triggerMetadata);
    return serviceBusScalerProvider;
});
```

### Alternatives considered

- **Register a no-op `IHostedService` in `AddServiceBus`** that depends on `CleanupService`. Equivalent effect; adds a wrapper type and a hosted-service registration for no additional coverage on the current SC path (still depends on `AddServiceBus()` being called upstream). Not shipping.
- **Make `ServiceBusScalerProvider` implement `IDisposable` and dispose the client itself** (Cosmos pattern). Rejected — the client is shared via `MessagingProvider.ClientCache`, so per-provider disposal would race with other consumers of the same cached client; also would leave `MessageSenderCache` / `MessageReceiverCache` untouched. Contradicts the SDK's stated ownership model (`Listeners/ServiceBusListener.cs:311`).
- **Make `MessagingProvider` implement `IAsyncDisposable` and delete `CleanupService`**. Cleanest long-term, but blocked by the SDK-owner comment at `Primitives/MessagingProvider.cs:224` deferring this to the next major version.

### Files changed

- `sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs` — one-line resolve inside the `AddServiceBusScaleForTrigger` factory (+ block comment).
- `sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md` — bugs-fixed entry under `5.18.0-beta.1 (Unreleased)`.

### Testing

Build: `dotnet build sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj -c Release` — 0 warnings, 0 errors.

Behavioural validation for the fix will be done via ScaleController's own repro + canary heap dump gates:

- Build a scale-only host with a Service Bus trigger via `AddServiceBus()` + `AddServiceBusScaleForTrigger(...)`; resolve the scale monitor provider; capture the `ServiceBusClient` from `MessagingProvider.ClientCache` (via internal accessor / reflection); `host.Dispose()`; assert `serviceBusClient.IsClosed == true`. On `main` this assertion currently fails; with this fix it passes.
- Heap dump on a canary Scale Controller stamp: `AmqpConnectionScope`, `AmqpConnection+HeartBeat+TimedHeartBeat`, `TimerQueueTimer` counts must fall to the levels observed on a control (healthy) instance in the same stamp; managed heap size expected to fall from multi-GB to < 1.5 GB.

### Compatibility

- No public API change.
- No behaviour change on the binding path: `CleanupService` is a singleton; resolving it twice is a no-op.
- Requires `AddServiceBus()` to have been called on the same builder (which registers `CleanupService`). This is the case in the current Scale Controller path (`RegisteredExtensionHelper.cs`: `EnsureExtensionRegistration` calls `AddServiceBus()` before `AddTriggerScale` calls `AddServiceBusScaleForTrigger`).

### Related work items

- Antares AB#39357848 — SDK-side bug for this leak.
- Antares AB#39358273 — companion Scale Controller fixes to `SiteEnsureWorkersService` (dispose the previous `IHost` before replacing; harden the shutdown loop with per-host `try/catch`). Load-bearing for this SDK fix to take effect end-to-end.
