### PR TITLE
ContainerService: fix stable TypeSpec release provenance

### DIFF
--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/tsp-location.yaml
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/containerservice/resource-manager/Microsoft.ContainerService/aks
-commit: a94a6f6fd978a5ebbcba1c5672ea72b7881cddf3
+commit: f4e9802a2e707b2f7e05186c6ddde89a00b79ccd
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 
 


### PR DESCRIPTION
## Summary

Point `Azure.ResourceManager.ContainerService` at the merged 2026-06 TypeSpec commit on `azure-rest-api-specs/main`.

## Why

Stable release build 6753225 passed APIView validation, build, signing, and integration, then failed its release-tag provenance check because `tsp-location.yaml` referenced synthetic PR merge commit `a94a6f6fd978a5ebbcba1c5672ea72b7881cddf3`. That commit is not on specs `main`.

The replacement `f4e9802a2e707b2f7e05186c6ddde89a00b79ccd` is the authoritative merge commit for azure-rest-api-specs PR 44949, is on `main`, and contains stable `2026-06-01` plus preview `2026-06-02-preview`.

## Validation

- `git diff --check`
- Verified `f4e9802a2e707b2f7e05186c6ddde89a00b79ccd` is an ancestor of current `azure-rest-api-specs/main`.
- Confirmed the change is limited to the `commit` field in the package `tsp-location.yaml`.