### PR TITLE
[CodeTransparency] Follow-up to #62471: ECDsa verifier overload, P-521 fix, CBOR no-throw fix

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -4,11 +4,34 @@
 
 ### Features Added
 
+- Added `CcfReceiptVerifier.VerifyTransparentStatementReceipt(ECDsa publicKey, string keyId, byte[] receiptBytes, byte[] signedStatementBytes)`.
+  This overload lets callers supply a key they already own as a standard `System.Security.Cryptography.ECDsa`
+  instance, instead of having to obtain an `Azure.Security.CodeTransparency.JsonWebKey`, which has no public
+  constructor and therefore could only be acquired from a service response.
+
 ### Breaking Changes
+
+- `CborUtils` is no longer public. It carried no service semantics and only existed on the public
+  surface so that the documented sample could dig the entry id out of the raw CBOR response body.
+  Use `CodeTransparencyClient.GetEntryIdFromLocation(Response)` instead, which is the supported way
+  to read the entry id from a submission response.
 
 ### Bugs Fixed
 
+- Fixed receipt verification for P-521 keys. The curve was matched against the non-existent name
+  `P-512` and validated against COSE algorithm `-39` (PS512, an RSA algorithm) rather than `-36`
+  (ES512), so every P-521 key was rejected with an "unsupported curve" error.
+- CBOR parsing no longer throws on malformed input. `CborUtils.GetStringValueFromCborMapByKey` is
+  documented to return an empty string when a value cannot be read, but a payload whose root was not
+  a CBOR map threw `InvalidOperationException` and a truncated map threw `CborContentException`. This
+  surfaced as an unhandled exception out of entry-creation polling when the service returned a body
+  that was not a CBOR map.
+
 ### Other Changes
+
+- Removed the dependency on `Azure.Security.KeyVault.Keys`. The whole Key Vault Keys client library was
+  being referenced solely to reuse its JSON Web Key to `ECDsa` conversion inside a single method body;
+  that conversion is now done directly against `System.Security.Cryptography`.
 
 ## 1.0.0-beta.12 (2026-07-31)
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/README.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/README.md
@@ -51,14 +51,13 @@ Use the following code to submit the signature:
 CodeTransparencyClient client = new(new Uri("https://<< service name >>.confidential-ledger.azure.com"));
 FileStream fileStream = File.OpenRead("signature.cose");
 BinaryData content = BinaryData.FromStream(fileStream);
-Operation<BinaryData> operation = await client.CreateEntryAsync(WaitUntil.Started, content);
+NullableResponse<BinaryData> submission = await client.CreateEntryAsync(content, waitForCommit: true);
 ```
 
 Then obtain the transparent statement:
 
 ```C# Snippet:CodeTransparencyDownloadTransparentStatement
-Response<BinaryData> operationResult = await operation.WaitForCompletionAsync();
-string entryId = CborUtils.GetStringValueFromCborMapByKey(operationResult.Value.ToArray(), "EntryId");
+string entryId = CodeTransparencyClient.GetEntryIdFromLocation(submission.GetRawResponse());
 Console.WriteLine($"The entry ID to use to retrieve the receipt and transparent statement is {{{entryId}}}");
 Response<BinaryData> transparentStatementResponse = await client.GetEntryStatementAsync(entryId);
 byte[] transparentStatementBytes = transparentStatementResponse.Value.ToArray();

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net10.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net10.0.cs
@@ -12,12 +12,6 @@ namespace Azure.Security.CodeTransparency
         public static Azure.Security.CodeTransparency.AzureSecurityCodeTransparencyContext Default { get { throw null; } }
         protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder builder) { throw null; }
     }
-    public partial class CborUtils
-    {
-        public CborUtils() { }
-        public static string GetStringValueFromCborMapByKey(byte[] cborBytes, int key) { throw null; }
-        public static string GetStringValueFromCborMapByKey(byte[] cborBytes, string key) { throw null; }
-    }
     public partial class CcfReceipt
     {
         public static readonly int CcfProofLeafLabel;
@@ -42,6 +36,7 @@ namespace Azure.Security.CodeTransparency
     {
         public CcfReceiptVerifier() { }
         public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
+        public static void VerifyTransparentStatementReceipt(System.Security.Cryptography.ECDsa publicKey, string keyId, byte[] receiptBytes, byte[] signedStatementBytes) { }
     }
     public partial class CodeTransparencyCertificateClient
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
@@ -12,12 +12,6 @@ namespace Azure.Security.CodeTransparency
         public static Azure.Security.CodeTransparency.AzureSecurityCodeTransparencyContext Default { get { throw null; } }
         protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder builder) { throw null; }
     }
-    public partial class CborUtils
-    {
-        public CborUtils() { }
-        public static string GetStringValueFromCborMapByKey(byte[] cborBytes, int key) { throw null; }
-        public static string GetStringValueFromCborMapByKey(byte[] cborBytes, string key) { throw null; }
-    }
     public partial class CcfReceipt
     {
         public static readonly int CcfProofLeafLabel;
@@ -42,6 +36,7 @@ namespace Azure.Security.CodeTransparency
     {
         public CcfReceiptVerifier() { }
         public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
+        public static void VerifyTransparentStatementReceipt(System.Security.Cryptography.ECDsa publicKey, string keyId, byte[] receiptBytes, byte[] signedStatementBytes) { }
     }
     public partial class CodeTransparencyCertificateClient
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
@@ -12,12 +12,6 @@ namespace Azure.Security.CodeTransparency
         public static Azure.Security.CodeTransparency.AzureSecurityCodeTransparencyContext Default { get { throw null; } }
         protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder builder) { throw null; }
     }
-    public partial class CborUtils
-    {
-        public CborUtils() { }
-        public static string GetStringValueFromCborMapByKey(byte[] cborBytes, int key) { throw null; }
-        public static string GetStringValueFromCborMapByKey(byte[] cborBytes, string key) { throw null; }
-    }
     public partial class CcfReceipt
     {
         public static readonly int CcfProofLeafLabel;
@@ -42,6 +36,7 @@ namespace Azure.Security.CodeTransparency
     {
         public CcfReceiptVerifier() { }
         public static void VerifyTransparentStatementReceipt(Azure.Security.CodeTransparency.JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes) { }
+        public static void VerifyTransparentStatementReceipt(System.Security.Cryptography.ECDsa publicKey, string keyId, byte[] receiptBytes, byte[] signedStatementBytes) { }
     }
     public partial class CodeTransparencyCertificateClient
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Azure.Security.CodeTransparency.csproj
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Azure.Security.CodeTransparency.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="System.Security.Cryptography.Cose" />
   </ItemGroup>
 </Project>

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CborUtils.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CborUtils.cs
@@ -13,7 +13,7 @@ namespace Azure.Security.CodeTransparency
     /// absence, or unexpected CBOR shapes they return an empty string instead of throwing,
     /// allowing callers to decide whether absence is an error condition.
     /// </summary>
-    public class CborUtils
+    internal static class CborUtils
     {
         /// <summary>
         /// Reads a CBOR-encoded map and returns the text string value associated with the specified key.
@@ -31,37 +31,46 @@ namespace Azure.Security.CodeTransparency
 
             string value = string.Empty;
 
-            CborReader cborReader = new(cborBytes);
-            cborReader.ReadStartMap();
-            while (cborReader.PeekState() != CborReaderState.EndMap)
+            try
             {
-                CborReaderState keyState = cborReader.PeekState();
-
-                if (keyState != CborReaderState.TextString)
+                CborReader cborReader = new(cborBytes);
+                cborReader.ReadStartMap();
+                while (cborReader.PeekState() != CborReaderState.EndMap)
                 {
-                    // Non-text key: skip key and its value
-                    cborReader.SkipValue();
-                    cborReader.SkipValue();
-                    continue;
-                }
+                    CborReaderState keyState = cborReader.PeekState();
 
-                string currentKey = cborReader.ReadTextString();
-                if (string.Equals(currentKey, key, StringComparison.Ordinal))
-                {
-                    if (cborReader.PeekState() == CborReaderState.TextString)
+                    if (keyState != CborReaderState.TextString)
                     {
-                        value = cborReader.ReadTextString();
+                        // Non-text key: skip key and its value
+                        cborReader.SkipValue();
+                        cborReader.SkipValue();
+                        continue;
+                    }
+
+                    string currentKey = cborReader.ReadTextString();
+                    if (string.Equals(currentKey, key, StringComparison.Ordinal))
+                    {
+                        if (cborReader.PeekState() == CborReaderState.TextString)
+                        {
+                            value = cborReader.ReadTextString();
+                        }
+                        else
+                        {
+                            cborReader.SkipValue();
+                        }
+                        break;
                     }
                     else
                     {
                         cborReader.SkipValue();
                     }
-                    break;
                 }
-                else
-                {
-                    cborReader.SkipValue();
-                }
+            }
+            catch (Exception ex) when (ex is CborContentException || ex is InvalidOperationException)
+            {
+                // The payload is malformed or its root is not a map. The documented contract is to
+                // report absence rather than throw, so callers can decide whether that is an error.
+                return string.Empty;
             }
 
             return value;
@@ -83,40 +92,49 @@ namespace Azure.Security.CodeTransparency
 
             string value = string.Empty;
 
-            CborReader cborReader = new(cborBytes);
-            cborReader.ReadStartMap();
-            while (cborReader.PeekState() != CborReaderState.EndMap)
+            try
             {
-                int? currentIntKey = null;
-                switch (cborReader.PeekState())
+                CborReader cborReader = new(cborBytes);
+                cborReader.ReadStartMap();
+                while (cborReader.PeekState() != CborReaderState.EndMap)
                 {
-                    case CborReaderState.UnsignedInteger:
-                    case CborReaderState.NegativeInteger:
-                        currentIntKey = cborReader.ReadInt32();
-                        break;
-                    default:
-                        // Unsupported key type - skip key and its value
-                        cborReader.SkipValue();
-                        cborReader.SkipValue();
-                        continue;
-                }
-
-                if (currentIntKey.HasValue && currentIntKey.Value == key)
-                {
-                    if (cborReader.PeekState() == CborReaderState.TextString)
+                    int? currentIntKey = null;
+                    switch (cborReader.PeekState())
                     {
-                        value = cborReader.ReadTextString();
+                        case CborReaderState.UnsignedInteger:
+                        case CborReaderState.NegativeInteger:
+                            currentIntKey = cborReader.ReadInt32();
+                            break;
+                        default:
+                            // Unsupported key type - skip key and its value
+                            cborReader.SkipValue();
+                            cborReader.SkipValue();
+                            continue;
+                    }
+
+                    if (currentIntKey.HasValue && currentIntKey.Value == key)
+                    {
+                        if (cborReader.PeekState() == CborReaderState.TextString)
+                        {
+                            value = cborReader.ReadTextString();
+                        }
+                        else
+                        {
+                            cborReader.SkipValue();
+                        }
+                        break;
                     }
                     else
                     {
                         cborReader.SkipValue();
                     }
-                    break;
                 }
-                else
-                {
-                    cborReader.SkipValue();
-                }
+            }
+            catch (Exception ex) when (ex is CborContentException || ex is InvalidOperationException)
+            {
+                // The payload is malformed or its root is not a map. The documented contract is to
+                // report absence rather than throw, so callers can decide whether that is an error.
+                return string.Empty;
             }
 
             return value;

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceiptVerifier.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CcfReceiptVerifier.cs
@@ -26,8 +26,52 @@ namespace Azure.Security.CodeTransparency
     /// </summary>
     public class CcfReceiptVerifier
     {
+        // COSE algorithm identifiers, https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+        private const int CoseAlgorithmEs256 = -7;
+        private const int CoseAlgorithmEs384 = -35;
+        private const int CoseAlgorithmEs512 = -36;
+
         /// <summary>
-        /// Verify a CCF SCITT receipt.
+        /// Converts an elliptic-curve <see cref="JsonWebKey"/> into an <see cref="ECDsa"/> public key.
+        /// </summary>
+        /// <param name="jsonWebKey">The JWK to convert.</param>
+        /// <returns>An <see cref="ECDsa"/> holding the public key material.</returns>
+        /// <exception cref="InvalidOperationException">The key is not an EC key or uses an unsupported curve.</exception>
+        internal static ECDsa ConvertToECDsa(JsonWebKey jsonWebKey)
+        {
+            if (!string.Equals(jsonWebKey.Kty, "EC", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Only EC keys are supported for receipt verification. Found key type '{jsonWebKey.Kty}'.");
+            }
+
+            if (string.IsNullOrEmpty(jsonWebKey.X) || string.IsNullOrEmpty(jsonWebKey.Y))
+            {
+                throw new InvalidOperationException("The EC key is missing the X or Y coordinate.");
+            }
+
+            ECCurve curve = jsonWebKey.Crv switch
+            {
+                "P-256" => ECCurve.NamedCurves.nistP256,
+                "P-384" => ECCurve.NamedCurves.nistP384,
+                "P-521" => ECCurve.NamedCurves.nistP521,
+                _ => throw new InvalidOperationException($"Unsupported elliptic curve '{jsonWebKey.Crv}'.")
+            };
+
+            ECParameters parameters = new()
+            {
+                Curve = curve,
+                Q = new ECPoint
+                {
+                    X = Base64Url.Decode(jsonWebKey.X),
+                    Y = Base64Url.Decode(jsonWebKey.Y)
+                }
+            };
+
+            return ECDsa.Create(parameters);
+        }
+
+        /// <summary>
+        /// Verify a CCF SCITT receipt using the service's public key (JWK).
         /// If the verification fails, an exception is thrown explaining in which step the verification failed.
         /// #1 Reference: https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/
         /// #2 Reference: https://datatracker.ietf.org/doc/draft-birkholz-cose-receipts-ccf-profile/
@@ -38,13 +82,37 @@ namespace Azure.Security.CodeTransparency
         /// <exception cref="InvalidOperationException">Thrown when the verification fails.</exception>
         public static void VerifyTransparentStatementReceipt(JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes)
         {
+            Argument.AssertNotNull(jsonWebKey, nameof(jsonWebKey));
+
+            using ECDsa publicKey = ConvertToECDsa(jsonWebKey);
+            VerifyTransparentStatementReceipt(publicKey, jsonWebKey.Kid, receiptBytes, signedStatementBytes);
+        }
+
+        /// <summary>
+        /// Verify a CCF SCITT receipt using the service's public key.
+        /// If the verification fails, an exception is thrown explaining in which step the verification failed.
+        /// #1 Reference: https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/
+        /// #2 Reference: https://datatracker.ietf.org/doc/draft-birkholz-cose-receipts-ccf-profile/
+        /// </summary>
+        /// <param name="publicKey">The service's receipt signing public key.</param>
+        /// <param name="keyId">The key id (<c>kid</c>) that the receipt's COSE header is expected to carry.</param>
+        /// <param name="receiptBytes">Receipt in COSE_Sign1 cbor bytes.</param>
+        /// <param name="signedStatementBytes">The input signed statement bytes.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the verification fails.</exception>
+        public static void VerifyTransparentStatementReceipt(ECDsa publicKey, string keyId, byte[] receiptBytes, byte[] signedStatementBytes)
+        {
+            Argument.AssertNotNull(publicKey, nameof(publicKey));
+            Argument.AssertNotNullOrEmpty(keyId, nameof(keyId));
+            Argument.AssertNotNull(receiptBytes, nameof(receiptBytes));
+            Argument.AssertNotNull(signedStatementBytes, nameof(signedStatementBytes));
+
             using SHA256 sha256 = SHA256.Create();
             byte[] claimsDigest = sha256.ComputeHash(signedStatementBytes);
 
             // Extract the expected KID from the public key used for verification,
             // and check it against the value set in the COSE header before using
             // it to verify the proofs.
-            byte[] expectedKid = Encoding.UTF8.GetBytes(jsonWebKey.Kid);
+            byte[] expectedKid = Encoding.UTF8.GetBytes(keyId);
 
             CoseSign1Message receipt = CoseMessage.DecodeSign1(receiptBytes);
 
@@ -58,22 +126,17 @@ namespace Azure.Security.CodeTransparency
             // Get the ECDsa key size from the certificate
             int algValue = alg.GetValueAsInt32();
 
-            switch (jsonWebKey.Crv)
+            int expectedAlg = publicKey.KeySize switch
             {
-                case "P-256":
-                    if (algValue != -7)
-                        throw new InvalidOperationException($"The ECDsa key uses the wrong algorithm. Expected -7 Found {algValue}");
-                    break;
-                case "P-384":
-                    if (algValue != -35)
-                        throw new InvalidOperationException($"The ECDsa key uses the wrong algorithm. Expected -35 Found {algValue}");
-                    break;
-                case "P-512":
-                    if (algValue != -39)
-                        throw new InvalidOperationException($"The ECDsa key uses the wrong algorithm. Expected -39 Found {algValue}");
-                    break;
-                default:
-                    throw new InvalidOperationException("ECDsa key and Alg mismatch.");
+                256 => CoseAlgorithmEs256,
+                384 => CoseAlgorithmEs384,
+                521 => CoseAlgorithmEs512,
+                _ => throw new InvalidOperationException($"Unsupported ECDsa key size {publicKey.KeySize}.")
+            };
+
+            if (algValue != expectedAlg)
+            {
+                throw new InvalidOperationException($"The ECDsa key uses the wrong algorithm. Expected {expectedAlg} Found {algValue}");
             }
 
             if (!receipt.ProtectedHeaders.TryGetValue(CoseHeaderLabel.KeyIdentifier, out CoseHeaderValue kid) ||
@@ -163,20 +226,7 @@ namespace Azure.Security.CodeTransparency
                     }
                 }
 
-                // We are mapping our JWK with AKV JWK in order to leverage the already established
-                // ECDsa conversion given a JWK.
-                KeyVault.Keys.JsonWebKey tmpAkvKey = new KeyVault.Keys.JsonWebKey(null)
-                {
-                    CurveName = jsonWebKey.Crv,
-                    X = Base64Url.Decode(jsonWebKey.X),
-                    Y = Base64Url.Decode(jsonWebKey.Y),
-                    Id = jsonWebKey.Kid,
-                    KeyType = jsonWebKey.Kty
-                };
-
-                using ECDsa ecdsaKey = tmpAkvKey.ToECDsa(false);
-
-                if (!receipt.VerifyDetached(ecdsaKey, new ReadOnlySpan<byte>(accumulator)))
+                if (!receipt.VerifyDetached(publicKey, new ReadOnlySpan<byte>(accumulator)))
                 {
                     throw new InvalidOperationException("Signature verification failed");
                 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CborUtilsTest.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CborUtilsTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Formats.Cbor;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -312,6 +313,82 @@ namespace Azure.Security.CodeTransparency.Tests
 
             // Assert
             Assert.AreEqual(string.Empty, result);
+        }
+
+        private static byte[] CborArrayRoot()
+        {
+            var writer = new CborWriter();
+            writer.WriteStartArray(1);
+            writer.WriteTextString("not-a-map");
+            writer.WriteEndArray();
+            return writer.Encode();
+        }
+
+        private static byte[] CborTextStringRoot()
+        {
+            var writer = new CborWriter();
+            writer.WriteTextString("not-a-map");
+            return writer.Encode();
+        }
+
+        private static byte[] CborIntegerRoot()
+        {
+            var writer = new CborWriter();
+            writer.WriteInt32(42);
+            return writer.Encode();
+        }
+
+        // 0xA1 declares a map of one pair, 0x67 declares a 7-byte text string that is not present.
+        private static byte[] TruncatedCborMap() => new byte[] { 0xA1, 0x67 };
+
+        // Major type 7 with an invalid additional-information value.
+        private static byte[] GarbageCborBytes() => new byte[] { 0xFF, 0xFF, 0xFF };
+
+        private static IEnumerable<TestCaseData> MalformedPayloads()
+        {
+            yield return new TestCaseData(CborArrayRoot()).SetName("{m}_ArrayRoot");
+            yield return new TestCaseData(CborTextStringRoot()).SetName("{m}_TextStringRoot");
+            yield return new TestCaseData(CborIntegerRoot()).SetName("{m}_IntegerRoot");
+            yield return new TestCaseData(TruncatedCborMap()).SetName("{m}_TruncatedMap");
+            yield return new TestCaseData(GarbageCborBytes()).SetName("{m}_GarbageBytes");
+        }
+
+        [TestCaseSource(nameof(MalformedPayloads))]
+        public void GetStringValueFromCborMapByStringKey_MalformedPayload_ReturnsEmptyStringAndDoesNotThrow(byte[] cborBytes)
+        {
+            string result = null;
+
+            Assert.DoesNotThrow(() => result = CborUtils.GetStringValueFromCborMapByKey(cborBytes, "key"));
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [TestCaseSource(nameof(MalformedPayloads))]
+        public void GetStringValueFromCborMapByIntKey_MalformedPayload_ReturnsEmptyStringAndDoesNotThrow(byte[] cborBytes)
+        {
+            string result = null;
+
+            Assert.DoesNotThrow(() => result = CborUtils.GetStringValueFromCborMapByKey(cborBytes, 1));
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [Test]
+        public void GetStringValueFromCborMapByStringKey_TrailingGarbageAfterMap_DoesNotThrow()
+        {
+            var writer = new CborWriter();
+            writer.WriteStartMap(1);
+            writer.WriteTextString("key");
+            writer.WriteTextString("value");
+            writer.WriteEndMap();
+            byte[] valid = writer.Encode();
+
+            byte[] withTrailingGarbage = new byte[valid.Length + 2];
+            Buffer.BlockCopy(valid, 0, withTrailingGarbage, 0, valid.Length);
+            withTrailingGarbage[valid.Length] = 0xFF;
+            withTrailingGarbage[valid.Length + 1] = 0xFF;
+
+            string result = null;
+            Assert.DoesNotThrow(() => result = CborUtils.GetStringValueFromCborMapByKey(withTrailingGarbage, "key"));
+            Assert.AreEqual("value", result);
         }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CcfReceiptVerifierTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CcfReceiptVerifierTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -123,6 +124,197 @@ namespace Azure.Security.CodeTransparency.Tests
             Assert.IsNull(CcfReceipt.GetRegistrationTransactionId(null));
             Assert.IsNull(CcfReceipt.GetRegistrationTransactionId(Array.Empty<byte>()));
             Assert.IsNull(CcfReceipt.GetRegistrationTransactionId(new byte[] { 0x01, 0x02, 0x03 }));
+        }
+
+        private const string MatchingKid = "87d64669f1c5988e28f22da4f3526334de860ad2395a71a735de59f9ec3aa662";
+
+        private static JsonWebKey CreateMatchingP384Key() => CodeTransparencyModelFactory.JsonWebKey(
+            crv: "P-384",
+            kid: MatchingKid,
+            kty: "EC",
+            x: "9y7Zs09nKjYQHdJ7oAsxftOvSK9RfGWJM3p0_5XXyBuvkUs-kN-YB-EQCCuB_Hsw",
+            y: "teV4Jkd2zphYJa2gPSm5HEjuvEM9MNu3e5E7z1L_0s0GWKaEqmHpAiXBtLGHC5-A");
+
+        private static string Base64UrlEncode(byte[] value) =>
+            Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+#if !NET462
+        private static JsonWebKey ToJsonWebKey(ECDsa key, string curveName, string kid)
+        {
+            ECParameters parameters = key.ExportParameters(includePrivateParameters: false);
+            return CodeTransparencyModelFactory.JsonWebKey(
+                crv: curveName,
+                kid: kid,
+                kty: "EC",
+                x: Base64UrlEncode(parameters.Q.X),
+                y: Base64UrlEncode(parameters.Q.Y));
+        }
+#endif
+
+        [Test]
+        public void VerifyTransparentStatementReceipt_EcdsaOverload_BehavesIdenticallyToJsonWebKeyOverload()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            byte[] receiptBytes = readFileBytes("receipt.cose");
+            byte[] inputSignedPayloadBytes = readFileBytes("input_signed_claims");
+            JsonWebKey jsonWebKey = CreateMatchingP384Key();
+
+            // The JWK overload reaches the claim-digest check, which means the ECDsa signature over
+            // the accumulator verified successfully with this key.
+            var fromJwk = Assert.Throws<InvalidOperationException>(
+                () => CcfReceiptVerifier.VerifyTransparentStatementReceipt(jsonWebKey, receiptBytes, inputSignedPayloadBytes));
+
+            using ECDsa publicKey = CcfReceiptVerifier.ConvertToECDsa(jsonWebKey);
+            var fromEcdsa = Assert.Throws<InvalidOperationException>(
+                () => CcfReceiptVerifier.VerifyTransparentStatementReceipt(publicKey, MatchingKid, receiptBytes, inputSignedPayloadBytes));
+
+            StringAssert.Contains("Claim digest mismatch", fromJwk.Message);
+            Assert.AreEqual(fromJwk.Message, fromEcdsa.Message);
+#endif
+        }
+
+        [Test]
+        public void VerifyTransparentStatementReceipt_EcdsaOverload_KidMismatch_Throws()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            byte[] receiptBytes = readFileBytes("receipt.cose");
+            byte[] inputSignedPayloadBytes = readFileBytes("input_signed_claims");
+
+            using ECDsa publicKey = CcfReceiptVerifier.ConvertToECDsa(CreateMatchingP384Key());
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => CcfReceiptVerifier.VerifyTransparentStatementReceipt(publicKey, "not-the-right-kid", receiptBytes, inputSignedPayloadBytes));
+            StringAssert.Contains("KID mismatch", exception.Message);
+#endif
+        }
+
+        [Test]
+        public void VerifyTransparentStatementReceipt_EcdsaOverload_KeySizeAlgorithmMismatch_Throws()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            byte[] receiptBytes = readFileBytes("receipt.cose");
+            byte[] inputSignedPayloadBytes = readFileBytes("input_signed_claims");
+
+            // The receipt is signed with ES384; a P-256 key must be rejected on the algorithm check.
+            using ECDsa p256 = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => CcfReceiptVerifier.VerifyTransparentStatementReceipt(p256, MatchingKid, receiptBytes, inputSignedPayloadBytes));
+            StringAssert.Contains("The ECDsa key uses the wrong algorithm. Expected -7 Found -35", exception.Message);
+#endif
+        }
+
+        [Test]
+        public void VerifyTransparentStatementReceipt_NullArguments_Throw()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            byte[] some = new byte[] { 0x01 };
+            using ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+            Assert.Throws<ArgumentNullException>(() => CcfReceiptVerifier.VerifyTransparentStatementReceipt((JsonWebKey)null, some, some));
+            Assert.Throws<ArgumentNullException>(() => CcfReceiptVerifier.VerifyTransparentStatementReceipt((ECDsa)null, "kid", some, some));
+            Assert.Throws<ArgumentNullException>(() => CcfReceiptVerifier.VerifyTransparentStatementReceipt(key, null, some, some));
+            Assert.Throws<ArgumentException>(() => CcfReceiptVerifier.VerifyTransparentStatementReceipt(key, string.Empty, some, some));
+            Assert.Throws<ArgumentNullException>(() => CcfReceiptVerifier.VerifyTransparentStatementReceipt(key, "kid", null, some));
+            Assert.Throws<ArgumentNullException>(() => CcfReceiptVerifier.VerifyTransparentStatementReceipt(key, "kid", some, null));
+#endif
+        }
+
+        [TestCase("P-256", 256)]
+        [TestCase("P-384", 384)]
+        [TestCase("P-521", 521)]
+        public void ConvertToECDsa_RoundTripsSupportedCurves(string curveName, int expectedKeySize)
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            ECCurve curve = curveName switch
+            {
+                "P-256" => ECCurve.NamedCurves.nistP256,
+                "P-384" => ECCurve.NamedCurves.nistP384,
+                _ => ECCurve.NamedCurves.nistP521
+            };
+
+            using ECDsa original = ECDsa.Create(curve);
+            JsonWebKey jwk = ToJsonWebKey(original, curveName, "kid-" + curveName);
+
+            using ECDsa converted = CcfReceiptVerifier.ConvertToECDsa(jwk);
+
+            Assert.AreEqual(expectedKeySize, converted.KeySize);
+
+            // The converted key must validate a signature produced by the original private key.
+            byte[] data = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] signature = original.SignData(data, HashAlgorithmName.SHA256);
+            Assert.IsTrue(converted.VerifyData(data, signature, HashAlgorithmName.SHA256));
+#endif
+        }
+
+        [Test]
+        public void ConvertToECDsa_P521_IsSupported()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            // Regression test: the previous implementation matched on the non-existent curve name
+            // "P-512" and expected COSE algorithm -39 (PS512) rather than -36 (ES512), so P-521
+            // keys always fell through to the default branch and threw.
+            using ECDsa original = ECDsa.Create(ECCurve.NamedCurves.nistP521);
+            JsonWebKey jwk = ToJsonWebKey(original, "P-521", "p521-kid");
+
+            using ECDsa converted = CcfReceiptVerifier.ConvertToECDsa(jwk);
+
+            Assert.AreEqual(521, converted.KeySize);
+#endif
+        }
+
+        [Test]
+        public void ConvertToECDsa_RejectsUnsupportedCurve()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            JsonWebKey jwk = CodeTransparencyModelFactory.JsonWebKey(crv: "P-512", kid: "k", kty: "EC", x: "AQAB", y: "AQAB");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => CcfReceiptVerifier.ConvertToECDsa(jwk));
+            StringAssert.Contains("Unsupported elliptic curve 'P-512'.", exception.Message);
+#endif
+        }
+
+        [Test]
+        public void ConvertToECDsa_RejectsNonEcKeyType()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            JsonWebKey jwk = CodeTransparencyModelFactory.JsonWebKey(crv: "P-256", kid: "k", kty: "RSA", x: "AQAB", y: "AQAB");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => CcfReceiptVerifier.ConvertToECDsa(jwk));
+            StringAssert.Contains("Only EC keys are supported", exception.Message);
+#endif
+        }
+
+        [TestCase(null, "AQAB")]
+        [TestCase("AQAB", null)]
+        [TestCase("", "AQAB")]
+        [TestCase("AQAB", "")]
+        public void ConvertToECDsa_RejectsMissingCoordinates(string x, string y)
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            JsonWebKey jwk = CodeTransparencyModelFactory.JsonWebKey(crv: "P-256", kid: "k", kty: "EC", x: x, y: y);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => CcfReceiptVerifier.ConvertToECDsa(jwk));
+            StringAssert.Contains("missing the X or Y coordinate", exception.Message);
+#endif
         }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -1076,7 +1076,7 @@ namespace Azure.Security.CodeTransparency.Tests
             byte[] transparentStatementBytes = readFileBytes("transparent_statement.cose");
 
             var exception = Assert.Throws<AggregateException>(() => CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options));
-            Assert.AreEqual("The ECDsa key uses the wrong algorithm. Expected -39 Found -35", exception.InnerExceptions[0].Message);
+            Assert.AreEqual("Unsupported elliptic curve 'P-512'.", exception.InnerExceptions[0].Message);
 #endif
         }
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
@@ -82,12 +82,11 @@ namespace Azure.Security.CodeTransparency.Tests
             FileStream fileStream = File.OpenRead("signature.cose");
             BinaryData content = BinaryData.FromStream(fileStream);
 #endif
-            Operation<BinaryData> operation = await client.CreateEntryAsync(WaitUntil.Started, content);
+            NullableResponse<BinaryData> submission = await client.CreateEntryAsync(content, waitForCommit: true);
             #endregion Snippet:CodeTransparencySubmission
 
             #region Snippet:CodeTransparencyDownloadTransparentStatement
-            Response<BinaryData> operationResult = await operation.WaitForCompletionAsync();
-            string entryId = CborUtils.GetStringValueFromCborMapByKey(operationResult.Value.ToArray(), "EntryId");
+            string entryId = CodeTransparencyClient.GetEntryIdFromLocation(submission.GetRawResponse());
             Console.WriteLine($"The entry ID to use to retrieve the receipt and transparent statement is {{{entryId}}}");
             #region Snippet:CodeTransparencySample2_GetEntryStatement
             Response<BinaryData> transparentStatementResponse = await client.GetEntryStatementAsync(entryId);
@@ -95,8 +94,7 @@ namespace Azure.Security.CodeTransparency.Tests
             #endregion Snippet:CodeTransparencySample2_GetEntryStatement
             #endregion Snippet:CodeTransparencyDownloadTransparentStatement
 
-            Assert.IsTrue(operation.HasCompleted);
-            Assert.IsTrue(operation.HasValue);
+            Assert.AreEqual("123.23", entryId);
 
             #region Snippet:CodeTransparencySample2_GetRawReceipt
 #if SNIPPET


### PR DESCRIPTION
> **Draft / prototype.** Superseded in part by #62471, which landed first and covers the same two headline changes. See "Relationship to #62471" below — I plan to rebase this onto that PR and keep only the non-overlapping parts.

## Relationship to #62471

@ryazhang-microsoft opened #62471 about three hours before this one, addressing the same APIView feedback. It overlaps on two of my four changes and goes further in places I did not touch (internalizing `CcfReceipt`, constructor overloads, `CreateEntryOperation` as the concrete LRO return type, de-obsoleting the LRO overloads).

**Overlapping — his version should win, mine dropped on rebase:**

| Change | #62471 | This PR |
| --- | --- | --- |
| `CborUtils` made internal | yes | yes |
| Drop `Azure.Security.KeyVault.Keys` dependency | yes | yes |

**Not in #62471 — what I would like to keep:**

| Change | #62471 | This PR |
| --- | --- | --- |
| Public `ECDsa` overload on `CcfReceiptVerifier` | no | yes |
| P-521 / ES512 curve-and-algorithm fix | no (bug is carried forward) | yes |
| `CborUtils` honours its documented no-throw contract | no | yes |
| Samples updated to stop referencing now-internal types | no (four docs left broken) | partially |
| Malformed-CBOR and curve round-trip test coverage | no | yes |

I have left review comments on #62471 for the three defects below. Everything here is verified against the source and covered by tests; details and evidence are in the sections that follow.

## The API-design argument

APIView feedback on `Azure.Security.CodeTransparency`:

> **KrzysztofCwalina:** we dont want such general purpose type in this package. it should be in Azure.Core. Please works with Jesse Squire on this

> **ivarprudnikov:** I see that `JsonWebKey` is already implemented as a separate class in other SDKs [...] you cannot easily have a canonical representation because our services add slightly different properties to the class. [...] We do also plan to move away from the JSON representation altogether in favour of structures implemented in CBOR.

I think Ivar is right that a shared `JsonWebKey` in Azure.Core is not worth chasing — three existing Azure `JsonWebKey` types already disagree on their members, and unifying them is a large cross-team effort this package could not consume until it lands.

But that does not fully answer the objection, which is not *"this type should live elsewhere"* so much as *"a service package should not define and expose general-purpose primitives."* That is satisfiable without moving anything, by removing general-purpose types from the public **input** contract. Output models are a different case: they describe what the service returned, they have internal constructors, and callers never construct them. That is why I would leave `JsonWebKey` and `JwksDocument` in place as response models while removing `CborUtils` and adding a non-JWK way to supply a key.

## 1. Public `ECDsa` overload on `CcfReceiptVerifier`

`JsonWebKey` has only an `internal` constructor, yet it was the sole input type of the one verification method:

```csharp
public static void VerifyTransparentStatementReceipt(JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes)
```

A caller who already holds the service's public key — from their own config, a cert store, Key Vault, anywhere — has no way to hand it over; the only supported path is to round-trip through a service response. This adds an overload taking what the code actually needs:

```csharp
public static void VerifyTransparentStatementReceipt(ECDsa publicKey, string keyId, byte[] receiptBytes, byte[] signedStatementBytes)
```

The `JsonWebKey` overload is kept and delegates to it. This is also robust to the planned CBOR/post-quantum migration, since key material outlives the wire format used to carry it.

## 2. P-521 verification has never worked, and #62471 carries the bug forward

The original curve switch matched on `"P-512"` — a curve that does not exist; the real JOSE name is `P-521` (RFC 7518 §6.2.1.1) — and expected COSE algorithm `-39`, which is **PS512, an RSA algorithm**, rather than `-36` (ES512). Every P-521 key fell through to `default:` and threw.

The existing test `VerifyTransparentStatement_InvalidCurve_InvalidOperationException` **enshrined** the bug: its fixture used `crv: "P-512"` with P-384-sized coordinates and asserted the `-39` message, so it passed only by routing through the bogus branch.

#62471 preserves the misspelling in its replacement mapping:

```csharp
"P-512" => ECCurve.NamedCurves.nistP521,
```

so a correctly-formed `crv: "P-521"` key now throws `Unsupported ECDsa curve 'P-521'`, and a `"P-512"` key still fails the untouched `-39` algorithm check upstream. P-521 remains unverifiable either way.

This PR keys the algorithm check off `ECDsa.KeySize` instead of the curve string, which removes the duplicated curve-name knowledge entirely.

## 3. `CborUtils` throws despite documenting that it does not

The XML docs promise an empty string for "absence, or unexpected CBOR shapes", but there was no `try`/`catch`. Verified empirically against real payloads: a non-map root throws `InvalidOperationException`, a truncated map throws `CborContentException`. Only null/empty/absent-key returned `""`.

This has a reliability impact beyond the docs being wrong: `CreateEntryOperation.UpdateState` calls it after only a status-code and non-empty-body check, so a response body that is not a CBOR map surfaces as a raw `InvalidOperationException` out of `WaitForCompletion` rather than a `RequestFailedException`.

## 4. Internalizing types silently breaks four published docs

This is the part I would most like folded into #62471 before it merges, because **CI cannot catch it**.

The snippets in `README.md` and `samples/*.md` are sourced from `tests/SamplesUnitTests.cs` and `tests/CodeTransparencyClientRecordedTests.cs`, both of which live in the Tests assembly and therefore have `InternalsVisibleTo` access (`src/Properties/AssemblyInfo.cs:6`). Internalizing a type leaves the snippet compiling and the build green, while the published documentation instructs users to call something they cannot reach.

With `CborUtils` and `CcfReceipt` both internal, these four references become uncompilable for a consumer:

- `README.md` — `CborUtils.GetStringValueFromCborMapByKey(...)`
- `samples/Sample1_HelloWorld.md:43` — `CcfReceipt.CoseHeaderEmbeddedReceipts`
- `samples/Sample1_HelloWorld.md:51` — `CcfReceipt.GetRegistrationTransactionId(...)`
- `samples/Sample4_DeserializeTransparentStatement.md:28` — `CcfReceipt.CoseHeaderEmbeddedReceipts`

`CcfReceipt.GetRegistrationTransactionId` is also worth a second look on its own: it was added as an advertised public feature in `1.0.0-beta.11` (CHANGELOG line 62) and is the documented way to recover an entry id when a redirect response has no `Location` header.

This PR rewrites the README sample onto the supported accessor:

```diff
-Operation<BinaryData> operation = await client.CreateEntryAsync(WaitUntil.Started, content);
-Response<BinaryData> operationResult = await operation.WaitForCompletionAsync();
-string entryId = CborUtils.GetStringValueFromCborMapByKey(operationResult.Value.ToArray(), "EntryId");
+NullableResponse<BinaryData> submission = await client.CreateEntryAsync(content, waitForCommit: true);
+string entryId = CodeTransparencyClient.GetEntryIdFromLocation(submission.GetRawResponse());
```

Worth noting how circular the old path was: the `[Obsolete]` `CreateEntry(WaitUntil, ...)` overload internally calls the modern overload, extracts the entry id, then **re-encodes it back into CBOR** purely so the caller can decode it again with `CborUtils`.

## Aside: the Key Vault dependency was invisible to API review

The package referenced the entire Key Vault Keys client library to reuse one conversion inside a single method body. Both PRs remove it, but the interesting part is how it survived: .NET APIView renders only the public surface, and `grep KeyVault` over all three checked-in `api/*.cs` files returns zero hits, because the usage was entirely inside a method body. A service package taking a dependency on another service's client library is exactly what review should catch, and the tooling structurally cannot see it. Probably worth raising with the architects independently.

## Testing

Passing on `net8.0`, `net9.0`, `net10.0` and `net462` — 310 passed / 0 failed (240 on net462, where the extra skips are the pre-existing "JWK to ECDsa is not supported on net462" ignores).

New coverage:

- Equivalence test proving the `ECDsa` and `JsonWebKey` overloads produce identical results against the real `receipt.cose` / `input_signed_claims` fixtures — i.e. removing Key Vault preserved crypto behaviour.
- `ConvertToECDsa` round-trip over P-256/P-384/P-521, verifying a signature made by the original private key.
- P-521 regression test, plus rejection cases for unsupported curve, non-EC `kty`, and missing coordinates.
- `CborUtilsTest` previously had **zero** malformed-input coverage across its 20 tests. Added array/text/integer roots, truncated maps, garbage bytes, and trailing garbage after a valid map.

Both fixes were mutation-tested rather than just observed green:

- Neutralizing the `catch` filter in `CborUtils` fails the new malformed-payload tests.
- Mis-mapping `P-521` to `nistP384` fails the round-trip and P-521 regression tests.

## Deliberately not done here

- **`JwksDocument` is left alone.** It is the return type of a real operation (`GetPublicKeys`), and an output model with an internal constructor is the correct pattern. Its `ContentType` member (hardcoded `"application/json"` — an HTTP header leaked into a model body) and `Keys` being `IList` rather than `IReadOnlyList` are both worth fixing, but those files are `<auto-generated/>` and need **TypeSpec** changes.
- **`CcfReceipt`** — #62471 internalizes it. I have no objection in principle, only to doing it without updating the three samples that use it.

## Open questions

1. The rewritten sample relies on the `Location` header being present. `GetEntryIdFromLocation` throws `RequestFailedException` if it is not; the internal `CreateCompletedEntryOperation` falls back to `CcfReceipt.GetRegistrationTransactionId` for the 303-redirect case. Should the public sample show the fallback, or should the client expose one accessor that handles both? This interacts directly with internalizing `CcfReceipt`.
2. `CborUtils` going internal is a **breaking change** for anyone who took the dependency after `1.0.0-beta.6` exposed it. Given the package is still in beta and the type was only ever public to work around a gap that is now closed, I think that is acceptable — but it is a judgment call, and #62471 does not currently call it out as breaking.

/cc @KrzysztofCwalina @ivarprudnikov @ryazhang-microsoft

--generated by Copilot