### PR TITLE
Clean up Container Service spelling exceptions

### DIFF
--- a/sdk/containerservice/cspell.yaml
+++ b/sdk/containerservice/cspell.yaml
@@ -6,37 +6,12 @@ words:
 overrides:
   - filename: '**/sdk/containerservice/Azure.ResourceManager.ContainerService/**/*.cs'
     words:
-      - aksadvancednetworking
-      - distros
       - dranet
-      - iloveyou
-      - inodes
-      - karpenter
-      - krustlet
-      - kubeconfig
-      - kubeletidentity
-      - millicores
-      - numa
-      - reimaging
-      - rmem
-      - snat
   - filename: '**/sdk/containerservice/Azure.Provisioning.ContainerService/**/*.cs'
     words:
       - aksadvancednetworking
-      - aren
-      - doesn
-      - iloveyou
       - karpenter
-      - kata
       - krustlet
-      - kubeletidentity
-      - numa
-      - ossku
       - reimaged
-      - reimaging
-      - rmem
       - schedulable
-      - snat
-      - tcpkeepalive
-      - undrainable
-      - vtpm
+      - trycep


### PR DESCRIPTION
## Description

Cleans up the Container Service cspell overrides called out in https://github.com/Azure/azure-sdk-for-net/pull/62362#discussion_r3869219951.

- Keeps only the management-plane term introduced by the API update.
- Removes stale provisioning exceptions and adds the shared provisioning test helper term.