### PR TITLE
Fix PublicIPPrefixData public IP address preservation

### DIFF
--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/ArmNetworkModelFactory.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/ArmNetworkModelFactory.cs
@@ -17,6 +17,7 @@ namespace Azure.ResourceManager.Network.Models
     [CodeGenSuppress("EffectiveBaseSecurityAdminRule", typeof(ResourceIdentifier), typeof(string), typeof(string), typeof(IEnumerable<NetworkManagerSecurityGroupItem>), typeof(IEnumerable<NetworkConfigurationGroup>), typeof(string))]
     [CodeGenSuppress("PeerRouteList", typeof(string), typeof(string), typeof(string), typeof(string), typeof(string), typeof(string), typeof(int?))]
     [CodeGenSuppress("EffectiveNetworkSecurityGroup", typeof(ResourceIdentifier), typeof(EffectiveNetworkSecurityGroupAssociation), typeof(IEnumerable<EffectiveNetworkSecurityRule>), typeof(string))]
+    [CodeGenSuppress("PublicIPPrefixData", typeof(ResourceIdentifier), typeof(string), typeof(ResourceType?), typeof(AzureLocation?), typeof(IDictionary<string, string>), typeof(ExtendedLocation), typeof(PublicIPPrefixSku), typeof(ETag?), typeof(IEnumerable<string>), typeof(NetworkIPVersion?), typeof(IEnumerable<IPTag>), typeof(int?), typeof(string), typeof(IEnumerable<SubResource>), typeof(ResourceIdentifier), typeof(ResourceIdentifier), typeof(Guid?), typeof(NetworkProvisioningState?), typeof(NatGatewayData))]
     // The generated factory signature includes the internal ApplicationGatewayForContainersReferenceDefinition helper type,
     // which would make a public method less accessible than one of its parameters.
     [CodeGenSuppress("WebApplicationFirewallPolicyData", typeof(ResourceIdentifier), typeof(string), typeof(string), typeof(AzureLocation?), typeof(IDictionary<string, string>), typeof(PolicySettings), typeof(IEnumerable<WebApplicationFirewallCustomRule>), typeof(IEnumerable<ApplicationGatewayData>), typeof(NetworkProvisioningState?), typeof(WebApplicationFirewallPolicyResourceState?), typeof(ManagedRulesDefinition), typeof(IEnumerable<WritableSubResource>), typeof(IEnumerable<WritableSubResource>), typeof(IEnumerable<ApplicationGatewayForContainersReferenceDefinition>), typeof(ETag?))]
@@ -89,6 +90,56 @@ namespace Azure.ResourceManager.Network.Models
                 result.Rules.Add(item);
             }
             return result;
+        }
+
+        /// <summary> Initializes a new instance of <see cref="Network.PublicIPPrefixData"/>. </summary>
+        /// <param name="id"> Resource ID. </param>
+        /// <param name="name"> Resource name. </param>
+        /// <param name="resourceType"> Resource type. </param>
+        /// <param name="location"> Resource location. </param>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="extendedLocation"> The extended location of the public ip address. </param>
+        /// <param name="sku"> The public IP prefix SKU. </param>
+        /// <param name="etag"> A unique read-only string that changes whenever the resource is updated. </param>
+        /// <param name="zones"> A list of availability zones denoting the IP allocated for the resource needs to come from. </param>
+        /// <param name="publicIPAddressVersion"> The public IP address version. </param>
+        /// <param name="ipTags"> The list of tags associated with the public IP prefix. </param>
+        /// <param name="prefixLength"> The Length of the Public IP Prefix. </param>
+        /// <param name="ipPrefix"> The allocated Prefix. </param>
+        /// <param name="publicIPAddresses"> The list of all referenced PublicIPAddresses. </param>
+        /// <param name="loadBalancerFrontendIPConfigurationId"> The reference to load balancer frontend IP configuration associated with the public IP prefix. </param>
+        /// <param name="customIPPrefixId"> The customIpPrefix that this prefix is associated with. </param>
+        /// <param name="resourceGuid"> The resource GUID property of the public IP prefix resource. </param>
+        /// <param name="provisioningState"> The provisioning state of the public IP prefix resource. </param>
+        /// <param name="natGateway"> NatGateway of Public IP Prefix. </param>
+        /// <returns> A new <see cref="Network.PublicIPPrefixData"/> instance for mocking. </returns>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static PublicIPPrefixData PublicIPPrefixData(ResourceIdentifier id = default, string name = default, ResourceType? resourceType = default, AzureLocation? location = default, IDictionary<string, string> tags = default, ExtendedLocation extendedLocation = default, PublicIPPrefixSku sku = default, ETag? etag = default, IEnumerable<string> zones = default, NetworkIPVersion? publicIPAddressVersion = default, IEnumerable<IPTag> ipTags = default, int? prefixLength = default, string ipPrefix = default, IEnumerable<SubResource> publicIPAddresses = default, ResourceIdentifier loadBalancerFrontendIPConfigurationId = default, ResourceIdentifier customIPPrefixId = default, Guid? resourceGuid = default, NetworkProvisioningState? provisioningState = default, NatGatewayData natGateway = default)
+        {
+            return new PublicIPPrefixData(
+                id,
+                name,
+                default,
+                location,
+                tags ?? new ChangeTrackingDictionary<string, string>(),
+                default,
+                publicIPAddressVersion is null && ipTags is null && prefixLength is null && ipPrefix is null && publicIPAddresses is null && loadBalancerFrontendIPConfigurationId is null && customIPPrefixId is null && resourceGuid is null && provisioningState is null && natGateway is null ? default : new PublicIPPrefixPropertiesFormat(
+                    publicIPAddressVersion,
+                    (ipTags ?? new ChangeTrackingList<IPTag>()).ToList(),
+                    prefixLength,
+                    ipPrefix,
+                    (publicIPAddresses ?? Enumerable.Empty<SubResource>()).Select(item => item is null ? default : new ReferencedPublicIpAddress(item.Id?.ToString(), default)).ToList(),
+                    new NetworkSubResource(loadBalancerFrontendIPConfigurationId, default),
+                    new NetworkSubResource(customIPPrefixId, default),
+                    resourceGuid,
+                    provisioningState,
+                    natGateway,
+                    default,
+                    default),
+                extendedLocation,
+                sku,
+                etag,
+                (zones ?? new ChangeTrackingList<string>()).ToList());
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PeerRoute"/>. </summary>

--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/PublicIPPrefixData.RemainingMemberCompatibility.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/PublicIPPrefixData.RemainingMemberCompatibility.cs
@@ -16,7 +16,7 @@ namespace Azure.ResourceManager.Network
     [CodeGenSuppress("PublicIPAddresses")]
     public partial class PublicIPPrefixData
     {
-        /// <summary> Gets or sets the PublicIPAddresses compatibility property. </summary>
+        /// <summary> Gets the PublicIPAddresses compatibility property. </summary>
         public IReadOnlyList<SubResource> PublicIPAddresses => Properties is null
             ? Array.Empty<SubResource>()
             : new ReadOnlyReferencedPublicIpAddressList(Properties.PublicIPAddresses);

--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/PublicIPPrefixData.RemainingMemberCompatibility.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/PublicIPPrefixData.RemainingMemberCompatibility.cs
@@ -17,6 +17,8 @@ namespace Azure.ResourceManager.Network
     public partial class PublicIPPrefixData
     {
         /// <summary> Gets or sets the PublicIPAddresses compatibility property. </summary>
-        public IReadOnlyList<SubResource> PublicIPAddresses { get; } = new global::System.Collections.Generic.List<SubResource>();
+        public IReadOnlyList<SubResource> PublicIPAddresses => Properties is null
+            ? Array.Empty<SubResource>()
+            : new ReadOnlyReferencedPublicIpAddressList(Properties.PublicIPAddresses);
     }
 }

--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/ReadOnlyReferencedPublicIpAddressList.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/ReadOnlyReferencedPublicIpAddressList.cs
@@ -5,7 +5,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using Azure.Core;
 using Azure.ResourceManager.Network.Models;
 using Azure.ResourceManager.Resources.Models;
 

--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/ReadOnlyReferencedPublicIpAddressList.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/ReadOnlyReferencedPublicIpAddressList.cs
@@ -5,6 +5,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using Azure.Core;
 using Azure.ResourceManager.Network.Models;
 using Azure.ResourceManager.Resources.Models;
 

--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/ReadOnlyReferencedPublicIpAddressList.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/ReadOnlyReferencedPublicIpAddressList.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System.Collections;
+using System.Collections.Generic;
+using Azure.Core;
+using Azure.ResourceManager.Network.Models;
+using Azure.ResourceManager.Resources.Models;
+
+namespace Azure.ResourceManager.Network
+{
+    internal sealed class ReadOnlyReferencedPublicIpAddressList : IReadOnlyList<SubResource>
+    {
+        private readonly IReadOnlyList<ReferencedPublicIpAddress> _source;
+
+        public ReadOnlyReferencedPublicIpAddressList(IReadOnlyList<ReferencedPublicIpAddress> source) => _source = source;
+
+        public int Count => _source.Count;
+
+        public SubResource this[int index] => ToSubResource(_source[index]);
+
+        public IEnumerator<SubResource> GetEnumerator()
+        {
+            foreach (ReferencedPublicIpAddress item in _source)
+            {
+                yield return ToSubResource(item);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private static SubResource ToSubResource(ReferencedPublicIpAddress value) => value is null
+            ? default
+            : new ReferencedSubResource(value.Id is null ? default : new ResourceIdentifier(value.Id));
+
+        private sealed class ReferencedSubResource : SubResource
+        {
+            public ReferencedSubResource(ResourceIdentifier id) : base(id)
+            {
+            }
+        }
+    }
+}

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/ArmNetworkModelFactory.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/ArmNetworkModelFactory.cs
@@ -17886,56 +17886,6 @@ namespace Azure.ResourceManager.Network.Models
             return new PrivateDnsZoneGroupData(id, default, name, default, provisioningState is null && privateDnsZoneConfigs is null ? default : new PrivateDnsZoneGroupPropertiesFormat(provisioningState, (privateDnsZoneConfigs ?? new ChangeTrackingList<PrivateDnsZoneConfig>()).ToList(), default));
         }
 
-        /// <summary> Initializes a new instance of <see cref="Network.PublicIPPrefixData"/>. </summary>
-        /// <param name="id"> Resource ID. </param>
-        /// <param name="name"> Resource name. </param>
-        /// <param name="resourceType"> Resource type. </param>
-        /// <param name="location"> Resource location. </param>
-        /// <param name="tags"> Resource tags. </param>
-        /// <param name="extendedLocation"> The extended location of the public ip address. </param>
-        /// <param name="sku"> The public IP prefix SKU. </param>
-        /// <param name="etag"> A unique read-only string that changes whenever the resource is updated. </param>
-        /// <param name="zones"> A list of availability zones denoting the IP allocated for the resource needs to come from. </param>
-        /// <param name="publicIPAddressVersion"> The public IP address version. </param>
-        /// <param name="ipTags"> The list of tags associated with the public IP prefix. </param>
-        /// <param name="prefixLength"> The Length of the Public IP Prefix. </param>
-        /// <param name="ipPrefix"> The allocated Prefix. </param>
-        /// <param name="publicIPAddresses"> The list of all referenced PublicIPAddresses. </param>
-        /// <param name="loadBalancerFrontendIPConfigurationId"> The reference to load balancer frontend IP configuration associated with the public IP prefix. </param>
-        /// <param name="customIPPrefixId"> The customIpPrefix that this prefix is associated with. </param>
-        /// <param name="resourceGuid"> The resource GUID property of the public IP prefix resource. </param>
-        /// <param name="provisioningState"> The provisioning state of the public IP prefix resource. </param>
-        /// <param name="natGateway"> NatGateway of Public IP Prefix. </param>
-        /// <returns> A new <see cref="Network.PublicIPPrefixData"/> instance for mocking. </returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static PublicIPPrefixData PublicIPPrefixData(ResourceIdentifier id = default, string name = default, ResourceType? resourceType = default, AzureLocation? location = default, IDictionary<string, string> tags = default, ExtendedLocation extendedLocation = default, PublicIPPrefixSku sku = default, ETag? etag = default, IEnumerable<string> zones = default, NetworkIPVersion? publicIPAddressVersion = default, IEnumerable<IPTag> ipTags = default, int? prefixLength = default, string ipPrefix = default, IEnumerable<SubResource> publicIPAddresses = default, ResourceIdentifier loadBalancerFrontendIPConfigurationId = default, ResourceIdentifier customIPPrefixId = default, Guid? resourceGuid = default, NetworkProvisioningState? provisioningState = default, NatGatewayData natGateway = default)
-        {
-            return new PublicIPPrefixData(
-                id,
-                name,
-                default,
-                location,
-                tags ?? new ChangeTrackingDictionary<string, string>(),
-                default,
-                publicIPAddressVersion is null && ipTags is null && prefixLength is null && ipPrefix is null && loadBalancerFrontendIPConfigurationId is null && customIPPrefixId is null && resourceGuid is null && provisioningState is null && natGateway is null ? default : new PublicIPPrefixPropertiesFormat(
-                    publicIPAddressVersion,
-                    (ipTags ?? new ChangeTrackingList<IPTag>()).ToList(),
-                    prefixLength,
-                    ipPrefix,
-                    default,
-                    new NetworkSubResource(loadBalancerFrontendIPConfigurationId, default),
-                    new NetworkSubResource(customIPPrefixId, default),
-                    resourceGuid,
-                    provisioningState,
-                    natGateway,
-                    default,
-                    default),
-                extendedLocation,
-                sku,
-                etag,
-                (zones ?? new ChangeTrackingList<string>()).ToList());
-        }
-
         /// <summary> Initializes a new instance of <see cref="Network.RouteFilterData"/>. </summary>
         /// <param name="id"> Resource ID. </param>
         /// <param name="name"> Resource name. </param>

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/UnitTest.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/UnitTest.cs
@@ -4,6 +4,7 @@
 using System.ClientModel.Primitives;
 using System.IO;
 using System.Text.Json;
+using Azure.Core;
 using Azure.ResourceManager.Network.Models;
 using Azure.ResourceManager.Resources.Models;
 using NUnit.Framework;

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/UnitTest.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/UnitTest.cs
@@ -4,7 +4,6 @@
 using System.ClientModel.Primitives;
 using System.IO;
 using System.Text.Json;
-using Azure.Core;
 using Azure.ResourceManager.Network.Models;
 using Azure.ResourceManager.Resources.Models;
 using NUnit.Framework;

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/UnitTest.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/UnitTest.cs
@@ -4,7 +4,9 @@
 using System.ClientModel.Primitives;
 using System.IO;
 using System.Text.Json;
+using Azure.Core;
 using Azure.ResourceManager.Network.Models;
+using Azure.ResourceManager.Resources.Models;
 using NUnit.Framework;
 
 namespace Azure.ResourceManager.Network.Tests
@@ -39,6 +41,41 @@ namespace Azure.ResourceManager.Network.Tests
             Assert.AreEqual("920130", data.Rules[3]); // Originally number
             Assert.AreEqual("920140", data.Rules[4]); // Originally string
             Assert.AreEqual("920150", data.Rules[5]); // Originally number
+        }
+
+        [Test]
+        public void DeserializePublicIPPrefixDataPreservesPublicIPAddresses()
+        {
+            using var jsonContent = JsonDocument.Parse("{\"properties\":{\"publicIPAddresses\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1\"},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2\"}]}}");
+
+            var data = PublicIPPrefixData.DeserializePublicIPPrefixData(jsonContent.RootElement, ModelReaderWriterOptions.Json);
+
+            Assert.That(data.PublicIPAddresses, Has.Count.EqualTo(2));
+            Assert.That(data.PublicIPAddresses[0].Id.Name, Is.EqualTo("pip1"));
+            Assert.That(data.PublicIPAddresses[1].Id.Name, Is.EqualTo("pip2"));
+        }
+
+        [Test]
+        public void PublicIPPrefixDataFactoryPreservesPublicIPAddresses()
+        {
+            var publicIPAddresses = new[]
+            {
+                new TestSubResource(new ResourceIdentifier("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1")),
+                new TestSubResource(new ResourceIdentifier("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"))
+            };
+
+            var data = ArmNetworkModelFactory.PublicIPPrefixData(resourceType: default, publicIPAddresses: publicIPAddresses);
+
+            Assert.That(data.PublicIPAddresses, Has.Count.EqualTo(2));
+            Assert.That(data.PublicIPAddresses[0].Id, Is.EqualTo(publicIPAddresses[0].Id));
+            Assert.That(data.PublicIPAddresses[1].Id, Is.EqualTo(publicIPAddresses[1].Id));
+        }
+
+        private sealed class TestSubResource : SubResource
+        {
+            public TestSubResource(ResourceIdentifier id) : base(id)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #61648 by preserving referenced public IP addresses exposed through `PublicIPPrefixData.PublicIPAddresses`.

The change:
- Adapts the generated `ReferencedPublicIpAddress` collection to the backward-compatible `IReadOnlyList<SubResource>` API.
- Restores `ArmNetworkModelFactory.PublicIPPrefixData` behavior so supplied public IP addresses are retained.
- Adds regression tests for REST response deserialization and model factory construction.

## Testing

- `dotnet build sdk/network/Azure.ResourceManager.Network/tests/Azure.ResourceManager.Network.Tests.csproj -f net10.0 --no-restore`
- `dotnet test sdk/network/Azure.ResourceManager.Network/tests/Azure.ResourceManager.Network.Tests.csproj -f net10.0 --no-build --filter "FullyQualifiedName~Azure.ResourceManager.Network.Tests.UnitTest"` (4 passed)
- `eng/scripts/Export-API.ps1 network` (no API changes)

## Breaking Changes

No breaking changes intended.