### PR TITLE
[Experiment] Measure NuGet cache grouping

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -19,6 +19,14 @@ parameters:
   - name: SkipPrValidation
     type: boolean
     default: false
+  - name: NuGetCacheExperiment
+    displayName: NuGet cache experiment grouping
+    type: string
+    default: none
+    values:
+      - none
+      - os
+      - class
   # Switch to canary to test canary 1es branch. 1es template validation will set this parameter
   # to canary on run.
   - name: oneESTemplateTag
@@ -33,6 +41,7 @@ extends:
   parameters:
     oneESTemplateTag: ${{ parameters.oneESTemplateTag }}
     SkipPrValidation: ${{ parameters.SkipPrValidation }}
+    NuGetCacheExperiment: ${{ parameters.NuGetCacheExperiment }}
     # Short term hack to get 1es canary validation working until we can fix manual runs with 'auto'
     ${{ if and(eq(parameters.oneESTemplateTag, 'canary'), eq(parameters.Service, 'auto')) }}:
       ServiceDirectory: template

--- a/eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+++ b/eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
@@ -1,0 +1,98 @@
+parameters:
+  - name: Bucket
+    type: string
+  - name: CacheLabel
+    type: string
+  - name: ServiceDirectory
+    type: string
+  - name: SDKType
+    type: string
+  - name: OSName
+    type: string
+  - name: SeedBuild
+    type: boolean
+    default: false
+  - name: SeedAnalyze
+    type: boolean
+    default: false
+  - name: SeedTest
+    type: boolean
+    default: false
+
+jobs:
+  - job: NuGet${{ parameters.Bucket }}Seed
+    displayName: NuGet ${{ parameters.CacheLabel }} seed
+    variables:
+      System.Debug: true
+    pool:
+      ${{ if eq(parameters.OSName, 'macOS') }}:
+        vmImage: $(MACVMIMAGE)
+        name: $(MACPOOL)
+        os: macOS
+      ${{ elseif eq(parameters.OSName, 'Windows') }}:
+        name: $(WINDOWSPOOL)
+        image: $(WINDOWSVMIMAGE)
+        os: windows
+      ${{ else }}:
+        name: $(LINUXPOOL)
+        image: $(LINUXVMIMAGE)
+        os: linux
+    steps:
+      - template: /eng/pipelines/templates/steps/install-dotnet.yml
+        parameters:
+          EnableNuGetCache: false
+      - template: /eng/pipelines/templates/steps/nuget-cache-experiment.yml
+        parameters:
+          CacheLabel: ${{ parameters.CacheLabel }}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      - pwsh: ./eng/scripts/Measure-NuGetCache.ps1 -Path '$(NUGET_PACKAGES)' -Label '${{ parameters.CacheLabel }} seed after cache restore'
+        displayName: Measure restored NuGet cache
+      - template: /eng/pipelines/templates/steps/nuget-cache-experiment-restore.yml
+        parameters:
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          SDKType: ${{ parameters.SDKType }}
+          RestoreBuild: ${{ parameters.SeedBuild }}
+          RestoreAnalyze: ${{ parameters.SeedAnalyze }}
+          RestoreTest: ${{ parameters.SeedTest }}
+          Condition: and(succeeded(), ne(variables['NUGET_EXPERIMENT_CACHE_HIT'], 'true'))
+      - pwsh: ./eng/scripts/Measure-NuGetCache.ps1 -Path '$(NUGET_PACKAGES)' -Label '${{ parameters.CacheLabel }} seed complete'
+        displayName: Measure seeded NuGet cache
+
+  - job: NuGet${{ parameters.Bucket }}Consumer
+    displayName: NuGet ${{ parameters.CacheLabel }} consumer
+    dependsOn: NuGet${{ parameters.Bucket }}Seed
+    variables:
+      System.Debug: true
+    pool:
+      ${{ if eq(parameters.OSName, 'macOS') }}:
+        vmImage: $(MACVMIMAGE)
+        name: $(MACPOOL)
+        os: macOS
+      ${{ elseif eq(parameters.OSName, 'Windows') }}:
+        name: $(WINDOWSPOOL)
+        image: $(WINDOWSVMIMAGE)
+        os: windows
+      ${{ else }}:
+        name: $(LINUXPOOL)
+        image: $(LINUXVMIMAGE)
+        os: linux
+    steps:
+      - template: /eng/pipelines/templates/steps/install-dotnet.yml
+        parameters:
+          EnableNuGetCache: false
+      - template: /eng/pipelines/templates/steps/nuget-cache-experiment.yml
+        parameters:
+          CacheLabel: ${{ parameters.CacheLabel }}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      - pwsh: ./eng/scripts/Measure-NuGetCache.ps1 -Path '$(NUGET_PACKAGES)' -Label '${{ parameters.CacheLabel }} consumer after cache restore'
+        displayName: Measure downloaded NuGet cache
+      # Consumers always restore; the package cache is an additive baseline, not a replacement for NuGet evaluation.
+      - template: /eng/pipelines/templates/steps/nuget-cache-experiment-restore.yml
+        parameters:
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          SDKType: ${{ parameters.SDKType }}
+          RestoreBuild: ${{ parameters.SeedBuild }}
+          RestoreAnalyze: ${{ parameters.SeedAnalyze }}
+          RestoreTest: ${{ parameters.SeedTest }}
+      - pwsh: ./eng/scripts/Measure-NuGetCache.ps1 -Path '$(NUGET_PACKAGES)' -Label '${{ parameters.CacheLabel }} consumer complete'
+        displayName: Measure NuGet cache after warm restore

--- a/eng/pipelines/templates/jobs/nuget-cache-experiment.yml
+++ b/eng/pipelines/templates/jobs/nuget-cache-experiment.yml
@@ -1,0 +1,80 @@
+parameters:
+  - name: Grouping
+    type: string
+  - name: ServiceDirectory
+    type: string
+  - name: SDKType
+    type: string
+
+jobs:
+  # OS-only caches restore each workload into one additive package directory.
+  - ${{ if eq(parameters.Grouping, 'os') }}:
+    - template: /eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+      parameters:
+        Bucket: WindowsAll
+        CacheLabel: os-windows
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        SDKType: ${{ parameters.SDKType }}
+        OSName: Windows
+        SeedBuild: true
+        SeedTest: true
+    - template: /eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+      parameters:
+        Bucket: LinuxAll
+        CacheLabel: os-linux
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        SDKType: ${{ parameters.SDKType }}
+        OSName: Linux
+        SeedAnalyze: true
+        SeedTest: true
+    - template: /eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+      parameters:
+        Bucket: MacTest
+        CacheLabel: os-macos
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        SDKType: ${{ parameters.SDKType }}
+        OSName: macOS
+        SeedTest: true
+
+  # Class caches measure whether smaller worker downloads justify additional seeds.
+  - ${{ if eq(parameters.Grouping, 'class') }}:
+    - template: /eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+      parameters:
+        Bucket: WindowsBuild
+        CacheLabel: class-windows-build
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        SDKType: ${{ parameters.SDKType }}
+        OSName: Windows
+        SeedBuild: true
+    - template: /eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+      parameters:
+        Bucket: LinuxAnalyze
+        CacheLabel: class-linux-analyze
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        SDKType: ${{ parameters.SDKType }}
+        OSName: Linux
+        SeedAnalyze: true
+    - template: /eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+      parameters:
+        Bucket: LinuxTest
+        CacheLabel: class-linux-test
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        SDKType: ${{ parameters.SDKType }}
+        OSName: Linux
+        SeedTest: true
+    - template: /eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+      parameters:
+        Bucket: WindowsTest
+        CacheLabel: class-windows-test
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        SDKType: ${{ parameters.SDKType }}
+        OSName: Windows
+        SeedTest: true
+    - template: /eng/pipelines/templates/jobs/nuget-cache-experiment-bucket.yml
+      parameters:
+        Bucket: MacTest
+        CacheLabel: class-macos-test
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        SDKType: ${{ parameters.SDKType }}
+        OSName: macOS
+        SeedTest: true

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -17,6 +17,9 @@ parameters:
   - name: SkipPrValidation
     type: boolean
     default: false
+  - name: NuGetCacheExperiment
+    type: string
+    default: none
   - name: BuildSnippets
     type: boolean
     default: true
@@ -90,33 +93,51 @@ extends:
           - template: /eng/pipelines/templates/variables/globals.yml
           - template: /eng/pipelines/templates/variables/image.yml
         jobs:
-          - template: /eng/pipelines/templates/jobs/ci.yml
-            parameters:
-              SDKType: ${{ parameters.SDKType }}
-              ServiceDirectory: ${{ parameters.ServiceDirectory }}
-              Artifacts: ${{ parameters.Artifacts }}
-              ${{ if eq(parameters.ServiceDirectory, 'template') }}:
-                TestPipeline: true
-              ArtifactName: packages
-              LimitForPullRequest: ${{ parameters.LimitForPullRequest }}
-              BuildSnippets: ${{ parameters.BuildSnippets }}
-              TestSetupSteps: ${{ parameters.TestSetupSteps }}
-              TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
-              MatrixConfigs:
-                - ${{ each config in parameters.MatrixConfigs }}:
-                    - ${{ config }}
-                - ${{ each config in parameters.AdditionalMatrixConfigs }}:
-                    - ${{ config }}
-              MatrixFilters: ${{ parameters.MatrixFilters }}
-              MatrixReplace:
-                # For nightly/release pipelines we build and test release only
-                - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-                    - BuildConfiguration=Debug/Release
-                - ${{ parameters.MatrixReplace }}
-              TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
+          - ${{ if eq(parameters.NuGetCacheExperiment, 'none') }}:
+            - template: /eng/pipelines/templates/jobs/ci.yml
+              parameters:
+                SDKType: ${{ parameters.SDKType }}
+                ServiceDirectory: ${{ parameters.ServiceDirectory }}
+                Artifacts: ${{ parameters.Artifacts }}
+                ${{ if eq(parameters.ServiceDirectory, 'template') }}:
+                  TestPipeline: true
+                ArtifactName: packages
+                LimitForPullRequest: ${{ parameters.LimitForPullRequest }}
+                BuildSnippets: ${{ parameters.BuildSnippets }}
+                TestSetupSteps: ${{ parameters.TestSetupSteps }}
+                TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+                MatrixConfigs:
+                  - ${{ each config in parameters.MatrixConfigs }}:
+                      - ${{ config }}
+                  - ${{ each config in parameters.AdditionalMatrixConfigs }}:
+                      - ${{ config }}
+                MatrixFilters: ${{ parameters.MatrixFilters }}
+                MatrixReplace:
+                  # For nightly/release pipelines we build and test release only
+                  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+                      - BuildConfiguration=Debug/Release
+                  - ${{ parameters.MatrixReplace }}
+                TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
+          - ${{ if and(ne(parameters.NuGetCacheExperiment, 'none'), eq(parameters.ServiceDirectory, 'auto')) }}:
+            - job: InvalidNuGetCacheExperiment
+              displayName: NuGet cache experiment requires a service
+              pool:
+                name: $(LINUXPOOL)
+                image: $(LINUXVMIMAGE)
+                os: linux
+              steps:
+                - checkout: none
+                - pwsh: throw "Queue the NuGet cache experiment manually with an explicit Service value, such as 'core' or 'storage'."
+                  displayName: Reject automatic service selection
+          - ${{ if and(ne(parameters.NuGetCacheExperiment, 'none'), ne(parameters.ServiceDirectory, 'auto')) }}:
+            - template: /eng/pipelines/templates/jobs/nuget-cache-experiment.yml
+              parameters:
+                Grouping: ${{ parameters.NuGetCacheExperiment }}
+                ServiceDirectory: ${{ parameters.ServiceDirectory }}
+                SDKType: ${{ parameters.SDKType }}
 
       # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-      - ${{if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+      - ${{if and(eq(parameters.NuGetCacheExperiment, 'none'), not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
 
         - template: archetype-net-release.yml
           parameters:

--- a/eng/pipelines/templates/steps/nuget-cache-experiment-restore.yml
+++ b/eng/pipelines/templates/steps/nuget-cache-experiment-restore.yml
@@ -1,0 +1,67 @@
+parameters:
+  - name: ServiceDirectory
+    type: string
+  - name: SDKType
+    type: string
+  - name: RestoreBuild
+    type: boolean
+    default: false
+  - name: RestoreAnalyze
+    type: boolean
+    default: false
+  - name: RestoreTest
+    type: boolean
+    default: false
+  - name: Condition
+    type: string
+    default: succeeded()
+
+steps:
+  # Analyze and Test both consume repository-local tools from the NuGet global-packages folder.
+  - ${{ if or(eq(parameters.RestoreAnalyze, true), eq(parameters.RestoreTest, true)) }}:
+    - pwsh: dotnet tool restore
+      condition: ${{ parameters.Condition }}
+      displayName: Restore .NET tools
+
+  - ${{ if eq(parameters.RestoreBuild, true) }}:
+    - pwsh: >
+        dotnet restore eng/service.proj
+        /p:SDKType=${{ parameters.SDKType }}
+        /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
+        /p:IncludeTests=false
+        /p:IncludePerf=false
+        /p:IncludeStress=false
+        /p:IncludeIntegrationTests=false
+        /p:PublicSign=false
+        /p:Configuration=Release
+      condition: ${{ parameters.Condition }}
+      displayName: Restore Build graph
+
+  - ${{ if eq(parameters.RestoreAnalyze, true) }}:
+    - pwsh: >
+        dotnet restore eng/service.proj
+        /p:SDKType=${{ parameters.SDKType }}
+        /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
+        /p:IncludeTests=false
+        /p:IncludeSamples=false
+        /p:IncludePerf=false
+        /p:IncludeStress=false
+        /p:IncludeIntegrationTests=false
+        /p:BuildSnippets=true
+        /p:Configuration=$(BuildConfiguration)
+      condition: ${{ parameters.Condition }}
+      displayName: Restore Analyze graph
+
+  - ${{ if eq(parameters.RestoreTest, true) }}:
+    - pwsh: >
+        dotnet restore eng/service.proj
+        /p:SDKType=${{ parameters.SDKType }}
+        /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
+        /p:IncludeSrc=false
+        /p:IncludeSamples=false
+        /p:IncludePerf=false
+        /p:IncludeStress=false
+        /p:IncludeIntegrationTests=false
+        /p:Configuration=$(BuildConfiguration)
+      condition: ${{ parameters.Condition }}
+      displayName: Restore Test graph

--- a/eng/pipelines/templates/steps/nuget-cache-experiment.yml
+++ b/eng/pipelines/templates/steps/nuget-cache-experiment.yml
@@ -1,0 +1,13 @@
+parameters:
+  - name: CacheLabel
+    type: string
+  - name: ServiceDirectory
+    type: string
+
+steps:
+  - task: Cache@2
+    inputs:
+      key: '"nuget-experiment-v1" | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "${{ parameters.CacheLabel }}" | "${{ parameters.ServiceDirectory }}" | global.json | NuGet.Config | .config/dotnet-tools.json | eng/centralpackagemanagement/**/*.props | Directory.Build.props | Directory.Build.targets | eng/Directory.Build.Common.props | eng/Directory.Build.Common.targets'
+      path: $(NUGET_PACKAGES)
+      cacheHitVar: NUGET_EXPERIMENT_CACHE_HIT
+    displayName: Restore NuGet experiment cache

--- a/eng/scripts/Measure-NuGetCache.ps1
+++ b/eng/scripts/Measure-NuGetCache.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+Measures a NuGet global-packages directory for the pipeline cache experiment.
+
+.DESCRIPTION
+Writes one machine-readable NUGET_CACHE_METRICS JSON line and an Azure Pipelines
+summary containing logical file size, compressed .nupkg size, file count, and
+package ID/version count. A missing cache directory is reported as an empty cache.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Path,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Label
+)
+
+$ErrorActionPreference = 'Stop'
+$resolvedPath = [System.IO.Path]::GetFullPath($Path)
+$files = @()
+$packageVersionCount = 0
+
+if (Test-Path $resolvedPath) {
+    # A NuGet global-packages folder is organized as <package ID>/<version>/..., so the
+    # second-level directory count describes the dependency working set more usefully
+    # than a raw package ID count.
+    $files = @(Get-ChildItem -Path $resolvedPath -File -Recurse -Force)
+    $packageVersionCount = @(
+        Get-ChildItem -Path $resolvedPath -Directory -Force |
+            ForEach-Object { Get-ChildItem -Path $_.FullName -Directory -Force }
+    ).Count
+}
+
+$logicalBytes = [long](($files | Measure-Object -Property Length -Sum).Sum ?? 0)
+$nupkgBytes = [long](($files | Where-Object Extension -EQ '.nupkg' | Measure-Object -Property Length -Sum).Sum ?? 0)
+$metrics = [ordered]@{
+    label = $Label
+    path = $resolvedPath
+    fileCount = $files.Count
+    packageVersionCount = $packageVersionCount
+    logicalBytes = $logicalBytes
+    logicalMiB = [Math]::Round($logicalBytes / 1MB, 1)
+    nupkgBytes = $nupkgBytes
+    nupkgMiB = [Math]::Round($nupkgBytes / 1MB, 1)
+}
+
+$json = $metrics | ConvertTo-Json -Compress
+Write-Host "NUGET_CACHE_METRICS $json"
+
+# Add a compact, human-readable measurement to the Azure Pipelines run summary while
+# retaining the single-line JSON above for automated comparison of experiment runs.
+$summaryPath = Join-Path $env:AGENT_TEMPDIRECTORY "nuget-cache-$([Guid]::NewGuid().ToString('N')).md"
+@"
+## NuGet cache: $Label
+
+| Metric | Value |
+| --- | ---: |
+| Logical size | $($metrics.logicalMiB) MiB |
+| `.nupkg` size | $($metrics.nupkgMiB) MiB |
+| Files | $($metrics.fileCount) |
+| Package ID/version pairs | $($metrics.packageVersionCount) |
+"@ | Set-Content -Path $summaryPath
+
+Write-Host "##vso[task.uploadsummary]$summaryPath"


### PR DESCRIPTION
## Purpose

Add an opt-in experiment to compare NuGet pipeline caches grouped only by operating system against caches split by Build, Analyze, and Test workload class.

Normal pull-request validation remains unchanged unless `NuGetCacheExperiment` is explicitly set to `os` or `class` on a manual run. Experiment runs also require an explicit `Service` value, such as `core` or `storage`.

## Experiment design

- Create a dedicated seed job for each cache bucket, followed by a dependent consumer job.
- Skip graph restoration in the seed on an exact cache hit; always run restore in the consumer to measure warm-restore behavior.
- Include OS, architecture, grouping, service, tool manifests, central package props, and shared build inputs in the cache key.
- Emit logical size, `.nupkg` size, file count, and package ID/version count before and after restoration.
- Enable Cache@2 diagnostic output to capture dedup upload/download behavior and duration.

## Validation

- Parsed all changed YAML files successfully.
- Verified all new template references resolve.
- Parsed and fixture-tested `Measure-NuGetCache.ps1`.
- `git diff --check` passes.
- Local `dotnet restore` was not completed because local `dotnet` processes were terminated with exit 137.

This is intentionally a draft experimental PR. No production cache behavior changes when the new parameter uses its default value.