### PR TITLE
[mgmt] Regenerate model factory back-compat docs instead of reusing last contract docs

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Management.Visitors
@@ -267,65 +266,24 @@ namespace Azure.Generator.Management.Visitors
                 }
             }
 
-            var signature = CreateBackwardCompatSignature(method.Signature, parameterDescriptions);
+            var signature = CreateBackwardCompatSignature(method.Signature, modelProvider, parameterDescriptions);
             updatedMethod = new MethodProvider(
                 signature,
                 Return(New.Instance(method.Signature.ReturnType, arguments)),
-                enclosingType,
-                CreateModelFactoryXmlDocs(signature, modelProvider));
+                enclosingType);
             return true;
         }
 
         /// <summary>
-        /// Mirrors how the primary factory method is documented: the model's structured summary is reused as-is so
-        /// nested lines and inner statements survive, while parameters and the return doc come from the signature,
-        /// which <see cref="CreateBackwardCompatSignature"/> has already regenerated.
-        /// </summary>
-        private static XmlDocProvider CreateModelFactoryXmlDocs(MethodSignature signature, ModelProvider modelProvider)
-        {
-            return new XmlDocProvider(
-                modelProvider.XmlDocs.Summary,
-                [.. signature.Parameters.Select(parameter => new XmlDocParamStatement(parameter))],
-                returns: new XmlDocReturnsStatement(signature.ReturnDescription!));
-        }
-
-        private static FormattableString RemoveCommonContinuationIndentation(FormattableString description)
-        {
-            var lines = description.Format.ReplaceLineEndings("\n").Split('\n');
-            if (lines.Length < 2)
-            {
-                return description;
-            }
-
-            var commonIndentation = lines
-                .Skip(1)
-                .Where(line => line.Length > 0)
-                .Select(line => line.Length - line.TrimStart().Length)
-                .DefaultIfEmpty(0)
-                .Min();
-            if (commonIndentation == 0)
-            {
-                return description;
-            }
-
-            for (int i = 1; i < lines.Length; i++)
-            {
-                lines[i] = lines[i].Length >= commonIndentation
-                    ? lines[i][commonIndentation..]
-                    : string.Empty;
-            }
-
-            return FormattableStringFactory.Create(string.Join("\n", lines), description.GetArguments());
-        }
-
-        /// <summary>
         /// Creates the hidden compatibility signature, regenerating its documentation from the current model.
-        /// The summary is deliberately left off the signature: it lives on the <see cref="XmlDocProvider"/> built by
-        /// <see cref="CreateModelFactoryXmlDocs"/>, exactly as it does for the primary factory methods, so multiple
-        /// lines and nested statements survive verbatim and the previous contract's description is never reused.
+        /// Every description comes from the current model; the previous contract supplies only the parameter list.
+        /// A parameter that no longer maps to the model has no current description, and the previous one is not
+        /// salvaged: it was parsed back out of generated C#, so it has already lost its cref text and accumulated
+        /// the writer's indentation.
         /// </summary>
         private static MethodSignature CreateBackwardCompatSignature(
             MethodSignature signature,
+            ModelProvider modelProvider,
             IReadOnlyDictionary<string, FormattableString> parameterDescriptions)
         {
             var attributes = signature.Attributes.Any(attribute =>
@@ -335,17 +293,14 @@ namespace Azure.Generator.Management.Visitors
 
             foreach (var parameter in signature.Parameters)
             {
-                // Prefer the current model's description. A parameter that no longer exists on the model has no
-                // current source, so strip the indentation the previous generation baked into the parsed
-                // description instead, which keeps regeneration idempotent.
                 parameter.Update(description: parameterDescriptions.TryGetValue(parameter.Name, out var currentDescription)
                     ? currentDescription
-                    : RemoveCommonContinuationIndentation(parameter.Description));
+                    : $"");
             }
 
             return new MethodSignature(
                 signature.Name,
-                null,
+                modelProvider.Description,
                 signature.Modifiers,
                 signature.ReturnType,
                 $"A new {signature.ReturnType:C} instance for mocking.",

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
@@ -262,34 +262,12 @@ namespace Azure.Generator.Management.Visitors
                 }
             }
 
-            var signature = CreateBackwardCompatSignature(method.Signature);
+            var signature = CreateBackwardCompatSignature(method.Signature, modelProvider, parameterDescriptions);
             updatedMethod = new MethodProvider(
                 signature,
                 Return(New.Instance(method.Signature.ReturnType, arguments)),
-                enclosingType,
-                CreateModelFactoryXmlDocs(signature, modelProvider, parameterDescriptions));
+                enclosingType);
             return true;
-        }
-
-        private static XmlDocProvider CreateModelFactoryXmlDocs(
-            MethodSignature signature,
-            ModelProvider modelProvider,
-            IReadOnlyDictionary<string, FormattableString> parameterDescriptions)
-        {
-            var parameters = new List<XmlDocParamStatement>(signature.Parameters.Count);
-            foreach (var parameter in signature.Parameters)
-            {
-                var description = parameterDescriptions.TryGetValue(parameter.Name, out var currentDescription)
-                    ? currentDescription
-                    : RemoveCommonContinuationIndentation(parameter.Description);
-                var documentedParameter = new ParameterProvider(parameter.Name, description, parameter.Type);
-                parameters.Add(new XmlDocParamStatement(documentedParameter));
-            }
-
-            return new XmlDocProvider(
-                modelProvider.XmlDocs.Summary,
-                parameters,
-                returns: new XmlDocReturnsStatement($"A new {signature.ReturnType:C} instance for mocking."));
         }
 
         private static FormattableString RemoveCommonContinuationIndentation(FormattableString description)
@@ -321,25 +299,51 @@ namespace Azure.Generator.Management.Visitors
             return FormattableStringFactory.Create(string.Join("\n", lines), description.GetArguments());
         }
 
-        private static MethodSignature CreateBackwardCompatSignature(MethodSignature signature)
+        /// <summary>
+        /// Creates the hidden compatibility signature, regenerating its documentation from the current model.
+        /// The descriptions must live on the signature rather than on an <see cref="XmlDocProvider"/> because
+        /// <see cref="MethodProvider.Update"/> rebuilds the docs from the signature whenever a signature is supplied,
+        /// which happens again at write time in <see cref="FixModelFactoryBackwardCompatOverloads"/>.
+        /// </summary>
+        private static MethodSignature CreateBackwardCompatSignature(
+            MethodSignature signature,
+            ModelProvider modelProvider,
+            IReadOnlyDictionary<string, FormattableString> parameterDescriptions)
         {
             var attributes = signature.Attributes.Any(attribute =>
                 attribute.Type is { IsFrameworkType: true } && attribute.Type.FrameworkType == typeof(EditorBrowsableAttribute))
                     ? signature.Attributes
                     : [.. signature.Attributes, new AttributeStatement(typeof(EditorBrowsableAttribute), FrameworkEnumValue(EditorBrowsableState.Never))];
 
+            foreach (var parameter in signature.Parameters)
+            {
+                // Prefer the current model's description; otherwise strip the indentation the previous
+                // generation baked into the parsed description so regeneration is idempotent.
+                parameter.Update(description: parameterDescriptions.TryGetValue(parameter.Name, out var currentDescription)
+                    ? currentDescription
+                    : RemoveCommonContinuationIndentation(parameter.Description));
+            }
+
             return new MethodSignature(
                 signature.Name,
-                signature.Description,
+                GetSummary(modelProvider) ?? signature.Description,
                 signature.Modifiers,
                 signature.ReturnType,
-                signature.ReturnDescription,
+                $"A new {signature.ReturnType:C} instance for mocking.",
                 signature.Parameters,
                 attributes,
                 signature.GenericArguments,
                 signature.GenericParameterConstraints,
                 signature.ExplicitInterface,
                 signature.NonDocumentComment);
+        }
+
+        private static FormattableString? GetSummary(ModelProvider modelProvider)
+        {
+            // Model summaries are single line in practice; anything else is left to the previous description
+            // rather than attempting to re-index the format arguments of several formattable strings.
+            var lines = modelProvider.XmlDocs.Summary?.Lines;
+            return lines?.Count == 1 ? lines[0] : null;
         }
 
         /// <summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Management.Visitors
@@ -244,11 +245,16 @@ namespace Azure.Generator.Management.Visitors
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
             var arguments = new List<ValueExpression>(constructorParameters.Count);
+            var parameterDescriptions = new Dictionary<string, FormattableString>(StringComparer.Ordinal);
             foreach (var constructorParameter in constructorParameters)
             {
                 if (TryBuildCompatibilityArgument(method, constructorParameter, directParameterNames, out var argument))
                 {
                     arguments.Add(argument.Argument);
+                    foreach (var parameterDocumentation in argument.ParameterDocumentation)
+                    {
+                        parameterDescriptions.TryAdd(parameterDocumentation.Parameter.Name, parameterDocumentation.Description);
+                    }
                 }
                 else
                 {
@@ -256,11 +262,63 @@ namespace Azure.Generator.Management.Visitors
                 }
             }
 
+            var signature = CreateBackwardCompatSignature(method.Signature);
             updatedMethod = new MethodProvider(
-                CreateBackwardCompatSignature(method.Signature),
+                signature,
                 Return(New.Instance(method.Signature.ReturnType, arguments)),
-                enclosingType);
+                enclosingType,
+                CreateModelFactoryXmlDocs(signature, modelProvider, parameterDescriptions));
             return true;
+        }
+
+        private static XmlDocProvider CreateModelFactoryXmlDocs(
+            MethodSignature signature,
+            ModelProvider modelProvider,
+            IReadOnlyDictionary<string, FormattableString> parameterDescriptions)
+        {
+            var parameters = new List<XmlDocParamStatement>(signature.Parameters.Count);
+            foreach (var parameter in signature.Parameters)
+            {
+                var description = parameterDescriptions.TryGetValue(parameter.Name, out var currentDescription)
+                    ? currentDescription
+                    : RemoveCommonContinuationIndentation(parameter.Description);
+                var documentedParameter = new ParameterProvider(parameter.Name, description, parameter.Type);
+                parameters.Add(new XmlDocParamStatement(documentedParameter));
+            }
+
+            return new XmlDocProvider(
+                modelProvider.XmlDocs.Summary,
+                parameters,
+                returns: new XmlDocReturnsStatement($"A new {signature.ReturnType:C} instance for mocking."));
+        }
+
+        private static FormattableString RemoveCommonContinuationIndentation(FormattableString description)
+        {
+            var lines = description.Format.ReplaceLineEndings("\n").Split('\n');
+            if (lines.Length < 2)
+            {
+                return description;
+            }
+
+            var commonIndentation = lines
+                .Skip(1)
+                .Where(line => line.Length > 0)
+                .Select(line => line.Length - line.TrimStart().Length)
+                .DefaultIfEmpty(0)
+                .Min();
+            if (commonIndentation == 0)
+            {
+                return description;
+            }
+
+            for (int i = 1; i < lines.Length; i++)
+            {
+                lines[i] = lines[i].Length >= commonIndentation
+                    ? lines[i][commonIndentation..]
+                    : string.Empty;
+            }
+
+            return FormattableStringFactory.Create(string.Join("\n", lines), description.GetArguments());
         }
 
         private static MethodSignature CreateBackwardCompatSignature(MethodSignature signature)
@@ -632,7 +690,10 @@ namespace Azure.Generator.Management.Visitors
             // resolution uses combined/contextual names to avoid stealing outer parameters with the same name.
             if (TryGetMethodParameter(method, constructorParameter.Name, constructorParameter.Type, constructorParameter.Property, out var directParameter))
             {
-                argument = new CompatibilityArgument(BuildParameterArgument(directParameter, constructorParameter.Type), [directParameter]);
+                argument = new CompatibilityArgument(
+                    BuildParameterArgument(directParameter, constructorParameter.Type),
+                    [directParameter],
+                    [new ParameterDocumentation(directParameter, constructorParameter.Description)]);
                 return true;
             }
 
@@ -681,12 +742,14 @@ namespace Azure.Generator.Management.Visitors
             var nestedConstructorParameters = nestedModel.FullConstructor.Signature.Parameters;
             var nestedArguments = new List<ValueExpression>(nestedConstructorParameters.Count);
             var matchedParameters = new List<ParameterProvider>();
+            var parameterDocumentation = new List<ParameterDocumentation>();
             foreach (var nestedParameter in nestedConstructorParameters)
             {
                 if (TryGetNestedCompatibilityArgument(method, constructorParameter.Property, constructorParameter.Name, nestedParameter, visitedTypes, unavailableDirectParameterNames, out var nestedArgument))
                 {
                     nestedArguments.Add(nestedArgument.Argument);
                     matchedParameters.AddRange(nestedArgument.MatchedParameters);
+                    parameterDocumentation.AddRange(nestedArgument.ParameterDocumentation);
                 }
                 else
                 {
@@ -708,7 +771,7 @@ namespace Azure.Generator.Management.Visitors
             var expression = condition is null
                 ? newInstance
                 : new TernaryConditionalExpression(condition, Default, newInstance);
-            argument = new CompatibilityArgument(expression, matchedParameters);
+            argument = new CompatibilityArgument(expression, matchedParameters, parameterDocumentation);
             visitedTypes.Remove(constructorParameter.Type);
             return true;
         }
@@ -734,7 +797,10 @@ namespace Azure.Generator.Management.Visitors
                 var combinedName = PropertyHelpers.GetCombinedPropertyName(nestedParameter.Property, parentProperty).ToVariableName();
                 if (TryGetMethodParameter(method, combinedName, nestedParameter.Type, nestedParameter.Property, out var combinedParameter))
                 {
-                    argument = new CompatibilityArgument(BuildParameterArgument(combinedParameter, nestedParameter.Type), [combinedParameter]);
+                    argument = new CompatibilityArgument(
+                        BuildParameterArgument(combinedParameter, nestedParameter.Type),
+                        [combinedParameter],
+                        [new ParameterDocumentation(combinedParameter, nestedParameter.Description)]);
                     return true;
                 }
             }
@@ -746,7 +812,10 @@ namespace Azure.Generator.Management.Visitors
                 && nestedParameter.Property is not null
                 && TryGetContextualMethodParameter(method, parentName, nestedParameter, out var contextualParameter))
             {
-                argument = new CompatibilityArgument(BuildParameterArgument(contextualParameter, nestedParameter.Type), [contextualParameter]);
+                argument = new CompatibilityArgument(
+                    BuildParameterArgument(contextualParameter, nestedParameter.Type),
+                    [contextualParameter],
+                    [new ParameterDocumentation(contextualParameter, nestedParameter.Description)]);
                 return true;
             }
 
@@ -756,7 +825,10 @@ namespace Azure.Generator.Management.Visitors
             if (TryGetMethodParameter(method, nestedParameter.Name, nestedParameter.Type, nestedParameter.Property, out var directParameter)
                 && !unavailableDirectParameterNames.Contains(directParameter.Name))
             {
-                argument = new CompatibilityArgument(BuildParameterArgument(directParameter, nestedParameter.Type), [directParameter]);
+                argument = new CompatibilityArgument(
+                    BuildParameterArgument(directParameter, nestedParameter.Type),
+                    [directParameter],
+                    [new ParameterDocumentation(directParameter, nestedParameter.Description)]);
                 return true;
             }
 
@@ -930,6 +1002,11 @@ namespace Azure.Generator.Management.Visitors
             return false;
         }
 
-        private record CompatibilityArgument(ValueExpression Argument, IReadOnlyList<ParameterProvider> MatchedParameters);
+        private record ParameterDocumentation(ParameterProvider Parameter, FormattableString Description);
+
+        private record CompatibilityArgument(
+            ValueExpression Argument,
+            IReadOnlyList<ParameterProvider> MatchedParameters,
+            IReadOnlyList<ParameterDocumentation> ParameterDocumentation);
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
@@ -12,10 +12,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Management.Visitors
@@ -269,7 +267,7 @@ namespace Azure.Generator.Management.Visitors
                 }
             }
 
-            var signature = CreateBackwardCompatSignature(method.Signature, modelProvider, parameterDescriptions);
+            var signature = CreateBackwardCompatSignature(method.Signature, parameterDescriptions);
             updatedMethod = new MethodProvider(
                 signature,
                 Return(New.Instance(method.Signature.ReturnType, arguments)),
@@ -322,13 +320,12 @@ namespace Azure.Generator.Management.Visitors
 
         /// <summary>
         /// Creates the hidden compatibility signature, regenerating its documentation from the current model.
-        /// The descriptions must live on the signature rather than on an <see cref="XmlDocProvider"/> because
-        /// <see cref="MethodProvider.Update"/> rebuilds the docs from the signature whenever a signature is supplied,
-        /// which happens again at write time in <see cref="FixModelFactoryBackwardCompatOverloads"/>.
+        /// The summary is deliberately left off the signature: it lives on the <see cref="XmlDocProvider"/> built by
+        /// <see cref="CreateModelFactoryXmlDocs"/>, exactly as it does for the primary factory methods, so multiple
+        /// lines and nested statements survive verbatim and the previous contract's description is never reused.
         /// </summary>
         private static MethodSignature CreateBackwardCompatSignature(
             MethodSignature signature,
-            ModelProvider modelProvider,
             IReadOnlyDictionary<string, FormattableString> parameterDescriptions)
         {
             var attributes = signature.Attributes.Any(attribute =>
@@ -338,8 +335,9 @@ namespace Azure.Generator.Management.Visitors
 
             foreach (var parameter in signature.Parameters)
             {
-                // Prefer the current model's description; otherwise strip the indentation the previous
-                // generation baked into the parsed description so regeneration is idempotent.
+                // Prefer the current model's description. A parameter that no longer exists on the model has no
+                // current source, so strip the indentation the previous generation baked into the parsed
+                // description instead, which keeps regeneration idempotent.
                 parameter.Update(description: parameterDescriptions.TryGetValue(parameter.Name, out var currentDescription)
                     ? currentDescription
                     : RemoveCommonContinuationIndentation(parameter.Description));
@@ -347,7 +345,7 @@ namespace Azure.Generator.Management.Visitors
 
             return new MethodSignature(
                 signature.Name,
-                GetSummary(modelProvider) ?? signature.Description,
+                null,
                 signature.Modifiers,
                 signature.ReturnType,
                 $"A new {signature.ReturnType:C} instance for mocking.",
@@ -357,83 +355,6 @@ namespace Azure.Generator.Management.Visitors
                 signature.GenericParameterConstraints,
                 signature.ExplicitInterface,
                 signature.NonDocumentComment);
-        }
-
-        private static FormattableString? GetSummary(ModelProvider modelProvider)
-            => CombineDocLines(modelProvider.XmlDocs.Summary?.Lines);
-
-        /// <summary>
-        /// Flattens the lines of a structured doc statement into a single <see cref="FormattableString"/> so it can be
-        /// carried on a <see cref="MethodSignature"/>. Placeholder indexes are re-based as the arguments are appended.
-        /// </summary>
-        private static FormattableString? CombineDocLines(IReadOnlyList<FormattableString>? lines)
-        {
-            if (lines is null || lines.Count == 0)
-            {
-                return null;
-            }
-
-            if (lines.Count == 1)
-            {
-                return lines[0];
-            }
-
-            var format = new StringBuilder();
-            var arguments = new List<object?>();
-            foreach (var line in lines)
-            {
-                if (format.Length > 0)
-                {
-                    format.Append('\n');
-                }
-
-                format.Append(OffsetPlaceholders(line.Format, arguments.Count));
-                arguments.AddRange(line.GetArguments());
-            }
-
-            return FormattableStringFactory.Create(format.ToString(), [.. arguments]);
-        }
-
-        private static string OffsetPlaceholders(string format, int offset)
-        {
-            if (offset == 0)
-            {
-                return format;
-            }
-
-            var builder = new StringBuilder(format.Length);
-            for (int i = 0; i < format.Length; i++)
-            {
-                if (format[i] != '{')
-                {
-                    builder.Append(format[i]);
-                    continue;
-                }
-
-                if (i + 1 < format.Length && format[i + 1] == '{')
-                {
-                    builder.Append("{{");
-                    i++;
-                    continue;
-                }
-
-                var digitsEnd = i + 1;
-                while (digitsEnd < format.Length && char.IsAsciiDigit(format[digitsEnd]))
-                {
-                    digitsEnd++;
-                }
-
-                if (digitsEnd == i + 1)
-                {
-                    builder.Append('{');
-                    continue;
-                }
-
-                builder.Append('{').Append(int.Parse(format[(i + 1)..digitsEnd], CultureInfo.InvariantCulture) + offset);
-                i = digitsEnd - 1;
-            }
-
-            return builder.ToString();
         }
 
         /// <summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs
@@ -12,8 +12,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Management.Visitors
@@ -55,7 +57,9 @@ namespace Azure.Generator.Management.Visitors
 
                 if (bodyUpdated)
                 {
-                    method.Update(signature: method.Signature, bodyStatements: updatedBodyStatements);
+                    // Only the body changed. Passing the signature back would make MethodProvider rebuild the XML docs
+                    // from the (empty) signature description and drop the summary this method was created with.
+                    method.Update(bodyStatements: updatedBodyStatements);
                 }
             }
         }
@@ -99,7 +103,7 @@ namespace Azure.Generator.Management.Visitors
                     {
                         updatedBodyStatements.RemoveAll(statement => IsUnusedLocalDeclaration(statement, unusedLocalVariables));
                     }
-                    method.Update(signature: method.Signature, bodyStatements: updatedBodyStatements);
+                    method.Update(bodyStatements: updatedBodyStatements);
                 }
             }
         }
@@ -166,7 +170,10 @@ namespace Azure.Generator.Management.Visitors
 
                 if (bodyUpdated)
                 {
-                    method.Update(signature: method.Signature, bodyStatements: updatedBodyStatements);
+                    // Deliberately does not re-supply the signature: it is this method's own signature, so passing it
+                    // changes nothing except forcing MethodProvider.Update to rebuild XmlDocs, discarding the
+                    // documentation regenerated when the overload was created.
+                    method.Update(bodyStatements: updatedBodyStatements);
                 }
             }
         }
@@ -266,8 +273,22 @@ namespace Azure.Generator.Management.Visitors
             updatedMethod = new MethodProvider(
                 signature,
                 Return(New.Instance(method.Signature.ReturnType, arguments)),
-                enclosingType);
+                enclosingType,
+                CreateModelFactoryXmlDocs(signature, modelProvider));
             return true;
+        }
+
+        /// <summary>
+        /// Mirrors how the primary factory method is documented: the model's structured summary is reused as-is so
+        /// nested lines and inner statements survive, while parameters and the return doc come from the signature,
+        /// which <see cref="CreateBackwardCompatSignature"/> has already regenerated.
+        /// </summary>
+        private static XmlDocProvider CreateModelFactoryXmlDocs(MethodSignature signature, ModelProvider modelProvider)
+        {
+            return new XmlDocProvider(
+                modelProvider.XmlDocs.Summary,
+                [.. signature.Parameters.Select(parameter => new XmlDocParamStatement(parameter))],
+                returns: new XmlDocReturnsStatement(signature.ReturnDescription!));
         }
 
         private static FormattableString RemoveCommonContinuationIndentation(FormattableString description)
@@ -339,11 +360,80 @@ namespace Azure.Generator.Management.Visitors
         }
 
         private static FormattableString? GetSummary(ModelProvider modelProvider)
+            => CombineDocLines(modelProvider.XmlDocs.Summary?.Lines);
+
+        /// <summary>
+        /// Flattens the lines of a structured doc statement into a single <see cref="FormattableString"/> so it can be
+        /// carried on a <see cref="MethodSignature"/>. Placeholder indexes are re-based as the arguments are appended.
+        /// </summary>
+        private static FormattableString? CombineDocLines(IReadOnlyList<FormattableString>? lines)
         {
-            // Model summaries are single line in practice; anything else is left to the previous description
-            // rather than attempting to re-index the format arguments of several formattable strings.
-            var lines = modelProvider.XmlDocs.Summary?.Lines;
-            return lines?.Count == 1 ? lines[0] : null;
+            if (lines is null || lines.Count == 0)
+            {
+                return null;
+            }
+
+            if (lines.Count == 1)
+            {
+                return lines[0];
+            }
+
+            var format = new StringBuilder();
+            var arguments = new List<object?>();
+            foreach (var line in lines)
+            {
+                if (format.Length > 0)
+                {
+                    format.Append('\n');
+                }
+
+                format.Append(OffsetPlaceholders(line.Format, arguments.Count));
+                arguments.AddRange(line.GetArguments());
+            }
+
+            return FormattableStringFactory.Create(format.ToString(), [.. arguments]);
+        }
+
+        private static string OffsetPlaceholders(string format, int offset)
+        {
+            if (offset == 0)
+            {
+                return format;
+            }
+
+            var builder = new StringBuilder(format.Length);
+            for (int i = 0; i < format.Length; i++)
+            {
+                if (format[i] != '{')
+                {
+                    builder.Append(format[i]);
+                    continue;
+                }
+
+                if (i + 1 < format.Length && format[i + 1] == '{')
+                {
+                    builder.Append("{{");
+                    i++;
+                    continue;
+                }
+
+                var digitsEnd = i + 1;
+                while (digitsEnd < format.Length && char.IsAsciiDigit(format[digitsEnd]))
+                {
+                    digitsEnd++;
+                }
+
+                if (digitsEnd == i + 1)
+                {
+                    builder.Append('{');
+                    continue;
+                }
+
+                builder.Append('{').Append(int.Parse(format[(i + 1)..digitsEnd], CultureInfo.InvariantCulture) + offset);
+                i = digitsEnd - 1;
+            }
+
+            return builder.ToString();
         }
 
         /// <summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -487,10 +487,13 @@ namespace Azure.Generator.Mgmt.Tests
                 }
             }
 
-            foreach (var line in method.XmlDocs.Returns?.Lines ?? [])
+            if (method.XmlDocs.Returns is not null)
             {
                 builder.AppendLine("<returns>");
-                builder.AppendLine(line.ToString());
+                foreach (var line in method.XmlDocs.Returns.Lines)
+                {
+                    builder.AppendLine(line.ToString());
+                }
             }
 
             return builder.ToString().Replace("\r\n", "\n");

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -12,6 +12,7 @@ using Microsoft.TypeSpec.Generator.Statements;
 using NUnit.Framework;
 using System;
 using System.Reflection;
+using System.Text;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Mgmt.Tests
@@ -149,6 +150,63 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(rendered, Does.Contain("EditorBrowsable"));
             Assert.That(rendered, Does.Contain("EditorBrowsableState.Never"));
             Assert.That(rendered, Does.Contain("return new global::Samples.Models.TestModel"));
+        }
+
+        [Test]
+        public void RestoredFactoryMethodRegeneratesDocumentationFromCurrentModel()
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("value", InputPrimitiveType.String)]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
+            var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            model.FullConstructor.Signature.Parameters.Single(parameter => parameter.Name == "value")
+                .Update(description: $"Current parameter summary.\nCurrent parameter details.");
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+            var previousMethod = CreatePreviousFactoryMethod(
+                modelFactory,
+                model.Type,
+                "value",
+                $"Previous parameter summary.\n            Previous parameter details.");
+
+            Assert.That(
+                Management.Visitors.ModelFactoryBackwardCompatHelper.TryCreateBackwardCompatMethod(
+                    previousMethod,
+                    modelFactory,
+                    out var restoredMethod),
+                Is.True);
+
+            var docs = DescribeDocs(restoredMethod!);
+
+            Assert.That(docs, Does.Contain("TestModel description"));
+            Assert.That(docs, Does.Contain("Current parameter summary."));
+            Assert.That(docs, Does.Contain("Current parameter details."));
+            Assert.That(docs, Does.Not.Contain("Previous model summary."));
+            Assert.That(docs, Does.Not.Contain("Previous parameter summary."));
+            Assert.That(docs, Does.Not.Contain("Previous parameter details."));
+            Assert.That(restoredMethod!.XmlDocs.Returns, Is.Not.Null);
+        }
+
+        [Test]
+        public void RestoredFactoryMethodNormalizesUnmatchedLastContractDocumentation()
+        {
+            var docs = DescribeDocs(BuildRestoredMethodWithUnmatchedParameter(
+                $"Legacy parameter summary.\n            \n             - First item.\n            Legacy parameter details."));
+
+            Assert.That(docs, Does.Contain("Legacy parameter summary.\n\n - First item.\nLegacy parameter details."));
+        }
+
+        [Test]
+        public void RestoredFactoryMethodDocumentationIsIndependentOfLastContractIndentation()
+        {
+            var firstDocs = DescribeDocs(BuildRestoredMethodWithUnmatchedParameter(
+                $"Legacy parameter summary.\n             - First item.\n            Legacy parameter details."));
+            var secondDocs = DescribeDocs(BuildRestoredMethodWithUnmatchedParameter(
+                $"Legacy parameter summary.\n                         - First item.\n                        Legacy parameter details."));
+
+            Assert.That(secondDocs, Is.EqualTo(firstDocs));
         }
 
         [Test]
@@ -366,6 +424,76 @@ namespace Azure.Generator.Mgmt.Tests
             var rendered = new TypeProviderWriter(modelFactory).Write().Content;
             Assert.That(rendered, Does.Contain("return new global::Samples.Models.TestModel(vmwareId, ((global::System.Collections.Generic.IDictionary<string, global::System.BinaryData>)default));"));
             Assert.That(rendered, Does.Not.Contain("TestModel(vMwareId"));
+        }
+
+        private static MethodProvider CreatePreviousFactoryMethod(
+            TypeProvider modelFactory,
+            CSharpType returnType,
+            string parameterName,
+            FormattableString parameterDescription)
+        {
+            var previousSignature = new MethodSignature(
+                "TestModel",
+                $"Previous model summary.",
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                returnType,
+                $"Previous return summary.",
+                [new ParameterProvider(parameterName, parameterDescription, typeof(string))]);
+            var lastContractView = new TestModelFactoryView(modelFactory.Name);
+            return new MethodProvider(previousSignature, MethodBodyStatement.Empty, lastContractView);
+        }
+
+        private static MethodProvider BuildRestoredMethodWithUnmatchedParameter(FormattableString parameterDescription)
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("value", InputPrimitiveType.String)]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
+            var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+            var previousMethod = CreatePreviousFactoryMethod(
+                modelFactory,
+                model.Type,
+                "legacyValue",
+                parameterDescription);
+
+            Assert.That(
+                Management.Visitors.ModelFactoryBackwardCompatHelper.TryCreateBackwardCompatMethod(
+                    previousMethod,
+                    modelFactory,
+                    out var restoredMethod),
+                Is.True);
+
+            return restoredMethod!;
+        }
+
+        private static string DescribeDocs(MethodProvider method)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("<summary>");
+            foreach (var line in method.XmlDocs.Summary?.Lines ?? [])
+            {
+                builder.AppendLine(line.ToString());
+            }
+
+            foreach (var parameter in method.XmlDocs.Parameters)
+            {
+                builder.AppendLine($"<param name=\"{parameter.Parameter.Name}\">");
+                foreach (var line in parameter.Lines)
+                {
+                    builder.AppendLine(line.ToString());
+                }
+            }
+
+            foreach (var line in method.XmlDocs.Returns?.Lines ?? [])
+            {
+                builder.AppendLine("<returns>");
+                builder.AppendLine(line.ToString());
+            }
+
+            return builder.ToString().Replace("\r\n", "\n");
         }
 
         private static void SetLastContractView(TypeProvider typeProvider, TypeProvider lastContractView)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -191,36 +191,18 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
-        public void RestoredFactoryMethodPreservesMultiLineCurrentModelSummary()
-        {
-            var restored = BuildRestoredMethodWithUnmatchedParameter(
-                $"Legacy parameter summary.",
-                summary: new XmlDocSummaryStatement(
-                [
-                    $"First summary line for {typeof(int):C}.",
-                    $"Second summary line for {typeof(string):C}.",
-                ]));
-
-            // Both lines are reproduced from the current model; the previous contract's summary is never consulted.
-            Assert.That(DescribeDocs(restored), Is.EqualTo(
-                "<summary>\nFirst summary line for System.Int32.\nSecond summary line for System.String.\n"
-                + "<param name=\"legacyValue\">\nLegacy parameter summary.\n"
-                + "<returns>\nA new global::Samples.Models.TestModel instance for mocking.\n"));
-        }
-
-        [Test]
-        public void RestoredFactoryMethodSignatureNeverCarriesLastContractDescription()
+        public void RestoredFactoryMethodSignatureCarriesCurrentModelDescription()
         {
             var restored = BuildRestoredMethodWithUnmatchedParameter(
                 $"Legacy parameter summary.\n            Legacy parameter details.");
 
-            // The summary belongs on the XmlDocProvider, matching the primary factory methods. Leaving it off the
-            // signature is what guarantees the stale last-contract description can never leak back in.
-            Assert.That(restored.Signature.Description, Is.Null);
+            // The signature is the single source of the docs, so it must carry the current model's description.
+            // Leaving it empty is what let a later rebuild silently produce no summary at all.
+            Assert.That(restored.Signature.Description?.ToString(), Is.EqualTo("TestModel description"));
 
             var docs = DescribeDocs(restored);
             Assert.That(docs, Does.Contain("TestModel description"));
-            Assert.That(docs, Does.Not.Contain("            Legacy parameter details."));
+            Assert.That(docs, Does.Not.Contain("Legacy parameter details."));
             Assert.That(docs, Does.Not.Contain("Previous model summary."));
             Assert.That(docs, Does.Not.Contain("Previous return summary."));
         }
@@ -262,12 +244,20 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
-        public void RestoredFactoryMethodNormalizesUnmatchedLastContractDocumentation()
+        public void RestoredFactoryMethodDropsUnmatchedLastContractDocumentation()
         {
-            var docs = DescribeDocs(BuildRestoredMethodWithUnmatchedParameter(
-                $"Legacy parameter summary.\n            \n             - First item.\n            Legacy parameter details."));
+            var restored = BuildRestoredMethodWithUnmatchedParameter(
+                $"Legacy parameter summary.\n            \n             - First item.\n            Legacy parameter details.");
+            var docs = DescribeDocs(restored);
 
-            Assert.That(docs, Does.Contain("Legacy parameter summary.\n\n - First item.\nLegacy parameter details."));
+            // The parameter no longer maps to the model, so there is no current description to regenerate. The
+            // previous one is dropped rather than salvaged: it came back out of generated C# with its cref text
+            // already lost and the writer's indentation baked in.
+            Assert.That(docs, Does.Not.Contain("Legacy parameter"));
+            Assert.That(docs, Does.Contain("<param name=\"legacyValue\">"));
+
+            // Model factory methods are for mocking and never validate, so they must not document exceptions.
+            Assert.That(restored.XmlDocs.Exceptions, Is.Empty);
         }
 
         [Test]
@@ -516,8 +506,7 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         private static MethodProvider BuildRestoredMethodWithUnmatchedParameter(
-            FormattableString parameterDescription,
-            XmlDocSummaryStatement? summary = null)
+            FormattableString parameterDescription)
         {
             var inputModel = InputFactory.Model(
                 "TestModel",
@@ -526,10 +515,6 @@ namespace Azure.Generator.Mgmt.Tests
 
             var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
             var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
-            if (summary is not null)
-            {
-                model.XmlDocs.Update(summary: summary);
-            }
 
             var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
             var previousMethod = CreatePreviousFactoryMethod(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -191,7 +191,7 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
-        public void RestoredFactoryMethodCombinesMultiLineCurrentModelSummary()
+        public void RestoredFactoryMethodPreservesMultiLineCurrentModelSummary()
         {
             var restored = BuildRestoredMethodWithUnmatchedParameter(
                 $"Legacy parameter summary.",
@@ -201,34 +201,28 @@ namespace Azure.Generator.Mgmt.Tests
                     $"Second summary line for {typeof(string):C}.",
                 ]));
 
-            var docs = DescribeDocs(restored);
-            Assert.That(docs, Does.Contain("First summary line for System.Int32."));
-            Assert.That(docs, Does.Contain("Second summary line for System.String."));
-            Assert.That(docs, Does.Not.Contain("Previous model summary."));
-
-            // The signature must carry the combined summary too, so a rebuild cannot fall back to the last contract.
-            Assert.That(restored.Signature.Description?.ToString(),
-                Is.EqualTo("First summary line for System.Int32.\nSecond summary line for System.String."));
-
-            restored.Update(signature: restored.Signature, bodyStatements: MethodBodyStatement.Empty);
-            Assert.That(DescribeDocs(restored), Does.Not.Contain("Previous model summary."));
+            // Both lines are reproduced from the current model; the previous contract's summary is never consulted.
+            Assert.That(DescribeDocs(restored), Is.EqualTo(
+                "<summary>\nFirst summary line for System.Int32.\nSecond summary line for System.String.\n"
+                + "<param name=\"legacyValue\">\nLegacy parameter summary.\n"
+                + "<returns>\nA new global::Samples.Models.TestModel instance for mocking.\n"));
         }
 
         [Test]
-        public void RestoredFactoryMethodDocumentationSurvivesWriteTimeSignatureUpdate()
+        public void RestoredFactoryMethodSignatureNeverCarriesLastContractDescription()
         {
             var restored = BuildRestoredMethodWithUnmatchedParameter(
                 $"Legacy parameter summary.\n            Legacy parameter details.");
-            var before = DescribeDocs(restored);
 
-            // FixModelFactoryBackwardCompatOverloads repairs bodies at write time and re-supplies the
-            // signature, which makes MethodProvider.Update rebuild XmlDocs from scratch.
-            restored.Update(signature: restored.Signature, bodyStatements: MethodBodyStatement.Empty);
+            // The summary belongs on the XmlDocProvider, matching the primary factory methods. Leaving it off the
+            // signature is what guarantees the stale last-contract description can never leak back in.
+            Assert.That(restored.Signature.Description, Is.Null);
 
-            Assert.That(DescribeDocs(restored), Is.EqualTo(before));
-            Assert.That(before, Does.Not.Contain("            Legacy parameter details."));
-            Assert.That(before, Does.Not.Contain("Previous model summary."));
-            Assert.That(before, Does.Not.Contain("Previous return summary."));
+            var docs = DescribeDocs(restored);
+            Assert.That(docs, Does.Contain("TestModel description"));
+            Assert.That(docs, Does.Not.Contain("            Legacy parameter details."));
+            Assert.That(docs, Does.Not.Contain("Previous model summary."));
+            Assert.That(docs, Does.Not.Contain("Previous return summary."));
         }
 
         [Test]

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -191,6 +191,30 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
+        public void RestoredFactoryMethodCombinesMultiLineCurrentModelSummary()
+        {
+            var restored = BuildRestoredMethodWithUnmatchedParameter(
+                $"Legacy parameter summary.",
+                summary: new XmlDocSummaryStatement(
+                [
+                    $"First summary line for {typeof(int):C}.",
+                    $"Second summary line for {typeof(string):C}.",
+                ]));
+
+            var docs = DescribeDocs(restored);
+            Assert.That(docs, Does.Contain("First summary line for System.Int32."));
+            Assert.That(docs, Does.Contain("Second summary line for System.String."));
+            Assert.That(docs, Does.Not.Contain("Previous model summary."));
+
+            // The signature must carry the combined summary too, so a rebuild cannot fall back to the last contract.
+            Assert.That(restored.Signature.Description?.ToString(),
+                Is.EqualTo("First summary line for System.Int32.\nSecond summary line for System.String."));
+
+            restored.Update(signature: restored.Signature, bodyStatements: MethodBodyStatement.Empty);
+            Assert.That(DescribeDocs(restored), Does.Not.Contain("Previous model summary."));
+        }
+
+        [Test]
         public void RestoredFactoryMethodDocumentationSurvivesWriteTimeSignatureUpdate()
         {
             var restored = BuildRestoredMethodWithUnmatchedParameter(
@@ -497,7 +521,9 @@ namespace Azure.Generator.Mgmt.Tests
             return new MethodProvider(previousSignature, MethodBodyStatement.Empty, lastContractView);
         }
 
-        private static MethodProvider BuildRestoredMethodWithUnmatchedParameter(FormattableString parameterDescription)
+        private static MethodProvider BuildRestoredMethodWithUnmatchedParameter(
+            FormattableString parameterDescription,
+            XmlDocSummaryStatement? summary = null)
         {
             var inputModel = InputFactory.Model(
                 "TestModel",
@@ -506,6 +532,11 @@ namespace Azure.Generator.Mgmt.Tests
 
             var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
             var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            if (summary is not null)
+            {
+                model.XmlDocs.Update(summary: summary);
+            }
+
             var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
             var previousMethod = CreatePreviousFactoryMethod(
                 modelFactory,
@@ -578,5 +609,27 @@ namespace Azure.Generator.Mgmt.Tests
 
             protected override MethodProvider[] BuildMethods() => MethodsToBuild;
         }
-    }
+
+        [Test]
+        public void PrimaryFactoryMethodDocumentationSurvivesConstructorCallFixup()
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("value", InputPrimitiveType.String)]);
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
+            _ = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+
+            var before = DescribeDocs(modelFactory.Methods.Single());
+            Assert.That(before, Does.Contain("TestModel description"));
+
+            Management.Visitors.ModelFactoryBackwardCompatHelper.FixModelFactoryConstructorCalls(modelFactory.Methods);
+
+            // Rebuilding the constructor call only changes the body. The summary that core attached to the primary
+            // factory method lives on the XmlDocProvider, not on the (empty) signature description, so a signature
+            // round-trip would silently erase it.
+            Assert.That(DescribeDocs(modelFactory.Methods.Single()), Is.EqualTo(before));
+        }
+}
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -186,7 +186,8 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(docs, Does.Not.Contain("Previous model summary."));
             Assert.That(docs, Does.Not.Contain("Previous parameter summary."));
             Assert.That(docs, Does.Not.Contain("Previous parameter details."));
-            Assert.That(restoredMethod!.XmlDocs.Returns, Is.Not.Null);
+            Assert.That(docs, Does.Contain("A new global::Samples.Models.TestModel instance for mocking."));
+            Assert.That(docs, Does.Not.Contain("Previous return summary."));
         }
 
         [Test]

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -191,6 +191,59 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
+        public void RestoredFactoryMethodDocumentationSurvivesWriteTimeSignatureUpdate()
+        {
+            var restored = BuildRestoredMethodWithUnmatchedParameter(
+                $"Legacy parameter summary.\n            Legacy parameter details.");
+            var before = DescribeDocs(restored);
+
+            // FixModelFactoryBackwardCompatOverloads repairs bodies at write time and re-supplies the
+            // signature, which makes MethodProvider.Update rebuild XmlDocs from scratch.
+            restored.Update(signature: restored.Signature, bodyStatements: MethodBodyStatement.Empty);
+
+            Assert.That(DescribeDocs(restored), Is.EqualTo(before));
+            Assert.That(before, Does.Not.Contain("            Legacy parameter details."));
+            Assert.That(before, Does.Not.Contain("Previous model summary."));
+            Assert.That(before, Does.Not.Contain("Previous return summary."));
+        }
+
+        [Test]
+        public void RestoredFactoryMethodDocumentationSurvivesBackwardCompatOverloadFixup()
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("value", InputPrimitiveType.String)]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
+            var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+            var previousMethod = CreatePreviousFactoryMethod(
+                modelFactory,
+                model.Type,
+                "value",
+                $"Previous parameter summary.\n            Previous parameter details.");
+
+            Assert.That(
+                Management.Visitors.ModelFactoryBackwardCompatHelper.TryCreateBackwardCompatMethod(
+                    previousMethod,
+                    modelFactory,
+                    out var restoredMethod),
+                Is.True);
+
+            var primaryMethod = modelFactory.Methods.Single(
+                method => !Management.Visitors.ModelFactoryBackwardCompatHelper.IsBackwardCompatMethod(method)
+                    && method.Signature.Name == "TestModel");
+            var docsBeforeFixup = DescribeDocs(restoredMethod!);
+
+            Management.Visitors.ModelFactoryBackwardCompatHelper.FixModelFactoryBackwardCompatOverloads(
+                [primaryMethod, restoredMethod!]);
+
+            Assert.That(DescribeDocs(restoredMethod!), Is.EqualTo(docsBeforeFixup));
+            Assert.That(docsBeforeFixup, Does.Not.Contain("Previous parameter details."));
+        }
+
+        [Test]
         public void RestoredFactoryMethodNormalizesUnmatchedLastContractDocumentation()
         {
             var docs = DescribeDocs(BuildRestoredMethodWithUnmatchedParameter(

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec-MultiService/src/Generated/MgmtTypeSpecMultiServiceTestsModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec-MultiService/src/Generated/MgmtTypeSpecMultiServiceTestsModelFactory.cs
@@ -16,6 +16,7 @@ namespace Azure.Generator.MgmtTypeSpec.MultiService.Tests.Models
     /// <summary> A factory class for creating instances of the models for mocking. </summary>
     public static partial class MgmtTypeSpecMultiServiceTestsModelFactory
     {
+        /// <summary> The CheckAvailabilityRequest. </summary>
         /// <param name="name"> The name to check availability for. </param>
         /// <returns> A new <see cref="Models.CheckAvailabilityRequest"/> instance for mocking. </returns>
         public static CheckAvailabilityRequest CheckAvailabilityRequest(string name = default)
@@ -23,6 +24,7 @@ namespace Azure.Generator.MgmtTypeSpec.MultiService.Tests.Models
             return new CheckAvailabilityRequest(name, default);
         }
 
+        /// <summary> The CheckAvailabilityResponse. </summary>
         /// <param name="isAvailable"> Whether the name is available. </param>
         /// <param name="reason"> Reason the name is not available. </param>
         /// <returns> A new <see cref="Models.CheckAvailabilityResponse"/> instance for mocking. </returns>
@@ -31,6 +33,7 @@ namespace Azure.Generator.MgmtTypeSpec.MultiService.Tests.Models
             return new CheckAvailabilityResponse(isAvailable, reason, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -54,6 +57,7 @@ namespace Azure.Generator.MgmtTypeSpec.MultiService.Tests.Models
                 default);
         }
 
+        /// <summary> The FooProperties. </summary>
         /// <param name="displayName"></param>
         /// <param name="provisioningState"></param>
         /// <returns> A new <see cref="Models.FooProperties"/> instance for mocking. </returns>
@@ -62,6 +66,7 @@ namespace Azure.Generator.MgmtTypeSpec.MultiService.Tests.Models
             return new FooProperties(displayName, provisioningState, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -85,6 +90,7 @@ namespace Azure.Generator.MgmtTypeSpec.MultiService.Tests.Models
                 default);
         }
 
+        /// <summary> The BarProperties. </summary>
         /// <param name="description"></param>
         /// <param name="provisioningState"></param>
         /// <returns> A new <see cref="Models.BarProperties"/> instance for mocking. </returns>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
@@ -19,6 +19,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
     /// <summary> A factory class for creating instances of the models for mocking. </summary>
     public static partial class MgmtTypeSpecTestsModelFactory
     {
+        /// <summary> The FooPreviewAction. </summary>
         /// <param name="action"> The action to be performed. </param>
         /// <param name="result"></param>
         /// <returns> A new <see cref="Models.FooPreviewAction"/> instance for mocking. </returns>
@@ -27,6 +28,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new FooPreviewAction(action, result, default);
         }
 
+        /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -46,6 +48,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Properties of a private link resource. </summary>
         /// <param name="groupId"> The private link resource group id. </param>
         /// <param name="requiredMembers"> The private link resource required member names. </param>
         /// <param name="requiredZoneNames"> The private link resource private link DNS zone name. </param>
@@ -58,6 +61,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new AzureGeneratorMgmtTypeSpecTestsPrivateLinkResourceProperties(groupId, (requiredMembers ?? new ChangeTrackingList<string>()).ToList(), (requiredZoneNames ?? new ChangeTrackingList<string>()).ToList(), default);
         }
 
+        /// <summary> A private endpoint connection resource. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -75,6 +79,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Properties of the private endpoint connection. </summary>
         /// <param name="groupIds"> The group ids for the private endpoint resource. </param>
         /// <param name="privateEndpoint"> The private endpoint resource. </param>
         /// <param name="privateLinkServiceConnectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
@@ -87,6 +92,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new PrivateEndpointConnectionProperties((groupIds ?? new ChangeTrackingList<string>()).ToList(), privateEndpoint, privateLinkServiceConnectionState, provisioningState, default);
         }
 
+        /// <summary> A collection of information about the state of the connection between service consumer and provider. </summary>
         /// <param name="status"> Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. </param>
         /// <param name="description"> The reason for approval/rejection of the connection. </param>
         /// <param name="actionsRequired"> A message indicating if changes on the service provider require any updates on the consumer. </param>
@@ -143,7 +149,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="extendedLocation"> The extended location of the resource. </param>
         /// <param name="identity"> The managed service identities assigned to this resource. </param>
         /// <param name="plan"> Details of the resource plan. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="something"/>, <paramref name="prop1"/> or <paramref name="nestedPropertyProperties"/> is null. </exception>
         /// <returns> A new <see cref="Tests.FooData"/> instance for mocking. </returns>
         public static FooData FooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, AzureLocation location = default, Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, ETag? eTag = default, WritableSubResource writableSubResourceProp = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default, ExtendedLocation extendedLocation = default, ManagedServiceIdentity identity = default, ArmPlan plan = default)
         {
@@ -190,7 +195,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="eTag"> ETag property for testing etag parameter name generation. </param>
         /// <param name="writableSubResourceProp"> WritableSubResource property for testing WritableSubResource type replacement. </param>
         /// <param name="computeFleetVmCapacityReservationGroupId"> Gets or sets the Id. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="nestedPropertyProperties"/> is null. </exception>
         /// <returns> A new <see cref="Models.FooProperties"/> instance for mocking. </returns>
         public static FooProperties FooProperties(Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ETag? eTag = default, WritableSubResource writableSubResourceProp = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default)
         {
@@ -214,6 +218,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The FooActionRequest. </summary>
         /// <param name="id"></param>
         /// <returns> A new <see cref="Models.FooActionRequest"/> instance for mocking. </returns>
         public static FooActionRequest FooActionRequest(string id = default)
@@ -221,6 +226,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new FooActionRequest(id, default);
         }
 
+        /// <summary> The FooActionResult. </summary>
         /// <param name="msg"></param>
         /// <param name="error"></param>
         /// <returns> A new <see cref="Models.FooActionResult"/> instance for mocking. </returns>
@@ -229,6 +235,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new FooActionResult(msg, error, default);
         }
 
+        /// <summary> The FooDependency. </summary>
         /// <param name="dependencyName"></param>
         /// <param name="version"></param>
         /// <returns> A new <see cref="Models.FooDependency"/> instance for mocking. </returns>
@@ -237,6 +244,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new FooDependency(dependencyName, version, default);
         }
 
+        /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -271,6 +279,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Marketplace details for an organization. </summary>
         /// <param name="subscriptionId"> Azure subscription id for the the marketplace offer is purchased from. </param>
         /// <param name="subscriptionStatus"> Marketplace subscription status. </param>
         /// <param name="saasResourceId"> Marketplace SaaS Resource Id. </param>
@@ -281,6 +290,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new MarketplaceDetails(subscriptionId, subscriptionStatus, saasResourceId, offerDetails, default);
         }
 
+        /// <summary> Offer details for the marketplace that is selected by the user. </summary>
         /// <param name="publisherId"> Publisher Id for the marketplace offer. </param>
         /// <param name="offerId"> Offer Id for the marketplace offer. </param>
         /// <param name="planId"> Plan Id for the marketplace offer. </param>
@@ -300,6 +310,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> User details for an organization. </summary>
         /// <param name="firstName"> First name of the user. </param>
         /// <param name="lastName"> Last name of the user. </param>
         /// <param name="emailAddress"> Email address of the user. </param>
@@ -317,6 +328,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The type used for update operations of the FooSettings. </summary>
         /// <param name="properties"> The resource-specific properties for this resource. </param>
         /// <returns> A new <see cref="Models.FooConfigurationPatch"/> instance for mocking. </returns>
         public static FooConfigurationPatch FooConfigurationPatch(FooSettingsUpdateProperties properties = default)
@@ -324,6 +336,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new FooConfigurationPatch(properties, default);
         }
 
+        /// <summary> The updatable properties of the FooSettings. </summary>
         /// <param name="marketplace"> Marketplace details of the resource. </param>
         /// <param name="user"> Details of the user. </param>
         /// <param name="accessControlEnabled"></param>
@@ -333,6 +346,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new FooSettingsUpdateProperties(marketplace, user, accessControlEnabled, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -356,6 +370,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The BarProperties. </summary>
         /// <param name="serviceUri"> the service url. </param>
         /// <param name="something"> something. </param>
         /// <param name="boolValue"> boolean value. </param>
@@ -373,6 +388,10 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary>
+        /// LimitJson abstract class.
+        /// Please note this is the abstract base class. The derived classes available for instantiation are: 
+        /// </summary>
         /// <param name="limitObjectType"> The limit object type. </param>
         /// <returns> A new <see cref="Models.LimitJsonObject"/> instance for mocking. </returns>
         public static LimitJsonObject LimitJsonObject(string limitObjectType = default)
@@ -380,6 +399,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new UnknownLimitJsonObject(default, default);
         }
 
+        /// <summary> An Employee resource. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -403,6 +423,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Employee properties. </summary>
         /// <param name="age"> Age of employee. </param>
         /// <param name="city"> City of employee. </param>
         /// <returns> A new <see cref="Models.EmployeeProperties"/> instance for mocking. </returns>
@@ -411,6 +432,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new EmployeeProperties(age, city, default);
         }
 
+        /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -434,6 +456,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The BazProperties. </summary>
         /// <param name="something"> something. </param>
         /// <param name="boolValue"> boolean value. </param>
         /// <returns> A new <see cref="Models.BazProperties"/> instance for mocking. </returns>
@@ -486,6 +509,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The ZooProperties. </summary>
         /// <param name="something"> something. </param>
         /// <param name="requiredInt">
         /// Required value-type property. Used to validate that required value types
@@ -512,6 +536,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The type used for update operations of the Zoo. </summary>
         /// <param name="tags"> Resource tags. </param>
         /// <param name="properties"> The resource-specific properties for this resource. </param>
         /// <returns> A new <see cref="Models.ZooPatch"/> instance for mocking. </returns>
@@ -522,6 +547,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new ZooPatch(tags ?? new ChangeTrackingDictionary<string, string>(), properties, default);
         }
 
+        /// <summary> The updatable properties of the Zoo. </summary>
         /// <param name="something"> something. </param>
         /// <param name="requiredInt">
         /// Required value-type property. Used to validate that required value types
@@ -548,6 +574,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Paged collection of ZooAddress items. </summary>
         /// <param name="value"> The ZooAddress items on this page. </param>
         /// <param name="nextLink"> The link to the next page of items. </param>
         /// <returns> A new <see cref="Models.ZooAddressListListResult"/> instance for mocking. </returns>
@@ -558,6 +585,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new ZooAddressListListResult((value ?? new ChangeTrackingList<SubResource>()).ToList(), nextLink, default);
         }
 
+        /// <summary> The ZooRecommendation. </summary>
         /// <param name="recommendedValue"> The recommended value. </param>
         /// <param name="reason"> The reason for the recommendation. </param>
         /// <returns> A new <see cref="Models.ZooRecommendation"/> instance for mocking. </returns>
@@ -566,6 +594,10 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new ZooRecommendation(recommendedValue, reason, default);
         }
 
+        /// <summary>
+        /// Test resource to reproduce issue #55436 - Missing constructor parameters in factory methods.
+        /// This uses a patch model with properties that extend a base type with nested complex objects.
+        /// </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -647,6 +679,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The check availability request body. </summary>
         /// <param name="name"> The name of the resource for which availability needs to be checked. </param>
         /// <param name="type"> The resource type. </param>
         /// <returns> A new <see cref="Models.CheckNameAvailabilityRequest"/> instance for mocking. </returns>
@@ -655,6 +688,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new CheckNameAvailabilityRequest(name, @type, default);
         }
 
+        /// <summary> The CheckNameAvailabilityResponse. </summary>
         /// <param name="nameAvailable"></param>
         /// <param name="reason"></param>
         /// <param name="message"></param>
@@ -664,6 +698,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new CheckNameAvailabilityResponse(nameAvailable, reason, message, default);
         }
 
+        /// <summary> Subscription-level location-based Playwright quota resource. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -681,6 +716,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Subscription-level location-based Playwright quota resource properties. </summary>
         /// <param name="freeTrial"> The subscription-level location-based Playwright quota resource free-trial properties. </param>
         /// <param name="provisioningState"> The status of the last resource operation. </param>
         /// <returns> A new <see cref="Models.PlaywrightQuotaProperties"/> instance for mocking. </returns>
@@ -696,7 +732,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="tags"> Resource tags. </param>
         /// <param name="location"> The geo-location where the resource lives. </param>
         /// <param name="jobName"> Gets or sets the JobName. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="jobName"/> is null. </exception>
         /// <returns> A new <see cref="Tests.JobResourceData"/> instance for mocking. </returns>
         public static JobResourceData JobResourceData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, AzureLocation location = default, string jobName = default)
         {
@@ -740,6 +775,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The new quota limit request status. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -795,6 +831,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> SubscriptionIds and quota allocated to subscriptions from the GroupQuota. </summary>
         /// <param name="subscriptionId"> An Azure subscriptionId. </param>
         /// <param name="quotaAllocated"> The amount of quota allocated to this subscriptionId from the GroupQuotasEntity. </param>
         /// <returns> A new <see cref="Models.AllocatedToSubscription"/> instance for mocking. </returns>
@@ -803,6 +840,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new AllocatedToSubscription(subscriptionId, quotaAllocated, default);
         }
 
+        /// <summary> Subscription quota list. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -820,6 +858,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The SubscriptionQuotaAllocationsListProperties. </summary>
         /// <param name="value"> Subscription quota list. </param>
         /// <param name="nextLink"> The URL to use for getting the next set of results. </param>
         /// <returns> A new <see cref="Models.SubscriptionQuotaAllocationsListProperties"/> instance for mocking. </returns>
@@ -830,6 +869,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new SubscriptionQuotaAllocationsListProperties((value ?? new ChangeTrackingList<string>()).ToList(), nextLink, default);
         }
 
+        /// <summary> Request for querying network sibling set. </summary>
         /// <param name="location"> Location to query. </param>
         /// <param name="subscriptionId"> Subscription ID to query. </param>
         /// <returns> A new <see cref="Models.QueryNetworkSiblingSetRequest"/> instance for mocking. </returns>
@@ -838,6 +878,10 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new QueryNetworkSiblingSetRequest(location, subscriptionId, default);
         }
 
+        /// <summary>
+        /// Network sibling set information returned by the query operation.
+        /// This is a non-resource model used in a provider-level LRO operation.
+        /// </summary>
         /// <param name="id"> Unique identifier for the sibling set. </param>
         /// <param name="name"> Name of the sibling set. </param>
         /// <param name="type"> Type of the resource. </param>
@@ -848,6 +892,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new NetworkSiblingSet(id, name, @type, properties, default);
         }
 
+        /// <summary> Properties of the network sibling set. </summary>
         /// <param name="siblings"> List of network siblings. </param>
         /// <param name="status"> Status of the query. </param>
         /// <returns> A new <see cref="Models.NetworkSiblingSetProperties"/> instance for mocking. </returns>
@@ -858,6 +903,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new NetworkSiblingSetProperties((siblings ?? new ChangeTrackingList<NetworkSibling>()).ToList(), status, default);
         }
 
+        /// <summary> Information about a network sibling. </summary>
         /// <param name="subscriptionId"> Subscription ID. </param>
         /// <param name="resourceGroupName"> Resource group name. </param>
         /// <param name="networkInterfaceId"> Network interface ID. </param>
@@ -867,6 +913,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new NetworkSibling(subscriptionId, resourceGroupName, networkInterfaceId, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -921,6 +968,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The SAPAvailabilityZoneDetailsRequest. </summary>
         /// <param name="preferredAvailabilityZone"> The preferred availability zone. </param>
         /// <returns> A new <see cref="Models.SAPAvailabilityZoneDetailsRequest"/> instance for mocking. </returns>
         public static SAPAvailabilityZoneDetailsRequest SAPAvailabilityZoneDetailsRequest(string preferredAvailabilityZone = default)
@@ -928,6 +976,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new SAPAvailabilityZoneDetailsRequest(preferredAvailabilityZone, default);
         }
 
+        /// <summary> The SAPAvailabilityZoneDetailsResult. </summary>
         /// <param name="recommendedAvailabilityZonePair"> The recommended availability zone pair. </param>
         /// <returns> A new <see cref="Models.SAPAvailabilityZoneDetailsResult"/> instance for mocking. </returns>
         public static SAPAvailabilityZoneDetailsResult SAPAvailabilityZoneDetailsResult(string recommendedAvailabilityZonePair = default)
@@ -935,6 +984,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new SAPAvailabilityZoneDetailsResult(recommendedAvailabilityZonePair, default);
         }
 
+        /// <summary> A best practice resource - used by both parent and child operations. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -954,6 +1004,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Best practice properties. </summary>
         /// <param name="provisioningState"> The provisioning state of the resource. </param>
         /// <param name="description"> The description of the best practice. </param>
         /// <returns> A new <see cref="Models.BestPracticeProperties"/> instance for mocking. </returns>
@@ -962,6 +1013,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new BestPracticeProperties(provisioningState, description, default);
         }
 
+        /// <summary> The complex type of the extended location. </summary>
         /// <param name="name"> The name of the extended location. </param>
         /// <param name="type"> The type of the extended location. </param>
         /// <returns> A new <see cref="Models.ExtendedLocationOptionalModel"/> instance for mocking. </returns>
@@ -977,6 +1029,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new BestPracticeUpdate(bestPracticeUpdateDescription is null ? default : new BestPracticeUpdateProperties(bestPracticeUpdateDescription, default), default);
         }
 
+        /// <summary> Test resource with nullable ResourceType properties. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1000,6 +1053,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Properties of test resource with nullable armResourceType. </summary>
         /// <param name="optionalResourceType"> Nullable resource type - this tests the fix for nullable value type serialization. </param>
         /// <param name="status"> Status of the resource. </param>
         /// <returns> A new <see cref="Models.ResourceTypeTestProperties"/> instance for mocking. </returns>
@@ -1008,6 +1062,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new ResourceTypeTestProperties(optionalResourceType, status, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1031,6 +1086,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The SampleDataProperties. </summary>
         /// <param name="sampleValue"> the sample value. </param>
         /// <param name="anotherValue"> another value. </param>
         /// <returns> A new <see cref="Models.SampleDataProperties"/> instance for mocking. </returns>
@@ -1039,6 +1095,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new SampleDataProperties(sampleValue, anotherValue, default);
         }
 
+        /// <summary> The scheduled action extension. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1056,6 +1113,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Scheduled action properties. </summary>
         /// <param name="actionId"> The scheduled action identifier. </param>
         /// <param name="status"> The scheduled action status. </param>
         /// <returns> A new <see cref="Models.ScheduledActionsExtensionProperties"/> instance for mocking. </returns>
@@ -1064,6 +1122,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new ScheduledActionsExtensionProperties(actionId, status, default);
         }
 
+        /// <summary> Parent resource for workload networks. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1087,6 +1146,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The WorkloadNetworksProperties. </summary>
         /// <param name="displayName"> Display name of the workload network. </param>
         /// <param name="provisioningState"> Provisioning state of the resource. </param>
         /// <returns> A new <see cref="Models.WorkloadNetworksProperties"/> instance for mocking. </returns>
@@ -1095,6 +1155,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new WorkloadNetworksProperties(displayName, provisioningState, default);
         }
 
+        /// <summary> Test resource for verifying Get and Delete operation naming with. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1118,6 +1179,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The WorkloadNetworkVmGroupProperties. </summary>
         /// <param name="displayName"> Display name of the VM group. </param>
         /// <param name="members"> Virtual machine members of this group. </param>
         /// <param name="provisioningState"> Provisioning state of the resource. </param>
@@ -1129,6 +1191,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new WorkloadNetworkVmGroupProperties(displayName, (members ?? new ChangeTrackingList<string>()).ToList(), provisioningState, default);
         }
 
+        /// <summary> Test resource for verifying Get and Delete operation naming with. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1152,6 +1215,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The WorkloadNetworkSegmentProperties. </summary>
         /// <param name="displayName"> Display name of the segment. </param>
         /// <param name="connectedGateway"> Connected gateway. </param>
         /// <param name="subnet"> Subnet for the segment. </param>
@@ -1162,6 +1226,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new WorkloadNetworkSegmentProperties(displayName, connectedGateway, subnet, provisioningState, default);
         }
 
+        /// <summary> Model that represents a Target resource. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1228,6 +1293,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The CustomerManagedKeyEncryption. </summary>
         /// <param name="keyEncryptionKeyIdentity"></param>
         /// <param name="keyEncryptionKeyUri"></param>
         /// <returns> A new <see cref="Models.CustomerManagedKeyEncryption"/> instance for mocking. </returns>
@@ -1236,6 +1302,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new CustomerManagedKeyEncryption(keyEncryptionKeyIdentity, keyEncryptionKeyUri, default);
         }
 
+        /// <summary> The KeyEncryptionKeyIdentity. </summary>
         /// <param name="userAssignedIdentityResourceId"></param>
         /// <param name="identityType"></param>
         /// <returns> A new <see cref="Models.KeyEncryptionKeyIdentity"/> instance for mocking. </returns>
@@ -1244,6 +1311,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new KeyEncryptionKeyIdentity(userAssignedIdentityResourceId, identityType, default);
         }
 
+        /// <summary> The MaintenanceWindow. </summary>
         /// <param name="dayOfWeek"></param>
         /// <param name="startHour"></param>
         /// <param name="duration"></param>
@@ -1253,6 +1321,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new MaintenanceWindow(dayOfWeek, startHour, duration, default);
         }
 
+        /// <summary> Concrete proxy resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1279,6 +1348,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new RedisPrivateEndpointConnectionProperties(privateEndpointId is null ? default : new RedisPrivateEndpoint(privateEndpointId, default), privateLinkServiceConnectionState, provisioningState, default);
         }
 
+        /// <summary> The RedisPrivateLinkServiceConnectionState. </summary>
         /// <param name="status"></param>
         /// <param name="description"></param>
         /// <param name="actionsRequired"></param>
@@ -1315,6 +1385,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Site at ServiceGroup scope. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1332,6 +1403,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Site properties. </summary>
         /// <param name="displayName"> displayName of Site resource. </param>
         /// <param name="description"> Description of Site resource. </param>
         /// <param name="provisioningState"> Provisioning state of last operation. </param>
@@ -1341,6 +1413,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new ServiceGroupSiteProperties(displayName, description, provisioningState, default);
         }
 
+        /// <summary> The TrafficProfileData. </summary>
         /// <param name="id"></param>
         /// <param name="name"></param>
         /// <param name="type"></param>
@@ -1362,6 +1435,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 properties);
         }
 
+        /// <summary> The TrafficProfileProperties. </summary>
         /// <param name="profileStatus"></param>
         /// <param name="trafficRoutingMethod"></param>
         /// <returns> A new <see cref="Models.TrafficProfileProperties"/> instance for mocking. </returns>
@@ -1370,6 +1444,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new TrafficProfileProperties(profileStatus, trafficRoutingMethod, default);
         }
 
+        /// <summary> The TrafficTrackedResource. </summary>
         /// <param name="id"></param>
         /// <param name="name"></param>
         /// <param name="type"></param>
@@ -1389,6 +1464,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 location);
         }
 
+        /// <summary> The TrafficResource. </summary>
         /// <param name="id"></param>
         /// <param name="name"></param>
         /// <param name="type"></param>
@@ -1398,6 +1474,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new TrafficResource(id, name, @type, default);
         }
 
+        /// <summary> The TrafficEndpointData. </summary>
         /// <param name="id"></param>
         /// <param name="name"></param>
         /// <param name="type"></param>
@@ -1408,6 +1485,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new TrafficEndpointData(id, name, @type, default, properties);
         }
 
+        /// <summary> The TrafficEndpointProperties. </summary>
         /// <param name="targetResourceId"></param>
         /// <param name="target"></param>
         /// <param name="endpointStatus"></param>
@@ -1427,6 +1505,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The TrafficProxyResource. </summary>
         /// <param name="id"></param>
         /// <param name="name"></param>
         /// <param name="type"></param>
@@ -1436,6 +1515,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new TrafficProxyResource(id, name, @type, default);
         }
 
+        /// <summary> Configuration assignment for VM scope. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1453,6 +1533,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Configuration assignment properties. </summary>
         /// <param name="configurationName"> The configuration name. </param>
         /// <param name="complianceStatus"> The compliance status. </param>
         /// <returns> A new <see cref="Models.VmConfigurationAssignmentProperties"/> instance for mocking. </returns>
@@ -1461,6 +1542,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new VmConfigurationAssignmentProperties(configurationName, complianceStatus, default);
         }
 
+        /// <summary> Configuration assignment for hybrid machine scope. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1478,6 +1560,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> HCRP Configuration assignment properties. </summary>
         /// <param name="configurationName"> The configuration name. </param>
         /// <param name="machineComplianceStatus"> Machine compliance status. </param>
         /// <returns> A new <see cref="Models.HcrpConfigurationAssignmentProperties"/> instance for mocking. </returns>
@@ -1486,6 +1569,11 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new HcrpConfigurationAssignmentProperties(configurationName, machineComplianceStatus, default);
         }
 
+        /// <summary>
+        /// Test resource for verifying explicit ResourceName on ExtensionOperations.
+        /// Same model used by two different extension interfaces with different parent paths.
+        /// Each interface specifies an explicit ResourceName to control generated class names.
+        /// </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1503,6 +1591,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The PolicyAssignmentProperties. </summary>
         /// <param name="displayName"> Display name of the policy assignment. </param>
         /// <param name="description"> Description of the policy assignment. </param>
         /// <returns> A new <see cref="Models.PolicyAssignmentProperties"/> instance for mocking. </returns>
@@ -1574,6 +1663,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Parameters for creating or updating a certificate. </summary>
         /// <param name="properties"> The properties associated with the certificate. </param>
         /// <returns> A new <see cref="Models.TestCertificateCreateOrUpdateContent"/> instance for mocking. </returns>
         public static TestCertificateCreateOrUpdateContent TestCertificateCreateOrUpdateContent(TestCertificateCreateOrUpdateProperties properties = default)
@@ -1581,6 +1671,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new TestCertificateCreateOrUpdateContent(properties, default);
         }
 
+        /// <summary> Properties for creating or updating a certificate. </summary>
         /// <param name="thumbprintAlgorithm"> The thumbprint algorithm. </param>
         /// <param name="thumbprintString"> The thumbprint string. </param>
         /// <returns> A new <see cref="Models.TestCertificateCreateOrUpdateProperties"/> instance for mocking. </returns>
@@ -1589,6 +1680,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new TestCertificateCreateOrUpdateProperties(thumbprintAlgorithm, thumbprintString, default);
         }
 
+        /// <summary> Shared configuration - used at both RG and Subscription scope. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1612,6 +1704,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> A shared configuration resource. </summary>
         /// <param name="displayName"> Display name. </param>
         /// <param name="description"> Description. </param>
         /// <param name="provisioningState"> The provisioning state of the resource. </param>
@@ -1621,6 +1714,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new SharedConfigProperties(displayName, description, provisioningState, default);
         }
 
+        /// <summary> Paged collection of ContainerItemLike items. </summary>
         /// <param name="value"> The ContainerItemLike items on this page. </param>
         /// <param name="nextLink"> The link to the next page of items. </param>
         /// <returns> A new <see cref="Models.ContainerItemLikeListResult"/> instance for mocking. </returns>
@@ -1650,6 +1744,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 containerItemLikeSomething is null ? default : new ContainerItemLikeProperties(containerItemLikeSomething, default));
         }
 
+        /// <summary> Entity Resource Like. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1667,6 +1762,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Paged collection of DerivedPatch items. </summary>
         /// <param name="value"> The DerivedPatch items on this page. </param>
         /// <param name="nextLink"> The link to the next page of items. </param>
         /// <returns> A new <see cref="Models.SharedParamReproListResult"/> instance for mocking. </returns>
@@ -1677,6 +1773,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new SharedParamReproListResult((value ?? new ChangeTrackingList<DerivedPatch>()).ToList(), nextLink, default);
         }
 
+        /// <summary> A derived patch model extending the custom base — triggers FixRawDataFieldReference. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1698,6 +1795,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 derivedProp);
         }
 
+        /// <summary> A custom patch base model extending Resource directly. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1717,6 +1815,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Paged collection of SiblingPatch items. </summary>
         /// <param name="value"> The SiblingPatch items on this page. </param>
         /// <param name="nextLink"> The link to the next page of items. </param>
         /// <returns> A new <see cref="Models.SiblingPatchListResult"/> instance for mocking. </returns>
@@ -1727,6 +1826,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new SiblingPatchListResult((value ?? new ChangeTrackingList<SiblingPatch>()).ToList(), nextLink, default);
         }
 
+        /// <summary> A sibling model that also extends Resource — affected by the shared mutation. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1744,6 +1844,11 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary>
+        /// A polymorphic extension resource that uses DiscriminatedExtensionResource with 'kind' as the discriminator.
+        /// This tests that the generator correctly handles abstract resource data types in serialization.
+        /// Please note this is the abstract base class. The derived classes available for instantiation are: <see cref="Models.TypeAPolyDevice"/>.
+        /// </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1779,6 +1884,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 typeAPolyDeviceDescription is null ? default : new TypeAPolyDeviceProperties(typeAPolyDeviceDescription, default));
         }
 
+        /// <summary> Paged collection of GrandparentFlattenLeaf items. </summary>
         /// <param name="value"> The GrandparentFlattenLeaf items on this page. </param>
         /// <param name="nextLink"> The link to the next page of items. </param>
         /// <returns> A new <see cref="Models.GrandparentFlattenLeafListResult"/> instance for mocking. </returns>
@@ -1844,6 +1950,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1867,6 +1974,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> The CycleTestStoreProperties. </summary>
         /// <param name="endpoint"> The endpoint for the store. </param>
         /// <param name="connections"> Related connections. </param>
         /// <returns> A new <see cref="Models.CycleTestStoreProperties"/> instance for mocking. </returns>
@@ -1941,6 +2049,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> EventGrid private endpoint connection model. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -1958,6 +2067,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 default);
         }
 
+        /// <summary> Private endpoint connection properties. </summary>
         /// <param name="status"> Connection status. </param>
         /// <param name="description"> Description. </param>
         /// <returns> A new <see cref="Models.EventGridPrivateEndpointConnectionProperties"/> instance for mocking. </returns>
@@ -1987,6 +2097,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 solutionsApplicationDefinitionDisplayName is null ? default : new SolutionsApplicationDefinitionProperties(solutionsApplicationDefinitionDisplayName, default));
         }
 
+        /// <summary> Reduced Solutions generic resource. </summary>
         /// <param name="id"> Resource ID. </param>
         /// <param name="name"> Resource name. </param>
         /// <param name="type"> Resource type. </param>
@@ -2006,6 +2117,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 managedBy);
         }
 
+        /// <summary> Reduced Solutions resource information. </summary>
         /// <param name="id"> Resource ID. </param>
         /// <param name="name"> Resource name. </param>
         /// <param name="type"> Resource type. </param>
@@ -2018,6 +2130,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
             return new SolutionsResource(id, name, @type, tags ?? new ChangeTrackingDictionary<string, string>(), default);
         }
 
+        /// <summary> Information about a query-suffixed application definition request. </summary>
         /// <param name="tags"> Application definition tags. </param>
         /// <returns> A new <see cref="Models.SolutionsApplicationDefinitionPatch"/> instance for mocking. </returns>
         public static SolutionsApplicationDefinitionPatch SolutionsApplicationDefinitionPatch(IDictionary<string, string> tags = default)

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Spector/http/azure/resource-manager/operation-templates/src/Generated/ArmOperationTemplatesModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Spector/http/azure/resource-manager/operation-templates/src/Generated/ArmOperationTemplatesModelFactory.cs
@@ -18,6 +18,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
     public static partial class ArmOperationTemplatesModelFactory
     {
 
+        /// <summary> The check availability request body. </summary>
         /// <param name="name"> The name of the resource for which availability needs to be checked. </param>
         /// <param name="type"> The resource type. </param>
         /// <returns> A new <see cref="Models.CheckNameAvailabilityRequest"/> instance for mocking. </returns>
@@ -26,6 +27,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new CheckNameAvailabilityRequest(name, @type, default);
         }
 
+        /// <summary> The check availability result. </summary>
         /// <param name="nameAvailable"> Indicates if the resource name is available. </param>
         /// <param name="reason"> The reason why the given name is not available. </param>
         /// <param name="message"> Detailed reason why the given name is not available. </param>
@@ -35,6 +37,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new CheckNameAvailabilityResponse(nameAvailable, reason, message, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -58,6 +61,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
                 default);
         }
 
+        /// <summary> The OrderProperties. </summary>
         /// <param name="productId"> The product ID of the order. </param>
         /// <param name="amount"> Amount of the product. </param>
         /// <param name="provisioningState"> The provisioning state of the product. </param>
@@ -67,6 +71,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new OrderProperties(productId, amount, provisioningState, default);
         }
 
+        /// <summary> The ExportRequest. </summary>
         /// <param name="format"> Format of the exported order. </param>
         /// <returns> A new <see cref="Models.ExportRequest"/> instance for mocking. </returns>
         public static ExportRequest ExportRequest(string format = default)
@@ -74,6 +79,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new ExportRequest(format, default);
         }
 
+        /// <summary> The ExportResult. </summary>
         /// <param name="content"> Content of the exported order. </param>
         /// <returns> A new <see cref="Models.ExportResult"/> instance for mocking. </returns>
         public static ExportResult ExportResult(string content = default)
@@ -81,6 +87,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new ExportResult(content, default);
         }
 
+        /// <summary> Concrete extension resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -98,6 +105,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
                 default);
         }
 
+        /// <summary> The CostReportProperties. </summary>
         /// <param name="downloadUri"> The download URL for the cost report. </param>
         /// <param name="provisioningState"> The provisioning state of the cost report. </param>
         /// <returns> A new <see cref="Models.CostReportProperties"/> instance for mocking. </returns>
@@ -106,6 +114,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new CostReportProperties(downloadUri, provisioningState, default);
         }
 
+        /// <summary> The DiagnosticInfo. </summary>
         /// <param name="name"> The diagnostic name. </param>
         /// <param name="status"> The diagnostic status. </param>
         /// <returns> A new <see cref="Models.DiagnosticInfo"/> instance for mocking. </returns>
@@ -114,6 +123,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new DiagnosticInfo(name, status, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -137,6 +147,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
                 default);
         }
 
+        /// <summary> The ConfigurationProperties. </summary>
         /// <param name="configValue"> The configuration value. </param>
         /// <param name="provisioningState"> The provisioning state. </param>
         /// <returns> A new <see cref="Models.ConfigurationProperties"/> instance for mocking. </returns>
@@ -145,6 +156,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new ConfigurationProperties(configValue, provisioningState, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -168,6 +180,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
                 default);
         }
 
+        /// <summary> The WidgetProperties. </summary>
         /// <param name="name"> The name of the widget. </param>
         /// <param name="description"> The description of the widget. </param>
         /// <param name="provisioningState"> The provisioning state of the widget. </param>
@@ -177,6 +190,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new WidgetProperties(name, description, provisioningState, default);
         }
 
+        /// <summary> The ActionRequest. </summary>
         /// <param name="actionType"> The action type to perform. </param>
         /// <param name="parameters"> Additional action parameters. </param>
         /// <returns> A new <see cref="Models.ActionRequest"/> instance for mocking. </returns>
@@ -185,6 +199,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new ActionRequest(actionType, parameters, default);
         }
 
+        /// <summary> The ActionResult. </summary>
         /// <param name="result"> The result of the action. </param>
         /// <returns> A new <see cref="Models.ActionResult"/> instance for mocking. </returns>
         public static ActionResult ActionResult(string result = default)
@@ -192,6 +207,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new ActionResult(result, default);
         }
 
+        /// <summary> The ChangeAllowanceRequest. </summary>
         /// <param name="totalAllowed"> The new total allowed widgets. </param>
         /// <param name="reason"> The reason for the change. </param>
         /// <returns> A new <see cref="Models.ChangeAllowanceRequest"/> instance for mocking. </returns>
@@ -200,6 +216,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new ChangeAllowanceRequest(totalAllowed, reason, default);
         }
 
+        /// <summary> The ChangeAllowanceResult. </summary>
         /// <param name="totalAllowed"> The new total allowed widgets. </param>
         /// <param name="status"> The status of the change. </param>
         /// <returns> A new <see cref="Models.ChangeAllowanceResult"/> instance for mocking. </returns>
@@ -208,6 +225,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new ChangeAllowanceResult(totalAllowed, status, default);
         }
 
+        /// <summary> Concrete tracked resource types can be created by aliasing this type using a specific property type. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
@@ -231,6 +249,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
                 default);
         }
 
+        /// <summary> The MonitorProperties. </summary>
         /// <param name="status"> The status of the monitor. </param>
         /// <param name="provisioningState"> The provisioning state. </param>
         /// <returns> A new <see cref="Models.MonitorProperties"/> instance for mocking. </returns>
@@ -239,6 +258,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new MonitorProperties(status, provisioningState, default);
         }
 
+        /// <summary> The LogStatusRequest. </summary>
         /// <param name="filter"> Filter for the monitored resources. </param>
         /// <returns> A new <see cref="Models.LogStatusRequest"/> instance for mocking. </returns>
         public static LogStatusRequest LogStatusRequest(string filter = default)
@@ -246,6 +266,7 @@ namespace Azure.ResourceManager.OperationTemplates.Models
             return new LogStatusRequest(filter, default);
         }
 
+        /// <summary> The MonitoredResource. </summary>
         /// <param name="id"> The resource ID. </param>
         /// <param name="sendingMetrics"> Whether metrics are being sent. </param>
         /// <returns> A new <see cref="Models.MonitoredResource"/> instance for mocking. </returns>


### PR DESCRIPTION
Fixes #62444

### Problem

Model factory backward-compatibility overloads that the management generator restores from the last contract view copied their XML documentation straight off the previously generated source.

`MethodProvider`, when constructed without an explicit `XmlDocProvider`, falls back to `MethodProviderHelpers.BuildXmlDocs(signature, enclosingType)`, which wraps the raw `Description` strings from the last contract signature. Those strings were parsed back out of the last generated `.cs` file, so they still carry the indentation the `CodeWriter` emitted last time. Writing them again adds another level, so every regeneration grows multiline `<param>` docs by 12 spaces.

Measured on `sdk/network/Azure.ResourceManager.Network/src/Generated/ArmNetworkModelFactory.cs`, spaces after `///` on the affected continuation lines:

| Commit | PR | Spaces |
| --- | --- | --- |
| `d9545d39` | #59847 | 13 |
| `cba1ac8e` | #60135 | 25 |
| `30d826a5` | #60571 | 37 |
| `85c57d1b` | #62404 | 49 |

Every affected doc block in that file belongs to an `[EditorBrowsable(EditorBrowsableState.Never)]` overload, i.e. the ones produced by `ModelFactoryBackwardCompatHelper.TryCreateBackwardCompatMethod`.

This is management-specific. The shared generator (`ModelFactoryProvider.BuildMethodsForBackCompatibility` in `microsoft/typespec`) also restores overloads from the last contract, but it forwards the already-structured `previousMethod.XmlDocs`, so it never round-trips rendered text back through the writer.

### Fix

The restored overload's documentation is now regenerated from the current model, and the last contract supplies only the parameter *list* — never any prose:

- the signature description is `ModelProvider.Description`, the same `FormattableString` the primary factory method documents itself with;
- each parameter description comes from the current model constructor parameter that the compatibility argument resolved to, tracked through the new `ParameterDocumentation` carried on `CompatibilityArgument`, including through nested/flattened models;
- the `<returns>` text is regenerated from the return type;
- a parameter with no current-model counterpart gets an empty description rather than a salvaged one (see below).

Because the signature now carries the correct description, no explicit `XmlDocProvider` is needed: `MethodProviderHelpers.BuildXmlDocs` reproduces identical docs from the signature, which keeps the signature the single source of truth and survives the `Update` calls made later during writing.

**Why unmatched parameters are blanked instead of normalized.** An earlier revision reflowed the legacy text with a `RemoveCommonContinuationIndentation` helper. That text is not merely over-indented, it is already gutted: `NamedTypeSymbolProvider.GetParameterXmlDocumentation` extracts `<param>` docs with `XElement.Value`, which concatenates text nodes only, so every `<see cref="..."/>` is dropped. The result is `Please note  is the base class` and `include  and .` — a sentence with no subject and a list with no items. (The sibling `GetSymbolXmlDoc` routes through `ProcessXmlContent`, which does preserve crefs; that asymmetry is filed as microsoft/typespec#11768.) These methods are also all `[EditorBrowsable(EditorBrowsableState.Never)]`, so they produce no public reference documentation and no IntelliSense — there is no consumer for the salvaged prose. Normalizing it would only make meaningless text tidier while keeping the round-trip that caused #62444.

**Two adjacent bugs fixed along the way.** Three `method.Update(signature: method.Signature, ...)` calls passed the method its own signature, which is a no-op except that it forces a doc rebuild. On *primary* factory methods that rebuild was destructive: it silently deleted their `<summary>` (their `signature.Description` is empty, so nothing was emitted), and it re-derived `<exception cref="ArgumentNullException">` docs that `ModelFactoryVisitor.FixArgumentNullExceptionXmlDoc` had deliberately cleared, documenting an exception the mocking bodies cannot throw. Removing those calls restores the summaries and drops three bogus exception docs in the generated test projects.

The last contract view is still used for API compatibility (parameter names, restoring removed overloads) — only the documentation is regenerated.

### Tests

Six tests in `ModelFactoryVisitorTests`:

- `RestoredFactoryMethodRegeneratesDocumentationFromCurrentModel` — current model/parameter docs win over the previous contract's.
- `RestoredFactoryMethodSignatureCarriesCurrentModelDescription` — the signature description is the current model's, not the last contract's and not null.
- `RestoredFactoryMethodDropsUnmatchedLastContractDocumentation` — legacy prose is dropped, the `<param>` tag remains, and no exception docs are re-derived.
- `RestoredFactoryMethodDocumentationIsIndependentOfLastContractIndentation` — the idempotency guard: two different input indentations must produce identical docs.
- `RestoredFactoryMethodDocumentationSurvivesBackwardCompatOverloadFixup` — docs survive the write-time `FixModelFactoryBackwardCompatOverloads` pass.
- `PrimaryFactoryMethodDocumentationSurvivesConstructorCallFixup` — primary methods keep their summary through `FixModelFactoryConstructorCalls`.

Full suite: 283/283 passing. Three mutants are each killed by a specific test — sourcing the description from the previous signature, sourcing it from `null`, and restoring the unmatched-parameter description. `eng/scripts/Generate.ps1` output is stable.