### PR TITLE
Support IAsyncEnumerable client instrumentation

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
@@ -14,6 +14,9 @@ namespace Azure.Core.Tests
     {
         private readonly Func<string, bool> _sourceNameFilter;
         private readonly AsyncLocal<bool> _collectThisStack;
+        private readonly object _operationToken;
+
+        private static readonly AsyncLocal<object> s_currentOperation = new AsyncLocal<object>();
 
         private List<IDisposable> _subscriptions = new List<IDisposable>();
         private readonly Action<ProducedDiagnosticScope> _scopeStartCallback;
@@ -26,7 +29,22 @@ namespace Azure.Core.Tests
         }
 
         public ClientDiagnosticListener(Func<string, bool> filter, bool asyncLocal = false, Action<ProducedDiagnosticScope> scopeStartCallback = default)
+            : this(filter, asyncLocal, scopeStartCallback, null)
         {
+        }
+
+        /// <summary>
+        /// Creates a listener that only collects events raised while <paramref name="operationToken"/> is the
+        /// current operation. Execution-context isolation alone is not enough for deferred operations such as
+        /// async iterators, because several of them can be created on, and interleaved within, the same flow.
+        /// </summary>
+        internal ClientDiagnosticListener(
+            Func<string, bool> filter,
+            bool asyncLocal,
+            Action<ProducedDiagnosticScope> scopeStartCallback,
+            object operationToken)
+        {
+            _operationToken = operationToken;
             if (asyncLocal)
             {
                 _collectThisStack = new AsyncLocal<bool> { Value = true };
@@ -35,6 +53,12 @@ namespace Azure.Core.Tests
             _scopeStartCallback = scopeStartCallback;
             DiagnosticListener.AllListeners.Subscribe(this);
         }
+
+        /// <summary>
+        /// Marks the calling asynchronous frame as belonging to <paramref name="operationToken"/>. The value only
+        /// flows into work started by that frame, so it does not leak back out to the caller.
+        /// </summary>
+        internal static void EnterOperation(object operationToken) => s_currentOperation.Value = operationToken;
 
         public void OnCompleted()
         {
@@ -47,6 +71,9 @@ namespace Azure.Core.Tests
         public void OnNext(KeyValuePair<string, object> value)
         {
             if (_collectThisStack?.Value == false)
+                return;
+
+            if (_operationToken != null && !ReferenceEquals(s_currentOperation.Value, _operationToken))
                 return;
 
             lock (Scopes)

--- a/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
@@ -79,30 +79,40 @@ namespace Azure.Core.Tests
                 else if (value.Key.EndsWith(stopSuffix))
                 {
                     var name = value.Key.Substring(0, value.Key.Length - stopSuffix.Length);
-                    foreach (ProducedDiagnosticScope producedDiagnosticScope in Scopes)
+                    ProducedDiagnosticScope scope = null;
+                    string activityId = Activity.Current?.Id;
+                    if (activityId != null)
                     {
-                        if (producedDiagnosticScope.Activity.Id == Activity.Current.Id)
-                        {
-                            producedDiagnosticScope.IsCompleted = true;
-                            return;
-                        }
+                        scope = Scopes.FirstOrDefault(s => s.Activity.Id == activityId && s.Name == name);
+                    }
+
+                    scope ??= Scopes.LastOrDefault(s => !s.IsCompleted && s.Name == name);
+                    if (scope != null)
+                    {
+                        scope.IsCompleted = true;
+                        return;
                     }
                     throw new InvalidOperationException($"Event '{name}' was not started");
                 }
                 else if (value.Key.EndsWith(exceptionSuffix))
                 {
                     var name = value.Key.Substring(0, value.Key.Length - exceptionSuffix.Length);
-                    foreach (ProducedDiagnosticScope producedDiagnosticScope in Scopes)
+                    ProducedDiagnosticScope scope = null;
+                    string activityId = Activity.Current?.Id;
+                    if (activityId != null)
                     {
-                        if (producedDiagnosticScope.Activity.Id == Activity.Current.Id)
-                        {
-                            if (producedDiagnosticScope.IsCompleted)
-                            {
-                                throw new InvalidOperationException("Scope should not be stopped when calling Failed");
-                            }
+                        scope = Scopes.FirstOrDefault(s => s.Activity.Id == activityId && s.Name == name);
+                    }
 
-                            producedDiagnosticScope.Exception = (Exception)value.Value;
-                        }
+                    scope ??= Scopes.LastOrDefault(s => !s.IsCompleted && s.Name == name);
+                    if (scope?.IsCompleted == true)
+                    {
+                        throw new InvalidOperationException("Scope should not be stopped when calling Failed");
+                    }
+
+                    if (scope != null)
+                    {
+                        scope.Exception = (Exception)value.Value;
                     }
                 }
             }

--- a/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
@@ -19,6 +19,7 @@ namespace Azure.Core.Tests
         private static readonly AsyncLocal<object> s_currentOperation = new AsyncLocal<object>();
 
         private List<IDisposable> _subscriptions = new List<IDisposable>();
+        private readonly IDisposable _allListenersSubscription;
         private readonly Action<ProducedDiagnosticScope> _scopeStartCallback;
 
         public List<ProducedDiagnosticScope> Scopes { get; } = new List<ProducedDiagnosticScope>();
@@ -51,7 +52,7 @@ namespace Azure.Core.Tests
             }
             _sourceNameFilter = filter;
             _scopeStartCallback = scopeStartCallback;
-            DiagnosticListener.AllListeners.Subscribe(this);
+            _allListenersSubscription = DiagnosticListener.AllListeners.Subscribe(this);
         }
 
         /// <summary>
@@ -177,6 +178,10 @@ namespace Azure.Core.Tests
             {
                 subscription.Dispose();
             }
+
+            // AllListeners is a process-wide observable, so failing to release this would keep the
+            // listener and every scope it captured alive for the lifetime of the process.
+            _allListenersSubscription?.Dispose();
 
             foreach (ProducedDiagnosticScope producedDiagnosticScope in Scopes)
             {

--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/AsyncEnumerableType.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/AsyncEnumerableType.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Azure.Core.TestFramework
+{
+    internal static class AsyncEnumerableType
+    {
+        public static Type GetItemType(Type type)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+            {
+                return type.GenericTypeArguments[0];
+            }
+
+            return type.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+                ?.GenericTypeArguments[0];
+        }
+
+        public static bool IsInterface(Type type)
+            => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>);
+    }
+}

--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
@@ -28,21 +28,22 @@ namespace Azure.Core.TestFramework
         public void Intercept(IInvocation invocation)
         {
             var type = invocation.Method.ReturnType;
-
-            var isAsyncEnumerable = false;
-            // cspell:ignore iface
-            foreach (var iface in type.GetInterfaces())
-            {
-                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
-                {
-                    isAsyncEnumerable = true;
-                }
-            }
+            Type asyncEnumerableItemType = AsyncEnumerableType.GetItemType(type);
 
             if (invocation.Method.Name.EndsWith("Async") &&
-                !isAsyncEnumerable)
+                asyncEnumerableItemType is null)
             {
                 WrapAsyncResult(invocation, this, ValidateDiagnosticScopeMethodInfo);
+                return;
+            }
+
+            if (asyncEnumerableItemType is not null && AsyncEnumerableType.IsInterface(type))
+            {
+                invocation.Proceed();
+                invocation.ReturnValue = Activator.CreateInstance(
+                    typeof(DiagnosticScopeValidatingEnumerable<>).MakeGenericType(asyncEnumerableItemType),
+                    invocation.ReturnValue,
+                    invocation.Method);
                 return;
             }
 
@@ -176,23 +177,7 @@ namespace Azure.Core.TestFramework
 
         internal static async ValueTask<T> ValidateDiagnosticScope<T>(Func<ValueTask<(T Result, bool SkipChecks)>> action, MethodInfo methodInfo, string source = null)
         {
-            var methodName = methodInfo.Name;
-            source ??= methodName;
-
-            Type declaringType = methodInfo.DeclaringType;
-            var methodNameWithoutSuffix = methodName.EndsWith("Async", StringComparison.OrdinalIgnoreCase) ?
-                methodName.Substring(0, methodName.Length - 5) :
-                methodName;
-
-            // check if this methodInfo is a "Core" method in mgmt plane, if it is, trim the Core suffix from the method name
-            if (methodInfo.IsFamily && methodNameWithoutSuffix.EndsWith("Core"))
-            {
-                methodNameWithoutSuffix = methodNameWithoutSuffix.Substring(0, methodNameWithoutSuffix.Length - 4);
-            }
-
-            var expectedName = declaringType.Name + "." + methodNameWithoutSuffix;
-            var forwardAttribute = methodInfo.GetCustomAttributes(true).FirstOrDefault(a => a.GetType().FullName == "Azure.Core.ForwardsClientCallsAttribute");
-            bool strict = forwardAttribute is null;
+            source ??= methodInfo.Name;
 
             Exception lastException = null;
             bool skipChecks = false;
@@ -221,48 +206,67 @@ namespace Azure.Core.TestFramework
             }
             finally
             {
-                // Remove subscribers before enumerating events.
-                diagnosticListener.Dispose();
-
-                var skipOverrideProperty = forwardAttribute is not null ? forwardAttribute.GetType().GetProperty("SkipChecks") : null;
-                bool skipOverride = skipOverrideProperty is not null ? (bool)skipOverrideProperty.GetValue(forwardAttribute) : false;
-                skipChecks |= skipOverride;
-                if (!skipChecks)
-                {
-                    diagnosticListener.Scopes.ForEach(s => CheckAttributes(s.Activity, strict));
-
-                    if (strict)
-                    {
-                        ClientDiagnosticListener.ProducedDiagnosticScope e = diagnosticListener.Scopes.FirstOrDefault(e => e.Name == expectedName);
-
-                        if (e == default)
-                        {
-                            throw new InvalidOperationException($"Expected diagnostic scope not created {expectedName} {Environment.NewLine}" +
-                                                                $"    created {diagnosticListener.Scopes.Count} scopes [{string.Join(", ", diagnosticListener.Scopes)}] {Environment.NewLine}" +
-                                                                $"    You may have forgotten to add clientDiagnostics.CreateScope(...), set your operationId to {expectedName} in {source} or applied the Azure.Core.ForwardsClientCallsAttribute to {source}.");
-                        }
-
-                        if (lastException != null && !e.IsFailed)
-                        {
-                            throw new InvalidOperationException($"Expected scope {expectedName} to be marked as failed but it succeeded{Environment.NewLine}Exception: {lastException}");
-                        }
-                    }
-                    else
-                    {
-                        // If ForwardsClientCallsAttribute is being used on the method, we don't know what the name of the scope should be because there could be many
-                        // differently named methods sharing the same scope name, but we do know that there should be some scope created other than the Azure.Core scope.
-                        if (!diagnosticListener.Scopes.Any(e => !e.Name.StartsWith("Azure.Core")))
-                        {
-                            throw new InvalidOperationException(
-                                "Expected some diagnostic scopes to be created other than the Azure.Core scopes, but no such scopes were present. " +
-                                $"Ensure that the inner method that client calls are being forwarded to from the '{source}' method has diagnostic scopes " +
-                                "defined by using clientDiagnostics.CreateScope(...).");
-                        }
-                    }
-                }
+                ValidateDiagnosticScopes(diagnosticListener, methodInfo, source, lastException, skipChecks);
             }
 
             return result;
+        }
+
+        private static void ValidateDiagnosticScopes(
+            ClientDiagnosticListener diagnosticListener,
+            MethodInfo methodInfo,
+            string source,
+            Exception lastException,
+            bool skipChecks)
+        {
+            diagnosticListener.Dispose();
+
+            string methodName = methodInfo.Name;
+            Type declaringType = methodInfo.DeclaringType;
+            string methodNameWithoutSuffix = methodName.EndsWith("Async", StringComparison.OrdinalIgnoreCase)
+                ? methodName.Substring(0, methodName.Length - 5)
+                : methodName;
+            if (methodInfo.IsFamily && methodNameWithoutSuffix.EndsWith("Core"))
+            {
+                methodNameWithoutSuffix = methodNameWithoutSuffix.Substring(0, methodNameWithoutSuffix.Length - 4);
+            }
+
+            string expectedName = declaringType.Name + "." + methodNameWithoutSuffix;
+            object forwardAttribute = methodInfo.GetCustomAttributes(true)
+                .FirstOrDefault(a => a.GetType().FullName == "Azure.Core.ForwardsClientCallsAttribute");
+            PropertyInfo skipOverrideProperty = forwardAttribute?.GetType().GetProperty("SkipChecks");
+            skipChecks |= skipOverrideProperty is not null && (bool)skipOverrideProperty.GetValue(forwardAttribute);
+            if (skipChecks)
+            {
+                return;
+            }
+
+            bool strict = forwardAttribute is null;
+            diagnosticListener.Scopes.ForEach(s => CheckAttributes(s.Activity, strict));
+
+            if (strict)
+            {
+                ClientDiagnosticListener.ProducedDiagnosticScope scope = diagnosticListener.Scopes
+                    .FirstOrDefault(e => e.Name == expectedName);
+                if (scope == default)
+                {
+                    throw new InvalidOperationException($"Expected diagnostic scope not created {expectedName} {Environment.NewLine}" +
+                                                        $"    created {diagnosticListener.Scopes.Count} scopes [{string.Join(", ", diagnosticListener.Scopes)}] {Environment.NewLine}" +
+                                                        $"    You may have forgotten to add clientDiagnostics.CreateScope(...), set your operationId to {expectedName} in {source} or applied the Azure.Core.ForwardsClientCallsAttribute to {source}.");
+                }
+
+                if (lastException != null && !scope.IsFailed)
+                {
+                    throw new InvalidOperationException($"Expected scope {expectedName} to be marked as failed but it succeeded{Environment.NewLine}Exception: {lastException}");
+                }
+            }
+            else if (!diagnosticListener.Scopes.Any(e => !e.Name.StartsWith("Azure.Core")))
+            {
+                throw new InvalidOperationException(
+                    "Expected some diagnostic scopes to be created other than the Azure.Core scopes, but no such scopes were present. " +
+                    $"Ensure that the inner method that client calls are being forwarded to from the '{source}' method has diagnostic scopes " +
+                    "defined by using clientDiagnostics.CreateScope(...).");
+            }
         }
 
         private static void CheckAttributes(Activity activity, bool strict)
@@ -366,6 +370,119 @@ namespace Azure.Core.TestFramework
                 }, _methodInfo, $"AsPages() implementation returned from {_methodInfo.Name}"))
                 {
                     yield return enumerator.Current;
+                }
+            }
+        }
+
+        internal sealed class DiagnosticScopeValidatingEnumerable<T> : IAsyncEnumerable<T>
+        {
+            private readonly IAsyncEnumerable<T> _enumerable;
+            private readonly MethodInfo _methodInfo;
+
+            public DiagnosticScopeValidatingEnumerable(
+                IAsyncEnumerable<T> enumerable,
+                MethodInfo methodInfo)
+            {
+                _enumerable = enumerable ?? throw new ArgumentNullException(
+                    nameof(enumerable),
+                    "Operations returning IAsyncEnumerable should never return null.");
+                _methodInfo = methodInfo;
+            }
+
+            public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+                => new DiagnosticScopeValidatingEnumerator(
+                    _enumerable,
+                    _methodInfo,
+                    cancellationToken);
+
+            private sealed class DiagnosticScopeValidatingEnumerator : IAsyncEnumerator<T>
+            {
+                private readonly ClientDiagnosticListener _diagnosticListener;
+                private readonly IAsyncEnumerator<T> _enumerator;
+                private readonly MethodInfo _methodInfo;
+                private bool _moveNextStarted;
+                private bool _validationCompleted;
+
+                public DiagnosticScopeValidatingEnumerator(
+                    IAsyncEnumerable<T> enumerable,
+                    MethodInfo methodInfo,
+                    CancellationToken cancellationToken)
+                {
+                    _methodInfo = methodInfo;
+                    _diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure."), asyncLocal: true);
+                    Activity.Current?.SetCustomProperty("az.sdk.scope", null);
+                    try
+                    {
+                        _enumerator = enumerable.GetAsyncEnumerator(cancellationToken);
+                    }
+                    catch
+                    {
+                        _diagnosticListener.Dispose();
+                        throw;
+                    }
+                }
+
+                public T Current => _enumerator.Current;
+
+                public async ValueTask<bool> MoveNextAsync()
+                {
+                    _moveNextStarted = true;
+                    try
+                    {
+                        bool movedNext = await _enumerator.MoveNextAsync();
+                        if (!movedNext)
+                        {
+                            CompleteValidation(null, false);
+                        }
+
+                        return movedNext;
+                    }
+                    catch (Exception ex)
+                    {
+                        CompleteValidation(ex, ex is ArgumentException);
+                        throw;
+                    }
+                }
+
+                public async ValueTask DisposeAsync()
+                {
+                    Exception exception = null;
+                    try
+                    {
+                        await _enumerator.DisposeAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+                        throw;
+                    }
+                    finally
+                    {
+                        if (_moveNextStarted)
+                        {
+                            CompleteValidation(exception, exception is ArgumentException);
+                        }
+                        else
+                        {
+                            _diagnosticListener.Dispose();
+                        }
+                    }
+                }
+
+                private void CompleteValidation(Exception exception, bool skipChecks)
+                {
+                    if (_validationCompleted)
+                    {
+                        return;
+                    }
+
+                    _validationCompleted = true;
+                    ValidateDiagnosticScopes(
+                        _diagnosticListener,
+                        _methodInfo,
+                        _methodInfo.Name,
+                        exception,
+                        skipChecks);
                 }
             }
         }

--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
@@ -400,6 +400,7 @@ namespace Azure.Core.TestFramework
                 private readonly ClientDiagnosticListener _diagnosticListener;
                 private readonly IAsyncEnumerator<T> _enumerator;
                 private readonly MethodInfo _methodInfo;
+                private readonly object _operationToken = new object();
                 private bool _moveNextStarted;
                 private bool _validationCompleted;
 
@@ -409,7 +410,14 @@ namespace Azure.Core.TestFramework
                     CancellationToken cancellationToken)
                 {
                     _methodInfo = methodInfo;
-                    _diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure."), asyncLocal: true);
+
+                    // Bind the listener to this enumerator so interleaved streams on the same async flow do not
+                    // record, or validate, each other's scopes.
+                    _diagnosticListener = new ClientDiagnosticListener(
+                        s => s.StartsWith("Azure."),
+                        asyncLocal: true,
+                        scopeStartCallback: null,
+                        operationToken: _operationToken);
                     UnsuppressCurrentActivity();
                     try
                     {
@@ -430,6 +438,7 @@ namespace Azure.Core.TestFramework
 
                     // The iterator body runs lazily, so the activity that hosts its scopes is only
                     // known here rather than when the enumerator was created.
+                    ClientDiagnosticListener.EnterOperation(_operationToken);
                     UnsuppressCurrentActivity();
                     try
                     {
@@ -451,6 +460,7 @@ namespace Azure.Core.TestFramework
                 public async ValueTask DisposeAsync()
                 {
                     Exception exception = null;
+                    ClientDiagnosticListener.EnterOperation(_operationToken);
                     UnsuppressCurrentActivity();
                     try
                     {

--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
@@ -410,7 +410,7 @@ namespace Azure.Core.TestFramework
                 {
                     _methodInfo = methodInfo;
                     _diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure."), asyncLocal: true);
-                    Activity.Current?.SetCustomProperty("az.sdk.scope", null);
+                    UnsuppressCurrentActivity();
                     try
                     {
                         _enumerator = enumerable.GetAsyncEnumerator(cancellationToken);
@@ -427,6 +427,10 @@ namespace Azure.Core.TestFramework
                 public async ValueTask<bool> MoveNextAsync()
                 {
                     _moveNextStarted = true;
+
+                    // The iterator body runs lazily, so the activity that hosts its scopes is only
+                    // known here rather than when the enumerator was created.
+                    UnsuppressCurrentActivity();
                     try
                     {
                         bool movedNext = await _enumerator.MoveNextAsync();
@@ -447,6 +451,7 @@ namespace Azure.Core.TestFramework
                 public async ValueTask DisposeAsync()
                 {
                     Exception exception = null;
+                    UnsuppressCurrentActivity();
                     try
                     {
                         await _enumerator.DisposeAsync();
@@ -467,6 +472,14 @@ namespace Azure.Core.TestFramework
                             _diagnosticListener.Dispose();
                         }
                     }
+                }
+
+                private static void UnsuppressCurrentActivity()
+                {
+                    // Activities may be suppressed if they are called in scope of other activities created by
+                    // other SDK methods. Unsuppress them so all attributes and properties can be checked
+                    // regardless of the test setup.
+                    Activity.Current?.SetCustomProperty("az.sdk.scope", null);
                 }
 
                 private void CompleteValidation(Exception exception, bool skipChecks)

--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/UseSyncMethodsInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/UseSyncMethodsInterceptor.cs
@@ -41,6 +41,12 @@ namespace Azure.Core.TestFramework
             Type[] parameterTypes = invocation.Method.GetParameters().Select(p => p.ParameterType).ToArray();
 
             var methodName = invocation.Method.Name;
+            if (AsyncEnumerableType.GetItemType(invocation.Method.ReturnType) is not null)
+            {
+                invocation.Proceed();
+                return;
+            }
+
             if (!methodName.EndsWith(AsyncSuffix))
             {
                 MethodInfo asyncAlternative = GetMethod(invocation, methodName + AsyncSuffix, parameterTypes);

--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/UseSyncMethodsInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/UseSyncMethodsInterceptor.cs
@@ -41,7 +41,10 @@ namespace Azure.Core.TestFramework
             Type[] parameterTypes = invocation.Method.GetParameters().Select(p => p.ParameterType).ToArray();
 
             var methodName = invocation.Method.Name;
-            if (AsyncEnumerableType.GetItemType(invocation.Method.ReturnType) is not null)
+
+            // Async-only streaming methods return IAsyncEnumerable<T> directly and have no sync counterpart.
+            // Types that merely implement the interface, like AsyncPageable<T>, still map to their sync overloads.
+            if (AsyncEnumerableType.IsInterface(invocation.Method.ReturnType))
             {
                 invocation.Proceed();
                 return;

--- a/sdk/core/Azure.Core.TestFramework/tests/ClientDiagnosticListenerTests.cs
+++ b/sdk/core/Azure.Core.TestFramework/tests/ClientDiagnosticListenerTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Azure.Core.Tests;
+using NUnit.Framework;
+
+namespace Azure.Core.TestFramework.Tests
+{
+    public class ClientDiagnosticListenerTests
+    {
+        [Test]
+        public void DisposeReleasesAllListenersSubscription()
+        {
+            var references = new List<WeakReference>();
+            for (int i = 0; i < 10; i++)
+            {
+                references.Add(CreateAndDisposeListener());
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            CollectionAssert.IsEmpty(
+                references.FindAll(r => r.IsAlive),
+                "Disposed listeners are still rooted by DiagnosticListener.AllListeners.");
+        }
+
+        // The listener must not be reachable from the caller's frame, otherwise it stays rooted
+        // regardless of whether the subscription was released.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static WeakReference CreateAndDisposeListener()
+        {
+            var listener = new ClientDiagnosticListener($"Source.{Guid.NewGuid()}");
+            listener.Dispose();
+            return new WeakReference(listener);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
+++ b/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
@@ -134,6 +134,22 @@ namespace Azure.Core.TestFramework.Tests
         }
 
         [Test]
+        public async Task AsyncEnumerableUnsuppressesScopesDuringEnumeration()
+        {
+            InvalidDiagnosticScopeTestClient client = InstrumentClient(new InvalidDiagnosticScopeTestClient());
+            IAsyncEnumerator<int> enumerator = client.StreamSuppressibleAsync().GetAsyncEnumerator();
+
+            // The iterator body only runs on MoveNextAsync, so it observes this activity rather than
+            // the one that was current when the enumerator was created.
+            using Activity activity = new Activity("Outer").Start();
+            activity.SetCustomProperty("az.sdk.scope", bool.TrueString);
+
+            Assert.IsTrue(await enumerator.MoveNextAsync());
+            Assert.IsFalse(await enumerator.MoveNextAsync());
+            await enumerator.DisposeAsync();
+        }
+
+        [Test]
         public async Task DirectListenerCapturesAsyncEnumerableScope()
         {
             using var listener = new ClientDiagnosticListener(s => s.StartsWith("Azure."), asyncLocal: true);
@@ -333,6 +349,27 @@ namespace Azure.Core.TestFramework.Tests
                     yield return 1;
                     await Task.Yield();
                     yield return 2;
+                }
+                finally
+                {
+                    scope.Dispose();
+                }
+            }
+
+            public virtual async IAsyncEnumerable<int> StreamSuppressibleAsync(
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                // Suppresses nested activities, so this scope is skipped entirely when the ambient
+                // activity is still marked with az.sdk.scope.
+                DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Core.Tests", "random", true, true, true);
+                DiagnosticScope scope = clientDiagnostics.CreateScope(
+                    $"{typeof(InvalidDiagnosticScopeTestClient).Name}.StreamSuppressible");
+                scope.Start();
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    yield return 1;
+                    await Task.Yield();
                 }
                 finally
                 {

--- a/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
+++ b/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
@@ -2,10 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
+using Azure.Core.Tests;
 using NUnit.Framework;
 
 namespace Azure.Core.TestFramework.Tests
@@ -110,6 +115,86 @@ namespace Azure.Core.TestFramework.Tests
         {
             InvalidDiagnosticScopeTestClient client = InstrumentClient(new InvalidDiagnosticScopeTestClient());
             await client.CorrectScopeAsync();
+        }
+
+        [Test]
+        public async Task AsyncEnumerableDoesNotRequireSyncCounterpart()
+        {
+            InvalidDiagnosticScopeTestClient client = InstrumentClient(new InvalidDiagnosticScopeTestClient());
+
+            Assert.AreEqual(new[] { 1, 2 }, await client.StreamValidAsync().ToEnumerableAsync());
+        }
+
+        [Test]
+        public async Task AsyncEnumerableAllowsForwardedScope()
+        {
+            InvalidDiagnosticScopeTestClient client = InstrumentClient(new InvalidDiagnosticScopeTestClient());
+
+            Assert.AreEqual(new[] { 1 }, await client.StreamForwardedAsync().ToEnumerableAsync());
+        }
+
+        [Test]
+        public async Task DirectListenerCapturesAsyncEnumerableScope()
+        {
+            using var listener = new ClientDiagnosticListener(s => s.StartsWith("Azure."), asyncLocal: true);
+
+            await new InvalidDiagnosticScopeTestClient().StreamValidAsync().ToEnumerableAsync();
+
+            Assert.IsTrue(listener.Scopes.Single().IsCompleted);
+        }
+
+        [Test]
+        public async Task AsyncEnumerableValidationIsDeferredUntilCompletion()
+        {
+            InvalidDiagnosticScopeTestClient client = InstrumentClient(new InvalidDiagnosticScopeTestClient());
+            IAsyncEnumerator<int> enumerator = client.StreamWithoutScopeAsync().GetAsyncEnumerator();
+
+            Assert.IsTrue(await enumerator.MoveNextAsync());
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await enumerator.MoveNextAsync());
+            StringAssert.Contains(
+                $"{typeof(InvalidDiagnosticScopeTestClient).Name}.StreamWithoutScope",
+                ex.Message);
+            await enumerator.DisposeAsync();
+        }
+
+        [Test]
+        public async Task AsyncEnumerableValidatesFailure()
+        {
+            InvalidDiagnosticScopeTestClient client = InstrumentClient(new InvalidDiagnosticScopeTestClient());
+            IAsyncEnumerator<int> enumerator = client.StreamFailureAsync().GetAsyncEnumerator();
+
+            Assert.IsTrue(await enumerator.MoveNextAsync());
+            Assert.ThrowsAsync<TestStreamingException>(async () => await enumerator.MoveNextAsync());
+            await enumerator.DisposeAsync();
+        }
+
+        [Test]
+        public async Task AsyncEnumerableValidatesCancellation()
+        {
+            InvalidDiagnosticScopeTestClient client = InstrumentClient(new InvalidDiagnosticScopeTestClient());
+            using var cancellationSource = new CancellationTokenSource();
+            IAsyncEnumerator<int> enumerator = client.StreamCancellationAsync(cancellationSource.Token)
+                .GetAsyncEnumerator();
+            Assert.IsTrue(await enumerator.MoveNextAsync());
+
+            cancellationSource.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
+            await enumerator.DisposeAsync();
+        }
+
+        [Test]
+        public async Task AsyncEnumerableValidatesDisposal()
+        {
+            var originalClient = new InvalidDiagnosticScopeTestClient();
+            InvalidDiagnosticScopeTestClient client = InstrumentClient(originalClient);
+            IAsyncEnumerator<int> enumerator = client.StreamDisposalAsync().GetAsyncEnumerator();
+            Assert.IsTrue(await enumerator.MoveNextAsync());
+
+            await enumerator.DisposeAsync();
+
+            Assert.IsTrue(originalClient.StreamDisposed);
         }
 
         public class InvalidDiagnosticScopeTestClient
@@ -237,6 +322,114 @@ namespace Azure.Core.TestFramework.Tests
                 return true;
             }
 
+            public virtual async IAsyncEnumerable<int> StreamValidAsync(
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                DiagnosticScope scope = CreateScope("StreamValid");
+                scope.Start();
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    yield return 1;
+                    await Task.Yield();
+                    yield return 2;
+                }
+                finally
+                {
+                    scope.Dispose();
+                }
+            }
+
+            public virtual async IAsyncEnumerable<int> StreamWithoutScopeAsync(
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return 1;
+                await Task.Yield();
+            }
+
+            [ForwardsClientCalls]
+            public virtual async IAsyncEnumerable<int> StreamForwardedAsync(
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                DiagnosticScope scope = CreateScope(nameof(CorrectScope));
+                scope.Start();
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    yield return 1;
+                    await Task.Yield();
+                }
+                finally
+                {
+                    scope.Dispose();
+                }
+            }
+
+            public virtual async IAsyncEnumerable<int> StreamFailureAsync(
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                DiagnosticScope scope = CreateScope("StreamFailure");
+                scope.Start();
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    yield return 1;
+                    await Task.Yield();
+                    var exception = new TestStreamingException();
+                    scope.Failed(exception);
+                    throw exception;
+                }
+                finally
+                {
+                    scope.Dispose();
+                }
+            }
+
+            public virtual async IAsyncEnumerable<int> StreamCancellationAsync(
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                DiagnosticScope scope = CreateScope("StreamCancellation");
+                scope.Start();
+                try
+                {
+                    yield return 1;
+                    try
+                    {
+                        await Task.Delay(Timeout.Infinite, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        scope.Failed(ex);
+                        throw;
+                    }
+                }
+                finally
+                {
+                    scope.Dispose();
+                }
+            }
+
+            public bool StreamDisposed { get; private set; }
+
+            public virtual async IAsyncEnumerable<int> StreamDisposalAsync(
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                DiagnosticScope scope = CreateScope("StreamDisposal");
+                scope.Start();
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    yield return 1;
+                    await Task.Yield();
+                }
+                finally
+                {
+                    StreamDisposed = true;
+                    scope.Dispose();
+                }
+            }
+
             [ForwardsClientCalls]
             public virtual Task<bool> ForwardsAsync(bool includeCoreScope = false)
             {
@@ -325,6 +518,10 @@ namespace Azure.Core.TestFramework.Tests
                     return Page<int>.FromValues(new[] { 4, 5, 6 }, null, new MockResponse(200));
                 });
             }
+        }
+
+        private sealed class TestStreamingException : Exception
+        {
         }
     }
 }

--- a/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
+++ b/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
@@ -150,6 +150,18 @@ namespace Azure.Core.TestFramework.Tests
         }
 
         [Test]
+        public void ListenerThrowsWhenStopEventHasNoMatchingScope()
+        {
+            using var listener = new ClientDiagnosticListener(s => s == "Azure.Core.Tests.Fake", asyncLocal: true);
+            using var source = new DiagnosticListener("Azure.Core.Tests.Fake");
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => source.Write("FakeClient.FakeMethod.Stop", null));
+
+            StringAssert.Contains("was not started", ex.Message);
+        }
+
+        [Test]
         public async Task DirectListenerCapturesAsyncEnumerableScope()
         {
             using var listener = new ClientDiagnosticListener(s => s.StartsWith("Azure."), asyncLocal: true);

--- a/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
+++ b/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
@@ -150,6 +150,26 @@ namespace Azure.Core.TestFramework.Tests
         }
 
         [Test]
+        public async Task InterleavedAsyncEnumerablesValidateIndependently()
+        {
+            InvalidDiagnosticScopeTestClient client = InstrumentClient(new InvalidDiagnosticScopeTestClient());
+
+            IAsyncEnumerator<int> first = client.StreamValidAsync().GetAsyncEnumerator();
+            IAsyncEnumerator<int> second = client.StreamValidAsync().GetAsyncEnumerator();
+
+            // Completing the first stream must not observe the second stream's still-open scope.
+            Assert.IsTrue(await first.MoveNextAsync());
+            Assert.IsTrue(await second.MoveNextAsync());
+            Assert.IsTrue(await first.MoveNextAsync());
+            Assert.IsFalse(await first.MoveNextAsync());
+            await first.DisposeAsync();
+
+            Assert.IsTrue(await second.MoveNextAsync());
+            Assert.IsFalse(await second.MoveNextAsync());
+            await second.DisposeAsync();
+        }
+
+        [Test]
         public void ListenerThrowsWhenStopEventHasNoMatchingScope()
         {
             using var listener = new ClientDiagnosticListener(s => s == "Azure.Core.Tests.Fake", asyncLocal: true);

--- a/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseTests.cs
+++ b/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseTests.cs
@@ -212,6 +212,41 @@ namespace Azure.Core.TestFramework.Tests
         }
 
         [Test]
+        public async Task AsyncPageableMethodsStillUseSyncCounterpart()
+        {
+            var original = new PageableTestClient();
+            PageableTestClient client = InstrumentClient(original);
+
+            List<int> values = await client.GetValuesAsync().ToEnumerableAsync();
+
+            Assert.AreEqual(new[] { 1, 2 }, values);
+            Assert.AreEqual(IsAsync, original.AsyncCalled);
+            Assert.AreEqual(!IsAsync, original.SyncCalled);
+        }
+
+        public class PageableTestClient
+        {
+            public bool AsyncCalled { get; private set; }
+
+            public bool SyncCalled { get; private set; }
+
+            public virtual AsyncPageable<int> GetValuesAsync(CancellationToken cancellationToken = default)
+            {
+                AsyncCalled = true;
+                return AsyncPageable<int>.FromPages(new[] { CreatePage() });
+            }
+
+            public virtual Pageable<int> GetValues(CancellationToken cancellationToken = default)
+            {
+                SyncCalled = true;
+                return Pageable<int>.FromPages(new[] { CreatePage() });
+            }
+
+            private static Page<int> CreatePage()
+                => Page<int>.FromValues(new[] { 1, 2 }, null, new MockResponse(200));
+        }
+
+        [Test]
         [NonParallelizable]
         public async Task TasksValidateOwnScopes()
         {


### PR DESCRIPTION
## Summary
- allow async-only client methods returning `IAsyncEnumerable<T>` to bypass synchronous-counterpart lookup
- validate diagnostic scopes over iterator completion, failure, cancellation, and early disposal
- correlate diagnostic stop and exception events when async iterator execution restores `Activity.Current`
- add regression coverage for direct and forwarded scopes plus all iterator termination paths

## Testing
- `dotnet format` for the Azure.Core.TestFramework source and test projects
- full Azure.Core.TestFramework test suite on net10.0, net9.0, net8.0, and net462