### PR TITLE
[Monitor Exporter] Read recognized activity attributes by slot instead of scanning

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -29,13 +29,13 @@
   ([#62340](https://github.com/Azure/azure-sdk-for-net/pull/62340))
 
 - The pooled buffers used to categorize activity tags are no longer leaked from the shared array pool when converting an activity fails. The buffers were returned only on the success path, so every conversion failure permanently removed two buffers from the pool and forced later conversions to allocate.
-  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
 
 - The size used to rent those buffers is no longer held in shared mutable state. A single activity with an unusually large number of tags permanently raised the rent size for every subsequent activity in the process, and the value was written from multiple exporter threads without synchronization.
-  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
 
 - Pooled tag buffers no longer keep activity tag keys and values alive after they are returned to the shared array pool.
-  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
 
 - Log fields are now culture-invariant. ([#61996](https://github.com/Azure/azure-sdk-for-net/pull/61996))
 - Added the `telemetrySuccess` dimension to `Item_Dropped_Count` for request and dependency telemetry.
@@ -43,13 +43,13 @@
 ### Other Changes
 
 - Reading a recognized attribute while converting an activity is now a constant-time array index rather than a scan that compared the requested key against every mapped tag. A single conversion performs 13 to 26 such reads, and recognized attributes are held in that index alone rather than also being appended to a list, so a conversion rents two pooled buffers instead of three. Every span shape measures faster; the shape performing the most reads, a span carrying Application Insights override attributes, converts about a third faster. Building the values for a multi-attribute read no longer allocates two arrays per call.
-  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
 
 - Removed two attribute lookups that could never succeed. `http.server_name` and `server.socket.address` are not recognized when activity tags are categorized, so they were never present in the list that the request-url and dependency-target logic searched. Both attributes continue to be exported as custom properties, unchanged.
-  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
 
 - Standard metrics no longer collect the attributes they do not read. Extracting the dependency duration metric categorized every tag on the activity, including the ones destined for custom properties, and then used only the recognized ones. Skipping the rest avoids a pooled buffer and the string conversion of array-valued tags on every dependency span, and measures 18% to 31% faster depending on tag count.
-  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
 
 ## 1.8.3 (2026-07-24)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -28,31 +28,20 @@
 - Statsbeat no longer holds up process exit. It exports once more as its meter provider is disposed, which put an ingestion round trip on the exit path; that final export now runs in the background, and its network timeout is bounded at five seconds rather than the pipeline default of 100 seconds. The customer SDK stats meter provider is instead left to live for the process lifetime, so it never exports on the exit path at all; its stats are delivered by its own periodic reader.
   ([#62340](https://github.com/Azure/azure-sdk-for-net/pull/62340))
 
-- The pooled buffers used to categorize activity tags are no longer leaked from the shared array pool when converting an activity fails. The buffers were returned only on the success path, so every conversion failure permanently removed two buffers from the pool and forced later conversions to allocate.
-  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
-
-- The size used to rent those buffers is no longer held in shared mutable state. A single activity with an unusually large number of tags permanently raised the rent size for every subsequent activity in the process, and the value was written from multiple exporter threads without synchronization.
-  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
-
-- Pooled tag buffers no longer keep activity tag keys and values alive after they are returned to the shared array pool.
-  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
-
-- An activity tag with a null key no longer prevents the remaining tags from being exported as custom properties. `Activity` does not reject a null key; the tag is now skipped during categorization rather than failing partway through building the custom properties.
-  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
-
 - Log fields are now culture-invariant. ([#61996](https://github.com/Azure/azure-sdk-for-net/pull/61996))
 - Added the `telemetrySuccess` dimension to `Item_Dropped_Count` for request and dependency telemetry.
 
 ### Other Changes
 
-- Reading a recognized attribute while converting an activity is now a constant-time array index rather than a scan that compared the requested key against every mapped tag. A single conversion performs 13 to 26 such reads, and recognized attributes are held in that index alone rather than also being appended to a list, so a conversion rents two pooled buffers instead of three. Every span shape measures faster; the shape performing the most reads, a span carrying Application Insights override attributes, converts about a third faster. Building the values for a multi-attribute read no longer allocates two arrays per call.
+- Reworked how activity tags are stored and read while converting an activity. Recognized attributes are assigned a dense index during categorization and read by array index, rather than by scanning the requested key against every mapped tag; a single conversion performs 13 to 26 such reads. They are held in that index alone rather than also being appended to a list, so a conversion rents two pooled buffers instead of three. Every span shape measures faster, and the shape performing the most reads, a span carrying Application Insights override attributes, converts about a third faster.
   ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
-
-- Removed two attribute lookups that could never succeed. `http.server_name` and `server.socket.address` are not recognized when activity tags are categorized, so they were never present in the list that the request-url and dependency-target logic searched. Both attributes continue to be exported as custom properties, unchanged.
-  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
-
-- Standard metrics no longer collect the attributes they do not read. Extracting the dependency duration metric categorized every tag on the activity, including the ones destined for custom properties, and then used only the recognized ones. Skipping the rest avoids a pooled buffer and the string conversion of array-valued tags on every dependency span, and measures 18% to 31% faster depending on tag count.
-  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
+  - Standard metrics no longer collect the attributes they do not read. Extracting the dependency duration metric categorized every tag on the activity, including the ones destined for custom properties, and then used only the recognized ones. Skipping the rest measures 18% to 31% faster depending on tag count.
+  - Building the values for a multi-attribute read no longer allocates two arrays per call.
+  - Removed two attribute lookups that could never succeed. `http.server_name` and `server.socket.address` are not recognized when activity tags are categorized, so they were never present in the list that the request-url and dependency-target logic searched. Both attributes continue to be exported as custom properties, unchanged.
+  - Fixed pooled buffers being leaked from the shared array pool when converting an activity fails. The buffers were returned only on the success path, so every conversion failure permanently removed two buffers from the pool and forced later conversions to allocate.
+  - Fixed the size used to rent those buffers being held in shared mutable state. A single activity with an unusually large number of tags permanently raised the rent size for every subsequent activity in the process, and the value was written from multiple exporter threads without synchronization.
+  - Fixed pooled tag buffers keeping activity tag keys and values alive after they are returned to the shared array pool.
+  - Fixed an activity tag with a null key preventing the remaining tags from being exported as custom properties. `Activity` does not reject a null key; the tag is now skipped during categorization rather than failing partway through building the custom properties.
 
 ## 1.8.3 (2026-07-24)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -33,15 +33,12 @@
 
 ### Other Changes
 
-- Reworked how activity tags are stored and read while converting an activity. Recognized attributes are assigned a dense index during categorization and read by array index, rather than by scanning the requested key against every mapped tag; a single conversion performs 13 to 26 such reads. They are held in that index alone rather than also being appended to a list, so a conversion rents two pooled buffers instead of three. Every span shape measures faster, and the shape performing the most reads, a span carrying Application Insights override attributes, converts about a third faster.
+- Improved activity conversion performance by reading recognized attributes from a fixed index instead of scanning the tag list for each one. Every span shape converts faster, by about a third for spans carrying Application Insights override attributes, and each conversion allocates less. Standard metrics no longer collect the tags they never read.
   ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
-  - Standard metrics no longer collect the attributes they do not read. Extracting the dependency duration metric categorized every tag on the activity, including the ones destined for custom properties, and then used only the recognized ones. Skipping the rest measures 18% to 31% faster depending on tag count.
-  - Building the values for a multi-attribute read no longer allocates two arrays per call.
-  - Removed two attribute lookups that could never succeed. `http.server_name` and `server.socket.address` are not recognized when activity tags are categorized, so they were never present in the list that the request-url and dependency-target logic searched. Both attributes continue to be exported as custom properties, unchanged.
-  - Fixed pooled buffers being leaked from the shared array pool when converting an activity fails. The buffers were returned only on the success path, so every conversion failure permanently removed two buffers from the pool and forced later conversions to allocate.
-  - Fixed the size used to rent those buffers being held in shared mutable state. A single activity with an unusually large number of tags permanently raised the rent size for every subsequent activity in the process, and the value was written from multiple exporter threads without synchronization.
-  - Fixed pooled tag buffers keeping activity tag keys and values alive after they are returned to the shared array pool.
-  - Fixed an activity tag with a null key preventing the remaining tags from being exported as custom properties. `Activity` does not reject a null key; the tag is now skipped during categorization rather than failing partway through building the custom properties.
+  - Fixed pooled tag buffers being leaked whenever converting an activity failed, and retaining tag keys and values after being returned to the pool.
+  - Fixed the buffer rent size being process-wide mutable state written without synchronization.
+  - Fixed an activity tag with a null key dropping the remaining tags from custom properties.
+  - Removed two attribute lookups that could never match. `http.server_name` and `server.socket.address` are still exported as custom properties, unchanged.
 
 ## 1.8.3 (2026-07-24)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -37,6 +37,9 @@
 - Pooled tag buffers no longer keep activity tag keys and values alive after they are returned to the shared array pool.
   ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
 
+- An activity tag with a null key no longer prevents the remaining tags from being exported as custom properties. `Activity` does not reject a null key; the tag is now skipped during categorization rather than failing partway through building the custom properties.
+  ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
+
 - Log fields are now culture-invariant. ([#61996](https://github.com/Azure/azure-sdk-for-net/pull/61996))
 - Added the `telemetrySuccess` dimension to `Item_Dropped_Count` for request and dependency telemetry.
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -28,10 +28,28 @@
 - Statsbeat no longer holds up process exit. It exports once more as its meter provider is disposed, which put an ingestion round trip on the exit path; that final export now runs in the background, and its network timeout is bounded at five seconds rather than the pipeline default of 100 seconds. The customer SDK stats meter provider is instead left to live for the process lifetime, so it never exports on the exit path at all; its stats are delivered by its own periodic reader.
   ([#62340](https://github.com/Azure/azure-sdk-for-net/pull/62340))
 
+- The pooled buffers used to categorize activity tags are no longer leaked from the shared array pool when converting an activity fails. The buffers were returned only on the success path, so every conversion failure permanently removed two buffers from the pool and forced later conversions to allocate.
+  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+
+- The size used to rent those buffers is no longer held in shared mutable state. A single activity with an unusually large number of tags permanently raised the rent size for every subsequent activity in the process, and the value was written from multiple exporter threads without synchronization.
+  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+
+- Pooled tag buffers no longer keep activity tag keys and values alive after they are returned to the shared array pool.
+  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+
 - Log fields are now culture-invariant. ([#61996](https://github.com/Azure/azure-sdk-for-net/pull/61996))
 - Added the `telemetrySuccess` dimension to `Item_Dropped_Count` for request and dependency telemetry.
 
 ### Other Changes
+
+- Reading a recognized attribute while converting an activity is now a constant-time array index rather than a scan that compared the requested key against every mapped tag. A single conversion performs 13 to 26 such reads, and recognized attributes are held in that index alone rather than also being appended to a list, so a conversion rents two pooled buffers instead of three. Every span shape measures faster; the shape performing the most reads, a span carrying Application Insights override attributes, converts about a third faster. Building the values for a multi-attribute read no longer allocates two arrays per call.
+  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+
+- Removed two attribute lookups that could never succeed. `http.server_name` and `server.socket.address` are not recognized when activity tags are categorized, so they were never present in the list that the request-url and dependency-target logic searched. Both attributes continue to be exported as custom properties, unchanged.
+  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
+
+- Standard metrics no longer collect the attributes they do not read. Extracting the dependency duration metric categorized every tag on the activity, including the ones destined for custom properties, and then used only the recognized ones. Skipping the rest avoids a pooled buffer and the string conversion of array-valued tags on every dependency span, and measures 18% to 31% faster depending on tag count.
+  ([#62439](https://github.com/Azure/azure-sdk-for-net/pull/62439))
 
 ## 1.8.3 (2026-07-24)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### Other Changes
 
-- Improved activity conversion performance by reading recognized attributes from a fixed index instead of scanning the tag list for each one. Every span shape converts faster, by about a third for spans carrying Application Insights override attributes, and each conversion allocates less. Standard metrics no longer collect the tags they never read.
+- Improved activity conversion performance by reading recognized attributes from a fixed index instead of scanning the tag list for each one. Every span shape converts faster, by about a third for spans carrying Application Insights override attributes, and each conversion rents fewer pooled buffers. Standard metrics no longer collect the tags they never read.
   ([#62614](https://github.com/Azure/azure-sdk-for-net/pull/62614))
   - Fixed pooled tag buffers being leaked whenever converting an activity failed, and retaining tag keys and values after being returned to the pool.
   - Fixed the buffer rent size being process-wide mutable state written without synchronization.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -12,18 +12,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         public RemoteDependencyData(int version, Activity activity, ref ActivityTagsProcessor activityTagsProcessor) : base(version)
         {
             string? dependencyName = null;
-            bool isNewSchemaVersion = false;
+            bool isNewSchemaVersion = activityTagsProcessor.IsV2;
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
 
-            if (activityTagsProcessor.activityType.HasFlag(OperationType.V2))
-            {
-                isNewSchemaVersion = true;
-                activityTagsProcessor.activityType &= ~OperationType.V2;
-            }
-
             // Process based on operation type
-            switch (activityTagsProcessor.activityType)
+            switch (activityTagsProcessor.BaseActivityType)
             {
                 case OperationType.Http:
                     SetHttpDependencyPropertiesAndDependencyName(activity, ref activityTagsProcessor.MappedTags, isNewSchemaVersion, out dependencyName);
@@ -42,11 +36,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             // Check for Microsoft override attributes only if present (avoids overhead for standalone OTel usage)
             if (activityTagsProcessor.HasOverrideAttributes)
             {
-                var overrideData = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftDependencyData)?.ToString();
-                var overrideName = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftDependencyName)?.ToString();
-                var overrideTarget = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftDependencyTarget)?.ToString();
-                var overrideType = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftDependencyType)?.ToString();
-                var overrideResultCode = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftDependencyResultCode)?.ToString();
+                var overrideData = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftDependencyData]?.ToString();
+                var overrideName = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftDependencyName]?.ToString();
+                var overrideTarget = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftDependencyTarget]?.ToString();
+                var overrideType = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftDependencyType]?.ToString();
+                var overrideResultCode = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftDependencyResultCode]?.ToString();
 
                 // Apply overrides if present (these take precedence)
                 if (!string.IsNullOrEmpty(overrideData))
@@ -111,17 +105,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
             if (isNewSchemaVersion)
             {
-                httpUrl = AzMonList.GetTagValue(ref httpTagObjects, SemanticConventions.AttributeUrlFull)?.ToString();
+                httpUrl = httpTagObjects[SemanticSlot.UrlFull]?.ToString();
                 dependencyName = httpTagObjects.GetNewSchemaHttpDependencyName(httpUrl) ?? activity.DisplayName;
                 target = httpTagObjects.GetNewSchemaHttpDependencyTarget();
-                resultCode = AzMonList.GetTagValue(ref httpTagObjects, SemanticConventions.AttributeHttpResponseStatusCode)?.ToString();
+                resultCode = httpTagObjects[SemanticSlot.HttpResponseStatusCode]?.ToString();
             }
             else
             {
                 httpUrl = httpTagObjects.GetDependencyUrl();
                 dependencyName = httpTagObjects.GetHttpDependencyName(httpUrl) ?? activity.DisplayName;
                 target = httpTagObjects.GetHttpDependencyTarget();
-                resultCode = AzMonList.GetTagValue(ref httpTagObjects, SemanticConventions.AttributeHttpStatusCode)?.ToString();
+                resultCode = httpTagObjects[SemanticSlot.HttpStatusCode]?.ToString();
             }
 
             Type = "Http";
@@ -132,23 +126,25 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
         private void SetDbDependencyProperties(ref AzMonList dbTagObjects, bool isNewSchemaVersion)
         {
-            string statementAttributeKey;
-            string statementSystemKey;
+            SemanticSlot statementSlot;
+            SemanticSlot systemSlot;
             if (isNewSchemaVersion)
             {
-                statementAttributeKey = SemanticConventions.AttributeDbQueryText;
-                statementSystemKey = SemanticConventions.AttributeDbSystemName;
+                statementSlot = SemanticSlot.DbQueryText;
+                systemSlot = SemanticSlot.DbSystemName;
             }
             else
             {
-                statementAttributeKey = SemanticConventions.AttributeDbStatement;
-                statementSystemKey = SemanticConventions.AttributeDbSystem;
+                statementSlot = SemanticSlot.DbStatement;
+                systemSlot = SemanticSlot.DbSystem;
             }
-            var dbAttributeTagObjects = AzMonList.GetTagValues(ref dbTagObjects, statementAttributeKey, statementSystemKey);
-            Data = dbAttributeTagObjects[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
+
+            var dbStatement = dbTagObjects[statementSlot];
+            var dbSystem = dbTagObjects[systemSlot];
+            Data = dbStatement?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
             var (DbName, DbTarget) = dbTagObjects.GetDbDependencyTargetAndName(isNewSchemaVersion);
             Target = DbTarget?.Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
-            Type = AzMonListExtensions.s_dbSystems.Contains(dbAttributeTagObjects[1]?.ToString()) ? "SQL" : dbAttributeTagObjects[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
+            Type = AzMonListExtensions.s_dbSystems.Contains(dbSystem?.ToString()) ? "SQL" : dbSystem?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
 
             // special case for db.name
             var sanitizedDbName = DbName?.Truncate(SchemaConstants.KVP_MaxValueLength);
@@ -163,7 +159,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             var (messagingUrl, target) = messagingTagObjects.GetMessagingUrlAndSourceOrTarget(activity.Kind);
             Data = messagingUrl?.Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
             Target = target?.Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
-            Type = AzMonList.GetTagValue(ref messagingTagObjects, SemanticConventions.AttributeMessagingSystem)?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
+            Type = messagingTagObjects[SemanticSlot.MessagingSystem]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
@@ -35,10 +35,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             // Check for Microsoft override attributes only if present (avoids overhead for standalone OTel usage)
             if (activityTagsProcessor.HasOverrideAttributes)
             {
-                var overrideUrl = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftRequestUrl)?.ToString();
-                var overrideName = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftRequestName)?.ToString();
-                var overrideSource = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftRequestSource)?.ToString();
-                var overrideResultCode = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftRequestResultCode)?.ToString();
+                var overrideUrl = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftRequestUrl]?.ToString();
+                var overrideName = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftRequestName]?.ToString();
+                var overrideSource = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftRequestSource]?.ToString();
+                var overrideResultCode = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftRequestResultCode]?.ToString();
 
                 // Apply overrides if present (these take precedence)
                 if (!string.IsNullOrEmpty(overrideUrl))
@@ -102,7 +102,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         private void SetHttpRequestPropertiesAndResponseCode(Activity activity, ref AzMonList httpTagObjects, out string responseCode)
         {
             Url ??= httpTagObjects.GetRequestUrl()?.Truncate(SchemaConstants.RequestData_Url_MaxLength);
-            responseCode = AzMonList.GetTagValue(ref httpTagObjects, SemanticConventions.AttributeHttpStatusCode)
+            responseCode = httpTagObjects[SemanticSlot.HttpStatusCode]
                                                 ?.ToString().Truncate(SchemaConstants.RequestData_ResponseCode_MaxLength)
                                                 ?? "0";
         }
@@ -110,7 +110,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         private void SetHttpV2RequestPropertiesAndResponseCode(Activity activity, ref AzMonList httpTagObjects, out string responseCode)
         {
             Url ??= httpTagObjects.GetNewSchemaRequestUrl()?.Truncate(SchemaConstants.RequestData_Url_MaxLength);
-            responseCode = AzMonList.GetTagValue(ref httpTagObjects, SemanticConventions.AttributeHttpResponseStatusCode)
+            responseCode = httpTagObjects[SemanticSlot.HttpResponseStatusCode]
                                     ?.ToString().Truncate(SchemaConstants.RequestData_ResponseCode_MaxLength)
                                     ?? "0";
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -29,11 +29,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
             Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString();
 
-            string? microsoftClientIp = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftClientIp)?.ToString();
+            string? microsoftClientIp = activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftClientIp]?.ToString();
 
             // Check for microsoft.operation_name override (applies to both request and dependency)
             string? overrideOperationName = activityTagsProcessor.HasOverrideAttributes
-                ? AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMicrosoftOperationName)?.ToString()
+                ? activityTagsProcessor.MappedTags[SemanticSlot.MicrosoftOperationName]?.ToString()
                 : null;
 
             if (activity.GetTelemetryType() == TelemetryType.Request)
@@ -58,7 +58,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 if (activity.Kind == ActivityKind.Server)
                 {
                     var locationIp = microsoftClientIp ??
-                                     AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeClientAddress)?.ToString();
+                                     activityTagsProcessor.MappedTags[SemanticSlot.ClientAddress]?.ToString();
 
                     if (locationIp != null)
                     {
@@ -79,8 +79,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 }
             }
 
-            var userAgent = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeUserAgentOriginal)?.ToString()
-                ?? AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpUserAgent)?.ToString();
+            var userAgent = activityTagsProcessor.MappedTags[SemanticSlot.UserAgentOriginal]?.ToString()
+                ?? activityTagsProcessor.MappedTags[SemanticSlot.HttpUserAgent]?.ToString();
 
             if (userAgent != null)
             {
@@ -301,19 +301,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetOverrideContextTags(ref ActivityTagsProcessor activityTagsProcessor)
         {
-            SetTagFromMappedTags(ref activityTagsProcessor, SemanticConventions.AttributeMicrosoftSessionId, ContextTagKeys.AiSessionId, SchemaConstants.Tags_AiSessionId_MaxLength);
-            SetTagFromMappedTags(ref activityTagsProcessor, SemanticConventions.AttributeAiDeviceId, ContextTagKeys.AiDeviceId, SchemaConstants.Tags_AiDeviceId_MaxLength);
-            SetTagFromMappedTags(ref activityTagsProcessor, SemanticConventions.AttributeAiDeviceModel, ContextTagKeys.AiDeviceModel, SchemaConstants.Tags_AiDeviceModel_MaxLength);
-            SetTagFromMappedTags(ref activityTagsProcessor, SemanticConventions.AttributeAiDeviceType, ContextTagKeys.AiDeviceType, SchemaConstants.Tags_AiDeviceType_MaxLength);
-            SetTagFromMappedTags(ref activityTagsProcessor, SemanticConventions.AttributeAiDeviceOsVersion, ContextTagKeys.AiDeviceOSVersion, SchemaConstants.Tags_AiDeviceOsVersion_MaxLength);
-            SetTagFromMappedTags(ref activityTagsProcessor, SemanticConventions.AttributeMicrosoftSyntheticSource, ContextTagKeys.AiOperationSyntheticSource, SchemaConstants.Tags_AiOperationSyntheticSource_MaxLength);
-            SetTagFromMappedTags(ref activityTagsProcessor, SemanticConventions.AttributeMicrosoftUserAccountId, ContextTagKeys.AiUserAccountId, SchemaConstants.Tags_AiUserAccountId_MaxLength);
+            SetTagFromMappedTags(ref activityTagsProcessor, SemanticSlot.MicrosoftSessionId, ContextTagKeys.AiSessionId, SchemaConstants.Tags_AiSessionId_MaxLength);
+            SetTagFromMappedTags(ref activityTagsProcessor, SemanticSlot.AiDeviceId, ContextTagKeys.AiDeviceId, SchemaConstants.Tags_AiDeviceId_MaxLength);
+            SetTagFromMappedTags(ref activityTagsProcessor, SemanticSlot.AiDeviceModel, ContextTagKeys.AiDeviceModel, SchemaConstants.Tags_AiDeviceModel_MaxLength);
+            SetTagFromMappedTags(ref activityTagsProcessor, SemanticSlot.AiDeviceType, ContextTagKeys.AiDeviceType, SchemaConstants.Tags_AiDeviceType_MaxLength);
+            SetTagFromMappedTags(ref activityTagsProcessor, SemanticSlot.AiDeviceOsVersion, ContextTagKeys.AiDeviceOSVersion, SchemaConstants.Tags_AiDeviceOsVersion_MaxLength);
+            SetTagFromMappedTags(ref activityTagsProcessor, SemanticSlot.MicrosoftSyntheticSource, ContextTagKeys.AiOperationSyntheticSource, SchemaConstants.Tags_AiOperationSyntheticSource_MaxLength);
+            SetTagFromMappedTags(ref activityTagsProcessor, SemanticSlot.MicrosoftUserAccountId, ContextTagKeys.AiUserAccountId, SchemaConstants.Tags_AiUserAccountId_MaxLength);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetTagFromMappedTags(ref ActivityTagsProcessor activityTagsProcessor, string attributeKey, ContextTagKeys contextTagKey, int maxLength)
+        private void SetTagFromMappedTags(ref ActivityTagsProcessor activityTagsProcessor, SemanticSlot slot, ContextTagKeys contextTagKey, int maxLength)
         {
-            var value = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, attributeKey)?.ToString();
+            var value = activityTagsProcessor.MappedTags[slot]?.ToString();
             if (value != null)
             {
                 Tags[contextTagKey.ToString()] = value.Truncate(maxLength);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -9,86 +9,22 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
     internal struct ActivityTagsProcessor
     {
-        private static readonly string[] s_semantics = {
-            SemanticConventions.AttributeDbStatement,
-            SemanticConventions.AttributeDbQueryText,
-            SemanticConventions.AttributeDbSystem,
-            SemanticConventions.AttributeDbSystemName,
-            SemanticConventions.AttributeDbName,
-            SemanticConventions.AttributeDbNamespace,
-
-            // required - HTTP
-            SemanticConventions.AttributeHttpMethod,
-            SemanticConventions.AttributeHttpUrl,
-            SemanticConventions.AttributeHttpStatusCode,
-            SemanticConventions.AttributeHttpScheme,
-            SemanticConventions.AttributeHttpHost,
-            SemanticConventions.AttributeHttpHostPort,
-            SemanticConventions.AttributeHttpTarget,
-            SemanticConventions.AttributeHttpUserAgent,
-            SemanticConventions.AttributeHttpRoute,
-
-            // required - HTTP V2
-            SemanticConventions.AttributeHttpRequestMethod,
-            SemanticConventions.AttributeHttpResponseStatusCode,
-            SemanticConventions.AttributeServerAddress,
-            SemanticConventions.AttributeServerPort,
-            SemanticConventions.AttributeUrlFull,
-            SemanticConventions.AttributeUrlPath,
-            SemanticConventions.AttributeUrlScheme,
-            SemanticConventions.AttributeUrlQuery,
-            SemanticConventions.AttributeUserAgentOriginal,
-            SemanticConventions.AttributeClientAddress,
-
-            // required - Azure
-            SemanticConventions.AttributeAzureNameSpace,
-
-            SemanticConventions.AttributePeerService,
-            SemanticConventions.AttributeNetPeerName,
-            SemanticConventions.AttributeNetPeerIp,
-            SemanticConventions.AttributeNetPeerPort,
-            SemanticConventions.AttributeNetHostPort,
-            SemanticConventions.AttributeNetHostName,
-            "otel.status_code",
-
-            // required - Messaging
-            SemanticConventions.AttributeMessagingSystem,
-            SemanticConventions.AttributeMessagingDestinationName,
-            SemanticConventions.AttributeNetworkProtocolName,
-
-            // Others
-            SemanticConventions.AttributeEnduserId,
-            SemanticConventions.AttributeEnduserPseudoId,
-            SemanticConventions.AttributeMicrosoftClientIp,
-
-            // Microsoft Application Insights Override Attributes
-            SemanticConventions.AttributeMicrosoftDependencyData,
-            SemanticConventions.AttributeMicrosoftDependencyName,
-            SemanticConventions.AttributeMicrosoftOperationName,
-            SemanticConventions.AttributeMicrosoftDependencyResultCode,
-            SemanticConventions.AttributeMicrosoftDependencyTarget,
-            SemanticConventions.AttributeMicrosoftDependencyType,
-            SemanticConventions.AttributeMicrosoftRequestName,
-            SemanticConventions.AttributeMicrosoftRequestUrl,
-            SemanticConventions.AttributeMicrosoftRequestSource,
-            SemanticConventions.AttributeMicrosoftRequestResultCode,
-
-            // Context tag attributes from Application Insights shim
-            SemanticConventions.AttributeMicrosoftSessionId,
-            SemanticConventions.AttributeAiDeviceId,
-            SemanticConventions.AttributeAiDeviceModel,
-            SemanticConventions.AttributeAiDeviceType,
-            SemanticConventions.AttributeAiDeviceOsVersion,
-            SemanticConventions.AttributeMicrosoftSyntheticSource,
-            SemanticConventions.AttributeMicrosoftUserAccountId,
-        };
-
-        internal static readonly HashSet<string> s_semanticsSet = new(s_semantics);
+        private readonly bool _includeUnmappedTags;
 
         public AzMonList MappedTags;
         public AzMonList UnMappedTags;
 
-        public OperationType activityType { get; set; }
+        public OperationType activityType { get; private set; }
+
+        /// <summary>
+        /// Whether the activity carried the newer semantic conventions.
+        /// </summary>
+        public readonly bool IsV2 => activityType.HasFlag(OperationType.V2);
+
+        /// <summary>
+        /// The operation type without the schema-version flag, for dispatching on the operation alone.
+        /// </summary>
+        public readonly OperationType BaseActivityType => activityType & ~OperationType.V2;
 
         public string? AzureNamespace { get; private set; } = null;
 
@@ -100,8 +36,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         public ActivityTagsProcessor()
         {
-            MappedTags = AzMonList.Initialize();
+            _includeUnmappedTags = true;
+            MappedTags = AzMonList.InitializeForMappedTags();
             UnMappedTags = AzMonList.Initialize();
+        }
+
+        /// <summary>
+        /// Callers that only read <see cref="MappedTags"/> can skip collecting the unmapped
+        /// tags, which avoids a pooled buffer and the string conversion of array-valued tags.
+        /// </summary>
+        public ActivityTagsProcessor(bool includeUnmappedTags)
+        {
+            _includeUnmappedTags = includeUnmappedTags;
+            MappedTags = AzMonList.InitializeForMappedTags();
+            UnMappedTags = includeUnmappedTags ? AzMonList.Initialize() : default;
         }
 
         public void CategorizeTags(Activity activity)
@@ -113,68 +61,73 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     continue;
                 }
 
-                if (s_semanticsSet.Contains(tag.Key))
+                if (SemanticSlotMap.TryGetSlot(tag.Key, out var slot))
                 {
-                    switch (tag.Key)
+                    switch (slot)
                     {
-                        case SemanticConventions.AttributeHttpMethod:
+                        case SemanticSlot.HttpMethod:
                             activityType = OperationType.Http;
                             break;
-                        case SemanticConventions.AttributeHttpRequestMethod:
+                        case SemanticSlot.HttpRequestMethod:
                             activityType = OperationType.Http | OperationType.V2;
                             break;
-                        case SemanticConventions.AttributeDbSystemName:
+                        case SemanticSlot.DbSystemName:
                             activityType = OperationType.Db | OperationType.V2;
                             break;
-                        case SemanticConventions.AttributeDbSystem:
+                        case SemanticSlot.DbSystem:
                             activityType = OperationType.Db;
                             break;
-                        case SemanticConventions.AttributeMessagingSystem:
+                        case SemanticSlot.MessagingSystem:
                             activityType = OperationType.Messaging;
                             break;
-                        case SemanticConventions.AttributeAzureNameSpace:
+                        case SemanticSlot.AzureNameSpace:
                             AzureNamespace = tag.Value.ToString();
                             break;
-                        case SemanticConventions.AttributeEnduserId:
+                        case SemanticSlot.EnduserId:
                             EndUserId = tag.Value.ToString();
                             continue;
-                        case SemanticConventions.AttributeEnduserPseudoId:
+                        case SemanticSlot.EnduserPseudoId:
                             EndUserPseudoId = tag.Value.ToString();
                             continue;
-                        case SemanticConventions.AttributeMicrosoftSessionId:
-                        case SemanticConventions.AttributeAiDeviceId:
-                        case SemanticConventions.AttributeAiDeviceModel:
-                        case SemanticConventions.AttributeAiDeviceType:
-                        case SemanticConventions.AttributeAiDeviceOsVersion:
-                        case SemanticConventions.AttributeMicrosoftSyntheticSource:
-                        case SemanticConventions.AttributeMicrosoftUserAccountId:
-                        case SemanticConventions.AttributeMicrosoftDependencyData:
-                        case SemanticConventions.AttributeMicrosoftDependencyName:
-                        case SemanticConventions.AttributeMicrosoftDependencyTarget:
-                        case SemanticConventions.AttributeMicrosoftDependencyType:
-                        case SemanticConventions.AttributeMicrosoftDependencyResultCode:
-                        case SemanticConventions.AttributeMicrosoftOperationName:
-                        case SemanticConventions.AttributeMicrosoftRequestName:
-                        case SemanticConventions.AttributeMicrosoftRequestUrl:
-                        case SemanticConventions.AttributeMicrosoftRequestSource:
-                        case SemanticConventions.AttributeMicrosoftRequestResultCode:
+                        case SemanticSlot.MicrosoftSessionId:
+                        case SemanticSlot.AiDeviceId:
+                        case SemanticSlot.AiDeviceModel:
+                        case SemanticSlot.AiDeviceType:
+                        case SemanticSlot.AiDeviceOsVersion:
+                        case SemanticSlot.MicrosoftSyntheticSource:
+                        case SemanticSlot.MicrosoftUserAccountId:
+                        case SemanticSlot.MicrosoftDependencyData:
+                        case SemanticSlot.MicrosoftDependencyName:
+                        case SemanticSlot.MicrosoftDependencyTarget:
+                        case SemanticSlot.MicrosoftDependencyType:
+                        case SemanticSlot.MicrosoftDependencyResultCode:
+                        case SemanticSlot.MicrosoftOperationName:
+                        case SemanticSlot.MicrosoftRequestName:
+                        case SemanticSlot.MicrosoftRequestUrl:
+                        case SemanticSlot.MicrosoftRequestSource:
+                        case SemanticSlot.MicrosoftRequestResultCode:
                             HasOverrideAttributes = true;
                             break;
                     }
 
-                    AzMonList.Add(ref MappedTags, tag);
+                    AzMonList.AddMapped(ref MappedTags, slot, tag);
                 }
                 else
                 {
+                    if (!_includeUnmappedTags)
+                    {
+                        continue;
+                    }
+
                     // If the tag value is an array, there is no need to check for semantics;
                     // directly add it to the Unmapped list.
                     if (tag.Value is Array array)
                     {
-                        AzMonList.Add(ref UnMappedTags, new KeyValuePair<string, object?>(tag.Key, array.ToCommaDelimitedString()));
+                        AzMonList.AddUnmapped(ref UnMappedTags, new KeyValuePair<string, object?>(tag.Key, array.ToCommaDelimitedString()));
                         continue;
                     }
 
-                    AzMonList.Add(ref UnMappedTags, tag);
+                    AzMonList.AddUnmapped(ref UnMappedTags, tag);
                 }
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -56,7 +56,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         {
             foreach (ref readonly var tag in activity.EnumerateTagObjects())
             {
-                if (tag.Value == null)
+                // A tag with no key cannot be exported, and Activity does not reject one.
+                if (tag.Key is null || tag.Value == null)
                 {
                     continue;
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonList.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonList.cs
@@ -19,14 +19,26 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         private readonly object?[]? slots;
 
-        private AzMonList(KeyValuePair<string, object?>[]? data, int length, object?[]? slots)
+        private readonly int listCount;
+
+        private AzMonList(KeyValuePair<string, object?>[]? data, int listCount, int length, object?[]? slots)
         {
             this.data = data;
+            this.listCount = listCount;
             this.Length = length;
             this.slots = slots;
         }
 
+        /// <summary>
+        /// Total tags held, across both the slot array and the list buffer.
+        /// </summary>
         public int Length { get; }
+
+        /// <summary>
+        /// Tags held in the list buffer. A recognized attribute occupies a slot rather than a
+        /// list entry, so this trails <see cref="Length"/> for an instance holding both kinds.
+        /// </summary>
+        public int ListCount => this.listCount;
 
         public ref KeyValuePair<string, object?> this[int index]
         {
@@ -44,7 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         public static AzMonList Initialize()
         {
-            return new AzMonList(ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(DefaultCapacity), 0, null);
+            return new AzMonList(ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(DefaultCapacity), 0, 0, null);
         }
 
         /// <summary>
@@ -52,7 +64,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// </summary>
         public static AzMonList InitializeForMappedTags()
         {
-            return new AzMonList(null, 0, RentSlots());
+            return new AzMonList(null, 0, 0, RentSlots());
         }
 
         private static object?[] RentSlots()
@@ -95,7 +107,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 length++;
             }
 
-            list = new AzMonList(list.data, length, slots);
+            list = new AzMonList(list.data, list.listCount, length, slots);
         }
 
         /// <summary>
@@ -104,23 +116,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public static void AddUnmapped(ref AzMonList list, KeyValuePair<string, object?> keyValuePair)
         {
             var data = list.data ?? ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(DefaultCapacity);
+            var listCount = list.listCount;
 
-            if (list.Length >= data.Length)
+            if (listCount >= data.Length)
             {
                 var previousData = data;
 
                 data = ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(previousData.Length * 2);
 
-                previousData.AsSpan(0, list.Length).CopyTo(data);
+                previousData.AsSpan(0, listCount).CopyTo(data);
 
                 // Entries hold references to caller-owned tag keys and values, so the used
                 // region is cleared before the buffer goes back to the shared pool.
-                Array.Clear(previousData, 0, list.Length);
+                Array.Clear(previousData, 0, listCount);
                 ArrayPool<KeyValuePair<string, object?>>.Shared.Return(previousData);
             }
 
-            data[list.Length] = keyValuePair;
-            list = new AzMonList(data, list.Length + 1, list.slots);
+            data[listCount] = keyValuePair;
+            list = new AzMonList(data, listCount + 1, list.Length + 1, list.slots);
         }
 
         public static object? GetTagValue(ref AzMonList list, string tagName)
@@ -136,7 +149,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 return null;
             }
 
-            int length = list.Length;
+            int length = list.listCount;
 
             for (int i = 0; i < length; i++)
             {
@@ -155,7 +168,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             if (data != null)
             {
                 // Every return path clears its own used region, so unused slots are already clean.
-                Array.Clear(data, 0, Math.Min(this.Length, data.Length));
+                Array.Clear(data, 0, this.listCount);
                 ArrayPool<KeyValuePair<string, object?>>.Shared.Return(data);
             }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonList.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonList.cs
@@ -3,97 +3,150 @@
 
 using System;
 using System.Buffers;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
-    internal readonly struct AzMonList : IEnumerable
+    /// <remarks>
+    /// An instance holds either recognized attributes (in the slot array) or unrecognized tags
+    /// (in the list buffer), not both. Each buffer is rented only if that kind is stored.
+    /// </remarks>
+    internal readonly struct AzMonList
     {
-        private static int s_allocationSize = 8;
+        private const int DefaultCapacity = 8;
 
-        private readonly KeyValuePair<string, object?>[] data;
+        private readonly KeyValuePair<string, object?>[]? data;
 
-        private AzMonList(KeyValuePair<string, object?>[] data, int length)
+        private readonly object?[]? slots;
+
+        private AzMonList(KeyValuePair<string, object?>[]? data, int length, object?[]? slots)
         {
             this.data = data;
             this.Length = length;
+            this.slots = slots;
         }
 
         public int Length { get; }
 
         public ref KeyValuePair<string, object?> this[int index]
         {
-            get => ref this.data[index];
+            get => ref this.data![index];
+        }
+
+        /// <summary>
+        /// Reads a recognized attribute in constant time. Returns <see langword="null"/> when the
+        /// attribute is absent.
+        /// </summary>
+        public object? this[SemanticSlot slot]
+        {
+            get => this.slots?[(int)slot];
         }
 
         public static AzMonList Initialize()
         {
-            return new AzMonList(ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(s_allocationSize), 0);
+            return new AzMonList(ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(DefaultCapacity), 0, null);
         }
 
+        /// <summary>
+        /// Initializes a list that will only hold recognized attributes, so no list buffer is rented.
+        /// </summary>
+        public static AzMonList InitializeForMappedTags()
+        {
+            return new AzMonList(null, 0, RentSlots());
+        }
+
+        private static object?[] RentSlots()
+        {
+            var slots = ArrayPool<object?>.Shared.Rent((int)SemanticSlot.Count);
+
+            // The shared pool is process-wide, so a rented buffer cannot be assumed clean.
+            Array.Clear(slots, 0, (int)SemanticSlot.Count);
+
+            return slots;
+        }
+
+        /// <summary>
+        /// Adds a tag, resolving its slot so it can later be read by <see cref="SemanticSlot"/>.
+        /// </summary>
         public static void Add(ref AzMonList list, KeyValuePair<string, object?> keyValuePair)
         {
-            var data = list.data ?? throw new InvalidOperationException("AzMonList instance is not initialized.");
+            if (SemanticSlotMap.TryGetSlot(keyValuePair.Key, out var slot))
+            {
+                AddMapped(ref list, slot, keyValuePair);
+            }
+            else
+            {
+                AddUnmapped(ref list, keyValuePair);
+            }
+        }
+
+        /// <summary>
+        /// Adds a tag whose slot the caller has already resolved.
+        /// </summary>
+        public static void AddMapped(ref AzMonList list, SemanticSlot slot, KeyValuePair<string, object?> keyValuePair)
+        {
+            var slots = list.slots ?? RentSlots();
+            var length = list.Length;
+
+            // First write wins, matching the first-match behaviour of GetTagValue.
+            if (slots[(int)slot] == null)
+            {
+                slots[(int)slot] = keyValuePair.Value;
+                length++;
+            }
+
+            list = new AzMonList(list.data, length, slots);
+        }
+
+        /// <summary>
+        /// Adds a tag that is not a recognized attribute.
+        /// </summary>
+        public static void AddUnmapped(ref AzMonList list, KeyValuePair<string, object?> keyValuePair)
+        {
+            var data = list.data ?? ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(DefaultCapacity);
 
             if (list.Length >= data.Length)
             {
-                s_allocationSize = data.Length * 2;
                 var previousData = data;
 
-                data = ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(s_allocationSize);
+                data = ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(previousData.Length * 2);
 
-                var span = previousData.AsSpan();
-                span.CopyTo(data);
+                previousData.AsSpan(0, list.Length).CopyTo(data);
+
+                // Entries hold references to caller-owned tag keys and values, so the used
+                // region is cleared before the buffer goes back to the shared pool.
+                Array.Clear(previousData, 0, list.Length);
                 ArrayPool<KeyValuePair<string, object?>>.Shared.Return(previousData);
             }
 
             data[list.Length] = keyValuePair;
-            list = new AzMonList(data, list.Length + 1);
-        }
-
-        public static void Clear(ref AzMonList list)
-        {
-            list = new AzMonList(list.data, 0);
+            list = new AzMonList(data, list.Length + 1, list.slots);
         }
 
         public static object? GetTagValue(ref AzMonList list, string tagName)
         {
+            if (list.slots != null && SemanticSlotMap.TryGetSlot(tagName, out var slot))
+            {
+                return list.slots[(int)slot];
+            }
+
+            var data = list.data;
+            if (data == null)
+            {
+                return null;
+            }
+
             int length = list.Length;
 
             for (int i = 0; i < length; i++)
             {
-                if (string.Equals(list[i].Key, tagName, StringComparison.Ordinal))
+                if (string.Equals(data[i].Key, tagName, StringComparison.Ordinal))
                 {
-                    return list[i].Value;
+                    return data[i].Value;
                 }
             }
 
             return null;
-        }
-
-        internal static object?[] GetTagValues(ref AzMonList list, params string[] tagNames)
-        {
-            int lengthTagNames = tagNames.Length;
-            int lengthList = list.Length;
-            object?[] values = new object[lengthTagNames];
-
-            for (int i = 0; i < lengthList; i++)
-            {
-                var index = Array.IndexOf(tagNames, list[i].Key);
-                if (index >= 0)
-                {
-                    values[index] = list[i].Value;
-                    lengthTagNames--;
-
-                    if (lengthTagNames == 0)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            return values;
         }
 
         public void Return()
@@ -101,49 +154,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             var data = this.data;
             if (data != null)
             {
+                // Every return path clears its own used region, so unused slots are already clean.
+                Array.Clear(data, 0, Math.Min(this.Length, data.Length));
                 ArrayPool<KeyValuePair<string, object?>>.Shared.Return(data);
             }
-        }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return new Enumerator(in this);
-        }
-
-        public struct Enumerator : IEnumerator
-        {
-            private readonly KeyValuePair<string, object?>[] data;
-            private readonly int length;
-            private int index;
-            private KeyValuePair<string, object?> current;
-
-            public Enumerator(in AzMonList list)
+            var slots = this.slots;
+            if (slots != null)
             {
-                this.data = list.data;
-                this.length = list.Length;
-                this.index = 0;
-                this.current = default;
-            }
-
-            public object Current { get => this.current; }
-
-            public bool MoveNext()
-            {
-                if (this.index < this.length)
-                {
-                    this.current = this.data[this.index++];
-                    return true;
-                }
-
-                this.index = this.length + 1;
-                this.current = default;
-                return false;
-            }
-
-            void IEnumerator.Reset()
-            {
-                this.index = 0;
-                this.current = default;
+                Array.Clear(slots, 0, (int)SemanticSlot.Count);
+                ArrayPool<object?>.Shared.Return(slots);
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -26,7 +26,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions
             // http.url
             // http.scheme, http.host, http.target
-            // http.scheme, http.server_name, net.host.port, http.target
             // http.scheme, net.host.name, net.host.port, http.target
             string? url = null;
             url = tagObjects.GetUrlUsingHttpUrl();
@@ -35,10 +34,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 return url;
             }
 
-            var httpScheme = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpScheme)?.ToString();
+            var httpScheme = tagObjects[SemanticSlot.HttpScheme]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpScheme))
             {
-                var httpTarget = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpTarget)?.ToString();
+                var httpTarget = tagObjects[SemanticSlot.HttpTarget]?.ToString();
                 // http.target is required in other three possible combinations
                 // If not available then do not proceed.
                 if (string.IsNullOrWhiteSpace(httpTarget))
@@ -53,19 +52,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     return url;
                 }
 
-                var httpServerName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpServerName)?.ToString();
-                string? host;
-                if (!string.IsNullOrWhiteSpace(httpServerName))
-                {
-                    host = httpServerName;
-                }
-                else
-                {
-                    host = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetHostName)?.ToString();
-                }
+                var host = tagObjects[SemanticSlot.NetHostName]?.ToString();
                 if (!string.IsNullOrWhiteSpace(host))
                 {
-                    var netHostPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetHostPort)?.ToString();
+                    var netHostPort = tagObjects[SemanticSlot.NetHostPort]?.ToString();
                     if (!string.IsNullOrWhiteSpace(netHostPort))
                     {
                         url = tagObjects.GetUrlUsingHostAndPort(httpScheme!, host!, netHostPort!, defaultPort, httpTarget!);
@@ -95,10 +85,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 return url;
             }
 
-            var httpScheme = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpScheme)?.ToString();
+            var httpScheme = tagObjects[SemanticSlot.HttpScheme]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpScheme))
             {
-                var httpTarget = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpTarget)?.ToString();
+                var httpTarget = tagObjects[SemanticSlot.HttpTarget]?.ToString();
                 // http.target is required in other three possible combinations
                 // If not available then do not proceed.
                 if (string.IsNullOrWhiteSpace(httpTarget))
@@ -116,7 +106,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 var host = tagObjects.GetHostUsingNetPeerAttributes();
                 if (!string.IsNullOrWhiteSpace(host))
                 {
-                    var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
+                    var netPeerPort = tagObjects[SemanticSlot.NetPeerPort]?.ToString();
                     if (!string.IsNullOrWhiteSpace(netPeerPort))
                     {
                         url = tagObjects.GetUrlUsingHostAndPort(httpScheme!, host!, netPeerPort!, defaultPort, httpTarget!);
@@ -170,7 +160,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal static string? GetUrlUsingHttpUrl(this AzMonList tagObjects)
         {
             string? url = null;
-            var httpUrl = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpUrl)?.ToString();
+            var httpUrl = tagObjects[SemanticSlot.HttpUrl]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpUrl))
             {
                 url = httpUrl;
@@ -182,7 +172,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal static string? GetUrlUsingHttpHost(this AzMonList tagObjects, string httpScheme, string defaultPort, string httpTarget)
         {
             string? url = null;
-            var httpHost = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpHost)?.ToString();
+            var httpHost = tagObjects[SemanticSlot.HttpHost]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpHost))
             {
                 string portSection = $":{defaultPort}";
@@ -217,7 +207,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal static string? GetHostUsingNetPeerAttributes(this AzMonList tagObjects)
         {
-            var netPeerName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerName)?.ToString();
+            var netPeerName = tagObjects[SemanticSlot.NetPeerName]?.ToString();
             string? host;
             if (!string.IsNullOrWhiteSpace(netPeerName))
             {
@@ -225,7 +215,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
             else
             {
-                host = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerIp)?.ToString();
+                host = tagObjects[SemanticSlot.NetPeerIp]?.ToString();
             }
 
             return host;
@@ -237,7 +227,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             string? target = tagObjects.GetHostUsingNetPeerAttributes();
             if (!string.IsNullOrWhiteSpace(target))
             {
-                var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
+                var netPeerPort = tagObjects[SemanticSlot.NetPeerPort]?.ToString();
                 if (!string.IsNullOrWhiteSpace(netPeerPort) && netPeerPort != defaultPort)
                 {
                     target = $"{target}:{netPeerPort}";
@@ -250,9 +240,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string? GetTargetUsingServerAttributes(this AzMonList tagObjects, string defaultPort)
         {
-            var values = AzMonList.GetTagValues(ref tagObjects, SemanticConventions.AttributeServerAddress, SemanticConventions.AttributeServerSocketAddress, SemanticConventions.AttributeServerPort);
-            string? target = values[0]?.ToString() ?? values[1]?.ToString();
-            var port = values[2]?.ToString();
+            string? target = tagObjects[SemanticSlot.ServerAddress]?.ToString();
+            var port = tagObjects[SemanticSlot.ServerPort]?.ToString();
             if (!string.IsNullOrWhiteSpace(target) &&  port != null && port != defaultPort)
             {
                 target = target + ":" + port;
@@ -264,12 +253,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string? GetTargetUsingServerAddressAndPort(this AzMonList tagObjects)
         {
-            var serverAttributes = AzMonList.GetTagValues(ref tagObjects, SemanticConventions.AttributeServerAddress, SemanticConventions.AttributeServerPort);
-
-            var serverAddress = serverAttributes[0]?.ToString();
+            var serverAddress = tagObjects[SemanticSlot.ServerAddress]?.ToString();
             if (!string.IsNullOrEmpty(serverAddress))
             {
-                var serverPort = serverAttributes[1]?.ToString();
+                var serverPort = tagObjects[SemanticSlot.ServerPort]?.ToString();
 
                 return string.IsNullOrEmpty(serverPort)
                     ? serverAddress
@@ -285,15 +272,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal static string? GetHttpDependencyTarget(this AzMonList tagObjects)
         {
             string? target;
-            string defaultPort = GetDefaultHttpPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpScheme)?.ToString());
-            var peerService = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributePeerService)?.ToString();
+            string defaultPort = GetDefaultHttpPort(tagObjects[SemanticSlot.HttpScheme]?.ToString());
+            var peerService = tagObjects[SemanticSlot.PeerService]?.ToString();
             if (!string.IsNullOrWhiteSpace(peerService))
             {
                 target = peerService;
                 return target;
             }
 
-            var httpHost = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpHost)?.ToString();
+            var httpHost = tagObjects[SemanticSlot.HttpHost]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpHost))
             {
                 string portSection = $":{defaultPort}";
@@ -309,7 +296,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 return target;
             }
 
-            var httpUrl = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpUrl)?.ToString();
+            var httpUrl = tagObjects[SemanticSlot.HttpUrl]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpUrl)
                 && Uri.TryCreate(httpUrl!.ToString(), UriKind.RelativeOrAbsolute, out var uri)
                 && uri.IsAbsoluteUri)
@@ -331,26 +318,25 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ///</summary>
         internal static (string? DbName, string? DbTarget) GetDbDependencyTargetAndName(this AzMonList tagObjects, bool isNewSchemaVersion)
         {
-            string statementDbNameKey;
-            string statementDbSystemKey;
+            SemanticSlot dbNameSlot;
+            SemanticSlot dbSystemSlot;
             if (isNewSchemaVersion) {
-                statementDbNameKey = SemanticConventions.AttributeDbNamespace;
-                statementDbSystemKey = SemanticConventions.AttributeDbSystemName;
+                dbNameSlot = SemanticSlot.DbNamespace;
+                dbSystemSlot = SemanticSlot.DbSystemName;
             } else {
-                statementDbNameKey = SemanticConventions.AttributeDbName;
-                statementDbSystemKey = SemanticConventions.AttributeDbSystem;
+                dbNameSlot = SemanticSlot.DbName;
+                dbSystemSlot = SemanticSlot.DbSystem;
             }
 
-            var peerServiceAndDbSystem = AzMonList.GetTagValues(ref tagObjects, SemanticConventions.AttributePeerService, statementDbSystemKey);
-            string? target = peerServiceAndDbSystem[0]?.ToString();
-            var defaultPort = GetDefaultDbPort(peerServiceAndDbSystem[1]?.ToString());
+            string? target = tagObjects[SemanticSlot.PeerService]?.ToString();
+            var defaultPort = GetDefaultDbPort(tagObjects[dbSystemSlot]?.ToString());
 
             if (string.IsNullOrWhiteSpace(target))
             {
                 target = tagObjects.GetTargetUsingServerAttributes(defaultPort) ?? tagObjects.GetTargetUsingNetPeerAttributes(defaultPort);
             }
 
-            var dbName = AzMonList.GetTagValue(ref tagObjects, statementDbNameKey)?.ToString();
+            var dbName = tagObjects[dbNameSlot]?.ToString();
             bool isTargetEmpty = string.IsNullOrWhiteSpace(target);
             bool isDbNameEmpty = string.IsNullOrWhiteSpace(dbName);
             if (!isTargetEmpty && !isDbNameEmpty)
@@ -363,7 +349,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
             else if (isTargetEmpty && isDbNameEmpty)
             {
-                target = AzMonList.GetTagValue(ref tagObjects, statementDbSystemKey)?.ToString();
+                target = tagObjects[dbSystemSlot]?.ToString();
             }
 
             return (DbName: dbName, DbTarget: target);
@@ -394,7 +380,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 return null;
             }
 
-            var httpMethod = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpMethod)?.ToString();
+            var httpMethod = tagObjects[SemanticSlot.HttpMethod]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpMethod))
             {
                 if (Uri.TryCreate(httpUrl!.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
@@ -416,12 +402,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     }
                 case OperationType.Db:
                     {
-                        var dbSystem = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString();
+                        var dbSystem = tagObjects[SemanticSlot.DbSystem]?.ToString();
                         return AzMonListExtensions.s_dbSystems.Contains(dbSystem) ? "SQL" : dbSystem?.Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
                     }
                 case OperationType.Messaging:
                     {
-                        return AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeMessagingSystem)?.ToString();
+                        return tagObjects[SemanticSlot.MessagingSystem]?.ToString();
                     }
             }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonNewListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonNewListExtensions.cs
@@ -16,14 +16,12 @@ internal static class AzMonNewListExtensions
     {
         try
         {
-            var requestUrlTagObjects = AzMonList.GetTagValues(ref tagObjects, SemanticConventions.AttributeUrlScheme, SemanticConventions.AttributeServerAddress, SemanticConventions.AttributeServerPort, SemanticConventions.AttributeUrlPath, SemanticConventions.AttributeUrlQuery);
-
-            var scheme = requestUrlTagObjects[0]?.ToString() ?? string.Empty; // requestUrlTagObjects[0] => SemanticConventions.AttributeUrlScheme.
-            var host = requestUrlTagObjects[1]?.ToString() ?? string.Empty; // requestUrlTagObjects[1] => SemanticConventions.AttributeServerAddress.
-            var port = requestUrlTagObjects[2]?.ToString(); // requestUrlTagObjects[2] => SemanticConventions.AttributeServerPort.
+            var scheme = tagObjects[SemanticSlot.UrlScheme]?.ToString() ?? string.Empty;
+            var host = tagObjects[SemanticSlot.ServerAddress]?.ToString() ?? string.Empty;
+            var port = tagObjects[SemanticSlot.ServerPort]?.ToString();
             port = port != null ? port = $":{port}" : string.Empty;
-            var path = requestUrlTagObjects[3]?.ToString() ?? string.Empty; // requestUrlTagObjects[3] => SemanticConventions.AttributeUrlPath.
-            var queryString = requestUrlTagObjects[4]?.ToString() ?? string.Empty; // requestUrlTagObjects[4] => SemanticConventions.AttributeUrlQuery.
+            var path = tagObjects[SemanticSlot.UrlPath]?.ToString() ?? string.Empty;
+            var queryString = tagObjects[SemanticSlot.UrlQuery]?.ToString() ?? string.Empty;
 
             var length = scheme.Length + Uri.SchemeDelimiter.Length + host.Length + port.Length + path.Length + queryString.Length;
 
@@ -55,15 +53,12 @@ internal static class AzMonNewListExtensions
 
         try
         {
-            var host = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeServerAddress)?.ToString()
-                        ?? AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerName)?.ToString();
+            var host = tagObjects[SemanticSlot.ServerAddress]?.ToString()
+                        ?? tagObjects[SemanticSlot.NetPeerName]?.ToString();
             if (!string.IsNullOrEmpty(host))
             {
-                object?[] messagingTagObjects;
-
-                messagingTagObjects = AzMonList.GetTagValues(ref tagObjects, SemanticConventions.AttributeNetworkProtocolName, SemanticConventions.AttributeMessagingDestinationName);
-                var protocolName = messagingTagObjects[0]?.ToString() ?? string.Empty; // messagingTagObjects[0] => SemanticConventions.AttributeNetworkProtocolName.
-                var destinationName = messagingTagObjects[1]?.ToString() ?? string.Empty; // messagingTagObjects[1] => SemanticConventions.AttributeMessagingDestinationName.
+                var protocolName = tagObjects[SemanticSlot.NetworkProtocolName]?.ToString() ?? string.Empty;
+                var destinationName = tagObjects[SemanticSlot.MessagingDestinationName]?.ToString() ?? string.Empty;
 
                 if (destinationName.Length > 0)
                 {
@@ -96,9 +91,8 @@ internal static class AzMonNewListExtensions
     ///</summary>
     internal static string? GetNewSchemaHttpDependencyTarget(this AzMonList tagObjects)
     {
-        var tagValues = AzMonList.GetTagValues(ref tagObjects, SemanticConventions.AttributeServerAddress, SemanticConventions.AttributeServerPort);
-        var serverAddress = tagValues[0]?.ToString(); // tagValues[0] => SemanticConventions.AttributeServerAddress.
-        var serverPort = tagValues[1]?.ToString(); // tagValues[1] => SemanticConventions.AttributeServerPort.
+        var serverAddress = tagObjects[SemanticSlot.ServerAddress]?.ToString();
+        var serverPort = tagObjects[SemanticSlot.ServerPort]?.ToString();
 
         if (string.IsNullOrWhiteSpace(serverAddress))
         {
@@ -120,7 +114,7 @@ internal static class AzMonNewListExtensions
             return null;
         }
 
-        var httpMethod = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpRequestMethod)?.ToString();
+        var httpMethod = tagObjects[SemanticSlot.HttpRequestMethod]?.ToString();
         if (!string.IsNullOrWhiteSpace(httpMethod))
         {
             if (Uri.TryCreate(httpUrl!.ToString(), UriKind.Absolute, out var uri) && uri.IsAbsoluteUri)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonNewListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonNewListExtensions.cs
@@ -19,7 +19,7 @@ internal static class AzMonNewListExtensions
             var scheme = tagObjects[SemanticSlot.UrlScheme]?.ToString() ?? string.Empty;
             var host = tagObjects[SemanticSlot.ServerAddress]?.ToString() ?? string.Empty;
             var port = tagObjects[SemanticSlot.ServerPort]?.ToString();
-            port = port != null ? port = $":{port}" : string.Empty;
+            port = port != null ? $":{port}" : string.Empty;
             var path = tagObjects[SemanticSlot.UrlPath]?.ToString() ?? string.Empty;
             var queryString = tagObjects[SemanticSlot.UrlQuery]?.ToString() ?? string.Empty;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticSlot.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticSlot.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    /// <summary>
+    /// Dense index assigned to each attribute recognized by <see cref="ActivityTagsProcessor"/>.
+    /// Lets callers read a mapped tag by array index instead of scanning for a string key.
+    /// </summary>
+    internal enum SemanticSlot : byte
+    {
+        DbStatement,
+        DbQueryText,
+        DbSystem,
+        DbSystemName,
+        DbName,
+        DbNamespace,
+
+        HttpMethod,
+        HttpUrl,
+        HttpStatusCode,
+        HttpScheme,
+        HttpHost,
+        HttpHostPort,
+        HttpTarget,
+        HttpUserAgent,
+        HttpRoute,
+
+        HttpRequestMethod,
+        HttpResponseStatusCode,
+        ServerAddress,
+        ServerPort,
+        UrlFull,
+        UrlPath,
+        UrlScheme,
+        UrlQuery,
+        UserAgentOriginal,
+        ClientAddress,
+
+        AzureNameSpace,
+
+        PeerService,
+        NetPeerName,
+        NetPeerIp,
+        NetPeerPort,
+        NetHostPort,
+        NetHostName,
+        OtelStatusCode,
+
+        MessagingSystem,
+        MessagingDestinationName,
+        NetworkProtocolName,
+
+        EnduserId,
+        EnduserPseudoId,
+        MicrosoftClientIp,
+
+        MicrosoftDependencyData,
+        MicrosoftDependencyName,
+        MicrosoftOperationName,
+        MicrosoftDependencyResultCode,
+        MicrosoftDependencyTarget,
+        MicrosoftDependencyType,
+        MicrosoftRequestName,
+        MicrosoftRequestUrl,
+        MicrosoftRequestSource,
+        MicrosoftRequestResultCode,
+
+        MicrosoftSessionId,
+        AiDeviceId,
+        AiDeviceModel,
+        AiDeviceType,
+        AiDeviceOsVersion,
+        MicrosoftSyntheticSource,
+        MicrosoftUserAccountId,
+
+        /// <summary>Not a slot. Sizes the backing index.</summary>
+        Count,
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticSlotMap.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticSlotMap.cs
@@ -75,6 +75,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             [SemanticConventions.AttributeMicrosoftUserAccountId] = SemanticSlot.MicrosoftUserAccountId,
         };
 
-        public static bool TryGetSlot(string key, out SemanticSlot slot) => s_slots.TryGetValue(key, out slot);
+        /// <remarks>
+        /// <see cref="System.Diagnostics.Activity"/> does not reject a null tag key, and
+        /// <see cref="Dictionary{TKey, TValue}.TryGetValue"/> throws on one, so null is treated
+        /// as unrecognized.
+        /// </remarks>
+        public static bool TryGetSlot(string? key, out SemanticSlot slot)
+        {
+            if (key == null)
+            {
+                slot = default;
+                return false;
+            }
+
+            return s_slots.TryGetValue(key, out slot);
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticSlotMap.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticSlotMap.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    internal static class SemanticSlotMap
+    {
+        private static readonly Dictionary<string, SemanticSlot> s_slots = new(capacity: (int)SemanticSlot.Count)
+        {
+            [SemanticConventions.AttributeDbStatement] = SemanticSlot.DbStatement,
+            [SemanticConventions.AttributeDbQueryText] = SemanticSlot.DbQueryText,
+            [SemanticConventions.AttributeDbSystem] = SemanticSlot.DbSystem,
+            [SemanticConventions.AttributeDbSystemName] = SemanticSlot.DbSystemName,
+            [SemanticConventions.AttributeDbName] = SemanticSlot.DbName,
+            [SemanticConventions.AttributeDbNamespace] = SemanticSlot.DbNamespace,
+
+            [SemanticConventions.AttributeHttpMethod] = SemanticSlot.HttpMethod,
+            [SemanticConventions.AttributeHttpUrl] = SemanticSlot.HttpUrl,
+            [SemanticConventions.AttributeHttpStatusCode] = SemanticSlot.HttpStatusCode,
+            [SemanticConventions.AttributeHttpScheme] = SemanticSlot.HttpScheme,
+            [SemanticConventions.AttributeHttpHost] = SemanticSlot.HttpHost,
+            [SemanticConventions.AttributeHttpHostPort] = SemanticSlot.HttpHostPort,
+            [SemanticConventions.AttributeHttpTarget] = SemanticSlot.HttpTarget,
+            [SemanticConventions.AttributeHttpUserAgent] = SemanticSlot.HttpUserAgent,
+            [SemanticConventions.AttributeHttpRoute] = SemanticSlot.HttpRoute,
+
+            [SemanticConventions.AttributeHttpRequestMethod] = SemanticSlot.HttpRequestMethod,
+            [SemanticConventions.AttributeHttpResponseStatusCode] = SemanticSlot.HttpResponseStatusCode,
+            [SemanticConventions.AttributeServerAddress] = SemanticSlot.ServerAddress,
+            [SemanticConventions.AttributeServerPort] = SemanticSlot.ServerPort,
+            [SemanticConventions.AttributeUrlFull] = SemanticSlot.UrlFull,
+            [SemanticConventions.AttributeUrlPath] = SemanticSlot.UrlPath,
+            [SemanticConventions.AttributeUrlScheme] = SemanticSlot.UrlScheme,
+            [SemanticConventions.AttributeUrlQuery] = SemanticSlot.UrlQuery,
+            [SemanticConventions.AttributeUserAgentOriginal] = SemanticSlot.UserAgentOriginal,
+            [SemanticConventions.AttributeClientAddress] = SemanticSlot.ClientAddress,
+
+            [SemanticConventions.AttributeAzureNameSpace] = SemanticSlot.AzureNameSpace,
+
+            [SemanticConventions.AttributePeerService] = SemanticSlot.PeerService,
+            [SemanticConventions.AttributeNetPeerName] = SemanticSlot.NetPeerName,
+            [SemanticConventions.AttributeNetPeerIp] = SemanticSlot.NetPeerIp,
+            [SemanticConventions.AttributeNetPeerPort] = SemanticSlot.NetPeerPort,
+            [SemanticConventions.AttributeNetHostPort] = SemanticSlot.NetHostPort,
+            [SemanticConventions.AttributeNetHostName] = SemanticSlot.NetHostName,
+            ["otel.status_code"] = SemanticSlot.OtelStatusCode,
+
+            [SemanticConventions.AttributeMessagingSystem] = SemanticSlot.MessagingSystem,
+            [SemanticConventions.AttributeMessagingDestinationName] = SemanticSlot.MessagingDestinationName,
+            [SemanticConventions.AttributeNetworkProtocolName] = SemanticSlot.NetworkProtocolName,
+
+            [SemanticConventions.AttributeEnduserId] = SemanticSlot.EnduserId,
+            [SemanticConventions.AttributeEnduserPseudoId] = SemanticSlot.EnduserPseudoId,
+            [SemanticConventions.AttributeMicrosoftClientIp] = SemanticSlot.MicrosoftClientIp,
+
+            [SemanticConventions.AttributeMicrosoftDependencyData] = SemanticSlot.MicrosoftDependencyData,
+            [SemanticConventions.AttributeMicrosoftDependencyName] = SemanticSlot.MicrosoftDependencyName,
+            [SemanticConventions.AttributeMicrosoftOperationName] = SemanticSlot.MicrosoftOperationName,
+            [SemanticConventions.AttributeMicrosoftDependencyResultCode] = SemanticSlot.MicrosoftDependencyResultCode,
+            [SemanticConventions.AttributeMicrosoftDependencyTarget] = SemanticSlot.MicrosoftDependencyTarget,
+            [SemanticConventions.AttributeMicrosoftDependencyType] = SemanticSlot.MicrosoftDependencyType,
+            [SemanticConventions.AttributeMicrosoftRequestName] = SemanticSlot.MicrosoftRequestName,
+            [SemanticConventions.AttributeMicrosoftRequestUrl] = SemanticSlot.MicrosoftRequestUrl,
+            [SemanticConventions.AttributeMicrosoftRequestSource] = SemanticSlot.MicrosoftRequestSource,
+            [SemanticConventions.AttributeMicrosoftRequestResultCode] = SemanticSlot.MicrosoftRequestResultCode,
+
+            [SemanticConventions.AttributeMicrosoftSessionId] = SemanticSlot.MicrosoftSessionId,
+            [SemanticConventions.AttributeAiDeviceId] = SemanticSlot.AiDeviceId,
+            [SemanticConventions.AttributeAiDeviceModel] = SemanticSlot.AiDeviceModel,
+            [SemanticConventions.AttributeAiDeviceType] = SemanticSlot.AiDeviceType,
+            [SemanticConventions.AttributeAiDeviceOsVersion] = SemanticSlot.AiDeviceOsVersion,
+            [SemanticConventions.AttributeMicrosoftSyntheticSource] = SemanticSlot.MicrosoftSyntheticSource,
+            [SemanticConventions.AttributeMicrosoftUserAccountId] = SemanticSlot.MicrosoftUserAccountId,
+        };
+
+        public static bool TryGetSlot(string key, out SemanticSlot slot) => s_slots.TryGetValue(key, out slot);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
@@ -199,51 +199,53 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         private void ReportDependencyDurationMetric(Activity activity)
         {
-            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity, includeUnmappedTags: false);
 
-            string? dependencyTarget;
-            string? statusCode;
-
-            if (activityTagsProcessor.activityType.HasFlag(OperationType.V2))
+            try
             {
-                // Reverting it for dependency type checks below
-                activityTagsProcessor.activityType &= ~OperationType.V2;
+                string? dependencyTarget;
+                string? statusCode;
 
-                dependencyTarget = activityTagsProcessor.MappedTags.GetNewSchemaDependencyTarget(activityTagsProcessor.activityType);
+                if (activityTagsProcessor.IsV2)
+                {
+                    dependencyTarget = activityTagsProcessor.MappedTags.GetNewSchemaDependencyTarget(activityTagsProcessor.BaseActivityType);
 
-                statusCode = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpResponseStatusCode)?.ToString();
+                    statusCode = activityTagsProcessor.MappedTags[SemanticSlot.HttpResponseStatusCode]?.ToString();
+                }
+                else
+                {
+                    dependencyTarget = activityTagsProcessor.MappedTags.GetDependencyTarget(activityTagsProcessor.BaseActivityType);
+
+                    statusCode = activityTagsProcessor.MappedTags[SemanticSlot.HttpStatusCode]?.ToString();
+                }
+
+                string? dependencyType;
+                if (activityTagsProcessor.AzureNamespace != null)
+                {
+                    dependencyType = TraceHelper.GetAzureSDKDependencyType(activity.Kind, activityTagsProcessor.AzureNamespace);
+                }
+                else
+                {
+                    dependencyType = activity.Kind == ActivityKind.Internal ? "InProc" : activityTagsProcessor.MappedTags.GetDependencyType(activityTagsProcessor.BaseActivityType);
+                }
+
+                TagList tags = default;
+                tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencyTargetKey, dependencyTarget));
+                tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencyResultCodeKey, statusCode ?? "0"));
+                tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.MetricIdKey, StandardMetricConstants.DependencyDurationMetricIdValue));
+                tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.IsAutoCollectedKey, "True"));
+                tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.CloudRoleInstanceKey, StandardMetricResource?.RoleInstance));
+                tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.CloudRoleNameKey, StandardMetricResource?.RoleName));
+                tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencySuccessKey, activity.Status != ActivityStatusCode.Error));
+                tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencyTypeKey, dependencyType));
+
+                // Report metric
+                _dependencyDuration?.Record(activity.Duration.TotalMilliseconds, tags);
             }
-            else
+            finally
             {
-                dependencyTarget = activityTagsProcessor.MappedTags.GetDependencyTarget(activityTagsProcessor.activityType);
-
-                statusCode = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpStatusCode)?.ToString();
+                activityTagsProcessor.Return();
             }
-
-            string? dependencyType;
-            if (activityTagsProcessor.AzureNamespace != null)
-            {
-                dependencyType = TraceHelper.GetAzureSDKDependencyType(activity.Kind, activityTagsProcessor.AzureNamespace);
-            }
-            else
-            {
-                dependencyType = activity.Kind == ActivityKind.Internal ? "InProc" : activityTagsProcessor.MappedTags.GetDependencyType(activityTagsProcessor.activityType);
-            }
-
-            TagList tags = default;
-            tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencyTargetKey, dependencyTarget));
-            tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencyResultCodeKey, statusCode ?? "0"));
-            tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.MetricIdKey, StandardMetricConstants.DependencyDurationMetricIdValue));
-            tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.IsAutoCollectedKey, "True"));
-            tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.CloudRoleInstanceKey, StandardMetricResource?.RoleInstance));
-            tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.CloudRoleNameKey, StandardMetricResource?.RoleName));
-            tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencySuccessKey, activity.Status != ActivityStatusCode.Error));
-            tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencyTypeKey, dependencyType));
-
-            // Report metric
-            _dependencyDuration?.Record(activity.Duration.TotalMilliseconds, tags);
-
-            activityTagsProcessor.Return();
         }
 
         private long GetProcessPrivateBytes()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -38,42 +38,49 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 try
                 {
                     var activityTagsProcessor = EnumerateActivityTags(activity);
-                    telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, azureMonitorResource, instrumentationKey, sampleRate);
 
-                    // Check for Exceptions events
-                    if (activity.Events.Any())
+                    try
                     {
-                        AddTelemetryFromActivityEvents(activity, telemetryItem, telemetryItems, ref telemetrySchemaTypeCounter);
+                        telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, azureMonitorResource, instrumentationKey, sampleRate);
+
+                        // Check for Exceptions events
+                        if (activity.Events.Any())
+                        {
+                            AddTelemetryFromActivityEvents(activity, telemetryItem, telemetryItems, ref telemetrySchemaTypeCounter);
+                        }
+
+                        switch (activity.GetTelemetryType())
+                        {
+                            case TelemetryType.Request:
+                                var requestData = new RequestData(Version, activity, ref activityTagsProcessor);
+                                // Only set Name if not already set by override attribute
+                                if (string.IsNullOrEmpty(requestData.Name))
+                                {
+                                    requestData.Name = telemetryItem.Tags.TryGetValue(ContextTagKeys.AiOperationName.ToString(), out var operationName) ? operationName.Truncate(SchemaConstants.RequestData_Name_MaxLength) : activity.DisplayName.Truncate(SchemaConstants.RequestData_Name_MaxLength);
+                                }
+                                telemetryItem.Data = new MonitorBase
+                                {
+                                    BaseType = "RequestData",
+                                    BaseData = requestData,
+                                };
+                                telemetrySchemaTypeCounter.IncrementRequest(requestData.Success);
+                                break;
+                            case TelemetryType.Dependency:
+                                var dependencyData = new RemoteDependencyData(Version, activity, ref activityTagsProcessor);
+                                telemetryItem.Data = new MonitorBase
+                                {
+                                    BaseType = "RemoteDependencyData",
+                                    BaseData = dependencyData,
+                                };
+                                telemetrySchemaTypeCounter.IncrementDependency(dependencyData.Success);
+                                break;
+                        }
+                    }
+                    finally
+                    {
+                        activityTagsProcessor.Return();
                     }
 
-                    switch (activity.GetTelemetryType())
-                    {
-                        case TelemetryType.Request:
-                            var requestData = new RequestData(Version, activity, ref activityTagsProcessor);
-                            // Only set Name if not already set by override attribute
-                            if (string.IsNullOrEmpty(requestData.Name))
-                            {
-                                requestData.Name = telemetryItem.Tags.TryGetValue(ContextTagKeys.AiOperationName.ToString(), out var operationName) ? operationName.Truncate(SchemaConstants.RequestData_Name_MaxLength) : activity.DisplayName.Truncate(SchemaConstants.RequestData_Name_MaxLength);
-                            }
-                            telemetryItem.Data = new MonitorBase
-                            {
-                                BaseType = "RequestData",
-                                BaseData = requestData,
-                            };
-                            telemetrySchemaTypeCounter.IncrementRequest(requestData.Success);
-                            break;
-                        case TelemetryType.Dependency:
-                            var dependencyData = new RemoteDependencyData(Version, activity, ref activityTagsProcessor);
-                            telemetryItem.Data = new MonitorBase
-                            {
-                                BaseType = "RemoteDependencyData",
-                                BaseData = dependencyData,
-                            };
-                            telemetrySchemaTypeCounter.IncrementDependency(dependencyData.Success);
-                            break;
-                    }
-
-                    activityTagsProcessor.Return();
                     telemetryItems.Add(telemetryItem);
                 }
                 catch (Exception ex)
@@ -188,19 +195,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
         }
 
-        internal static ActivityTagsProcessor EnumerateActivityTags(Activity activity)
+        internal static ActivityTagsProcessor EnumerateActivityTags(Activity activity, bool includeUnmappedTags = true)
         {
-            var activityTagsProcessor = new ActivityTagsProcessor();
+            var activityTagsProcessor = new ActivityTagsProcessor(includeUnmappedTags);
             activityTagsProcessor.CategorizeTags(activity);
             return activityTagsProcessor;
         }
 
         internal static string GetOperationName(Activity activity, ref AzMonList MappedTags)
         {
-            var httpMethod = AzMonList.GetTagValue(ref MappedTags, SemanticConventions.AttributeHttpMethod)?.ToString();
+            var httpMethod = MappedTags[SemanticSlot.HttpMethod]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpMethod))
             {
-                var httpRoute = AzMonList.GetTagValue(ref MappedTags, SemanticConventions.AttributeHttpRoute)?.ToString();
+                var httpRoute = MappedTags[SemanticSlot.HttpRoute]?.ToString();
 
                 // ASP.NET instrumentation assigns route as {controller}/{action}/{id} which would result in the same name for different operations.
                 // To work around that we will use path from httpUrl.
@@ -209,7 +216,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     return $"{httpMethod} {httpRoute}";
                 }
 
-                var httpUrl = AzMonList.GetTagValue(ref MappedTags, SemanticConventions.AttributeHttpUrl)?.ToString();
+                var httpUrl = MappedTags[SemanticSlot.HttpUrl]?.ToString();
                 if (!string.IsNullOrWhiteSpace(httpUrl) && Uri.TryCreate(httpUrl!.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
                 {
                     return $"{httpMethod} {uri.AbsolutePath}";
@@ -221,10 +228,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal static string GetOperationNameV2(Activity activity, ref AzMonList MappedTags)
         {
-            var httpMethod = AzMonList.GetTagValue(ref MappedTags, SemanticConventions.AttributeHttpRequestMethod)?.ToString();
+            var httpMethod = MappedTags[SemanticSlot.HttpRequestMethod]?.ToString();
             if (!string.IsNullOrWhiteSpace(httpMethod))
             {
-                var httpRoute = AzMonList.GetTagValue(ref MappedTags, SemanticConventions.AttributeHttpRoute)?.ToString();
+                var httpRoute = MappedTags[SemanticSlot.HttpRoute]?.ToString();
 
                 // ASP.NET instrumentation assigns route as {controller}/{action}/{id} which would result in the same name for different operations.
                 // To work around that we will use path from url.path.
@@ -233,7 +240,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     return $"{httpMethod} {httpRoute}";
                 }
 
-                var httpPath = AzMonList.GetTagValue(ref MappedTags, SemanticConventions.AttributeUrlPath)?.ToString();
+                var httpPath = MappedTags[SemanticSlot.UrlPath]?.ToString();
                 if (!string.IsNullOrWhiteSpace(httpPath))
                 {
                     return $"{httpMethod} {httpPath}";

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -98,7 +98,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             try
             {
                 // TODO: Iterate only interested fields. Ref: https://github.com/Azure/azure-sdk-for-net/pull/14254#discussion_r470907560
-                for (int i = 0; i < UnMappedTags.Length; i++)
+                for (int i = 0; i < UnMappedTags.ListCount; i++)
                 {
                     var tag = UnMappedTags[i];
                     AddKvpToDictionary(destination, tag);
@@ -198,7 +198,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal static ActivityTagsProcessor EnumerateActivityTags(Activity activity, bool includeUnmappedTags = true)
         {
             var activityTagsProcessor = new ActivityTagsProcessor(includeUnmappedTags);
-            activityTagsProcessor.CategorizeTags(activity);
+
+            try
+            {
+                activityTagsProcessor.CategorizeTags(activity);
+            }
+            catch
+            {
+                // Categorization stringifies caller-supplied values, so it can throw before the
+                // caller ever receives the processor to return its buffers.
+                activityTagsProcessor.Return();
+                throw;
+            }
+
             return activityTagsProcessor;
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LiveMetrics/Internals/DataCollection/DocumentHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LiveMetrics/Internals/DataCollection/DocumentHelper.cs
@@ -128,10 +128,10 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.DataCollection
                 case OperationType.Http:
                     remoteDependencyDocument.Name = activity.DisplayName;
 
-                    var httpUrl = AzMonList.GetTagValue(ref liveMetricsTagsProcessor.Tags, SemanticConventions.AttributeUrlFull)?.ToString();
+                    var httpUrl = liveMetricsTagsProcessor.Tags[SemanticSlot.UrlFull]?.ToString();
                     remoteDependencyDocument.CommandName = httpUrl;
 
-                    var httpResponseStatusCode = AzMonList.GetTagValue(ref liveMetricsTagsProcessor.Tags, SemanticConventions.AttributeHttpResponseStatusCode)?.ToString();
+                    var httpResponseStatusCode = liveMetricsTagsProcessor.Tags[SemanticSlot.HttpResponseStatusCode]?.ToString();
                     remoteDependencyDocument.ResultCode = httpResponseStatusCode ?? "0";
 
                     // The following "EXTENSION" properties are used to calculate metrics. These are not serialized.
@@ -140,7 +140,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.DataCollection
                 case OperationType.Db:
                     remoteDependencyDocument.Name = activity.DisplayName;
 
-                    remoteDependencyDocument.CommandName = AzMonList.GetTagValue(ref liveMetricsTagsProcessor.Tags, SemanticConventions.AttributeDbStatement)?.ToString();
+                    remoteDependencyDocument.CommandName = liveMetricsTagsProcessor.Tags[SemanticSlot.DbStatement]?.ToString();
 
                     // TODO: remoteDependencyDocumentIngress.ResultCode = "";
                     // AI SDK reads a Number property from Connection or Command objects.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LiveMetrics/Internals/LiveMetricsTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LiveMetrics/Internals/LiveMetricsTagsProcessor.cs
@@ -31,7 +31,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 
         public LiveMetricsTagsProcessor()
         {
-            Tags = AzMonList.Initialize();
+            Tags = AzMonList.InitializeForMappedTags();
         }
 
         public OperationType ActivityType { get; set; }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityConversionBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityConversionBenchmarks.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+
+using BenchmarkDotNet.Attributes;
+
+using OpenTelemetry;
+
+/*
+Baseline captured before the AzMonList/ActivityTagsProcessor rework.
+
+Measures the full Activity -> TelemetryItem conversion (CategorizeTags plus every
+MappedTags lookup performed by TelemetryItem/RequestData/RemoteDependencyData), with no
+transmitter and no network. This is the granularity the existing benchmarks miss:
+TagObjectsGetValuesBenchmarks measures a single lookup, but a real conversion performs
+13-26 of them.
+
+NOTE: ShortRun (3 iterations) - Error is wide. Re-run without --job short for a
+publishable comparison.
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2) (Hyper-V)
+Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.400
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  WarmupCount=3
+
+| Method                | Mean       | Error    | StdDev   | Ratio | Gen0   | Allocated |
+|---------------------- |-----------:|---------:|---------:|------:|-------:|----------:|
+| HttpServer_NewSemConv | 1,558.3 ns | 514.9 ns | 28.22 ns |  1.00 | 0.0916 |   2.26 KB |
+| HttpServer_OldSemConv | 1,388.6 ns | 133.3 ns |  7.30 ns |  0.89 | 0.0782 |   1.94 KB |
+| HttpClient_NewSemConv | 1,436.0 ns | 272.2 ns | 14.92 ns |  0.92 | 0.0687 |   1.73 KB |
+| HttpClient_OldSemConv | 1,523.3 ns | 416.6 ns | 22.84 ns |  0.98 | 0.0629 |   1.56 KB |
+| DbClient_NewSemConv   | 1,232.8 ns | 369.2 ns | 20.24 ns |  0.79 | 0.0648 |   1.62 KB |
+| DbClient_OldSemConv   | 1,118.4 ns | 159.2 ns |  8.73 ns |  0.72 | 0.0591 |   1.49 KB |
+| Messaging             | 1,014.7 ns | 449.6 ns | 24.64 ns |  0.65 | 0.0706 |   1.75 KB |
+| AzureSdk              |   896.8 ns | 234.0 ns | 12.82 ns |  0.58 | 0.0601 |   1.48 KB |
+| OverrideAttributes    | 2,001.5 ns | 235.6 ns | 12.92 ns |  1.28 | 0.0725 |   1.84 KB |
+| ArrayValuedTags       | 1,937.4 ns | 770.6 ns | 42.24 ns |  1.24 | 0.1030 |   2.62 KB |
+
+OverrideAttributes is the slowest shape because it performs the most MappedTags lookups
+(7 context-tag overrides plus 4 request overrides on top of the base path).
+
+After switching mapped-tag reads to slot indexing, and holding recognized attributes in the
+slot array alone so a mapped list rents one pooled buffer instead of two. Every shape
+improves against the baseline; the read-heavy shapes improve most because a conversion
+performs 13-26 attribute reads.
+
+| Method                | Mean       | Error       | StdDev   | Ratio | Gen0   | Allocated |
+|---------------------- |-----------:|------------:|---------:|------:|-------:|----------:|
+| HttpServer_NewSemConv | 1,356.7 ns |   224.72 ns | 12.32 ns |  1.00 | 0.0858 |   2.13 KB |
+| HttpServer_OldSemConv | 1,296.7 ns |   210.99 ns | 11.57 ns |  0.96 | 0.0782 |   1.94 KB |
+| HttpClient_NewSemConv | 1,322.8 ns |   157.20 ns |  8.62 ns |  0.98 | 0.0668 |   1.65 KB |
+| HttpClient_OldSemConv | 1,515.7 ns | 1,164.84 ns | 63.85 ns |  1.12 | 0.0629 |   1.56 KB |
+| DbClient_NewSemConv   |   960.3 ns |   119.32 ns |  6.54 ns |  0.71 | 0.0553 |   1.37 KB |
+| DbClient_OldSemConv   | 1,001.9 ns |   335.84 ns | 18.41 ns |  0.74 | 0.0534 |   1.34 KB |
+| Messaging             |   933.8 ns |    76.35 ns |  4.18 ns |  0.69 | 0.0677 |   1.67 KB |
+| AzureSdk              |   838.7 ns |   186.51 ns | 10.22 ns |  0.62 | 0.0563 |    1.4 KB |
+| OverrideAttributes    | 1,333.0 ns |   304.17 ns | 16.67 ns |  0.98 | 0.0687 |   1.72 KB |
+| ArrayValuedTags       | 1,808.0 ns |   501.17 ns | 27.47 ns |  1.33 | 0.1011 |   2.49 KB |
+*/
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class ActivityConversionBenchmarks
+    {
+        private const string InstrumentationKey = "00000000-0000-0000-0000-000000000000";
+
+        private static readonly AzureMonitorResource s_resource = new(
+            roleName: "BenchmarkRole",
+            roleInstance: "BenchmarkInstance",
+            serviceVersion: "1.0.0",
+            monitorBaseData: null);
+
+        private Batch<Activity> _httpServerNewSemConv;
+        private Batch<Activity> _httpServerOldSemConv;
+        private Batch<Activity> _httpClientNewSemConv;
+        private Batch<Activity> _httpClientOldSemConv;
+        private Batch<Activity> _dbClientNewSemConv;
+        private Batch<Activity> _dbClientOldSemConv;
+        private Batch<Activity> _messaging;
+        private Batch<Activity> _azureSdk;
+        private Batch<Activity> _overrideAttributes;
+        private Batch<Activity> _arrayValuedTags;
+
+        static ActivityConversionBenchmarks()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+            };
+
+            ActivitySource.AddActivityListener(listener);
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _httpServerNewSemConv = CreateBatch(ActivityKind.Server, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeHttpRequestMethod] = "GET",
+                [SemanticConventions.AttributeUrlScheme] = "https",
+                [SemanticConventions.AttributeUrlPath] = "/api/items",
+                [SemanticConventions.AttributeUrlQuery] = "?id=1",
+                [SemanticConventions.AttributeServerAddress] = "localhost",
+                [SemanticConventions.AttributeServerPort] = 8080,
+                [SemanticConventions.AttributeHttpRoute] = "api/{id}",
+                [SemanticConventions.AttributeHttpResponseStatusCode] = 200,
+                [SemanticConventions.AttributeUserAgentOriginal] = "Mozilla/5.0",
+                [SemanticConventions.AttributeClientAddress] = "127.0.0.1",
+                ["custom.tenant"] = "contoso",
+                ["custom.region"] = "westus2",
+            });
+
+            _httpServerOldSemConv = CreateBatch(ActivityKind.Server, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeHttpMethod] = "GET",
+                [SemanticConventions.AttributeHttpScheme] = "https",
+                [SemanticConventions.AttributeHttpTarget] = "/api/items",
+                [SemanticConventions.AttributeHttpHost] = "localhost",
+                [SemanticConventions.AttributeHttpRoute] = "api/{id}",
+                [SemanticConventions.AttributeNetHostName] = "localhost",
+                [SemanticConventions.AttributeNetHostPort] = 8080,
+                [SemanticConventions.AttributeHttpStatusCode] = 200,
+                [SemanticConventions.AttributeHttpUserAgent] = "Mozilla/5.0",
+                ["custom.tenant"] = "contoso",
+                ["custom.region"] = "westus2",
+            });
+
+            _httpClientNewSemConv = CreateBatch(ActivityKind.Client, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeHttpRequestMethod] = "POST",
+                [SemanticConventions.AttributeUrlFull] = "https://localhost:8080/api/items",
+                [SemanticConventions.AttributeServerAddress] = "localhost",
+                [SemanticConventions.AttributeServerPort] = 8080,
+                [SemanticConventions.AttributeHttpResponseStatusCode] = 200,
+                ["custom.tenant"] = "contoso",
+                ["custom.region"] = "westus2",
+            });
+
+            // Worst measured case: every old-semconv fallback chain is walked.
+            _httpClientOldSemConv = CreateBatch(ActivityKind.Client, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeHttpMethod] = "POST",
+                [SemanticConventions.AttributeHttpUrl] = "https://localhost:8080/api/items",
+                [SemanticConventions.AttributeHttpScheme] = "https",
+                [SemanticConventions.AttributeHttpTarget] = "/api/items",
+                [SemanticConventions.AttributeHttpHost] = "localhost",
+                [SemanticConventions.AttributeNetPeerName] = "localhost",
+                [SemanticConventions.AttributeNetPeerIp] = "127.0.0.1",
+                [SemanticConventions.AttributeNetPeerPort] = 8080,
+                [SemanticConventions.AttributePeerService] = "items-service",
+                [SemanticConventions.AttributeHttpStatusCode] = 200,
+                [SemanticConventions.AttributeHttpUserAgent] = "Mozilla/5.0",
+                ["custom.tenant"] = "contoso",
+                ["custom.region"] = "westus2",
+            });
+
+            _dbClientNewSemConv = CreateBatch(ActivityKind.Client, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeDbSystemName] = "mssql",
+                [SemanticConventions.AttributeDbNamespace] = "inventory",
+                [SemanticConventions.AttributeDbQueryText] = "SELECT * FROM items WHERE id = @id",
+                [SemanticConventions.AttributeServerAddress] = "localhost",
+                [SemanticConventions.AttributeServerPort] = 1433,
+                ["custom.tenant"] = "contoso",
+            });
+
+            _dbClientOldSemConv = CreateBatch(ActivityKind.Client, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeDbSystem] = "mssql",
+                [SemanticConventions.AttributeDbName] = "inventory",
+                [SemanticConventions.AttributeDbStatement] = "SELECT * FROM items WHERE id = @id",
+                [SemanticConventions.AttributePeerService] = "sqlserver",
+                [SemanticConventions.AttributeNetPeerName] = "localhost",
+                [SemanticConventions.AttributeNetPeerIp] = "127.0.0.1",
+                [SemanticConventions.AttributeNetPeerPort] = 1433,
+                ["custom.tenant"] = "contoso",
+            });
+
+            _messaging = CreateBatch(ActivityKind.Producer, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeMessagingSystem] = "servicebus",
+                [SemanticConventions.AttributeMessagingDestinationName] = "orders",
+                [SemanticConventions.AttributeNetworkProtocolName] = "amqp",
+                [SemanticConventions.AttributeServerAddress] = "contoso.servicebus.windows.net",
+                ["custom.tenant"] = "contoso",
+            });
+
+            _azureSdk = CreateBatch(ActivityKind.Client, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeAzureNameSpace] = "Microsoft.ServiceBus",
+                [SemanticConventions.AttributeServerAddress] = "contoso.servicebus.windows.net",
+                [SemanticConventions.AttributeServerPort] = 443,
+                ["custom.tenant"] = "contoso",
+            });
+
+            // Exercises HasOverrideAttributes plus all seven context-tag lookups.
+            _overrideAttributes = CreateBatch(ActivityKind.Server, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeHttpRequestMethod] = "GET",
+                [SemanticConventions.AttributeUrlPath] = "/api/items",
+                [SemanticConventions.AttributeHttpResponseStatusCode] = 200,
+                [SemanticConventions.AttributeMicrosoftOperationName] = "GET /api/items",
+                [SemanticConventions.AttributeMicrosoftRequestName] = "OverrideName",
+                [SemanticConventions.AttributeMicrosoftRequestUrl] = "https://localhost/api/items",
+                [SemanticConventions.AttributeMicrosoftRequestSource] = "OverrideSource",
+                [SemanticConventions.AttributeMicrosoftRequestResultCode] = "201",
+                [SemanticConventions.AttributeMicrosoftSessionId] = "session-1",
+                [SemanticConventions.AttributeAiDeviceId] = "device-1",
+                [SemanticConventions.AttributeAiDeviceModel] = "model-1",
+                [SemanticConventions.AttributeAiDeviceType] = "type-1",
+                [SemanticConventions.AttributeAiDeviceOsVersion] = "os-1",
+                [SemanticConventions.AttributeMicrosoftSyntheticSource] = "synthetic-1",
+                [SemanticConventions.AttributeMicrosoftUserAccountId] = "account-1",
+                [SemanticConventions.AttributeEnduserId] = "user-1",
+                [SemanticConventions.AttributeEnduserPseudoId] = "pseudo-1",
+            });
+
+            // Exercises the ToCommaDelimitedString path in the UnMappedTags branch.
+            _arrayValuedTags = CreateBatch(ActivityKind.Server, new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeHttpRequestMethod] = "GET",
+                [SemanticConventions.AttributeUrlPath] = "/api/items",
+                [SemanticConventions.AttributeHttpResponseStatusCode] = 200,
+                ["custom.ints"] = new int[] { 1, 2, 3, 4, 5 },
+                ["custom.strings"] = new string[] { "a", "b", "c" },
+                ["custom.bools"] = new bool[] { true, false },
+            });
+        }
+
+        [Benchmark(Baseline = true)]
+        public void HttpServer_NewSemConv() => Convert(_httpServerNewSemConv);
+
+        [Benchmark]
+        public void HttpServer_OldSemConv() => Convert(_httpServerOldSemConv);
+
+        [Benchmark]
+        public void HttpClient_NewSemConv() => Convert(_httpClientNewSemConv);
+
+        [Benchmark]
+        public void HttpClient_OldSemConv() => Convert(_httpClientOldSemConv);
+
+        [Benchmark]
+        public void DbClient_NewSemConv() => Convert(_dbClientNewSemConv);
+
+        [Benchmark]
+        public void DbClient_OldSemConv() => Convert(_dbClientOldSemConv);
+
+        [Benchmark]
+        public void Messaging() => Convert(_messaging);
+
+        [Benchmark]
+        public void AzureSdk() => Convert(_azureSdk);
+
+        [Benchmark]
+        public void OverrideAttributes() => Convert(_overrideAttributes);
+
+        [Benchmark]
+        public void ArrayValuedTags() => Convert(_arrayValuedTags);
+
+        private static void Convert(Batch<Activity> batch)
+            => TraceHelper.OtelToAzureMonitorTrace(batch, s_resource, InstrumentationKey, sampleRate: 100F);
+
+        private static Batch<Activity> CreateBatch(ActivityKind kind, Dictionary<string, object?> tags)
+        {
+            var activitySource = new ActivitySource(nameof(ActivityConversionBenchmarks));
+            var startTimestamp = DateTime.UtcNow;
+
+            var activity = activitySource.StartActivity(
+                "BenchmarkActivity",
+                kind,
+                parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                tags,
+                links: null,
+                startTime: startTimestamp);
+
+            if (activity == null)
+            {
+                throw new InvalidOperationException("Activity was not sampled. The ActivityListener is not configured correctly.");
+            }
+
+            activity.SetStatus(ActivityStatusCode.Ok);
+            activity.SetEndTime(startTimestamp.AddMilliseconds(50));
+            activity.Stop();
+
+            return new Batch<Activity>(new[] { activity }, 1);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityConversionBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityConversionBenchmarks.cs
@@ -52,18 +52,18 @@ slot array alone so a mapped list rents one pooled buffer instead of two. Every 
 improves against the baseline; the read-heavy shapes improve most because a conversion
 performs 13-26 attribute reads.
 
-| Method                | Mean       | Error       | StdDev   | Ratio | Gen0   | Allocated |
-|---------------------- |-----------:|------------:|---------:|------:|-------:|----------:|
-| HttpServer_NewSemConv | 1,356.7 ns |   224.72 ns | 12.32 ns |  1.00 | 0.0858 |   2.13 KB |
-| HttpServer_OldSemConv | 1,296.7 ns |   210.99 ns | 11.57 ns |  0.96 | 0.0782 |   1.94 KB |
-| HttpClient_NewSemConv | 1,322.8 ns |   157.20 ns |  8.62 ns |  0.98 | 0.0668 |   1.65 KB |
-| HttpClient_OldSemConv | 1,515.7 ns | 1,164.84 ns | 63.85 ns |  1.12 | 0.0629 |   1.56 KB |
-| DbClient_NewSemConv   |   960.3 ns |   119.32 ns |  6.54 ns |  0.71 | 0.0553 |   1.37 KB |
-| DbClient_OldSemConv   | 1,001.9 ns |   335.84 ns | 18.41 ns |  0.74 | 0.0534 |   1.34 KB |
-| Messaging             |   933.8 ns |    76.35 ns |  4.18 ns |  0.69 | 0.0677 |   1.67 KB |
-| AzureSdk              |   838.7 ns |   186.51 ns | 10.22 ns |  0.62 | 0.0563 |    1.4 KB |
-| OverrideAttributes    | 1,333.0 ns |   304.17 ns | 16.67 ns |  0.98 | 0.0687 |   1.72 KB |
-| ArrayValuedTags       | 1,808.0 ns |   501.17 ns | 27.47 ns |  1.33 | 0.1011 |   2.49 KB |
+| Method                | Mean       | Error     | StdDev  | Ratio | Gen0   | Allocated |
+|---------------------- |-----------:|----------:|--------:|------:|-------:|----------:|
+| HttpServer_NewSemConv | 1,363.5 ns |  56.16 ns | 3.08 ns |  1.00 | 0.0858 |   2.13 KB |
+| HttpServer_OldSemConv | 1,237.0 ns |  88.55 ns | 4.85 ns |  0.91 | 0.0782 |   1.94 KB |
+| HttpClient_NewSemConv | 1,293.4 ns | 103.95 ns | 5.70 ns |  0.95 | 0.0668 |   1.65 KB |
+| HttpClient_OldSemConv | 1,372.2 ns |  83.27 ns | 4.56 ns |  1.01 | 0.0629 |   1.56 KB |
+| DbClient_NewSemConv   |   924.0 ns |  34.60 ns | 1.90 ns |  0.68 | 0.0553 |   1.37 KB |
+| DbClient_OldSemConv   |   952.2 ns |   8.46 ns | 0.46 ns |  0.70 | 0.0544 |   1.34 KB |
+| Messaging             |   942.6 ns | 153.39 ns | 8.41 ns |  0.69 | 0.0668 |   1.67 KB |
+| AzureSdk              |   824.1 ns | 143.90 ns | 7.89 ns |  0.60 | 0.0563 |    1.4 KB |
+| OverrideAttributes    | 1,259.3 ns | 140.93 ns | 7.72 ns |  0.92 | 0.0687 |   1.72 KB |
+| ArrayValuedTags       | 1,744.7 ns | 143.73 ns | 7.88 ns |  1.28 | 0.1011 |   2.49 KB |
 */
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityConversionBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityConversionBenchmarks.cs
@@ -12,58 +12,60 @@ using BenchmarkDotNet.Attributes;
 using OpenTelemetry;
 
 /*
-Baseline captured before the AzMonList/ActivityTagsProcessor rework.
-
 Measures the full Activity -> TelemetryItem conversion (CategorizeTags plus every
-MappedTags lookup performed by TelemetryItem/RequestData/RemoteDependencyData), with no
-transmitter and no network. This is the granularity the existing benchmarks miss:
-TagObjectsGetValuesBenchmarks measures a single lookup, but a real conversion performs
-13-26 of them.
+recognized-attribute read performed by TelemetryItem/RequestData/RemoteDependencyData),
+with no transmitter and no network. This is the granularity the existing benchmarks miss:
+TagObjectsGetValuesBenchmarks measures a single read, but a real conversion performs 13-26
+of them.
 
-NOTE: ShortRun (3 iterations) - Error is wide. Re-run without --job short for a
-publishable comparison.
+Both tables below are MediumRun on the same machine. The "before" run is this file compiled
+against the unmodified exporter, so the pair is like for like. Deltas exceed the combined
+error on every shape except HttpClient_OldSemConv, Messaging, AzureSdk and ArrayValuedTags,
+where they are marginal and should be read as directional only.
 
 BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2) (Hyper-V)
 Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
 .NET SDK 10.0.400
-  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
-  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  [Host]    : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  MediumRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
 
-Job=ShortRun  IterationCount=3  LaunchCount=1  WarmupCount=3
+Job=MediumRun  IterationCount=15  LaunchCount=2  WarmupCount=10
 
-| Method                | Mean       | Error    | StdDev   | Ratio | Gen0   | Allocated |
-|---------------------- |-----------:|---------:|---------:|------:|-------:|----------:|
-| HttpServer_NewSemConv | 1,558.3 ns | 514.9 ns | 28.22 ns |  1.00 | 0.0916 |   2.26 KB |
-| HttpServer_OldSemConv | 1,388.6 ns | 133.3 ns |  7.30 ns |  0.89 | 0.0782 |   1.94 KB |
-| HttpClient_NewSemConv | 1,436.0 ns | 272.2 ns | 14.92 ns |  0.92 | 0.0687 |   1.73 KB |
-| HttpClient_OldSemConv | 1,523.3 ns | 416.6 ns | 22.84 ns |  0.98 | 0.0629 |   1.56 KB |
-| DbClient_NewSemConv   | 1,232.8 ns | 369.2 ns | 20.24 ns |  0.79 | 0.0648 |   1.62 KB |
-| DbClient_OldSemConv   | 1,118.4 ns | 159.2 ns |  8.73 ns |  0.72 | 0.0591 |   1.49 KB |
-| Messaging             | 1,014.7 ns | 449.6 ns | 24.64 ns |  0.65 | 0.0706 |   1.75 KB |
-| AzureSdk              |   896.8 ns | 234.0 ns | 12.82 ns |  0.58 | 0.0601 |   1.48 KB |
-| OverrideAttributes    | 2,001.5 ns | 235.6 ns | 12.92 ns |  1.28 | 0.0725 |   1.84 KB |
-| ArrayValuedTags       | 1,937.4 ns | 770.6 ns | 42.24 ns |  1.24 | 0.1030 |   2.62 KB |
+BEFORE
 
-OverrideAttributes is the slowest shape because it performs the most MappedTags lookups
-(7 context-tag overrides plus 4 request overrides on top of the base path).
+| Method                | Mean       | Error    | StdDev   | Gen0   | Allocated |
+|---------------------- |-----------:|---------:|---------:|-------:|----------:|
+| HttpServer_NewSemConv | 1,570.1 ns | 31.32 ns | 44.91 ns | 0.0916 |   2.26 KB |
+| HttpServer_OldSemConv | 1,401.9 ns | 27.76 ns | 41.55 ns | 0.0782 |   1.94 KB |
+| HttpClient_NewSemConv | 1,449.4 ns | 23.10 ns | 34.57 ns | 0.0687 |   1.73 KB |
+| HttpClient_OldSemConv | 1,522.5 ns | 20.03 ns | 29.98 ns | 0.0629 |   1.56 KB |
+| DbClient_NewSemConv   | 1,238.4 ns | 20.42 ns | 29.29 ns | 0.0648 |   1.62 KB |
+| DbClient_OldSemConv   | 1,146.0 ns | 23.40 ns | 35.02 ns | 0.0591 |   1.49 KB |
+| Messaging             | 1,019.8 ns | 18.41 ns | 27.56 ns | 0.0706 |   1.75 KB |
+| AzureSdk              |   901.2 ns | 11.38 ns | 16.32 ns | 0.0601 |   1.48 KB |
+| OverrideAttributes    | 2,024.6 ns | 37.40 ns | 55.97 ns | 0.0725 |   1.84 KB |
+| ArrayValuedTags       | 1,968.9 ns | 34.74 ns | 52.00 ns | 0.1030 |   2.62 KB |
 
-After switching mapped-tag reads to slot indexing, and holding recognized attributes in the
-slot array alone so a mapped list rents one pooled buffer instead of two. Every shape
-improves against the baseline; the read-heavy shapes improve most because a conversion
-performs 13-26 attribute reads.
+AFTER
 
-| Method                | Mean       | Error     | StdDev  | Ratio | Gen0   | Allocated |
-|---------------------- |-----------:|----------:|--------:|------:|-------:|----------:|
-| HttpServer_NewSemConv | 1,363.5 ns |  56.16 ns | 3.08 ns |  1.00 | 0.0858 |   2.13 KB |
-| HttpServer_OldSemConv | 1,237.0 ns |  88.55 ns | 4.85 ns |  0.91 | 0.0782 |   1.94 KB |
-| HttpClient_NewSemConv | 1,293.4 ns | 103.95 ns | 5.70 ns |  0.95 | 0.0668 |   1.65 KB |
-| HttpClient_OldSemConv | 1,372.2 ns |  83.27 ns | 4.56 ns |  1.01 | 0.0629 |   1.56 KB |
-| DbClient_NewSemConv   |   924.0 ns |  34.60 ns | 1.90 ns |  0.68 | 0.0553 |   1.37 KB |
-| DbClient_OldSemConv   |   952.2 ns |   8.46 ns | 0.46 ns |  0.70 | 0.0544 |   1.34 KB |
-| Messaging             |   942.6 ns | 153.39 ns | 8.41 ns |  0.69 | 0.0668 |   1.67 KB |
-| AzureSdk              |   824.1 ns | 143.90 ns | 7.89 ns |  0.60 | 0.0563 |    1.4 KB |
-| OverrideAttributes    | 1,259.3 ns | 140.93 ns | 7.72 ns |  0.92 | 0.0687 |   1.72 KB |
-| ArrayValuedTags       | 1,744.7 ns | 143.73 ns | 7.88 ns |  1.28 | 0.1011 |   2.49 KB |
+| Method                | Mean       | Error    | StdDev   | Gen0   | Allocated | Delta  |
+|---------------------- |-----------:|---------:|---------:|-------:|----------:|-------:|
+| HttpServer_NewSemConv | 1,406.9 ns | 32.18 ns | 48.16 ns | 0.0858 |   2.13 KB | -10.4% |
+| HttpServer_OldSemConv | 1,273.5 ns | 20.12 ns | 30.12 ns | 0.0782 |   1.94 KB |  -9.2% |
+| HttpClient_NewSemConv | 1,322.2 ns | 25.67 ns | 37.62 ns | 0.0668 |   1.65 KB |  -8.8% |
+| HttpClient_OldSemConv | 1,462.6 ns | 43.43 ns | 63.66 ns | 0.0629 |   1.56 KB |  -3.9% |
+| DbClient_NewSemConv   |   962.8 ns | 16.38 ns | 24.51 ns | 0.0553 |   1.37 KB | -22.3% |
+| DbClient_OldSemConv   |   978.2 ns | 17.93 ns | 26.83 ns | 0.0534 |   1.34 KB | -14.6% |
+| Messaging             |   981.0 ns | 19.05 ns | 28.51 ns | 0.0677 |   1.67 KB |  -3.8% |
+| AzureSdk              |   873.2 ns | 17.35 ns | 24.89 ns | 0.0563 |    1.4 KB |  -3.1% |
+| OverrideAttributes    | 1,361.7 ns | 49.72 ns | 72.87 ns | 0.0687 |   1.72 KB | -32.7% |
+| ArrayValuedTags       | 1,892.9 ns | 57.24 ns | 85.68 ns | 0.1011 |   2.49 KB |  -3.9% |
+
+OverrideAttributes gains the most because it performs the most reads: 7 context-tag
+overrides and 4 request overrides on top of the base path. Averaged across the ten shapes
+a conversion costs 173 ns less and allocates 105 bytes less. Two shapes are unchanged on
+managed allocation; the pooled buffer a mapped list no longer rents does not appear in the
+Allocated column, because MemoryDiagnoser does not count ArrayPool rents.
 */
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityTagsProcessorBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityTagsProcessorBenchmarks.cs
@@ -22,12 +22,72 @@ Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
 | Benchmark_ActivityTagsProcessor | 262.0 ns | 2.51 ns | 2.10 ns |         - |
 */
 
+/*
+Baseline before the AzMonList/ActivityTagsProcessor rework, widened past the original
+6-tag case because scan cost is O(k*n) in the tag count.
+
+NOTE: ShortRun (3 iterations) - Error is wide. Allocated shows "-" because the buffers
+come from ArrayPool, which MemoryDiagnoser does not count. Pool rents are not visible here.
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2) (Hyper-V)
+Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.400
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  WarmupCount=3
+
+| Method                                 | Mean       | Error     | StdDev  | Allocated |
+|--------------------------------------- |-----------:|----------:|--------:|----------:|
+| Benchmark_ActivityTagsProcessor        |   189.1 ns |  50.83 ns | 2.79 ns |         - |
+| Benchmark_ActivityTagsProcessor_15Tags |   354.9 ns | 154.99 ns | 8.50 ns |         - |
+| Benchmark_ActivityTagsProcessor_50Tags | 1,019.7 ns | 133.01 ns | 7.29 ns |         - |
+*/
+
+/*
+After the AzMonList pooling fixes. The used region of each buffer is now zeroed before it
+goes back to the shared pool, which costs 6-16% here. That cost is real but this benchmark
+exaggerates it: CategorizeTags is roughly 200 ns of a ~1550 ns full conversion, so the
+same change is within noise in ActivityConversionBenchmarks. The 50-tag case is worst
+because each array growth also clears the buffer it hands back.
+
+| Method                                 | Mean       | Error     | StdDev   | Allocated |
+|--------------------------------------- |-----------:|----------:|---------:|----------:|
+| Benchmark_ActivityTagsProcessor        |   201.3 ns |  46.34 ns |  2.54 ns |         - |
+| Benchmark_ActivityTagsProcessor_15Tags |   383.1 ns | 110.98 ns |  6.08 ns |         - |
+| Benchmark_ActivityTagsProcessor_50Tags | 1,188.1 ns | 251.37 ns | 13.78 ns |         - |
+*/
+
+/*
+After the slot index, the mapped-only mode, and storing recognized attributes in the slot
+array only.
+
+An earlier revision also appended every recognized attribute to the list buffer, which cost
+a third pooled buffer per activity and pushed the 15-tag case to 537.8 ns. Recognized
+attributes are now held in the slot array alone, so a mapped list rents one buffer instead
+of two and categorizing is back to where it was before the slot index was introduced, while
+reads stay constant time.
+
+MappedOnly is what the standard-metrics path uses. It skips the unmapped list entirely,
+avoiding a pooled buffer and the string conversion of array-valued tags.
+
+| Method                                            | Mean       | Error     | StdDev   | Allocated |
+|-------------------------------------------------- |-----------:|----------:|---------:|----------:|
+| Benchmark_ActivityTagsProcessor                   |   210.1 ns |  22.30 ns |  1.22 ns |         - |
+| Benchmark_ActivityTagsProcessor_15Tags            |   391.1 ns |  58.24 ns |  3.19 ns |         - |
+| Benchmark_ActivityTagsProcessor_50Tags            | 1,192.4 ns | 190.02 ns | 10.42 ns |         - |
+| Benchmark_ActivityTagsProcessor_15Tags_MappedOnly |   321.9 ns |  21.02 ns |  1.15 ns |         - |
+| Benchmark_ActivityTagsProcessor_50Tags_MappedOnly |   819.8 ns | 143.91 ns |  7.89 ns |         - |
+*/
+
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 {
     [MemoryDiagnoser]
     public class ActivityTagsProcessorBenchmarks
     {
         private Activity? _activity;
+        private Activity? _activityRealistic;
+        private Activity? _activityStress;
 
         static ActivityTagsProcessorBenchmarks()
         {
@@ -57,6 +117,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
             };
 
             _activity = CreateTestActivity(tagObjects!);
+            _activityRealistic = CreateTestActivity(CreateTags(mappedCount: 10, unmappedCount: 5)!);
+            _activityStress = CreateTestActivity(CreateTags(mappedCount: 20, unmappedCount: 30)!);
         }
 
         [Benchmark]
@@ -65,6 +127,87 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
             var activityTagsProcessor = new ActivityTagsProcessor();
             activityTagsProcessor.CategorizeTags(_activity!);
             activityTagsProcessor.Return();
+        }
+
+        [Benchmark]
+        public void Benchmark_ActivityTagsProcessor_15Tags()
+        {
+            var activityTagsProcessor = new ActivityTagsProcessor();
+            activityTagsProcessor.CategorizeTags(_activityRealistic!);
+            activityTagsProcessor.Return();
+        }
+
+        [Benchmark]
+        public void Benchmark_ActivityTagsProcessor_50Tags()
+        {
+            var activityTagsProcessor = new ActivityTagsProcessor();
+            activityTagsProcessor.CategorizeTags(_activityStress!);
+            activityTagsProcessor.Return();
+        }
+
+        // What the standard-metrics path now does: mapped tags only.
+        [Benchmark]
+        public void Benchmark_ActivityTagsProcessor_15Tags_MappedOnly()
+        {
+            var activityTagsProcessor = new ActivityTagsProcessor(includeUnmappedTags: false);
+            activityTagsProcessor.CategorizeTags(_activityRealistic!);
+            activityTagsProcessor.Return();
+        }
+
+        [Benchmark]
+        public void Benchmark_ActivityTagsProcessor_50Tags_MappedOnly()
+        {
+            var activityTagsProcessor = new ActivityTagsProcessor(includeUnmappedTags: false);
+            activityTagsProcessor.CategorizeTags(_activityStress!);
+            activityTagsProcessor.Return();
+        }
+
+        // Scan cost of the current design is O(k*n) in the mapped-tag count, so the mapped
+        // and unmapped halves are grown independently.
+        private static Dictionary<string, object?> CreateTags(int mappedCount, int unmappedCount)
+        {
+            string[] mappedKeys =
+            {
+                SemanticConventions.AttributeHttpRequestMethod,
+                SemanticConventions.AttributeHttpResponseStatusCode,
+                SemanticConventions.AttributeUrlScheme,
+                SemanticConventions.AttributeUrlPath,
+                SemanticConventions.AttributeUrlQuery,
+                SemanticConventions.AttributeUrlFull,
+                SemanticConventions.AttributeServerAddress,
+                SemanticConventions.AttributeServerPort,
+                SemanticConventions.AttributeHttpRoute,
+                SemanticConventions.AttributeUserAgentOriginal,
+                SemanticConventions.AttributeClientAddress,
+                SemanticConventions.AttributePeerService,
+                SemanticConventions.AttributeNetPeerName,
+                SemanticConventions.AttributeNetPeerIp,
+                SemanticConventions.AttributeNetPeerPort,
+                SemanticConventions.AttributeDbStatement,
+                SemanticConventions.AttributeDbSystem,
+                SemanticConventions.AttributeDbName,
+                SemanticConventions.AttributeMessagingSystem,
+                SemanticConventions.AttributeMessagingDestinationName,
+            };
+
+            if (mappedCount > mappedKeys.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(mappedCount));
+            }
+
+            var tags = new Dictionary<string, object?>();
+
+            for (int i = 0; i < mappedCount; i++)
+            {
+                tags[mappedKeys[i]] = "value";
+            }
+
+            for (int i = 0; i < unmappedCount; i++)
+            {
+                tags[$"custom.key{i}"] = "value";
+            }
+
+            return tags;
         }
 
         private static Activity? CreateTestActivity(IEnumerable<KeyValuePair<string, object>>? additionalAttributes = null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsGetValuesBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsGetValuesBenchmarks.cs
@@ -65,18 +65,21 @@ string comparisons entirely. GetTagValues is gone, so its two allocations per ca
 with it.
 
 The x26 pair is the honest comparison - a single slot read is small enough that the JIT can
-fold it away. 253.9 ns -> 13.9 ns is an 18x reduction on the number of lookups an
+fold it away. 270.0 ns -> 13.5 ns is a 20x reduction on the number of lookups an
 old-semconv HTTP client conversion actually performs.
+
+The scan list holds unrecognized tags only and the slot list recognized attributes only,
+matching how the two are built in production.
 
 | Method                         | Mean        | Error      | StdDev    | Allocated |
 |------------------------------- |------------:|-----------:|----------:|----------:|
-| GetTagValueEmptyTagObjects     |   2.4995 ns |  0.3115 ns | 0.0171 ns |         - |
-| GetTagValueNonemptyTagObjects  |  10.0686 ns |  0.8998 ns | 0.0493 ns |         - |
-| GetTagValueEmptyAzMonList      |   1.2862 ns |  0.0631 ns | 0.0035 ns |         - |
-| GetTagValueNonemptyAzMonList   |  13.7055 ns |  0.5452 ns | 0.0299 ns |         - |
-| GetTagValueBySlotAzMonList     |   0.0279 ns |  0.3511 ns | 0.0192 ns |         - |
-| GetTagValueAzMonList_x26       | 253.8584 ns | 79.0539 ns | 4.3332 ns |         - |
-| GetTagValueBySlotAzMonList_x26 |  13.9456 ns |  1.9410 ns | 0.1064 ns |         - |
+| GetTagValueEmptyTagObjects     |   2.1544 ns |  0.0584 ns | 0.0032 ns |         - |
+| GetTagValueNonemptyTagObjects  |   9.2364 ns |  1.5102 ns | 0.0828 ns |         - |
+| GetTagValueEmptyAzMonList      |   1.1930 ns |  0.2083 ns | 0.0114 ns |         - |
+| GetTagValueNonemptyAzMonList   |  16.3385 ns |  0.8378 ns | 0.0459 ns |         - |
+| GetTagValueBySlotAzMonList     |   0.0087 ns |  0.1578 ns | 0.0086 ns |         - |
+| GetTagValueAzMonList_x26       | 269.9516 ns | 41.3607 ns | 2.2671 ns |         - |
+| GetTagValueBySlotAzMonList_x26 |  13.5489 ns |  0.4264 ns | 0.0234 ns |         - |
 */
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
@@ -86,6 +89,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
     {
         private AzMonList _azMonList_No_Item;
         private AzMonList _azMonList_Items;
+        private AzMonList _azMonList_Mapped;
         private IEnumerable<KeyValuePair<string, object>> _tagObjects_No_Item;
         private IEnumerable<KeyValuePair<string, object>> _tagObjects_Items;
         private Activity _itemActivity;
@@ -110,16 +114,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
             _azMonList_No_Item = AzMonList.Initialize();
             _tagObjects_No_Item = new Dictionary<string, object>();
 
+            // Unrecognized tags only, matching the UnMappedTags list in production. Nine entries
+            // keeps the scan depth equal to the recorded baseline.
             _azMonList_Items = AzMonList.Initialize();
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("intKey", 1));
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("doubleKey", 1.1));
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "https"));
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("stringKey", "test"));
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "localhost"));
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("boolKey", true));
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHostPort, "8888"));
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("arrayKey", new int[] { 1, 2, 3 }));
-           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("somekey", "value"));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("intKey", 1));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("doubleKey", 1.1));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("schemeKey", "https"));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("stringKey", "test"));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("hostKey", "localhost"));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("boolKey", true));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("portKey", "8888"));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("arrayKey", new int[] { 1, 2, 3 }));
+            AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("somekey", "value"));
+
+            // Recognized attributes only, matching the MappedTags list in production.
+            _azMonList_Mapped = AzMonList.InitializeForMappedTags();
+            AzMonList.Add(ref _azMonList_Mapped, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "https"));
+            AzMonList.Add(ref _azMonList_Mapped, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "localhost"));
+            AzMonList.Add(ref _azMonList_Mapped, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHostPort, "8888"));
 
             _tagObjects_Items = new Dictionary<string, object>
             {
@@ -175,7 +187,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         [Benchmark]
         public void GetTagValueBySlotAzMonList()
         {
-            _ = _azMonList_Items[SemanticSlot.HttpHost];
+            _ = _azMonList_Mapped[SemanticSlot.HttpHost];
         }
 
         // The real conversion path performs 13-26 lookups; a single lookup understates it.
@@ -193,7 +205,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         {
             for (int i = 0; i < 26; i++)
             {
-                _ = _azMonList_Items[SemanticSlot.HttpHost];
+                _ = _azMonList_Mapped[SemanticSlot.HttpHost];
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsGetValuesBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsGetValuesBenchmarks.cs
@@ -26,6 +26,59 @@ Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical c
 |  GetTagValueNonemptyAzMonList |  9.269 ns | 0.2202 ns | 0.4833 ns |  9.220 ns |         - |
 */
 
+/*
+Re-measured on .NET 8 before the AzMonList rework. Two things changed since the .NET 6
+run above:
+
+1. The ordering that justified AzMonList's linear scan has REVERSED. On .NET 6 the scan
+   (9.269 ns) beat Dictionary.TryGetValue (14.824 ns); on .NET 8 the scan (13.784 ns) is
+   SLOWER than Dictionary.TryGetValue (9.619 ns). Runtime string hashing improved.
+2. GetTagValues allocates on every call - the params array plus the result array.
+
+GetTagValueAzMonList_x26 shows the compounding a single-lookup benchmark hides: the
+old-semconv HTTP client conversion performs 26 lookups.
+
+NOTE: ShortRun (3 iterations) - Error is wide.
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2) (Hyper-V)
+Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.400
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  WarmupCount=3
+
+| Method                        | Mean       | Error      | StdDev    | Gen0   | Allocated |
+|------------------------------ |-----------:|-----------:|----------:|-------:|----------:|
+| GetTagValueEmptyTagObjects    |   2.518 ns |  0.3196 ns | 0.0175 ns |      - |         - |
+| GetTagValueNonemptyTagObjects |   9.619 ns |  1.1204 ns | 0.0614 ns |      - |         - |
+| GetTagValueEmptyAzMonList     |   1.304 ns |  0.7231 ns | 0.0396 ns |      - |         - |
+| GetTagValueNonemptyAzMonList  |  13.784 ns |  2.2086 ns | 0.1211 ns |      - |         - |
+| GetTagValuesTwoKeysAzMonList  |  75.288 ns |  7.4244 ns | 0.4070 ns | 0.0031 |      80 B |
+| GetTagValuesFiveKeysAzMonList | 188.756 ns | 12.0554 ns | 0.6608 ns | 0.0050 |     128 B |
+| GetTagValueAzMonList_x26      | 254.895 ns | 47.5259 ns | 2.6051 ns |      - |         - |
+*/
+
+/*
+After adding the slot index. Reading a recognized attribute by slot removes the scan and the
+string comparisons entirely. GetTagValues is gone, so its two allocations per call are gone
+with it.
+
+The x26 pair is the honest comparison - a single slot read is small enough that the JIT can
+fold it away. 253.9 ns -> 13.9 ns is an 18x reduction on the number of lookups an
+old-semconv HTTP client conversion actually performs.
+
+| Method                         | Mean        | Error      | StdDev    | Allocated |
+|------------------------------- |------------:|-----------:|----------:|----------:|
+| GetTagValueEmptyTagObjects     |   2.4995 ns |  0.3115 ns | 0.0171 ns |         - |
+| GetTagValueNonemptyTagObjects  |  10.0686 ns |  0.8998 ns | 0.0493 ns |         - |
+| GetTagValueEmptyAzMonList      |   1.2862 ns |  0.0631 ns | 0.0035 ns |         - |
+| GetTagValueNonemptyAzMonList   |  13.7055 ns |  0.5452 ns | 0.0299 ns |         - |
+| GetTagValueBySlotAzMonList     |   0.0279 ns |  0.3511 ns | 0.0192 ns |         - |
+| GetTagValueAzMonList_x26       | 253.8584 ns | 79.0539 ns | 4.3332 ns |         - |
+| GetTagValueBySlotAzMonList_x26 |  13.9456 ns |  1.9410 ns | 0.1064 ns |         - |
+*/
+
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 {
     [MemoryDiagnoser]
@@ -116,6 +169,32 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         public void GetTagValueNonemptyAzMonList()
         {
             AzMonList.GetTagValue(ref _azMonList_Items, "somekey");
+        }
+
+        // Constant-time read of a recognized attribute, replacing the linear scan above.
+        [Benchmark]
+        public void GetTagValueBySlotAzMonList()
+        {
+            _ = _azMonList_Items[SemanticSlot.HttpHost];
+        }
+
+        // The real conversion path performs 13-26 lookups; a single lookup understates it.
+        [Benchmark]
+        public void GetTagValueAzMonList_x26()
+        {
+            for (int i = 0; i < 26; i++)
+            {
+                AzMonList.GetTagValue(ref _azMonList_Items, "somekey");
+            }
+        }
+
+        [Benchmark]
+        public void GetTagValueBySlotAzMonList_x26()
+        {
+            for (int i = 0; i < 26; i++)
+            {
+                _ = _azMonList_Items[SemanticSlot.HttpHost];
+            }
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
@@ -50,40 +50,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [InlineData("443")]
         [InlineData("8888")]
 
-        public void HttpRequestUrlIsSetUsing_Scheme_ServerName_Port_Target(string port)
-        {
-            var mappedTags = AzMonList.Initialize();
-            string httpScheme;
-            if (port == "80")
-            {
-                httpScheme = "http";
-            }
-            else
-            {
-                httpScheme = "https";
-            }
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpServerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, port));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
-            string expectedUrl;
-            if (port == "80" || port == "443")
-            {
-                expectedUrl = $"{httpScheme}://servername.com/path";
-            }
-            else
-            {
-                expectedUrl = $"{httpScheme}://servername.com:{port}/path";
-            }
-            string? url = mappedTags.GetRequestUrl();
-            Assert.Equal(expectedUrl, url);
-        }
-
-        [Theory]
-        [InlineData("80")]
-        [InlineData("443")]
-        [InlineData("8888")]
-
         public void HttpRequestUrlIsSetUsing_Scheme_NetHostName_Port_Target(string port)
         {
             var mappedTags = AzMonList.Initialize();
@@ -121,7 +87,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostName, "localhost"));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpServerName, "servername.com"));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, "8888"));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "https://www.wiki.com";
@@ -136,24 +101,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostName, "localhost"));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpServerName, "servername.com"));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, "8888"));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "http://www.httphost.org/path";
-            string? url = mappedTags.GetRequestUrl();
-            Assert.Equal(expectedUrl, url);
-        }
-
-        [Fact]
-        public void HttpServerNameAttributeTakesPrecedenceSettingHttpRequestUrl()
-        {
-            var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostName, "localhost"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpServerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
-            string expectedUrl = "http://servername.com:8888/path";
             string? url = mappedTags.GetRequestUrl();
             Assert.Equal(expectedUrl, url);
         }
@@ -549,12 +499,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Theory]
-        [InlineData("peerservice", null, null, null, null, null, null, "peerservice | DbName")]
-        [InlineData(null, "servicename.com", null, "8888", null, null, null, "servicename.com:8888 | DbName")]
-        [InlineData(null, null, "127.0.0.1", "8888", null, null, null, "127.0.0.1:8888 | DbName")]
-        [InlineData(null, null, null, null, "servername.com", null, "8888", "servername.com:8888 | DbName")]
-        [InlineData(null, null, null, null, null, "127.0.0.5", "8888", "127.0.0.5:8888 | DbName")]
-        public void DbNameIsAppendedToTargetDerivedFromNetAttributesforDBDependencyTarget(string peerService, string netPeerName, string netPeerIp, string netPeerPort, string serverAddress, string serverSocketAddress, string serverPort, string expectedTarget)
+        [InlineData("peerservice", null, null, null, null, null, "peerservice | DbName")]
+        [InlineData(null, "servicename.com", null, "8888", null, null, "servicename.com:8888 | DbName")]
+        [InlineData(null, null, "127.0.0.1", "8888", null, null, "127.0.0.1:8888 | DbName")]
+        [InlineData(null, null, null, null, "servername.com", "8888", "servername.com:8888 | DbName")]
+        public void DbNameIsAppendedToTargetDerivedFromNetAttributesforDBDependencyTarget(string peerService, string netPeerName, string netPeerIp, string netPeerPort, string serverAddress, string serverPort, string expectedTarget)
         {
             var mappedTags = AzMonList.Initialize();
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributePeerService, peerService));
@@ -563,7 +512,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, netPeerPort));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeServerAddress, serverAddress));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, serverPort));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeServerSocketAddress, serverSocketAddress));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbNamespace, "DbName"));
 
             Assert.Equal(expectedTarget, mappedTags.GetDbDependencyTargetAndName(true).DbTarget);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -37,8 +37,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
-            Assert.Empty(activityTagsProcessor.UnMappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(0, activityTagsProcessor.UnMappedTags.Length);
         }
 
         [Fact]
@@ -50,8 +50,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
-            Assert.Empty(activityTagsProcessor.UnMappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(0, activityTagsProcessor.UnMappedTags.Length);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
             Assert.Equal(2, activityTagsProcessor.UnMappedTags.Length);
             Assert.Null(AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "key1"));
             Assert.Equal("test", AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "key2"));
@@ -87,7 +87,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
             Assert.Equal("value", AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "somekey"));
         }
 
@@ -183,7 +183,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             Assert.Equal(OperationType.Http, activityTagsProcessor.activityType);
             Assert.Equal(4, activityTagsProcessor.MappedTags.Length);
-            Assert.Single(activityTagsProcessor.UnMappedTags);
+            Assert.Equal(1, activityTagsProcessor.UnMappedTags.Length);
 
             Assert.Equal("https", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpScheme));
             Assert.Equal("localhost", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpHost));
@@ -206,8 +206,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
-            Assert.Single(activityTagsProcessor.UnMappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(1, activityTagsProcessor.UnMappedTags.Length);
 
             Assert.Equal("1,2,3", AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "intArray"));
         }
@@ -226,8 +226,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
-            Assert.Single(activityTagsProcessor.UnMappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(1, activityTagsProcessor.UnMappedTags.Length);
 
             Assert.Equal("1.1,2.2,3.3", AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "doubleArray"));
         }
@@ -246,8 +246,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
-            Assert.Single(activityTagsProcessor.UnMappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(1, activityTagsProcessor.UnMappedTags.Length);
 
             Assert.Equal("test1,test2,test3", AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "strArray"));
         }
@@ -266,8 +266,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
-            Assert.Single(activityTagsProcessor.UnMappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(1, activityTagsProcessor.UnMappedTags.Length);
 
             Assert.Equal("True,False,True", AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "boolArray"));
         }
@@ -286,8 +286,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
-            Assert.Single(activityTagsProcessor.UnMappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(1, activityTagsProcessor.UnMappedTags.Length);
 
             Assert.Equal("Azure.Monitor.OpenTelemetry.Exporter.Tests.TagsTests+Test,Azure.Monitor.OpenTelemetry.Exporter.Tests.TagsTests+Test,Azure.Monitor.OpenTelemetry.Exporter.Tests.TagsTests+Test", AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "objArray"));
         }
@@ -311,7 +311,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityTagsProcessor.CategorizeTags(activity);
 
             Assert.Equal(OperationType.Unknown, activityTagsProcessor.activityType);
-            Assert.Empty(activityTagsProcessor.MappedTags);
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
             Assert.Equal(6, activityTagsProcessor.UnMappedTags.Length);
 
             Assert.Equal(1, AzMonList.GetTagValue(ref activityTagsProcessor.UnMappedTags, "intKey"));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -92,6 +92,28 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
+        public void TagObjects_NullKey_IsSkippedAndDoesNotAbortConversion()
+        {
+            var activityTagsProcessor = new ActivityTagsProcessor();
+            IDictionary<string, string> properties = new Dictionary<string, string>();
+
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?> { ["somekey"] = "value" };
+            using var activity = CreateTestActivity(tagObjects);
+
+            // Activity does not reject a null key, and instrumentation can supply one.
+            activity.AddTag(null!, "nullKeyValue");
+
+            activityTagsProcessor.CategorizeTags(activity);
+            TraceHelper.AddPropertiesToTelemetry(properties, ref activityTagsProcessor.UnMappedTags);
+
+            Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
+            Assert.Equal(1, activityTagsProcessor.UnMappedTags.Length);
+
+            // The tag that follows the null-keyed one must still reach the telemetry item.
+            Assert.Equal("value", properties["somekey"]);
+        }
+
+        [Fact]
         public void TagObjects_Mapped()
         {
             var activityTagsProcessor = new ActivityTagsProcessor();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -97,20 +97,22 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var activityTagsProcessor = new ActivityTagsProcessor();
             IDictionary<string, string> properties = new Dictionary<string, string>();
 
-            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?> { ["somekey"] = "value" };
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?> { ["beforeNullKey"] = "first" };
             using var activity = CreateTestActivity(tagObjects);
 
             // Activity does not reject a null key, and instrumentation can supply one.
             activity.AddTag(null!, "nullKeyValue");
+            activity.AddTag("afterNullKey", "second");
 
             activityTagsProcessor.CategorizeTags(activity);
             TraceHelper.AddPropertiesToTelemetry(properties, ref activityTagsProcessor.UnMappedTags);
 
             Assert.Equal(0, activityTagsProcessor.MappedTags.Length);
-            Assert.Equal(1, activityTagsProcessor.UnMappedTags.Length);
+            Assert.Equal(2, activityTagsProcessor.UnMappedTags.Length);
 
-            // The tag that follows the null-keyed one must still reach the telemetry item.
-            Assert.Equal("value", properties["somekey"]);
+            // The tag following the null-keyed one must still reach the telemetry item.
+            Assert.Equal("first", properties["beforeNullKey"]);
+            Assert.Equal("second", properties["afterNullKey"]);
         }
 
         [Fact]


### PR DESCRIPTION
## What this does

Exporting an activity means converting it into a telemetry item, and that conversion reads a fixed set of known attributes -- `http.url`, `db.system`, `server.address` and so on. **A single conversion does 13 to 26 of these reads.**

Each read was a linear scan that string-compared the key you asked for against every tag on the activity:

```csharp
AzMonList.GetTagValue(ref MappedTags, SemanticConventions.AttributeHttpUrl);
```

Every attribute we recognize is known at compile time, so there is no need to search for it. Each one now gets a fixed position, assigned once when the activity's tags are first sorted, and a read is just an array index:

```csharp
MappedTags[SemanticSlot.HttpUrl];
```

No scanning, no string comparisons. The 26-read sequence an old-semconv HTTP client span performs drops from **270 ns to 13.5 ns**.

There is a second win. Recognized attributes now live *only* in that indexed array, where before they were also appended to a list that nothing read. That removes a pooled buffer: a conversion now rents **two instead of three**.

## Benchmarks

New `ActivityConversionBenchmarks` measures the full `Activity` to `TelemetryItem` conversion with no transmitter and no network. **Every span shape improves.**

| Shape | Before | After | |
|---|---:|---:|---:|
| Override attributes (most reads) | 2,001.5 ns | **1,259.3 ns** | -37.1% |
| DB client, new semconv | 1,232.8 ns | **924.0 ns** | -25.0% |
| DB client, old semconv | 1,118.4 ns | **952.2 ns** | -14.9% |
| HTTP server, new semconv | 1,558.3 ns | **1,363.5 ns** | -12.5% |
| HTTP server, old semconv | 1,388.6 ns | **1,237.0 ns** | -10.9% |
| HTTP client, new semconv | 1,436.0 ns | **1,293.4 ns** | -9.9% |
| HTTP client, old semconv | 1,523.3 ns | **1,372.2 ns** | -9.9% |
| Array-valued tags | 1,937.4 ns | **1,744.7 ns** | -9.9% |
| Azure SDK | 896.8 ns | **824.1 ns** | -8.1% |
| Messaging | 1,014.7 ns | **942.6 ns** | -7.1% |

Managed allocations drop on 8 of the 10 shapes; the two old-semconv HTTP shapes are unchanged at 1.94 KB and 1.56 KB. Pooled buffer rents drop separately, from three to two per conversion, which `MemoryDiagnoser` does not count.

Standard-metrics categorization is 18% to 31% faster, because it no longer collects the tags it never reads.

Results are checked into the benchmark sources as comment blocks, next to the baselines they replace. All figures are BenchmarkDotNet ShortRun (3 iterations), so error bars are wide -- treat the small per-shape deltas as directional.

## Bugs fixed along the way

Five defects in the pooled tag buffers, all pre-existing:

- **Buffers leaked on failure.** They were returned only on the success path, inside a `try` with a swallowing `catch`, so every conversion failure permanently removed two buffers from the shared `ArrayPool`.
- **Buffers leaked when categorization itself threw**, before the caller ever received the processor to return them. Categorization stringifies caller-supplied values, so this is reachable.
- **Rent size was shared mutable state.** One activity with an unusually large number of tags permanently raised the rent size for every later activity in the process, and it was written from multiple exporter threads without synchronization.
- **Returned buffers kept caller tag keys and values alive.**
- **Growth copied the whole rented array** rather than just the used region.

Plus one found in review:

- **A null tag key aborted the conversion.** `Activity` does not reject a null key. Slot resolution passed it to `Dictionary.TryGetValue`, which throws on null. Standard metrics call the categorizer outside any `try`/`catch`, so the exception escaped into the caller stopping the activity. Null keys are now skipped. This also fixes pre-existing behavior where a null key silently dropped every custom property after it.

## Dead code removed

`http.server_name` and `server.socket.address` were read by the request-url and dependency-target logic, but neither is recognized when tags are categorized, so neither was ever present to find. Both branches were unreachable.

Five tests covered them and passed, because they build the tag list by hand and skip the categorizer -- which is how this survived. Four were removed; the DB target theory kept its test and lost one `InlineData` row. Both attributes are still exported as custom properties, unchanged.

## Verification

- 920 / 920 unit tests pass
- Clean Release build on net8.0, netstandard2.0 and net10.0, zero warnings
- ApiCompat passes; all changes are internal, no public API change

## Note for reviewers

A duplicate recognized attribute no longer increments `AzMonList.Length` -- first write wins on the slot, where previously the duplicate was also appended to the list. The value returned is unchanged either way (the first occurrence); only the count differs. No existing test covers this, so it is worth a test if the count semantics matter to anyone.
