### PR TITLE
Bump mgmt emitter base dependency to 1.0.0-alpha.20260825.4

### DIFF
--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,6 +1,6 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-26 20:52:53 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-26 23:00:38 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Latest Published Version Chain
@@ -8,7 +8,7 @@
 ```
 @typespec/http-client-csharp (alpha.20260825.9)
   └─ @azure-typespec/http-client-csharp (alpha.20260826.1)
-       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260825.1)
+       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260826.3)
             └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260824.1)
 ```
 
@@ -17,8 +17,8 @@
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
 | `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | 1.0.0-alpha.20260825.9 | 1.0.0-alpha.20260825.9 | [210f84c](https://github.com/microsoft/typespec/commit/210f84c0dee6cfb8226ce95700562c9bf0922822) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260825.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260825.4) | [1.0.0-alpha.20260826.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260826.1) | [6327049](https://github.com/Azure/azure-sdk-for-net/commit/6327049a2b5121156bc3ebcc3f110d0a0c5231e6) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260820.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260820.2) | [1.0.0-alpha.20260825.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260825.1) | [d84ccb7](https://github.com/Azure/azure-sdk-for-net/commit/d84ccb7c940cba3ac9d146e53732f3d89c39f144) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | 1.0.0-alpha.20260825.4 | 1.0.0-alpha.20260826.1 | [6327049](https://github.com/Azure/azure-sdk-for-net/commit/6327049a2b5121156bc3ebcc3f110d0a0c5231e6) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | 1.0.0-alpha.20260820.2 | 1.0.0-alpha.20260826.3 | [d84ccb7](https://github.com/Azure/azure-sdk-for-net/commit/d84ccb7c940cba3ac9d146e53732f3d89c39f144) |
 
 ## Source Files
 

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,13 +1,13 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-25 23:58:37 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-08-26 20:52:53 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Latest Published Version Chain
 
 ```
 @typespec/http-client-csharp (alpha.20260825.9)
-  └─ @azure-typespec/http-client-csharp (alpha.20260825.3)
+  └─ @azure-typespec/http-client-csharp (alpha.20260826.1)
        └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260825.1)
             └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260824.1)
 ```
@@ -17,8 +17,8 @@
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
 | `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | 1.0.0-alpha.20260825.9 | 1.0.0-alpha.20260825.9 | [210f84c](https://github.com/microsoft/typespec/commit/210f84c0dee6cfb8226ce95700562c9bf0922822) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | 1.0.0-alpha.20260819.3 | 1.0.0-alpha.20260825.3 | [b77d431](https://github.com/Azure/azure-sdk-for-net/commit/b77d43115c7ebe317d6e736c77cd81ae9a735ee1) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | 1.0.0-alpha.20260820.2 | 1.0.0-alpha.20260825.1 | [d84ccb7](https://github.com/Azure/azure-sdk-for-net/commit/d84ccb7c940cba3ac9d146e53732f3d89c39f144) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260825.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260825.4) | [1.0.0-alpha.20260826.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260826.1) | [6327049](https://github.com/Azure/azure-sdk-for-net/commit/6327049a2b5121156bc3ebcc3f110d0a0c5231e6) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260820.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260820.2) | [1.0.0-alpha.20260825.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260825.1) | [d84ccb7](https://github.com/Azure/azure-sdk-for-net/commit/d84ccb7c940cba3ac9d146e53732f3d89c39f144) |
 
 ## Source Files
 

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
@@ -50,33 +50,6 @@ function Get-NpmLatestVersion([string]$PackageName) {
     return "unavailable"
 }
 
-function Test-NpmVersionExists([string]$PackageName, [string]$Version) {
-    if (-not $PackageName -or -not $Version -or $Version -eq "unavailable")
-    {
-        return $false
-    }
-    try {
-        $global:LASTEXITCODE = $null
-        $result = npm view "$PackageName@$Version" version --registry=https://registry.npmjs.org/ 2>$null
-        $resolvedVersion = ($result | Out-String).Trim()
-        if ($LASTEXITCODE -eq 0 -and $resolvedVersion -eq $Version) {
-            return $true
-        }
-    }
-    catch {}
-
-    return $false
-}
-
-
-function Get-NpmVersionLink([string]$PackageName, [string]$Version) {
-    if (-not (Test-NpmVersionExists $PackageName $Version)) {
-        return $Version
-    }
-    $url = "https://www.npmjs.com/package/$PackageName/v/$Version"
-    return "[$Version]($url)"
-}
-
 function Get-ShortVersion([string]$Version) {
     if ($Version -match 'alpha\.(\d{4})(\d{2})(\d{2})\.(\d+)$') {
         return "alpha.$($Matches[1])$($Matches[2])$($Matches[3]).$($Matches[4])"
@@ -106,16 +79,21 @@ $latestAzure = Get-NpmLatestVersion "@azure-typespec/http-client-csharp"
 $latestMgmt  = Get-NpmLatestVersion "@azure-typespec/http-client-csharp-mgmt"
 $latestProv  = Get-NpmLatestVersion "@azure-typespec/http-client-csharp-provisioning"
 
-# --- Build version links ---
+# --- Version cells ---
+# These are rendered as plain text rather than links to npmjs.com. The npm website
+# blocks automated requests, so the repo's link checker (eng/common/scripts/Verify-Links.ps1)
+# cannot verify them. Because the "Latest on npm" column tracks a moving target, every
+# regeneration after a new publish would introduce a fresh, unverifiable URL and fail CI.
+# The ignore list is matched by exact string (Verify-Links.ps1), so it cannot cover them either.
 
-$linkBaseDep    = Get-NpmVersionLink "@typespec/http-client-csharp" $baseDep_azure
-$linkAzureDep   = Get-NpmVersionLink "@azure-typespec/http-client-csharp" $azureDep_mgmt
-$linkMgmtDep    = Get-NpmVersionLink "@azure-typespec/http-client-csharp-mgmt" $mgmtDep_prov
+$linkBaseDep    = $baseDep_azure
+$linkAzureDep   = $azureDep_mgmt
+$linkMgmtDep    = $mgmtDep_prov
 
-$linkLatestBase  = Get-NpmVersionLink "@typespec/http-client-csharp" $latestBase
-$linkLatestAzure = Get-NpmVersionLink "@azure-typespec/http-client-csharp" $latestAzure
-$linkLatestMgmt  = Get-NpmVersionLink "@azure-typespec/http-client-csharp-mgmt" $latestMgmt
-$linkLatestProv  = Get-NpmVersionLink "@azure-typespec/http-client-csharp-provisioning" $latestProv
+$linkLatestBase  = $latestBase
+$linkLatestAzure = $latestAzure
+$linkLatestMgmt  = $latestMgmt
+$linkLatestProv  = $latestProv
 
 # --- Resolve the git commit that corresponds to each dependency version ---
 # We query the npm registry for the exact publish timestamp of each dependency

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260825.9</UnbrandedGeneratorVersion>
-    <AzureGeneratorVersion>1.0.0-alpha.20260819.3</AzureGeneratorVersion>
+    <AzureGeneratorVersion>1.0.0-alpha.20260825.4</AzureGeneratorVersion>
     <AzureManagementGeneratorVersion>1.0.0-alpha.20260820.2</AzureManagementGeneratorVersion>
   </PropertyGroup>
 

--- a/eng/packages/http-client-csharp-mgmt/README.md
+++ b/eng/packages/http-client-csharp-mgmt/README.md
@@ -46,7 +46,7 @@ See [Configuring output directory for more info](https://typespec.io/docs/handbo
 
 **Type:** `string | object`
 
-Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.
+Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace to its desired version. Nested namespaces must be represented as nested objects in `tspconfig.yaml`; services not listed default to their latest version.
 
 **Options:**
 

--- a/eng/packages/http-client-csharp-mgmt/docs/emitter.md
+++ b/eng/packages/http-client-csharp-mgmt/docs/emitter.md
@@ -40,7 +40,7 @@ See [Configuring output directory for more info](https://typespec.io/docs/handbo
 
 **Type:** `string | object`
 
-Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.
+Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace to its desired version. Nested namespaces must be represented as nested objects in `tspconfig.yaml`; services not listed default to their latest version.
 
 **Options:**
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -527,11 +527,11 @@ function assignRemainingOperations(
       const scope = buildScopeInfoFromPath(operationPath);
       const isCollectionAction = isResourceCollectionAction(sdkMethod);
       const target = isCollectionAction
-        ? findCollectionActionTargetResource(
+        ? (findCollectionActionTargetResource(
             resources,
             operationPath,
             actionTarget
-          ) ?? actionTarget
+          ) ?? actionTarget)
         : actionTarget;
       target.metadata.methods.push({
         methodId,

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
@@ -9,10 +9,7 @@ import {
   SdkHttpOperation,
   SdkMethod
 } from "@azure-tools/typespec-client-generator-core";
-import type {
-  CodeModel,
-  CSharpEmitterContext
-} from "./code-model-types.js";
+import type { CodeModel, CSharpEmitterContext } from "./code-model-types.js";
 import { getAllSdkClients } from "./sdk-client-utils.js";
 
 // https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-resource-manager/README.md#armprovidernamespace

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/NameVisitorTests.cs
@@ -38,12 +38,51 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(type?.Properties[0].Name, Is.EqualTo(testPropertyName.Replace("Url", "Uri")));
         }
 
+        [TestCase("StartTime", "StartsOn")]
+        [TestCase("EndTime", "EndsOn")]
+        [TestCase("CreationTime", "CreatedOn")]
+        [TestCase("ExpirationTime", "ExpiresOn")]
+        [TestCase("ModificationTime", "ModifiedOn")]
+        [TestCase("DeletionDate", "DeletedOn")]
+        [TestCase("LastModifiedTime", "LastModifiedOn")]
+        [TestCase("FirstSeenTime", "FirstSeenOn")]
+        [TestCase("TestDate", "TestOn")]
+        [TestCase("TestDateTime", "TestOn")]
+        // Names that must be preserved: the From/To prefixes and the PointInTime suffix are
+        // excluded by the visitor, and bare "Time"/"Date" are too short to carry a prefix.
+        [TestCase("FromTime", "FromTime")]
+        [TestCase("ToTime", "ToTime")]
+        [TestCase("RestorePointInTime", "RestorePointInTime")]
+        [TestCase("Time", "Time")]
+        [TestCase("Date", "Date")]
+        public void TestTransformTimePropertyName(string testPropertyName, string expectedPropertyName)
+        {
+            Assert.That(TransformDateTimePropertyName(testPropertyName, InputPrimitiveType.PlainDate), Is.EqualTo(expectedPropertyName));
+        }
+
+        // The rename keys off the input type rather than the mapped C# type, so utcDateTime must
+        // produce exactly the same names as plainDate.
+        [TestCase("StartTime", "StartsOn")]
+        [TestCase("EndTime", "EndsOn")]
+        [TestCase("CreationTime", "CreatedOn")]
+        [TestCase("ExpirationTime", "ExpiresOn")]
+        [TestCase("RestorePointInTime", "RestorePointInTime")]
+        public void TestTransformTimePropertyNameForUtcDateTime(string testPropertyName, string expectedPropertyName)
+        {
+            var utcDateTime = new InputDateTimeType(DateTimeKnownEncoding.Rfc3339, "utcDateTime", "TypeSpec.utcDateTime", InputPrimitiveType.String);
+            Assert.That(TransformDateTimePropertyName(testPropertyName, utcDateTime), Is.EqualTo(expectedPropertyName));
+        }
+
         [Test]
-        public void TestTransformTimePropertyName()
+        public void TestNonDateTimePropertyNameIsNotTransformed()
+        {
+            Assert.That(TransformDateTimePropertyName("StartTime", InputPrimitiveType.String), Is.EqualTo("StartTime"));
+        }
+
+        private static string? TransformDateTimePropertyName(string testPropertyName, InputType propertyType)
         {
             const string testModelName = "TestModel";
-            const string testPropertyName = "StartTime";
-            var modelProperty = InputFactory.Property(testPropertyName, InputPrimitiveType.PlainDate, serializedName: "testName", isRequired: true);
+            var modelProperty = InputFactory.Property(testPropertyName, propertyType, serializedName: "testName", isRequired: true);
             var model = InputFactory.Model(testModelName, properties: [modelProperty]);
             var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: model);
             var testNameParameter = InputFactory.MethodParameter("testName", InputPrimitiveType.String, location: InputRequestLocation.Path);
@@ -59,7 +98,7 @@ namespace Azure.Generator.Mgmt.Tests
 
             // PreVisitModel is called during the model creation
             var type = plugin.Object.TypeFactory.CreateModel(model);
-            Assert.That(type?.Properties[0].Name, Is.EqualTo(testPropertyName.Replace("Time", "On")));
+            return type?.Properties[0].Name;
         }
 
         [Test]

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
@@ -8770,7 +8770,7 @@
                 "discriminator": false,
                 "flatten": false,
                 "decorators": [],
-                "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.PrivateEndpointConnectionProperties.privateEndpoint",
+                "crossLanguageDefinitionId": "Azure.ResourceManager.Models.SubResource",
                 "serializationOptions": {
                   "json": {
                     "name": "privateEndpoint"
@@ -9541,7 +9541,7 @@
                 "discriminator": false,
                 "flatten": false,
                 "decorators": [],
-                "crossLanguageDefinitionId": "MgmtTypeSpec.FooProperties.something",
+                "crossLanguageDefinitionId": "Azure.ResourceManager.CommonTypes.ManagedServiceIdentity",
                 "serializationOptions": {
                   "json": {
                     "name": "something"
@@ -9985,7 +9985,7 @@
                 "discriminator": false,
                 "flatten": false,
                 "decorators": [],
-                "crossLanguageDefinitionId": "MgmtTypeSpec.FooProperties.writableSubResourceProp",
+                "crossLanguageDefinitionId": "Azure.ResourceManager.Models.WritableSubResource",
                 "serializationOptions": {
                   "json": {
                     "name": "writableSubResourceProp"
@@ -14017,7 +14017,7 @@
           "discriminator": false,
           "flatten": false,
           "decorators": [],
-          "crossLanguageDefinitionId": "MgmtTypeSpec.ZooAddressListListResult.value",
+          "crossLanguageDefinitionId": "TypeSpec.Array",
           "serializationOptions": {
             "json": {
               "name": "value"

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260819.3",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260819.14"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260825.4",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260825.9"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.44",
@@ -18,7 +18,7 @@
         "@azure-tools/typespec-azure-core": "0.71.0",
         "@azure-tools/typespec-azure-resource-manager": "0.71.0",
         "@azure-tools/typespec-azure-rulesets": "0.71.0",
-        "@azure-tools/typespec-client-generator-core": "0.71.1",
+        "@azure-tools/typespec-client-generator-core": "0.71.2",
         "@azure-tools/typespec-liftr-base": "0.14.0",
         "@eslint/js": "^10.0.1",
         "@types/node": "~26.0.1",
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.71.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.71.1.tgz",
-      "integrity": "sha512-OQsNmNID1OTRqO2EUfHNO0cTRn44tMKVfNrNfVcdBGJv5scsin8U+KiR90M/5nbTqOsGPXSxxExVl7yMuuGk2g==",
+      "version": "0.71.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.71.2.tgz",
+      "integrity": "sha1-iAiQErwq2e8JIHO1qRMVbM/2CaE=",
       "license": "MIT",
       "dependencies": {
         "change-case": "^5.4.4",
@@ -271,12 +271,12 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260819.3",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260819.3.tgz",
-      "integrity": "sha1-Ptb19vgE2CO1y0qtk9vG2VPknMY=",
+      "version": "1.0.0-alpha.20260825.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260825.4.tgz",
+      "integrity": "sha1-ni8z4rKgP2woBkldGIk3QRp7LPw=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260819.14"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260825.9"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2201,16 +2201,16 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260819.14",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260819.14.tgz",
-      "integrity": "sha512-FlHV1gfF6IhdHTqI3HOAdCpaxFZ7GKCwepKtBtHWcYHrbpGX1a5dkWj1i+EmxLN9JbxoylFs/e6NsEcFyizDCQ==",
+      "version": "1.0.0-alpha.20260825.9",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260825.9.tgz",
+      "integrity": "sha1-fTijGIv58R2aE4kol3ezIijJOXU=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.0"
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.71.0 <0.72.0 || ~0.72.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.71.1 <0.72.0 || ~0.72.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.71.2 <0.72.0 || ~0.72.0-0",
         "@typespec/compiler": "^1.15.0",
         "@typespec/events": ">=0.85.0 <0.86.0 || ~0.86.0-0",
         "@typespec/http": "^1.15.0",

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -38,8 +38,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260819.3",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260819.14"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260825.4",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260825.9"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.44",
@@ -47,7 +47,7 @@
     "@azure-tools/typespec-azure-core": "0.71.0",
     "@azure-tools/typespec-azure-resource-manager": "0.71.0",
     "@azure-tools/typespec-azure-rulesets": "0.71.0",
-    "@azure-tools/typespec-client-generator-core": "0.71.1",
+    "@azure-tools/typespec-client-generator-core": "0.71.2",
     "@azure-tools/typespec-liftr-base": "0.14.0",
     "@eslint/js": "^10.0.1",
     "@types/node": "~26.0.1",


### PR DESCRIPTION
Splits the management emitter base version bump out of #61958 so the dependency update can be reviewed and merged independently of the dynamic-model fix. Same pattern as #62284.

### Version changes

| Reference | Before | After |
| --- | --- | --- |
| `@azure-typespec/http-client-csharp` (mgmt `package.json`) | `1.0.0-alpha.20260819.3` | `1.0.0-alpha.20260825.4` |
| `@typespec/http-client-csharp` (mgmt `package.json`) | `1.0.0-alpha.20260819.14` | `1.0.0-alpha.20260825.9` |
| `AzureGeneratorVersion` (`Directory.Generation.Packages.props`) | `1.0.0-alpha.20260819.3` | `1.0.0-alpha.20260825.4` |
| `@azure-tools/typespec-client-generator-core` | `0.71.1` | `0.71.2` |

`20260825.4` is the version already pinned in `eng/azure-typespec-http-client-csharp-emitter-package.json` on `main`, which the `bump-mgmt-base-version` skill defines as the target. `20260825.9` is that package's own declared dependency, so the chain stays consistent. `UnbrandedGeneratorVersion` is untouched — `main` already carries `20260825.9`.

The TCGC bump is required, not cosmetic: `@typespec/http-client-csharp@20260825.9` declares a peer of `>=0.71.2 <0.72.0`, so `npm install` fails `ERESOLVE` without it. `0.71.2` is what `eng/packages/http-client-csharp/package.json` already pins.

### Naming behavior change

`NameVisitorTests.TestTransformTimePropertyName` asserted `StartTime` -> `StartOn`. The new base emitter produces `StartsOn`, which is the intended behavior from microsoft/typespec#11751 ("normalize date-time `Start*` and `End*` names to `StartsOn` and `EndsOn`"), itself a response to feedback on #62390.

The old assertion derived its expectation mechanically (`testPropertyName.Replace("Time", "On")`), so it only ever covered one input and encoded the naive transform. It is replaced with explicit cases pinning the observable contract:

| Input | Result |
| --- | --- |
| `StartTime` / `EndTime` | `StartsOn` / `EndsOn` |
| `CreationTime` / `ExpirationTime` / `ModificationTime` | `CreatedOn` / `ExpiresOn` / `ModifiedOn` |
| `DeletionDate` | `DeletedOn` |
| `LastModifiedTime` / `FirstSeenTime` | `LastModifiedOn` / `FirstSeenOn` |
| `TestDate` / `TestDateTime` | `TestOn` |
| `FromTime` / `ToTime` / `RestorePointInTime` | unchanged |
| `Time` / `Date` | unchanged |

Coverage added for `utcDateTime` (identical results to `plainDate`, since the rename keys off the input type rather than the mapped C# type) and for a non-date-time property being left alone. 277 -> 297 tests.

Worth flagging for review: disabling `DoPreVisitPropertyForTimePropertyName` in `NameVisitor` no longer changes any of these results — the base emitter now covers every case, including the `From`/`To`/`PointInTime` exclusions. I did **not** remove it here. `IsDateTimeInputType` deliberately inspects the input type so the rename survives mappings like `BicepValue<DateTimeOffset>`, and the provisioning generator is a downstream consumer that this test project does not exercise. Removing it belongs in its own change with provisioning validation.

### Other regenerated output

- `tspCodeModel.json`: four property entries now report the type's `crossLanguageDefinitionId` (e.g. `TypeSpec.Array`, `Azure.ResourceManager.Models.SubResource`) instead of the property path. Upstream TCGC behavior change; **no generated C# changed**.
- `README.md` / `docs/emitter.md`: regenerated `api-version` option text from the new base emitter.
- `resource-detection.ts` / `sdk-context-options.ts`: whitespace only. This is pre-existing prettier drift on `main` (same prettier 3.9.6 before and after), so `npm run prettier` fails on `main` today. Fixed here because this PR touches the emitter package and would otherwise inherit the red check.

### Emitter version dashboard link check

The first push failed the markdown link check. The dashboard rendered each version cell as a link to `https://www.npmjs.com/package/<pkg>/v/<version>`, and npmjs.com blocks automated requests — all four such URLs, including the bare package page, return `403` to a non-browser client.

This was a latent trap rather than anything specific to this bump. The **Latest on npm** column tracks a moving target, so every regeneration after a new publish mints a fresh URL that is absent from the link cache and therefore actually checked. `eng/ignore-links.txt` cannot cover it either: `Verify-Links.ps1` matches entries by exact string, so a domain-level entry has no effect while the exact URLs change on every run. `Test-NpmVersionExists` only proved the version existed in the *registry*, which says nothing about whether the *website* serves it to a bot.

The linking was also nondeterministic — emitted only when the operator's `npm view` calls succeeded, which is why the checked-in copy on `main` has plain text while a local regen produced links.

Versions are now rendered as plain text, matching the format already checked in on `main`, and the two unused helpers are removed. The remaining links are GitHub commit links, which verify fine. Confirmed locally: `Verify-Links.ps1` reports *"Checked 7 links. No broken links found."*, exit code 0.

### Validation

- `npm install`, `npm run build:emitter`, `npm run build:generator` — clean, no breaking API changes
- `npm run lint`, `npm run prettier` — pass
- `npm test` (emitter) — 145/145
- `dotnet test Azure.Generator.Mgmt.Tests` — 297/297
- `eng/scripts/Generate.ps1` — regenerated, no generated C# diff
- `doc/GeneratorVersions/Emitter_Version_Dashboard.ps1` — refreshed
- `eng/common/scripts/Verify-Links.ps1` on the three changed `.md` files — no broken links
