### PR TITLE
Prepare release 5.3.9 for Microsoft.Azure.WebJobs.Extensions.Storage, Blobs, and Queues

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Release History
 
-## 5.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.3.9 (2026-09-08)
 
 ### Bugs Fixed
 
+- Fixed queue scale metrics reporting `QueueLength=0` when messages were present but could not be decoded with the configured `MessageEncoding`, which prevented affected functions from scaling out. Scale metrics now read the queue using `QueueMessageEncoding.None`, so peek results are never filtered by decode failures. Message processing is unaffected and continues to use the configured encoding.
+- Fixed a bug where a failed `PeekMessages` call reset the reported queue length to zero instead of preserving `ApproximateMessagesCount`, which could cause premature scale-in while the queue still had messages.
+
 ### Other Changes
+
+- Replaced scaling warning/error log calls with the standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics.
 
 ## 5.3.8 (2026-03-19)
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -2,14 +2,8 @@
 
 ## 5.3.9 (2026-09-08)
 
-### Bugs Fixed
-
-- Fixed queue scale metrics reporting `QueueLength=0` when messages were present but could not be decoded with the configured `MessageEncoding`, which prevented affected functions from scaling out. Scale metrics now read the queue using `QueueMessageEncoding.None`, so peek results are never filtered by decode failures. Message processing is unaffected and continues to use the configured encoding.
-- Fixed a bug where a failed `PeekMessages` call reset the reported queue length to zero instead of preserving `ApproximateMessagesCount`, which could cause premature scale-in while the queue still had messages.
-
 ### Other Changes
-
-- Replaced scaling warning/error log calls with the standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics.
+- This release contains bug fixes to improve quality.
 
 ## 5.3.8 (2026-03-19)
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>5.4.0-beta.1</Version>
+    <Version>5.3.9</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.3.8</ApiCompatVersion>
 		<Description>This extension adds bindings for Storage</Description>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 5.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.3.9 (2026-09-08)
 
 ### Bugs Fixed
 
 - Fixed queue scale metrics reporting `QueueLength=0` when messages were present but could not be decoded with the configured `MessageEncoding`, which prevented affected functions from scaling out. Scale metrics now read the queue using `QueueMessageEncoding.None`, so peek results are never filtered by decode failures. Message processing is unaffected and continues to use the configured encoding.
+- Fixed a bug where a failed `PeekMessages` call reset the reported queue length to zero instead of preserving `ApproximateMessagesCount`, which could cause premature scale-in while the queue still had messages.
 
 ### Other Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>5.4.0-beta.1</Version>
+    <Version>5.3.9</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.3.8</ApiCompatVersion>
     <Description>This extension adds bindings for Storage</Description>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 5.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 5.3.9 (2026-09-08)
 
 ### Other Changes
+Please refer to [`Microsoft.Azure.WebJobs.Extension.Storage.Blobs`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md) and [`Microsoft.Azure.WebJobs.Extension.Storage.Queues`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md) for detailed list of changes.
 
 ## 5.3.8 (2026-03-19)
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/src/Microsoft.Azure.WebJobs.Extensions.Storage.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/src/Microsoft.Azure.WebJobs.Extensions.Storage.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>5.4.0-beta.1</Version>
+    <Version>5.3.9</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.3.8</ApiCompatVersion>
     <RunApiCompat>false</RunApiCompat>


### PR DESCRIPTION
Prepares the 5.3.9 patch release for the three WebJobs Storage extension packages.

## Packages

| Package | Version |
|---|---|
| Microsoft.Azure.WebJobs.Extensions.Storage | 5.3.8 -> 5.3.9 |
| Microsoft.Azure.WebJobs.Extensions.Storage.Blobs | 5.3.8 -> 5.3.9 |
| Microsoft.Azure.WebJobs.Extensions.Storage.Queues | 5.3.8 -> 5.3.9 |

## What is in the release

Three queue scale-metrics fixes that merged after 5.3.8 shipped:

- #61833 - queue scale metrics reported `QueueLength=0` when messages were present but could not be decoded with the configured `MessageEncoding`, which prevented affected functions from scaling out.
- #57518 - a failed `PeekMessages` call reset the reported queue length to zero instead of preserving `ApproximateMessagesCount`, which could cause premature scale-in.
- #53923 - scaling warning/error log calls replaced with the standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics.

## Why Blobs is included

All three fixes live under `Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/`. Both Blobs and Queues compile that directory as shared source:

```xml
<Compile Include="$(AzureStorageWebjobsExtensionSharedSources)\**\*.cs" LinkBase="Shared" />
```

so the Blobs assembly changes as well, even though no file under `Blobs/src` was modified in those PRs. Files touched: `QueueMetricsProvider.cs`, `QueueListener.cs`, `QueueScaleMonitor.cs`, `QueueTargetScaler.cs`.

The metapackage changelog uses the standard "please refer to Blobs and Queues" pointer, consistent with 5.3.1 through 5.3.7.

## Scope

Only `<Version>` bumps and CHANGELOG entries. No source changes in this PR. `ApiCompatVersion` remains 5.3.8 for all three.


The Blobs changelog uses the standard quality boilerplate rather than repeating the queue-specific fixes, matching the convention used in 5.3.2 and 5.3.4. The queue fixes are enumerated in the Queues changelog.
