### PR TITLE
Remove dead CloudMachine CODEOWNERS entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -127,9 +127,6 @@
 # ServiceLabel: %Azure Load Testing
 # ServiceOwners: @azure/testing-services
 
-# PRLabel: %Azure Projects
-/sdk/cloudmachine/    @KrzysztofCwalina
-
 # PRLabel: %Azure Stack
 /sdk/azurestack*/    @bganapa
 


### PR DESCRIPTION
## Summary
- Remove the stale CODEOWNERS entry for the retired CloudMachine product directory.

## Why
- The CloudMachine product is no longer active and its code has been removed from the repo.
- Keeping the old ownership record creates stale ownership metadata.

## Validation
- Confirmed the CloudMachine path no longer appears in .github/CODEOWNERS.