### PR TITLE
[PostgreSQL] Release Microsoft.Azure.PostgreSQL.Auth 1.0.0 (GA)

### DIFF
--- a/sdk/postgresql/Microsoft.Azure.PostgreSQL.Auth/CHANGELOG.md
+++ b/sdk/postgresql/Microsoft.Azure.PostgreSQL.Auth/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0 (2026-08-26)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- First stable release of the Entra ID authentication extension for the Npgsql PostgreSQL driver.
 
 ## 1.0.0-beta.1 (2026-04-09)
 

--- a/sdk/postgresql/Microsoft.Azure.PostgreSQL.Auth/README.md
+++ b/sdk/postgresql/Microsoft.Azure.PostgreSQL.Auth/README.md
@@ -11,7 +11,7 @@ The `Microsoft.Azure.PostgreSQL.Auth` library provides Entra ID (formerly Azure 
 Install the client library for .NET with [NuGet](https://www.nuget.org/):
 
 ```dotnetcli
-dotnet add package Microsoft.Azure.PostgreSQL.Auth --prerelease
+dotnet add package Microsoft.Azure.PostgreSQL.Auth
 ```
 
 ### Prerequisites

--- a/sdk/postgresql/Microsoft.Azure.PostgreSQL.Auth/src/Microsoft.Azure.PostgreSQL.Auth.csproj
+++ b/sdk/postgresql/Microsoft.Azure.PostgreSQL.Auth/src/Microsoft.Azure.PostgreSQL.Auth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Entra ID authentication extension for Npgsql driver</Description>
-    <Version>1.0.0-beta.2</Version>
+    <Version>1.0.0</Version>
     <PackageTags>Azure;Entra;PostgreSQL;Npgsql;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>


### PR DESCRIPTION
Prepares `Microsoft.Azure.PostgreSQL.Auth` for its first stable (GA) release, `1.0.0`.

### Changes

- `src/Microsoft.Azure.PostgreSQL.Auth.csproj`: version `1.0.0-beta.2` -> `1.0.0`
- `CHANGELOG.md`: replaced the unreleased `1.0.0-beta.2` section with a dated `1.0.0 (2026-08-26)` entry
- `README.md`: removed `--prerelease` from the install instructions now that a stable package is available

### Validation

- `dotnet format` - clean
- `eng/scripts/Export-API.ps1` - no public API surface changes since `1.0.0-beta.1`
- `eng/scripts/Update-Snippets.ps1` - no snippet drift
- `dotnet test --filter TestCategory!=Live` - 25/25 passing on net10.0, net9.0, net8.0 and net462
- `Confirm-ChangeLogEntry -ForRelease $true` - passes

### Notes

No code changes are included; the public API is unchanged from `1.0.0-beta.1`.