### PR TITLE
Add codeowners verification skip exemptions

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -57,6 +57,35 @@ steps:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)/PackageInfo'
       Artifacts: ${{ parameters.Artifacts }}
       EnablePrValidation: true
+      # Jesse Squire and his direct reports. Keep the email and alias lists in
+      # sync; emails apply to manually queued builds, aliases to pull request
+      # builds.
+      AllowSkipEmails: >-
+        jsquire@microsoft.com,
+        josar@microsoft.com,
+        weilim@microsoft.com,
+        vigera@microsoft.com,
+        alzimmer@microsoft.com,
+        vicolina@microsoft.com,
+        jolov@microsoft.com,
+        micnash@microsoft.com,
+        joncarde@microsoft.com,
+        jorgerangel@microsoft.com,
+        jairmyree@microsoft.com,
+        mailinhphan@microsoft.com
+      AllowSkipAliases: >-
+        jsquire,
+        joseharriaga,
+        weikanglim,
+        g2vinay,
+        alzimmermsft,
+        vcolin7,
+        JoshLove-msft,
+        m-nash,
+        JonathanCrd,
+        jorgerangel-msft,
+        jairmyree,
+        MaiLinhP
 
   - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
 


### PR DESCRIPTION
Adds emails and GitHub aliases to the codeowners verification skip lists.

- `AllowSkipEmails` covers manually queued builds, matched on `Build.RequestedForEmail`
- `AllowSkipAliases` covers pull request builds, matched on the PR author's GitHub login