### PR TITLE
Normalize provisioning project properties

### DIFF
--- a/sdk/attestation/Azure.Provisioning.Attestation/Directory.Build.props
+++ b/sdk/attestation/Azure.Provisioning.Attestation/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/attestation/Azure.Provisioning.Attestation/tests/Azure.Provisioning.Attestation.Tests.csproj
+++ b/sdk/attestation/Azure.Provisioning.Attestation/tests/Azure.Provisioning.Attestation.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/batch/Azure.Provisioning.Batch/Directory.Build.props
+++ b/sdk/batch/Azure.Provisioning.Batch/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/botservice/Azure.Provisioning.BotService/Directory.Build.props
+++ b/sdk/botservice/Azure.Provisioning.BotService/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/cdn/Azure.Provisioning.Cdn/Directory.Build.props
+++ b/sdk/cdn/Azure.Provisioning.Cdn/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/cognitiveservices/Azure.Provisioning.CognitiveServices/Directory.Build.props
+++ b/sdk/cognitiveservices/Azure.Provisioning.CognitiveServices/Directory.Build.props
@@ -10,8 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/cognitiveservices/Azure.Provisioning.CognitiveServices/tests/Azure.Provisioning.CognitiveServices.Tests.csproj
+++ b/sdk/cognitiveservices/Azure.Provisioning.CognitiveServices/tests/Azure.Provisioning.CognitiveServices.Tests.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />
     <ProjectReference Include="..\..\..\provisioning\Azure.Provisioning\src\Azure.Provisioning.csproj" />

--- a/sdk/communication/Azure.Provisioning.Communication/Directory.Build.props
+++ b/sdk/communication/Azure.Provisioning.Communication/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/compute/Azure.Provisioning.Compute/Directory.Build.props
+++ b/sdk/compute/Azure.Provisioning.Compute/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/containerinstance/Azure.Provisioning.ContainerInstance/Directory.Build.props
+++ b/sdk/containerinstance/Azure.Provisioning.ContainerInstance/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/containerregistry/Azure.Provisioning.ContainerRegistry/Directory.Build.props
+++ b/sdk/containerregistry/Azure.Provisioning.ContainerRegistry/Directory.Build.props
@@ -10,8 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/containerregistry/Azure.Provisioning.ContainerRegistry/tests/Azure.Provisioning.ContainerRegistry.Tests.csproj
+++ b/sdk/containerregistry/Azure.Provisioning.ContainerRegistry/tests/Azure.Provisioning.ContainerRegistry.Tests.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\..\..\common\ProvisioningTestShared\*.cs" LinkBase="Shared\ProvisioningTestShared" />
   </ItemGroup>

--- a/sdk/containerservice/Azure.Provisioning.ContainerService/Directory.Build.props
+++ b/sdk/containerservice/Azure.Provisioning.ContainerService/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/costmanagement/Azure.Provisioning.CostManagement/Directory.Build.props
+++ b/sdk/costmanagement/Azure.Provisioning.CostManagement/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/desktopvirtualization/Azure.Provisioning.DesktopVirtualization/Directory.Build.props
+++ b/sdk/desktopvirtualization/Azure.Provisioning.DesktopVirtualization/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/desktopvirtualization/Azure.Provisioning.DesktopVirtualization/tests/Azure.Provisioning.DesktopVirtualization.Tests.csproj
+++ b/sdk/desktopvirtualization/Azure.Provisioning.DesktopVirtualization/tests/Azure.Provisioning.DesktopVirtualization.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/domainregistration/Azure.Provisioning.DomainRegistration/Directory.Build.props
+++ b/sdk/domainregistration/Azure.Provisioning.DomainRegistration/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/durabletask/Azure.Provisioning.DurableTask/Directory.Build.props
+++ b/sdk/durabletask/Azure.Provisioning.DurableTask/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/enclave/Azure.Provisioning.Enclave/Directory.Build.props
+++ b/sdk/enclave/Azure.Provisioning.Enclave/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/enclave/Azure.Provisioning.Enclave/tests/Azure.Provisioning.Enclave.Tests.csproj
+++ b/sdk/enclave/Azure.Provisioning.Enclave/tests/Azure.Provisioning.Enclave.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/frontdoor/Azure.Provisioning.FrontDoor/Directory.Build.props
+++ b/sdk/frontdoor/Azure.Provisioning.FrontDoor/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/hybridkubernetes/Azure.Provisioning.Kubernetes/Directory.Build.props
+++ b/sdk/hybridkubernetes/Azure.Provisioning.Kubernetes/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/iothub/Azure.Provisioning.IotHub/Directory.Build.props
+++ b/sdk/iothub/Azure.Provisioning.IotHub/Directory.Build.props
@@ -9,7 +9,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/iothub/Azure.Provisioning.IotHub/tests/Azure.Provisioning.IotHub.Tests.csproj
+++ b/sdk/iothub/Azure.Provisioning.IotHub/tests/Azure.Provisioning.IotHub.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/keyvault/Azure.Provisioning.KeyVault/Directory.Build.props
+++ b/sdk/keyvault/Azure.Provisioning.KeyVault/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes/Directory.Build.props
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes/Directory.Build.props
@@ -9,8 +9,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes/tests/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes.Tests.csproj
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes/tests/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.Extensions/Directory.Build.props
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.Extensions/Directory.Build.props
@@ -9,8 +9,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.Extensions/tests/Azure.Provisioning.KubernetesConfiguration.Extensions.Tests.csproj
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.Extensions/tests/Azure.Provisioning.KubernetesConfiguration.Extensions.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations/Directory.Build.props
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations/Directory.Build.props
@@ -9,8 +9,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations/tests/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations.Tests.csproj
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations/tests/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes/Directory.Build.props
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes/Directory.Build.props
@@ -9,8 +9,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes/tests/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes.Tests.csproj
+++ b/sdk/kubernetesconfiguration/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes/tests/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/kusto/Azure.Provisioning.Kusto/Directory.Build.props
+++ b/sdk/kusto/Azure.Provisioning.Kusto/Directory.Build.props
@@ -10,8 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/kusto/Azure.Provisioning.Kusto/tests/Azure.Provisioning.Kusto.Tests.csproj
+++ b/sdk/kusto/Azure.Provisioning.Kusto/tests/Azure.Provisioning.Kusto.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/loadtestservice/Azure.Provisioning.LoadTesting/Directory.Build.props
+++ b/sdk/loadtestservice/Azure.Provisioning.LoadTesting/Directory.Build.props
@@ -9,7 +9,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/loadtestservice/Azure.Provisioning.LoadTesting/tests/Azure.Provisioning.LoadTesting.Tests.csproj
+++ b/sdk/loadtestservice/Azure.Provisioning.LoadTesting/tests/Azure.Provisioning.LoadTesting.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/machinelearningservices/Azure.Provisioning.MachineLearning/Directory.Build.props
+++ b/sdk/machinelearningservices/Azure.Provisioning.MachineLearning/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/mysql/Azure.Provisioning.MySql/Directory.Build.props
+++ b/sdk/mysql/Azure.Provisioning.MySql/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/Directory.Build.props
+++ b/sdk/operationalinsights/Azure.Provisioning.OperationalInsights/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/postgresql/Azure.Provisioning.PostgreSql/Directory.Build.props
+++ b/sdk/postgresql/Azure.Provisioning.PostgreSql/Directory.Build.props
@@ -10,8 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/postgresql/Azure.Provisioning.PostgreSql/src/Azure.Provisioning.PostgreSql.csproj
+++ b/sdk/postgresql/Azure.Provisioning.PostgreSql/src/Azure.Provisioning.PostgreSql.csproj
@@ -6,7 +6,6 @@
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.1</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Provisioning" />

--- a/sdk/postgresql/Azure.Provisioning.PostgreSql/tests/Azure.Provisioning.PostgreSql.Tests.csproj
+++ b/sdk/postgresql/Azure.Provisioning.PostgreSql/tests/Azure.Provisioning.PostgreSql.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/recoveryservices-backup/Azure.Provisioning.RecoveryServicesBackup/Directory.Build.props
+++ b/sdk/recoveryservices-backup/Azure.Provisioning.RecoveryServicesBackup/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/recoveryservices-backup/Azure.Provisioning.RecoveryServicesBackup/tests/Azure.Provisioning.RecoveryServicesBackup.Tests.csproj
+++ b/sdk/recoveryservices-backup/Azure.Provisioning.RecoveryServicesBackup/tests/Azure.Provisioning.RecoveryServicesBackup.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/recoveryservices/Azure.Provisioning.RecoveryServices/Directory.Build.props
+++ b/sdk/recoveryservices/Azure.Provisioning.RecoveryServices/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/recoveryservices/Azure.Provisioning.RecoveryServices/tests/Azure.Provisioning.RecoveryServices.Tests.csproj
+++ b/sdk/recoveryservices/Azure.Provisioning.RecoveryServices/tests/Azure.Provisioning.RecoveryServices.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/redis/Azure.Provisioning.Redis/Directory.Build.props
+++ b/sdk/redis/Azure.Provisioning.Redis/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/resourcegraph/Azure.Provisioning.ResourceGraph/Directory.Build.props
+++ b/sdk/resourcegraph/Azure.Provisioning.ResourceGraph/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/resourcehealth/Azure.Provisioning.ResourceHealth/Directory.Build.props
+++ b/sdk/resourcehealth/Azure.Provisioning.ResourceHealth/Directory.Build.props
@@ -9,7 +9,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/resourcehealth/Azure.Provisioning.ResourceHealth/tests/Azure.Provisioning.ResourceHealth.Tests.csproj
+++ b/sdk/resourcehealth/Azure.Provisioning.ResourceHealth/tests/Azure.Provisioning.ResourceHealth.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/search/Azure.Provisioning.Search/Directory.Build.props
+++ b/sdk/search/Azure.Provisioning.Search/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/servicebus/Azure.Provisioning.ServiceBus/Directory.Build.props
+++ b/sdk/servicebus/Azure.Provisioning.ServiceBus/Directory.Build.props
@@ -10,8 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/servicebus/Azure.Provisioning.ServiceBus/tests/Azure.Provisioning.ServiceBus.Tests.csproj
+++ b/sdk/servicebus/Azure.Provisioning.ServiceBus/tests/Azure.Provisioning.ServiceBus.Tests.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />
     <ProjectReference Include="..\..\..\provisioning\Azure.Provisioning\src\Azure.Provisioning.csproj" />

--- a/sdk/servicefabric/Azure.Provisioning.ServiceFabric/Directory.Build.props
+++ b/sdk/servicefabric/Azure.Provisioning.ServiceFabric/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/servicefabricmanagedclusters/Azure.Provisioning.ServiceFabricManagedClusters/Directory.Build.props
+++ b/sdk/servicefabricmanagedclusters/Azure.Provisioning.ServiceFabricManagedClusters/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/servicefabricmanagedclusters/Azure.Provisioning.ServiceFabricManagedClusters/tests/Azure.Provisioning.ServiceFabricManagedClusters.Tests.csproj
+++ b/sdk/servicefabricmanagedclusters/Azure.Provisioning.ServiceFabricManagedClusters/tests/Azure.Provisioning.ServiceFabricManagedClusters.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/servicenetworking/Azure.Provisioning.ServiceNetworking/Directory.Build.props
+++ b/sdk/servicenetworking/Azure.Provisioning.ServiceNetworking/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/servicenetworking/Azure.Provisioning.ServiceNetworking/src/Azure.Provisioning.ServiceNetworking.csproj
+++ b/sdk/servicenetworking/Azure.Provisioning.ServiceNetworking/src/Azure.Provisioning.ServiceNetworking.csproj
@@ -4,7 +4,6 @@
     <Description>Azure.Provisioning.ServiceNetworking simplifies declarative resource provisioning in .NET.</Description>
     <Version>1.0.0-beta.2</Version>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/servicenetworking/Azure.Provisioning.ServiceNetworking/tests/Azure.Provisioning.ServiceNetworking.Tests.csproj
+++ b/sdk/servicenetworking/Azure.Provisioning.ServiceNetworking/tests/Azure.Provisioning.ServiceNetworking.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/signalr/Azure.Provisioning.SignalR/src/Azure.Provisioning.SignalR.csproj
+++ b/sdk/signalr/Azure.Provisioning.SignalR/src/Azure.Provisioning.SignalR.csproj
@@ -6,7 +6,6 @@
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/standbypool/Azure.Provisioning.StandbyPool/Directory.Build.props
+++ b/sdk/standbypool/Azure.Provisioning.StandbyPool/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/standbypool/Azure.Provisioning.StandbyPool/tests/Azure.Provisioning.StandbyPool.Tests.csproj
+++ b/sdk/standbypool/Azure.Provisioning.StandbyPool/tests/Azure.Provisioning.StandbyPool.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/storage/Azure.Provisioning.Storage/Directory.Build.props
+++ b/sdk/storage/Azure.Provisioning.Storage/Directory.Build.props
@@ -10,8 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!--

--- a/sdk/storage/Azure.Provisioning.Storage/src/Azure.Provisioning.Storage.csproj
+++ b/sdk/storage/Azure.Provisioning.Storage/src/Azure.Provisioning.Storage.csproj
@@ -6,7 +6,6 @@
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.2</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="$('EXPERIMENTAL_PROVISIONING') == true">

--- a/sdk/storage/Azure.Provisioning.Storage/tests/Azure.Provisioning.Storage.Tests.csproj
+++ b/sdk/storage/Azure.Provisioning.Storage/tests/Azure.Provisioning.Storage.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />

--- a/sdk/trafficmanager/Azure.Provisioning.TrafficManager/Directory.Build.props
+++ b/sdk/trafficmanager/Azure.Provisioning.TrafficManager/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsMgmtLibrary>true</IsMgmtLibrary>
-    <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 
   <!--

--- a/sdk/trafficmanager/Azure.Provisioning.TrafficManager/src/Azure.Provisioning.TrafficManager.csproj
+++ b/sdk/trafficmanager/Azure.Provisioning.TrafficManager/src/Azure.Provisioning.TrafficManager.csproj
@@ -4,7 +4,6 @@
     <Description>Azure.Provisioning.TrafficManager simplifies declarative resource provisioning in .NET.</Description>
     <Version>1.0.0-beta.2</Version>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/trafficmanager/Azure.Provisioning.TrafficManager/tests/Azure.Provisioning.TrafficManager.Tests.csproj
+++ b/sdk/trafficmanager/Azure.Provisioning.TrafficManager/tests/Azure.Provisioning.TrafficManager.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Scope the change from the provisioning library inventory to 47 TypeSpec packages; skip all 18 reflection/no-generator packages.
- Remove package-level `Nullable`, `IncludeOperationsSharedSource`, and `LangVersion` overrides from `Directory.Build.props`, plus redundant `Nullable`/`LangVersion` overrides from source and test projects.
- Keep existing test-local nullable settings and add `Nullable=enable` only to test projects whose builds demonstrated that nullable context was required.

## Validation

All 47 affected test projects built successfully after the project-property changes and targeted nullable additions. Remaining pre-commit checks were skipped as requested.