### PR TITLE
Add repo-local Vally skill eval pipeline pilot

### DIFF
--- a/.github/skills/.vally.yaml
+++ b/.github/skills/.vally.yaml
@@ -1,0 +1,17 @@
+# Vally project config for Azure SDK for .NET skill evals.
+
+paths:
+  skills: "."
+  evals:
+    - pre-commit-checks/evals/
+  results: results/
+  evalFilenames: ["*.eval.yaml"]
+
+environments:
+  azsdk-mcp-mock:
+    mcpServers:
+      azure-sdk-mcp:
+        type: stdio
+        command: dotnet
+        args: ["../../artifacts/mcp/mock/azsdk-mock.dll"]
+        timeout: "60s"

--- a/.github/skills/.vally.yaml
+++ b/.github/skills/.vally.yaml
@@ -3,9 +3,16 @@
 paths:
   skills: "."
   evals:
+    - auto-build-repair/evals/
+    - azsdk-common-apiview-feedback-resolution/evals/
+    - azsdk-common-generate-sdk-locally/evals/
+    - azsdk-common-pipeline-analysis/evals/
+    - azsdk-common-pipeline-fixer/evals/
+    - azsdk-common-prepare-release-plan/evals/
+    - azsdk-common-sdk-release/evals/
     - pre-commit-checks/evals/
   results: results/
-  evalFilenames: ["*.eval.yaml"]
+  evalFilenames: ["eval.yaml", "*.eval.yaml"]
 
 environments:
   azsdk-mcp-mock:

--- a/.github/skills/pre-commit-checks/evals/smoke.eval.yaml
+++ b/.github/skills/pre-commit-checks/evals/smoke.eval.yaml
@@ -1,0 +1,26 @@
+name: dotnet-pre-commit-checks-smoke
+description: Verify that a package validation request routes to the .NET pre-commit checks skill.
+type: capability
+
+environment: azsdk-mcp-mock
+
+tags:
+  area: dotnet-pre-commit-checks
+  type: smoke
+
+defaults:
+  runs: 1
+  timeout: "90s"
+  model: gpt-5.4
+  executor: copilot-sdk
+
+scoring:
+  threshold: 1.0
+
+stimuli:
+  - name: route-package-validation-before-commit
+    prompt: "I changed an Azure SDK for .NET package and am ready to commit. What repository checks should I run first?"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["pre-commit-checks"]

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ tsp_client_metadata.yaml
 
 # Common toolchain intermediate files
 temp
+
+# Local Vally eval output
+.github/skills/results/

--- a/eng/pipelines/skill-eval.yml
+++ b/eng/pipelines/skill-eval.yml
@@ -1,0 +1,29 @@
+# Vally skill-eval pilot using the framework synced from azure-sdk-tools under eng/common.
+# Starts scheduled/manual and report-only; PR triggers and gating can follow after the pilot is stable.
+
+trigger: none
+
+pr: none
+
+schedules:
+  - cron: '0 8 * * *'
+    displayName: 'Daily skill-eval pilot'
+    branches:
+      include:
+        - main
+    always: true
+
+variables:
+  - template: /eng/pipelines/templates/variables/image.yml
+  - group: AzSDK_Eval_Variable_group
+
+extends:
+  template: /eng/common/pipelines/templates/stages/archetype-eval.yml
+  parameters:
+    mcpSetupTemplate: /eng/pipelines/templates/steps/eval-mcp-setup.yml
+    preEvalTemplate: /eng/pipelines/templates/steps/eval-fix-mcp-paths.yml
+    TestType: mock
+    vallyRoot: .github/skills
+    evalGlobs:
+      - 'pre-commit-checks/evals/smoke.eval.yaml'
+    failOnFailedTests: false

--- a/eng/pipelines/skill-eval.yml
+++ b/eng/pipelines/skill-eval.yml
@@ -25,5 +25,6 @@ extends:
     TestType: mock
     vallyRoot: .github/skills
     evalGlobs:
+      # Existing suites remain available under .github/skills; start with one deterministic smoke.
       - 'pre-commit-checks/evals/smoke.eval.yaml'
     failOnFailedTests: false

--- a/eng/pipelines/templates/steps/eval-fix-mcp-paths.yml
+++ b/eng/pipelines/templates/steps/eval-fix-mcp-paths.yml
@@ -1,0 +1,10 @@
+# Vally starts MCP servers from a per-stimulus temporary directory. Rewrite the checked-in relative
+# DLL path to an absolute path immediately before each shard so startup is independent of that cwd.
+
+steps:
+  - script: |
+      set -e
+      f="$(Build.SourcesDirectory)/.github/skills/.vally.yaml"
+      sed -i "s#\.\./\.\./artifacts/mcp/#$(Build.SourcesDirectory)/artifacts/mcp/#g" "$f"
+      grep -n "artifacts/mcp/" "$f"
+    displayName: 'Rewrite MCP DLL paths to absolute'

--- a/eng/pipelines/templates/steps/eval-mcp-setup.yml
+++ b/eng/pipelines/templates/steps/eval-mcp-setup.yml
@@ -1,0 +1,38 @@
+# Repo-local MCP build swap point for the shared eval archetype. Azure/azure-sdk-tools is public,
+# so the pilot checks it out anonymously without a GitHub service connection.
+
+parameters:
+  - name: TestType
+    type: string
+    default: mock
+    values:
+      - mock
+      - live
+  - name: toolsRepo
+    type: string
+    default: ''
+
+steps:
+  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+    parameters:
+      SkipCheckoutNone: true
+      Paths:
+        - '/tools'
+      Repositories:
+        - Name: Azure/azure-sdk-tools
+          Commitish: main
+          WorkingDirectory: azure-sdk-tools
+
+  - ${{ if eq(parameters.TestType, 'live') }}:
+    - script: |
+        set -e
+        dotnet build tools/azsdk-cli/Azure.Sdk.Tools.Cli -c Release -o "$(Build.SourcesDirectory)/artifacts/mcp/cli" --nologo
+      displayName: 'Build MCP: Cli (live) server'
+      workingDirectory: $(Build.SourcesDirectory)/azure-sdk-tools
+
+  - ${{ else }}:
+    - script: |
+        set -e
+        dotnet build tools/azsdk-cli/Azure.Sdk.Tools.Mock -c Release -o "$(Build.SourcesDirectory)/artifacts/mcp/mock" --nologo
+      displayName: 'Build MCP: Mock server'
+      workingDirectory: $(Build.SourcesDirectory)/azure-sdk-tools


### PR DESCRIPTION
## Existing repository baseline

This repository already contains substantial eval assets synced from `azure-sdk-tools`:

- the shared Vally pipeline framework under `eng/common/pipelines` and `eng/common/scripts/eval`
- 11 current-format Vally skill specs across seven skill directories under `.github/skills`
- a separate legacy `owners/eval.yaml`
- two unrelated Foundry Agent Optimization sample evals under `samples/agentserver`

What is missing on `main` is a repo-local `.vally.yaml`, a thin entrypoint under `eng/pipelines`, and a registered public ADO eval definition. This PR supplies that final runnable layer; it does not introduce the shared framework itself.

## Changes

- add `.github/skills/.vally.yaml` and register all seven existing current-format eval directories
- add a scheduled/manual, report-only entrypoint built on the synced `eng/common` archetype
- add the anonymous checkout/build hook for the Azure SDK mock MCP server
- add the cwd-independent MCP path rewrite proven by the specs-repo pilot
- add one deterministic .NET-specific smoke scenario for initial pipeline verification
- ignore local Vally result output

The initial schedule intentionally runs only the smoke scenario. Existing broader suites remain discoverable through the project config and can be enabled incrementally after their reliability is established. PR triggers and blocking gates remain disabled.

Tracks Azure/azure-sdk-tools#16348.

## Validation

- all 11 existing Vally skill specs pass strict static validation
- the shared matrix collector discovers seven existing eval shards plus the new smoke shard
- existing `auto-build-repair` capability suite executed at 66.7%; its trigger suite executed at 72.7%, both below their configured 80% threshold due to behavioral misses/timeouts rather than MCP or auth failures
- the new smoke scenario passed end to end at 100%
- `git diff --check`
- the public ADO build-definition inventory contains no registered eval definition for `Azure/azure-sdk-for-net`

## Before enabling the schedule

- register the ADO pipeline for `eng/pipelines/skill-eval.yml`
- authorize `AzSDK_Eval_Variable_group` for the new pipeline definition
- confirm the daily schedule and initial ownership/incident-response contacts

## Follow-up

Harden and enable the existing suites incrementally, record the tier threshold/blocking decision, then add selective PR path triggers after scheduled runs are reliable.
