### PR TITLE
Fix VMSS public IP address API version selection

### DIFF
--- a/sdk/network/Azure.ResourceManager.Network/src/Customization/Extensions/MockableNetworkResourceGroupResource.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Customization/Extensions/MockableNetworkResourceGroupResource.cs
@@ -4,12 +4,22 @@
 #nullable disable
 
 using Azure.Core;
+using Microsoft.TypeSpec.Generator.Customizations;
 
 namespace Azure.ResourceManager.Network.Mocking
 {
     /// <summary> Compatibility declaration for the MockableNetworkResourceGroupResource type. </summary>
+    [CodeGenSuppress("PublicIPAddressesOperationGroupRestClient")]
     public partial class MockableNetworkResourceGroupResource
     {
+        private PublicIPAddressesOperationGroup PublicIPAddressesOperationGroupRestClient => _publicIPAddressesOperationGroupRestClient ??= new PublicIPAddressesOperationGroup(PublicIPAddressesOperationGroupClientDiagnostics, Pipeline, Diagnostics.ApplicationId, Endpoint, GetVirtualMachineScaleSetPublicIPAddressApiVersion());
+
+        private string GetVirtualMachineScaleSetPublicIPAddressApiVersion()
+        {
+            TryGetApiVersion(new ResourceType("Microsoft.Compute/virtualMachineScaleSets/publicIPAddresses"), out string apiVersion);
+            return apiVersion ?? "2018-10-01";
+        }
+
         /// <summary> Invokes the CheckPrivateLinkServiceVisibilityByResourceGroupPrivateLinkService compatibility operation. </summary>
         public virtual global::Azure.ResourceManager.ArmOperation<global::Azure.ResourceManager.Network.Models.PrivateLinkServiceVisibility> CheckPrivateLinkServiceVisibilityByResourceGroupPrivateLinkService(global::Azure.WaitUntil waitUntil, global::Azure.Core.AzureLocation location, global::Azure.ResourceManager.Network.Models.CheckPrivateLinkServiceVisibilityRequest checkPrivateLinkServiceVisibilityRequest, global::System.Threading.CancellationToken cancellationToken)
             => CheckPrivateLinkServiceVisibilityByResourceGroup(waitUntil, location, checkPrivateLinkServiceVisibilityRequest, cancellationToken);

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/Extensions/MockableNetworkResourceGroupResource.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/Extensions/MockableNetworkResourceGroupResource.cs
@@ -70,8 +70,6 @@ namespace Azure.ResourceManager.Network.Mocking
 
         private ClientDiagnostics PublicIPAddressesOperationGroupClientDiagnostics => _publicIPAddressesOperationGroupClientDiagnostics ??= new ClientDiagnostics("Azure.ResourceManager.Network.Mocking", ProviderConstants.DefaultProviderNamespace, Diagnostics);
 
-        private PublicIPAddressesOperationGroup PublicIPAddressesOperationGroupRestClient => _publicIPAddressesOperationGroupRestClient ??= new PublicIPAddressesOperationGroup(PublicIPAddressesOperationGroupClientDiagnostics, Pipeline, Diagnostics.ApplicationId, Endpoint, "2025-09-01");
-
         private ClientDiagnostics AvailableResourceGroupDelegationsClientDiagnostics => _availableResourceGroupDelegationsClientDiagnostics ??= new ClientDiagnostics("Azure.ResourceManager.Network.Mocking", ProviderConstants.DefaultProviderNamespace, Diagnostics);
 
         private AvailableResourceGroupDelegations AvailableResourceGroupDelegationsRestClient => _availableResourceGroupDelegationsRestClient ??= new AvailableResourceGroupDelegations(AvailableResourceGroupDelegationsClientDiagnostics, Pipeline, Diagnostics.ApplicationId, Endpoint, "2025-09-01");

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/VmssPublicIPAddressApiVersionTests.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/VmssPublicIPAddressApiVersionTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.ResourceManager.Resources;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.Network.Tests
+{
+    public class VmssPublicIPAddressApiVersionTests
+    {
+        private const string SubscriptionId = "00000000-0000-0000-0000-000000000000";
+        private static readonly ResourceType s_resourceType = new("Microsoft.Compute/virtualMachineScaleSets/publicIPAddresses");
+
+        [TestCase(null, "2018-10-01")]
+        [TestCase("2024-07-01", "2024-07-01")]
+        public void GetVirtualMachineScaleSetPublicIPAddressesUsesExpectedApiVersion(string configuredVersion, string expectedVersion)
+        {
+            MockTransport transport = CreateTransport(configuredVersion, out ResourceGroupResource resourceGroup);
+
+            _ = resourceGroup.GetVirtualMachineScaleSetPublicIPAddresses("vmss").ToList();
+
+            Assert.That(transport.Requests.Single().Uri.Query, Does.Contain($"api-version={expectedVersion}"));
+        }
+
+        [TestCase(null, "2018-10-01")]
+        [TestCase("2024-07-01", "2024-07-01")]
+        public async Task GetVirtualMachineScaleSetPublicIPAddressesAsyncUsesExpectedApiVersion(string configuredVersion, string expectedVersion)
+        {
+            MockTransport transport = CreateTransport(configuredVersion, out ResourceGroupResource resourceGroup);
+
+            await foreach (PublicIPAddressData _ in resourceGroup.GetVirtualMachineScaleSetPublicIPAddressesAsync("vmss"))
+            {
+            }
+
+            Assert.That(transport.Requests.Single().Uri.Query, Does.Contain($"api-version={expectedVersion}"));
+        }
+
+        private static MockTransport CreateTransport(string configuredVersion, out ResourceGroupResource resourceGroup)
+        {
+            var transport = new MockTransport(new MockResponse(200).WithContent("{\"value\":[]}"));
+            var options = new ArmClientOptions { Transport = transport };
+            if (configuredVersion != null)
+            {
+                options.SetApiVersion(s_resourceType, configuredVersion);
+            }
+
+            var client = new ArmClient(new MockCredential(), SubscriptionId, options);
+            resourceGroup = client.GetResourceGroupResource(ResourceGroupResource.CreateResourceIdentifier(SubscriptionId, "rg"));
+            return transport;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #61649.

The VMSS public IP address extension operations target `Microsoft.Compute/virtualMachineScaleSets/publicIPAddresses`, but the generated mockable resource-group provider constructed their REST client with the Network package API version. It also bypassed `ArmClientOptions.SetApiVersion`.

This change suppresses that generated REST-client property and replaces it with a compatibility customization that:

- resolves the API version for `Microsoft.Compute/virtualMachineScaleSets/publicIPAddresses` through `TryGetApiVersion`;
- honors `ArmClientOptions.SetApiVersion` overrides;
- falls back to the operation's supported default, `2018-10-01`.

Regression tests cover synchronous and asynchronous calls with both the default and a configured override.

The generator-wide limitation is tracked by #62600.

## Testing

- `dotnet format` for the source and test projects
- `dotnet build sdk/network/Azure.ResourceManager.Network/src/Azure.ResourceManager.Network.csproj /t:GenerateCode --no-restore -v:minimal`
- `dotnet build sdk/network/Azure.ResourceManager.Network/tests/Azure.ResourceManager.Network.Tests.csproj -f net10.0 --no-restore`
- `dotnet test sdk/network/Azure.ResourceManager.Network/tests/Azure.ResourceManager.Network.Tests.csproj -f net10.0 --no-build --filter FullyQualifiedName~VmssPublicIPAddressApiVersionTests`
- `eng/scripts/Export-API.ps1 network`
- `git diff --check`