### PR TITLE
[Key Vault] Fix NullReferenceException on CAE claims challenge with an uncached authority

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
+
 ### Other Changes
 
 ## 4.9.0-beta.1 (2026-06-04)

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
+
 ### Other Changes
 
 - Internal: the `CertificateClient` transport now delegates to a TypeSpec-generated implementation. All public method signatures, return types, exception contracts, default service version, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are unchanged for existing callers. `CertificateClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end into the new pipeline. A small set of additive types from the new transport layer (`AzureSecurityKeyVaultCertificatesContext`, `KeyVaultCertificatesModelFactory`, and `IJsonModel<PlatformManaged>` / `IPersistableModel<PlatformManaged>` on `PlatformManaged`) appears on the public surface; these are net additions that existing customer code is unaffected by — same pattern as `Azure.Security.KeyVault.Administration`.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
+
 ### Other Changes
 
 ## 4.11.0-beta.3 (2026-07-16)

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
+
 ### Other Changes
 
 - Internal: the `SecretClient` transport now delegates to a TypeSpec-generated implementation. Public API surface, default service version, exception contracts, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are all unchanged. `SecretClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end. The TypeSpec emitter incidentally adds one additive public type (`AzureSecurityKeyVaultSecretsContext`, the `ModelReaderWriterContext` required for AOT-friendly `ModelReaderWriter` round-trip), matching the sibling `Azure.Security.KeyVault.Administration` package convention.

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -251,6 +251,26 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.IsNull(ChallengeBasedAuthenticationPolicy.getDecodedClaimsParameter(null, response401));
         }
 
+        [Test]
+        public void HandlesCaeChallengeWhenChallengeCacheIsEmpty()
+        {
+            // Regression: a CAE (insufficient_claims) challenge received for an authority that is not
+            // yet in the challenge cache must surface the service failure rather than throwing a
+            // NullReferenceException. Previously the claims branch dereferenced the null cached
+            // challenge on a cache miss.
+            MockTransport transport = new(new[]
+            {
+                new MockResponse(401).WithHeader(
+                    "WWW-Authenticate",
+                    @"Bearer realm="""", authorization_uri=""https://login.microsoftonline.com/common/oauth2/authorize"", error=""insufficient_claims"", claims=""eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiY3AxIn19fQ=="""),
+            });
+
+            SecretClientOptions options = new() { Transport = transport };
+            SecretClient client = new(VaultUri, new MockCredential(transport), options);
+
+            // Must surface as a service failure (401), not a NullReferenceException.
+            Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetSecretAsync("test-secret"));
+        }
         private class MockTransportBuilder
         {
             private const string AuthorizationHeader = "Authorization";

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -273,6 +273,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
                 async () => await client.GetSecretAsync("test-secret"));
             Assert.AreEqual(401, ex.Status);
         }
+
         private class MockTransportBuilder
         {
             private const string AuthorizationHeader = "Authorization";

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -268,8 +268,10 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             SecretClientOptions options = new() { Transport = transport };
             SecretClient client = new(VaultUri, new MockCredential(transport), options);
 
-            // Must surface as a service failure (401), not a NullReferenceException.
-            Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetSecretAsync("test-secret"));
+            // Must surface as the service 401, not a NullReferenceException.
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(
+                async () => await client.GetSecretAsync("test-secret"));
+            Assert.AreEqual(401, ex.Status);
         }
         private class MockTransportBuilder
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -132,9 +132,12 @@ namespace Azure.Security.KeyVault
             string claims = getDecodedClaimsParameter(error, message.Response);
             if (claims != null)
             {
-                // Get the scope from the cache
-                s_challengeCache.TryGetValue(authority, out _challenge);
-                scope = _challenge.Scopes[0];
+                // Reuse the cached scope for this authority when present; on a cache miss keep the
+                // scope parsed from this response instead of dereferencing a null challenge.
+                if (s_challengeCache.TryGetValue(authority, out _challenge))
+                {
+                    scope = _challenge.Scopes[0];
+                }
             }
 
             if (scope is null)
@@ -173,6 +176,11 @@ namespace Azure.Security.KeyVault
 
                 _challenge = new ChallengeParameters(authorizationUri, new string[] { scope });
                 s_challengeCache[authority] = _challenge;
+            }
+
+            if (_challenge is null)
+            {
+                return false;
             }
 
             var context = new TokenRequestContext(_challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: _challenge.TenantId, isCaeEnabled: true, claims: claims);

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -132,20 +132,20 @@ namespace Azure.Security.KeyVault
             string claims = getDecodedClaimsParameter(error, message.Response);
             if (claims != null)
             {
-                // Reuse the cached scope for this authority when present; on a cache miss keep the
-                // scope parsed from this response instead of dereferencing a null challenge.
-                if (s_challengeCache.TryGetValue(authority, out _challenge))
+                // Reuse the cached scope for this authority when one is present; on a cache miss there
+                // is no scope to reuse, so fall through and surface the challenge below.
+                if (s_challengeCache.TryGetValue(authority, out ChallengeParameters cached))
                 {
+                    _challenge = cached;
                     scope = _challenge.Scopes[0];
                 }
             }
 
             if (scope is null)
             {
-                if (s_challengeCache.TryGetValue(authority, out _challenge))
-                {
-                    return false;
-                }
+                // No scope from this challenge or the cache - surface the service failure rather than
+                // building a token request context from a null challenge.
+                return false;
             }
             else
             {
@@ -176,11 +176,6 @@ namespace Azure.Security.KeyVault
 
                 _challenge = new ChallengeParameters(authorizationUri, new string[] { scope });
                 s_challengeCache[authority] = _challenge;
-            }
-
-            if (_challenge is null)
-            {
-                return false;
             }
 
             var context = new TokenRequestContext(_challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: _challenge.TenantId, isCaeEnabled: true, claims: claims);


### PR DESCRIPTION
## Summary

Fixes a `NullReferenceException` in the Key Vault challenge-based authentication policy that occurs when a Continuous Access Evaluation (CAE) `insufficient_claims` challenge is received for an authority that is **not yet in the challenge cache**.

In `ChallengeBasedAuthenticationPolicy.AuthorizeRequestOnChallengeAsyncInternal`, the CAE claims branch looked the authority up in the cache and dereferenced the result unconditionally:

    s_challengeCache.TryGetValue(authority, out _challenge);
    scope = _challenge.Scopes[0];   // NRE when the authority is not cached

On a cache miss `_challenge` is `null`, so `_challenge.Scopes[0]` throws. A second latent NRE existed a few lines later where the `TokenRequestContext` was built from `_challenge.Scopes` without a null check.

## Fix

- Read the cached scope only when the cache lookup succeeds.
- Return `false` (surface the service challenge) when no challenge can be resolved, instead of building a token request context from a null challenge.

Both are minimal, surgical changes in the shared policy.

## Tests

Adds `HandlesCaeChallengeWhenChallengeCacheIsEmpty`, which sends a CAE `insufficient_claims` challenge against an empty challenge cache and asserts the request surfaces as `RequestFailedException` (401) rather than `NullReferenceException`. Verified it **fails** against the pre-fix policy (throws the NRE) and passes after the fix.

## Packages

The fix lives in `Azure.Security.KeyVault.Shared`, which is compiled into all four Key Vault packages. Changelog entries added to **Secrets**, **Keys**, **Certificates**, and **Administration**.
