### PR TITLE
[Key Vault] Resolve challenge auth per request endpoint

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
+- Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 
 ### Other Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
+- Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 
 ### Other Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
+- Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 
 ### Other Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
+- Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 
 ### Other Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -24,6 +25,8 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         private const string VaultHost = "test.vault.azure.net";
 
         private static Uri VaultUri => new Uri("https://" + VaultHost);
+
+        private static string Base64(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
 
         [SetUp]
         public void Setup()
@@ -237,6 +240,89 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.AreEqual(200, response.GetRawResponse().Status);
             Assert.AreEqual("secret-value", response.Value.Value);
             Assert.AreEqual(expectedTenantId, capturedTenantId);
+        }
+
+        // Regression test: a single ChallengeBasedAuthenticationPolicy instance must not reuse a challenge
+        // (or the token acquired for its scope and tenant) that was cached for one endpoint on a request to a
+        // different endpoint. Before the fix, the second request's pre-challenge fast path reused the first
+        // endpoint's sticky challenge, attaching the first vault's token to a request bound for the second.
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task DoesNotReuseTokenAcrossAuthorities(bool async)
+        {
+            const string hostA = "a.vault.azure.net";
+            const string hostB = "b.vault.azure.net";
+            const string tenantA = "11111111-1111-1111-1111-111111111111";
+            const string tenantB = "22222222-2222-2222-2222-222222222222";
+            string tokenA = Base64(tenantA);
+            string tokenB = Base64(tenantB);
+
+            List<string> authHeadersSentToHostB = new();
+
+            MockResponse Challenge(string tenant)
+            {
+                MockResponse response = new(401, "Unauthorized");
+                response.AddHeader(new HttpHeader("WWW-Authenticate", @$"Bearer authorization=""https://login.windows.net/{tenant}"", resource=""https://vault.azure.net"""));
+                return response;
+            }
+
+            MockTransport transport = new(request =>
+            {
+                string auth = request.Headers.TryGetValue("Authorization", out string value) ? value : null;
+                switch (request.Uri.Host)
+                {
+                    case hostA:
+                        return auth == $"Bearer {tokenA}"
+                            ? new MockResponse(200, "OK")
+                            : Challenge(tenantA);
+
+                    case hostB:
+                        if (auth != null)
+                        {
+                            authHeadersSentToHostB.Add(auth);
+                        }
+                        return auth == $"Bearer {tokenB}"
+                            ? new MockResponse(200, "OK")
+                            : Challenge(tenantB);
+
+                    default:
+                        throw new AssertionException($"Unexpected request: {request}");
+                }
+            });
+
+            // The credential honors the tenant from the challenge and mints a token unique to that tenant.
+            CallbackTokenCredential credential = new((requestContext, _) =>
+                new AccessToken(Base64(requestContext.TenantId), DateTimeOffset.UtcNow.AddHours(1)));
+
+            ChallengeBasedAuthenticationPolicy policy = new(credential, disableChallengeResourceVerification: false);
+            HttpPipeline pipeline = new(transport, new HttpPipelinePolicy[] { policy });
+
+            async Task SendAsync(string host)
+            {
+                Request request = pipeline.CreateRequest();
+                request.Method = RequestMethod.Get;
+                request.Uri.Reset(new Uri($"https://{host}/secrets/test?api-version=7.4"));
+                Response response = async
+                    ? await pipeline.SendRequestAsync(request, default)
+                    : pipeline.SendRequest(request, default);
+                Assert.AreEqual(200, response.Status);
+            }
+
+            // First, authenticate against host A. This populates the instance's sticky challenge and the base
+            // policy's token cache for tenant A.
+            await SendAsync(hostA);
+
+            // Then reuse the same policy instance for a different host. Host A's token must not be attached.
+            await SendAsync(hostB);
+
+            CollectionAssert.DoesNotContain(
+                authHeadersSentToHostB,
+                $"Bearer {tokenA}",
+                "The first endpoint's token was reused on a request to a different endpoint.");
+            CollectionAssert.Contains(
+                authHeadersSentToHostB,
+                $"Bearer {tokenB}",
+                "The second endpoint was never authenticated with its own token.");
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -308,7 +308,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
                 Assert.AreEqual(200, response.Status);
             }
 
-            // First, authenticate against host A. This populates the instance's sticky challenge and the base
+            // First, authenticate against host A. This populates the shared challenge cache and the base
             // policy's token cache for tenant A.
             await SendAsync(hostA);
 
@@ -323,6 +323,85 @@ namespace Azure.Security.KeyVault.Secrets.Tests
                 authHeadersSentToHostB,
                 $"Bearer {tokenB}",
                 "The second endpoint was never authenticated with its own token.");
+        }
+
+        // Regression test for the concurrent variant: interleaved requests to two endpoints on a single policy
+        // instance must each be authorized with their own endpoint's token. Because no challenge is memoized on
+        // the policy instance, a request bound for one endpoint can never observe the other endpoint's challenge.
+        [TestCase(10, 0, 0)]
+        [TestCase(10, 20, 200)]
+        public async Task DoesNotReuseTokenAcrossAuthoritiesConcurrently(int requestsPerHost, int minDelay, int maxDelay)
+        {
+            const string hostA = "a.vault.azure.net";
+            const string hostB = "b.vault.azure.net";
+            const string tenantA = "11111111-1111-1111-1111-111111111111";
+            const string tenantB = "22222222-2222-2222-2222-222222222222";
+            string tokenA = Base64(tenantA);
+            string tokenB = Base64(tenantB);
+
+            Random rand = new();
+
+            MockResponse Challenge(string tenant)
+            {
+                MockResponse response = new(401, "Unauthorized");
+                response.AddHeader(new HttpHeader("WWW-Authenticate", @$"Bearer authorization=""https://login.windows.net/{tenant}"", resource=""https://vault.azure.net"""));
+                return response;
+            }
+
+            // Assert on every authenticated request as it is processed: a request to one host must never carry
+            // the other host's token.
+            MockTransport transport = new(request =>
+            {
+                int delay;
+                lock (rand)
+                {
+                    delay = rand.Next(minDelay, maxDelay);
+                }
+
+                if (delay > 0)
+                {
+                    Thread.Sleep(delay);
+                }
+
+                string auth = request.Headers.TryGetValue("Authorization", out string value) ? value : null;
+                switch (request.Uri.Host)
+                {
+                    case hostA:
+                        Assert.AreNotEqual($"Bearer {tokenB}", auth, "Host B's token was attached to a host A request.");
+                        return auth == $"Bearer {tokenA}" ? new MockResponse(200, "OK") : Challenge(tenantA);
+
+                    case hostB:
+                        Assert.AreNotEqual($"Bearer {tokenA}", auth, "Host A's token was attached to a host B request.");
+                        return auth == $"Bearer {tokenB}" ? new MockResponse(200, "OK") : Challenge(tenantB);
+
+                    default:
+                        throw new AssertionException($"Unexpected request: {request}");
+                }
+            });
+
+            CallbackTokenCredential credential = new((requestContext, _) =>
+                new AccessToken(Base64(requestContext.TenantId), DateTimeOffset.UtcNow.AddHours(1)));
+
+            ChallengeBasedAuthenticationPolicy policy = new(credential, disableChallengeResourceVerification: false);
+            HttpPipeline pipeline = new(transport, new HttpPipelinePolicy[] { policy });
+
+            async Task SendAsync(string host)
+            {
+                Request request = pipeline.CreateRequest();
+                request.Method = RequestMethod.Get;
+                request.Uri.Reset(new Uri($"https://{host}/secrets/test?api-version=7.4"));
+                Response response = await pipeline.SendRequestAsync(request, default);
+                Assert.AreEqual(200, response.Status);
+            }
+
+            Task[] tasks = new Task[requestsPerHost * 2];
+            for (int i = 0; i < requestsPerHost; i++)
+            {
+                tasks[2 * i] = Task.Run(() => SendAsync(hostA));
+                tasks[2 * i + 1] = Task.Run(() => SendAsync(hostB));
+            }
+
+            await Task.WhenAll(tasks);
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -20,7 +20,6 @@ namespace Azure.Security.KeyVault
         /// Challenges are cached using the Key Vault or Managed HSM endpoint URI authority as the key.
         /// </summary>
         private static readonly ConcurrentDictionary<string, ChallengeParameters> s_challengeCache = new();
-        private ChallengeParameters _challenge;
 
         public ChallengeBasedAuthenticationPolicy(TokenCredential credential, bool disableChallengeResourceVerification) : base(credential, Array.Empty<string>())
         {
@@ -42,22 +41,16 @@ namespace Azure.Security.KeyVault
                 throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
             }
 
-            // Always resolve the challenge for the current request's authority. A single
-            // ChallengeBasedAuthenticationPolicy instance can process requests to more than one endpoint, so a
-            // challenge (and the token acquired for its scope and tenant) that was cached for one authority
-            // must not be reused for a request bound to a different authority: a token acquired for one vault
-            // must never be attached to a request to another. Only fall back to the static cache when the
-            // current per-instance challenge does not belong to this request's authority.
+            // Resolve the challenge for the current request's authority from the static cache, which is keyed
+            // by authority. A challenge (and the token acquired for its scope and tenant) cached for one
+            // endpoint is therefore never applied to a request bound for a different endpoint. No challenge is
+            // memoized on the policy instance, so concurrent requests to different authorities on the same
+            // instance cannot observe each other's challenge.
             string authority = GetRequestAuthority(message.Request);
-            if (_challenge == null || !_challenge.MatchesAuthority(authority))
-            {
-                s_challengeCache.TryGetValue(authority, out _challenge);
-            }
-
-            if (_challenge != null)
+            if (s_challengeCache.TryGetValue(authority, out ChallengeParameters challenge))
             {
                 // We fetched the challenge from the cache, but we have not initialized the Scopes in the base yet.
-                var context = new TokenRequestContext(_challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: _challenge.TenantId, isCaeEnabled: true);
+                var context = new TokenRequestContext(challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: challenge.TenantId, isCaeEnabled: true);
                 if (async)
                 {
                     await AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);
@@ -134,6 +127,7 @@ namespace Azure.Security.KeyVault
             }
 
             // Handle CAE Challenges
+            ChallengeParameters challenge = null;
             string claims = getDecodedClaimsParameter(error, message.Response);
             if (claims != null)
             {
@@ -141,8 +135,8 @@ namespace Azure.Security.KeyVault
                 // is no scope to reuse, so fall through and surface the challenge below.
                 if (s_challengeCache.TryGetValue(authority, out ChallengeParameters cached))
                 {
-                    _challenge = cached;
-                    scope = _challenge.Scopes[0];
+                    challenge = cached;
+                    scope = challenge.Scopes[0];
                 }
             }
 
@@ -179,11 +173,11 @@ namespace Azure.Security.KeyVault
                     throw new UriFormatException($"The challenge authorization URI '{authorization}' is invalid.");
                 }
 
-                _challenge = new ChallengeParameters(authority, authorizationUri, new string[] { scope });
-                s_challengeCache[authority] = _challenge;
+                challenge = new ChallengeParameters(authorizationUri, new string[] { scope });
+                s_challengeCache[authority] = challenge;
             }
 
-            var context = new TokenRequestContext(_challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: _challenge.TenantId, isCaeEnabled: true, claims: claims);
+            var context = new TokenRequestContext(challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: challenge.TenantId, isCaeEnabled: true, claims: claims);
             if (async)
             {
                 await AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);
@@ -273,9 +267,8 @@ namespace Azure.Security.KeyVault
 
         internal class ChallengeParameters
         {
-            internal ChallengeParameters(string sourceAuthority, Uri authorizationUri, string[] scopes)
+            internal ChallengeParameters(Uri authorizationUri, string[] scopes)
             {
-                SourceAuthority = sourceAuthority;
                 AuthorizationUri = authorizationUri;
                 TenantId = authorizationUri.Segments[1].Trim('/');
                 if (TenantId.Equals("dstsv2", StringComparison.OrdinalIgnoreCase) && authorizationUri.Segments.Length > 2)
@@ -284,20 +277,6 @@ namespace Azure.Security.KeyVault
                 }
                 Scopes = scopes;
             }
-
-            /// <summary>
-            /// Gets the Key Vault or Managed HSM endpoint authority (host and port) that produced this challenge.
-            /// Used to ensure a cached challenge, and the token acquired for it, is only ever applied to
-            /// requests targeting the same authority.
-            /// </summary>
-            public string SourceAuthority { get; }
-
-            /// <summary>
-            /// Determines whether this challenge was produced by the specified request authority.
-            /// </summary>
-            /// <param name="authority">The request authority (host and port) to compare against.</param>
-            internal bool MatchesAuthority(string authority)
-                => string.Equals(SourceAuthority, authority, StringComparison.OrdinalIgnoreCase);
 
             /// <summary>
             /// Gets the "authorization" or "authorization_uri" parameter from the challenge response.

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -42,10 +42,15 @@ namespace Azure.Security.KeyVault
                 throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
             }
 
-            // If this policy doesn't have challenge parameters cached try to get it from the static challenge cache.
-            if (_challenge == null)
+            // Always resolve the challenge for the current request's authority. A single
+            // ChallengeBasedAuthenticationPolicy instance can process requests to more than one endpoint, so a
+            // challenge (and the token acquired for its scope and tenant) that was cached for one authority
+            // must not be reused for a request bound to a different authority: a token acquired for one vault
+            // must never be attached to a request to another. Only fall back to the static cache when the
+            // current per-instance challenge does not belong to this request's authority.
+            string authority = GetRequestAuthority(message.Request);
+            if (_challenge == null || !_challenge.MatchesAuthority(authority))
             {
-                string authority = GetRequestAuthority(message.Request);
                 s_challengeCache.TryGetValue(authority, out _challenge);
             }
 
@@ -174,7 +179,7 @@ namespace Azure.Security.KeyVault
                     throw new UriFormatException($"The challenge authorization URI '{authorization}' is invalid.");
                 }
 
-                _challenge = new ChallengeParameters(authorizationUri, new string[] { scope });
+                _challenge = new ChallengeParameters(authority, authorizationUri, new string[] { scope });
                 s_challengeCache[authority] = _challenge;
             }
 
@@ -268,8 +273,9 @@ namespace Azure.Security.KeyVault
 
         internal class ChallengeParameters
         {
-            internal ChallengeParameters(Uri authorizationUri, string[] scopes)
+            internal ChallengeParameters(string sourceAuthority, Uri authorizationUri, string[] scopes)
             {
+                SourceAuthority = sourceAuthority;
                 AuthorizationUri = authorizationUri;
                 TenantId = authorizationUri.Segments[1].Trim('/');
                 if (TenantId.Equals("dstsv2", StringComparison.OrdinalIgnoreCase) && authorizationUri.Segments.Length > 2)
@@ -278,6 +284,20 @@ namespace Azure.Security.KeyVault
                 }
                 Scopes = scopes;
             }
+
+            /// <summary>
+            /// Gets the Key Vault or Managed HSM endpoint authority (host and port) that produced this challenge.
+            /// Used to ensure a cached challenge, and the token acquired for it, is only ever applied to
+            /// requests targeting the same authority.
+            /// </summary>
+            public string SourceAuthority { get; }
+
+            /// <summary>
+            /// Determines whether this challenge was produced by the specified request authority.
+            /// </summary>
+            /// <param name="authority">The request authority (host and port) to compare against.</param>
+            internal bool MatchesAuthority(string authority)
+                => string.Equals(SourceAuthority, authority, StringComparison.OrdinalIgnoreCase);
 
             /// <summary>
             /// Gets the "authorization" or "authorization_uri" parameter from the challenge response.


### PR DESCRIPTION
## Description

The Key Vault challenge-based authentication policy (`ChallengeBasedAuthenticationPolicy`, shared across the Secrets, Keys, Certificates, and Administration packages) cached the parsed authentication challenge (scope, tenant, and authorization URI) in a per-instance field and only re-read the per-authority challenge cache when that field was `null`. Once the field was populated for the first endpoint, the same challenge — and therefore the base `BearerTokenAuthenticationPolicy`'s cached access token — was reused for every subsequent request on that policy instance without checking the request's endpoint. A policy instance that processed requests to more than one endpoint could attach a token acquired for one vault to a request bound for a different vault.

This change records the source authority on the cached challenge and re-resolves the challenge for each request's endpoint, so a challenge (or the token acquired for it) is never reused for a different endpoint. Single-endpoint clients are unaffected — the same-endpoint fast path is unchanged.

### Changes
- Track `SourceAuthority` on `ChallengeParameters` and re-resolve the challenge per request authority in the pre-challenge fast path.
- Add `DoesNotReuseTokenAcrossAuthorities` regression tests (sync + async) that fail without the fix.
- Update `CHANGELOG.md` for Secrets, Keys, Certificates, and Administration (the packages that link the shared policy source).

### Validation
- No public API change (`ChallengeParameters` is an internal type; ApiCompat passes).
- Secrets `ChallengeBasedAuthenticationPolicyTests` 11/11 pass; Administration 8/8 pass. Verified the new tests fail when the fix is reverted.

---

- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### General Guidelines
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
