### PR TITLE
[mgmt] Make the model factory doc indentation regression test non-vacuous

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -263,12 +263,26 @@ namespace Azure.Generator.Mgmt.Tests
         [Test]
         public void RestoredFactoryMethodDocumentationIsIndependentOfLastContractIndentation()
         {
-            var firstDocs = DescribeDocs(BuildRestoredMethodWithUnmatchedParameter(
+            // The indentation is varied on a parameter that still maps to the model as well as one that does not,
+            // so this cannot pass merely because unmatched text is discarded.
+            var firstDocs = DescribeDocs(BuildRestoredMethodWithIndentedLegacyDocs(
+                $"Previous parameter summary.\n            Previous parameter details.",
                 $"Legacy parameter summary.\n             - First item.\n            Legacy parameter details."));
-            var secondDocs = DescribeDocs(BuildRestoredMethodWithUnmatchedParameter(
+            var secondDocs = DescribeDocs(BuildRestoredMethodWithIndentedLegacyDocs(
+                $"Previous parameter summary.\n                        Previous parameter details.",
                 $"Legacy parameter summary.\n                         - First item.\n                        Legacy parameter details."));
 
             Assert.That(secondDocs, Is.EqualTo(firstDocs));
+
+            // The matched parameter is documented from the current model regardless of how the last contract was
+            // indented, and no rendered line carries the writer's indentation. That growth is the #62444 regression.
+            Assert.That(firstDocs, Does.Contain("Current parameter summary."));
+            Assert.That(firstDocs, Does.Contain("Current parameter details."));
+            Assert.That(firstDocs, Does.Not.Contain("Previous parameter details."));
+            Assert.That(
+                firstDocs.Split('\n').Any(line => line.StartsWith("      ")),
+                Is.False,
+                "regenerated documentation must not carry the last contract's continuation indentation");
         }
 
         [Test]
@@ -522,6 +536,44 @@ namespace Azure.Generator.Mgmt.Tests
                 model.Type,
                 "legacyValue",
                 parameterDescription);
+
+            Assert.That(
+                Management.Visitors.ModelFactoryBackwardCompatHelper.TryCreateBackwardCompatMethod(
+                    previousMethod,
+                    modelFactory,
+                    out var restoredMethod),
+                Is.True);
+
+            return restoredMethod!;
+        }
+
+        private static MethodProvider BuildRestoredMethodWithIndentedLegacyDocs(
+            FormattableString matchedLegacyDescription,
+            FormattableString unmatchedLegacyDescription)
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("value", InputPrimitiveType.String)]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
+            var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            model.FullConstructor.Signature.Parameters.Single(parameter => parameter.Name == "value")
+                .Update(description: $"Current parameter summary.\nCurrent parameter details.");
+
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+            var previousSignature = new MethodSignature(
+                "TestModel",
+                $"Previous model summary.",
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                model.Type,
+                $"Previous return summary.",
+                [
+                    new ParameterProvider("value", matchedLegacyDescription, typeof(string)),
+                    new ParameterProvider("legacyValue", unmatchedLegacyDescription, typeof(string))
+                ]);
+            var lastContractView = new TestModelFactoryView(modelFactory.Name);
+            var previousMethod = new MethodProvider(previousSignature, MethodBodyStatement.Empty, lastContractView);
 
             Assert.That(
                 Management.Visitors.ModelFactoryBackwardCompatHelper.TryCreateBackwardCompatMethod(


### PR DESCRIPTION
Follow-up to #62446, which merged before this test change landed.

### Problem

`RestoredFactoryMethodDocumentationIsIndependentOfLastContractIndentation` varied the indentation of an **unmatched** parameter only. Since #62446 drops the description for parameters that no longer map to the current model, both inputs collapsed to the same empty string, so the equality assertion held for a reason unrelated to the property being tested. It would have kept passing even if matched parameters started reusing last-contract text again — which is precisely the regression in #62444.

Raised by the Copilot reviewer on #62446 (["The indentation regression test also passes trivially because both inputs are discarded"](https://github.com/Azure/azure-sdk-for-net/pull/62446#discussion_r3864494532)).

### Change

The test now varies the indentation of a parameter that **still maps to the model** as well as one that does not, and adds two assertions beyond the equality check:

- the matched parameter is documented from the current model (`Current parameter summary.` / `Current parameter details.`) and not from the last contract;
- no rendered documentation line carries the writer's continuation indentation:

```csharp
Assert.That(
    firstDocs.Split('\n').Any(line => line.StartsWith("      ")),
    Is.False,
    "regenerated documentation must not carry the last contract's continuation indentation");
```

That last assertion is the direct encoding of the growth reported in #62444, where the affected `<param>` blocks gained 12 spaces per regeneration.

Test-only change; no generator behavior is modified.

### Verification

303/303 passing on top of `main`.

Mutation-tested rather than eyeballed. Changing the source so matched parameters reuse the last-contract description — the original bug — now fails three tests:

```
Failed RestoredFactoryMethodDocumentationIsIndependentOfLastContractIndentation
Failed RestoredFactoryMethodDocumentationSurvivesBackwardCompatOverloadFixup
Failed RestoredFactoryMethodRegeneratesDocumentationFromCurrentModel
```

The previous version of the indentation test could not fail that way, because it contained no matched parameter.