### PR TITLE
Prepare KubernetesConfiguration provisioning packages for release

### DIFF
--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes/CHANGELOG.md
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2026-08-26)
 
 ### Features Added
 

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.Extensions/CHANGELOG.md
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.Extensions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2026-08-26)
 
 ### Features Added
 

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations/CHANGELOG.md
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2026-08-26)
 
 ### Features Added
 

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes/CHANGELOG.md
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2026-08-26)
 
 ### Features Added
 


### PR DESCRIPTION
## Description

Prepare the initial `1.0.0-beta.1` releases of the KubernetesConfiguration provisioning subpackages for 2026-08-26.

## Packages

- `Azure.Provisioning.KubernetesConfiguration.Extensions`
- `Azure.Provisioning.KubernetesConfiguration.ExtensionTypes`
- `Azure.Provisioning.KubernetesConfiguration.FluxConfigurations`
- `Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes`