### PR TITLE
Require KeyGuard for managed identity mTLS PoP

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -188,7 +188,7 @@
     <!-- Other approved packages -->
     <PackageVersion Include="Microsoft.Azure.Amqp" Version="2.7.0" />
     <PackageVersion Include="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.88.0" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.84.2" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />

--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -189,8 +189,8 @@
     <PackageVersion Include="Microsoft.Azure.Amqp" Version="2.7.0" />
     <PackageVersion Include="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.88.0" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.2" />
-    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.84.2" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.88.0" />
+    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.88.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.15.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Managed identity mTLS proof-of-possession now requires a KeyGuard-backed host capability and enforces KeyGuard as the minimum binding strength during token acquisition. ([#62585](https://github.com/Azure/azure-sdk-for-net/issues/62585))
+
 ### Other Changes
 
 ## 1.62.0 (2026-08-20)

--- a/sdk/core/Azure.Core/src/Identity/ImdsManagedIdentityProbeSource.cs
+++ b/sdk/core/Azure.Core/src/Identity/ImdsManagedIdentityProbeSource.cs
@@ -99,7 +99,10 @@ namespace Azure.Identity
             return message;
         }
 
-        public async override ValueTask<AccessToken> AuthenticateAsync(bool async, TokenRequestContext context, CancellationToken cancellationToken)
+        public override ValueTask<AccessToken> AuthenticateAsync(bool async, TokenRequestContext context, CancellationToken cancellationToken) =>
+            AuthenticateAsync(async, context, isKeyGuardAvailable: false, cancellationToken);
+
+        internal async ValueTask<AccessToken> AuthenticateAsync(bool async, TokenRequestContext context, bool isKeyGuardAvailable, CancellationToken cancellationToken)
         {
             bool continueIMDSRequestAfterProbe;
             try
@@ -141,7 +144,7 @@ namespace Azure.Identity
                 try
                 {
 #pragma warning disable AZC0110 // DO NOT use await keyword in possibly synchronous scope.
-                    var authResult = await _client.AcquireTokenForManagedIdentityAsync(context, false, cancellationToken).ConfigureAwait(false);
+                    var authResult = await _client.AcquireTokenForManagedIdentityAsync(context, isKeyGuardAvailable, cancellationToken).ConfigureAwait(false);
 #pragma warning restore AZC0110 // DO NOT use await keyword in possibly synchronous scope.
                     return authResult.ToAccessToken();
                 }

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -13,6 +13,7 @@ using Azure.Core.Pipeline;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensibility;
 using MSAL = Microsoft.Identity.Client.ManagedIdentity;
+using MtlsBindingStrength = Microsoft.Identity.Client.AppConfig.MtlsBindingStrength;
 
 namespace Azure.Identity
 {
@@ -119,9 +120,10 @@ namespace Azure.Identity
             try
             {
                 // The default case is to use the MSAL implementation, which does no probing of the IMDS endpoint.
+                bool isKeyGuardAvailable = capabilities.MaxSupportedBindingStrength >= MtlsBindingStrength.KeyGuard;
                 result = async ?
-                    await _msalManagedIdentityClient.AcquireTokenForManagedIdentityAsync(context, capabilities.IsMtlsPopSupportedByHost, cancellationToken).ConfigureAwait(false) :
-                    _msalManagedIdentityClient.AcquireTokenForManagedIdentity(context, capabilities.IsMtlsPopSupportedByHost, cancellationToken);
+                    await _msalManagedIdentityClient.AcquireTokenForManagedIdentityAsync(context, isKeyGuardAvailable, cancellationToken).ConfigureAwait(false) :
+                    _msalManagedIdentityClient.AcquireTokenForManagedIdentity(context, isKeyGuardAvailable, cancellationToken);
             }
             // If the IMDS endpoint is not available, we will throw a CredentialUnavailableException.
             catch (MsalServiceException ex) when (HasInnerExceptionMatching(ex, e => e is RequestFailedException && e.Message.Contains("timed out")))

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -93,13 +93,14 @@ namespace Azure.Identity
             }
 
             AzureIdentityEventSource.Singleton.ManagedIdentityCredentialSelected(capabilities.Source.ToString(), _options.ManagedIdentityId.ToString());
+            bool isKeyGuardAvailable = capabilities.MaxSupportedBindingStrength >= MtlsBindingStrength.KeyGuard;
 
             // If the source is DefaultToImds and the credential is chained, we should probe the IMDS endpoint first.
 #pragma warning disable CS0618 // DefaultToImds is obsolete but still returned by the sync GetManagedIdentitySource path
             if ((capabilities.Source == MSAL.ManagedIdentitySource.DefaultToImds || capabilities.Source == MSAL.ManagedIdentitySource.Imds) && _isChainedCredential && !_probeRequestSent)
 #pragma warning restore CS0618
             {
-                var probedFlowTokenResult = await AuthenticateCoreAsync(async, context, cancellationToken).ConfigureAwait(false);
+                var probedFlowTokenResult = await AuthenticateCoreAsync(async, context, isKeyGuardAvailable, cancellationToken).ConfigureAwait(false);
                 _probeRequestSent = true;
                 return probedFlowTokenResult;
             }
@@ -120,7 +121,6 @@ namespace Azure.Identity
             try
             {
                 // The default case is to use the MSAL implementation, which does no probing of the IMDS endpoint.
-                bool isKeyGuardAvailable = capabilities.MaxSupportedBindingStrength >= MtlsBindingStrength.KeyGuard;
                 result = async ?
                     await _msalManagedIdentityClient.AcquireTokenForManagedIdentityAsync(context, isKeyGuardAvailable, cancellationToken).ConfigureAwait(false) :
                     _msalManagedIdentityClient.AcquireTokenForManagedIdentity(context, isKeyGuardAvailable, cancellationToken);
@@ -143,9 +143,14 @@ namespace Azure.Identity
             return result.ToAccessToken();
         }
 
-        public virtual async ValueTask<AccessToken> AuthenticateCoreAsync(bool async, TokenRequestContext context,
+        public virtual async ValueTask<AccessToken> AuthenticateCoreAsync(bool async, TokenRequestContext context, bool isKeyGuardAvailable,
             CancellationToken cancellationToken)
         {
+            if (_identitySource.Value is ImdsManagedIdentityProbeSource imdsSource)
+            {
+                return await imdsSource.AuthenticateAsync(async, context, isKeyGuardAvailable, cancellationToken).ConfigureAwait(false);
+            }
+
             return await _identitySource.Value.AuthenticateAsync(async, context, cancellationToken).ConfigureAwait(false);
         }
 
@@ -153,7 +158,7 @@ namespace Azure.Identity
         {
             TokenRequestContext requestContext = new TokenRequestContext(parameters.Scopes.ToArray(), claims: parameters.Claims);
 
-            AccessToken token = await AuthenticateCoreAsync(true, requestContext, parameters.CancellationToken).ConfigureAwait(false);
+            AccessToken token = await AuthenticateCoreAsync(true, requestContext, false, parameters.CancellationToken).ConfigureAwait(false);
 
             var resfreshOn = ManagedIdentitySource.InferManagedIdentityRefreshInValue(token.ExpiresOn);
             long? refreshInSeconds = resfreshOn switch

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -93,7 +93,9 @@ namespace Azure.Identity
             }
 
             AzureIdentityEventSource.Singleton.ManagedIdentityCredentialSelected(capabilities.Source.ToString(), _options.ManagedIdentityId.ToString());
-            bool isKeyGuardAvailable = capabilities.MaxSupportedBindingStrength >= MtlsBindingStrength.KeyGuard;
+            bool isKeyGuardAvailable =
+                capabilities.IsMtlsPopSupportedByHost &&
+                capabilities.MaxSupportedBindingStrength >= MtlsBindingStrength.KeyGuard;
 
             // If the source is DefaultToImds and the credential is chained, we should probe the IMDS endpoint first.
 #pragma warning disable CS0618 // DefaultToImds is obsolete but still returned by the sync GetManagedIdentitySource path

--- a/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/ManagedIdentityClient.cs
@@ -148,6 +148,7 @@ namespace Azure.Identity
         public virtual async ValueTask<AccessToken> AuthenticateCoreAsync(bool async, TokenRequestContext context, bool isKeyGuardAvailable,
             CancellationToken cancellationToken)
         {
+            // IMDS re-enters MSAL after its probe, so preserve the binding capability discovered before probing.
             if (_identitySource.Value is ImdsManagedIdentityProbeSource imdsSource)
             {
                 return await imdsSource.AuthenticateAsync(async, context, isKeyGuardAvailable, cancellationToken).ConfigureAwait(false);

--- a/sdk/core/Azure.Core/src/Identity/MsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalManagedIdentityClient.cs
@@ -25,7 +25,7 @@ namespace Azure.Identity
         private const string WithAttestationSupportMethodName = "WithAttestationSupport";
         private static readonly string[] s_cp1Capabilities = ["CP1"];
 
-        private readonly ConcurrentDictionary<(bool EnableCae, bool IsTokenBinding), AsyncLockWithValue<IManagedIdentityApplication>> _clientCache = new();
+        private readonly ConcurrentDictionary<(bool EnableCae, bool EnableMtlsPop), AsyncLockWithValue<IManagedIdentityApplication>> _clientCache = new();
         private readonly bool _isForceRefreshEnabled;
         private readonly bool _disableMtlsProofOfPossession;
         private static readonly Lazy<Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder>> s_withAttestationSupport =
@@ -113,12 +113,12 @@ namespace Azure.Identity
             }
         }
 
-        protected ValueTask<IManagedIdentityApplication> CreateClientAsync(bool async, bool enableCae, bool isTokenBindingAvailable, CancellationToken cancellationToken)
+        protected ValueTask<IManagedIdentityApplication> CreateClientAsync(bool async, bool enableCae, bool enableMtlsPop, CancellationToken cancellationToken)
         {
-            return CreateClientCoreAsync(async, enableCae, isTokenBindingAvailable, cancellationToken);
+            return CreateClientCoreAsync(async, enableCae, enableMtlsPop, cancellationToken);
         }
 
-        protected virtual ValueTask<IManagedIdentityApplication> CreateClientCoreAsync(bool async, bool enableCae, bool isTokenBindingAvailable, CancellationToken cancellationToken)
+        protected virtual ValueTask<IManagedIdentityApplication> CreateClientCoreAsync(bool async, bool enableCae, bool enableMtlsPop, CancellationToken cancellationToken)
         {
             string[] clientCapabilities =
                 enableCae ? s_cp1Capabilities : Array.Empty<string>();
@@ -131,7 +131,7 @@ namespace Azure.Identity
             // client so it can perform the mTLS handshake with the platform's bound certificate.
             // The Azure.Core pipeline transport does not carry these mTLS credentials, so
             // WithHttpClientFactory is intentionally omitted in this path.
-            if (!isTokenBindingAvailable)
+            if (!enableMtlsPop)
             {
                 miAppBuilder.WithHttpClientFactory(new HttpPipelineClientFactory(Pipeline.HttpPipeline, Pipeline.ClientOptions), false);
             }
@@ -144,9 +144,9 @@ namespace Azure.Identity
             return new ValueTask<IManagedIdentityApplication>(miAppBuilder.Build());
         }
 
-        protected async ValueTask<IManagedIdentityApplication> GetClientAsync(bool async, bool enableCae, bool isTokenBindingAvailable, CancellationToken cancellationToken)
+        protected async ValueTask<IManagedIdentityApplication> GetClientAsync(bool async, bool enableCae, bool enableMtlsPop, CancellationToken cancellationToken)
         {
-            var key = (enableCae, isTokenBindingAvailable);
+            var key = (enableCae, enableMtlsPop);
             var lockInstance = _clientCache.GetOrAdd(key, _ => new AsyncLockWithValue<IManagedIdentityApplication>());
 
             using var asyncLock = await lockInstance.GetLockOrValueAsync(async, cancellationToken).ConfigureAwait(false);
@@ -156,7 +156,7 @@ namespace Azure.Identity
                 return asyncLock.Value;
             }
 
-            var client = await CreateClientAsync(async, enableCae, isTokenBindingAvailable, cancellationToken).ConfigureAwait(false);
+            var client = await CreateClientAsync(async, enableCae, enableMtlsPop, cancellationToken).ConfigureAwait(false);
             asyncLock.SetValue(client);
             return client;
         }
@@ -169,7 +169,13 @@ namespace Azure.Identity
 
         public virtual async ValueTask<AuthenticationResult> AcquireTokenForManagedIdentityAsyncCore(bool async, TokenRequestContext requestContext, bool isTokenBindingAvailable, CancellationToken cancellationToken)
         {
-            IManagedIdentityApplication client = await GetClientAsync(async, requestContext.IsCaeEnabled, isTokenBindingAvailable, cancellationToken).ConfigureAwait(false);
+            Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> withAttestationSupport =
+                ShouldAttemptMtlsPop(requestContext, isTokenBindingAvailable)
+                    ? GetAttestationSupport()
+                    : null;
+            bool enableMtlsPop = withAttestationSupport != null;
+
+            IManagedIdentityApplication client = await GetClientAsync(async, requestContext.IsCaeEnabled, enableMtlsPop, cancellationToken).ConfigureAwait(false);
             var builder = client.AcquireTokenForManagedIdentity(requestContext.Scopes.FirstOrDefault());
 
             if (!string.IsNullOrEmpty(requestContext.Claims))
@@ -177,9 +183,9 @@ namespace Azure.Identity
                 builder.WithClaims(requestContext.Claims);
             }
 
-            if (ShouldAttemptMtlsPop(requestContext, isTokenBindingAvailable))
+            if (enableMtlsPop)
             {
-                builder = ConfigureMtlsPop(builder, s_withAttestationSupport.Value);
+                builder = ConfigureMtlsPop(builder, withAttestationSupport);
             }
 
             if (_isForceRefreshEnabled)
@@ -234,5 +240,8 @@ namespace Azure.Identity
             !_disableMtlsProofOfPossession &&
             requestContext.IsProofOfPossessionEnabled &&
             isTokenBindingAvailable;
+
+        protected virtual Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> GetAttestationSupport() =>
+            s_withAttestationSupport.Value;
     }
 }

--- a/sdk/core/Azure.Core/src/Identity/MsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalManagedIdentityClient.cs
@@ -170,9 +170,7 @@ namespace Azure.Identity
         public virtual async ValueTask<AuthenticationResult> AcquireTokenForManagedIdentityAsyncCore(bool async, TokenRequestContext requestContext, bool isTokenBindingAvailable, CancellationToken cancellationToken)
         {
             Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> withAttestationSupport =
-                ShouldAttemptMtlsPop(requestContext, isTokenBindingAvailable)
-                    ? GetAttestationSupport()
-                    : null;
+                GetAttestationSupport(requestContext, isTokenBindingAvailable);
             bool enableMtlsPop = withAttestationSupport != null;
 
             IManagedIdentityApplication client = await GetClientAsync(async, requestContext.IsCaeEnabled, enableMtlsPop, cancellationToken).ConfigureAwait(false);
@@ -201,9 +199,18 @@ namespace Azure.Identity
 
         public virtual async ValueTask<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentityCapabilities> GetManagedIdentityCapabilitiesAsync(TokenRequestContext context, CancellationToken cancellationToken)
         {
-            // Keep honoring PoP request intent when selecting the cached MSAL MI app,
-            // same behavior as GetManagedIdentitySourceAsync.
-            IManagedIdentityApplication client = await GetClientAsync(true, context.IsCaeEnabled, context.IsProofOfPossessionEnabled, cancellationToken).ConfigureAwait(false);
+            // Capability discovery determines whether the host can satisfy PoP, so evaluate the
+            // request-level prerequisites here and apply the binding-strength requirement afterward.
+            bool enableMtlsPop = GetAttestationSupport(context, isTokenBindingAvailable: true) != null;
+            IManagedIdentityApplication client = await GetClientAsync(true, context.IsCaeEnabled, enableMtlsPop, cancellationToken).ConfigureAwait(false);
+            return await GetManagedIdentityCapabilitiesFromClientAsync(client, context, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected virtual async ValueTask<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentityCapabilities> GetManagedIdentityCapabilitiesFromClientAsync(
+            IManagedIdentityApplication client,
+            TokenRequestContext context,
+            CancellationToken cancellationToken)
+        {
             ManagedIdentityApplication app = client as ManagedIdentityApplication;
             return await app.GetManagedIdentityCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -241,7 +248,14 @@ namespace Azure.Identity
             requestContext.IsProofOfPossessionEnabled &&
             isTokenBindingAvailable;
 
-        protected virtual Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> GetAttestationSupport() =>
+        private Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> GetAttestationSupport(
+            TokenRequestContext requestContext,
+            bool isTokenBindingAvailable) =>
+            ShouldAttemptMtlsPop(requestContext, isTokenBindingAvailable)
+                ? ResolveAttestationSupport()
+                : null;
+
+        protected virtual Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> ResolveAttestationSupport() =>
             s_withAttestationSupport.Value;
     }
 }

--- a/sdk/core/Azure.Core/src/Identity/MsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalManagedIdentityClient.cs
@@ -12,6 +12,8 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Identity.Client;
+using MtlsBindingStrength = Microsoft.Identity.Client.AppConfig.MtlsBindingStrength;
+using PoPOptions = Microsoft.Identity.Client.AppConfig.PoPOptions;
 
 namespace Azure.Identity
 {
@@ -177,13 +179,7 @@ namespace Azure.Identity
 
             if (ShouldAttemptMtlsPop(requestContext, isTokenBindingAvailable))
             {
-                var withAttestationSupport = s_withAttestationSupport.Value;
-                if (withAttestationSupport != null)
-                {
-                    builder.WithMtlsProofOfPossession();
-                    AzureIdentityEventSource.Singleton.LogMsal(LogLevel.Verbose, "Managed identity token request configured with mTLS proof-of-possession.");
-                    builder = withAttestationSupport(builder);
-                }
+                builder = ConfigureMtlsPop(builder, s_withAttestationSupport.Value);
             }
 
             if (_isForceRefreshEnabled)
@@ -220,7 +216,21 @@ namespace Azure.Identity
 #pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
         }
 
-        private bool ShouldAttemptMtlsPop(TokenRequestContext requestContext, bool isTokenBindingAvailable) =>
+        internal static AcquireTokenForManagedIdentityParameterBuilder ConfigureMtlsPop(
+            AcquireTokenForManagedIdentityParameterBuilder builder,
+            Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> withAttestationSupport)
+        {
+            if (withAttestationSupport == null)
+            {
+                return builder;
+            }
+
+            builder.WithMtlsProofOfPossession(new PoPOptions { MinStrength = MtlsBindingStrength.KeyGuard });
+            AzureIdentityEventSource.Singleton.LogMsal(LogLevel.Verbose, "Managed identity token request configured with mTLS proof-of-possession.");
+            return withAttestationSupport(builder);
+        }
+
+        internal bool ShouldAttemptMtlsPop(TokenRequestContext requestContext, bool isTokenBindingAvailable) =>
             !_disableMtlsProofOfPossession &&
             requestContext.IsProofOfPossessionEnabled &&
             isTokenBindingAvailable;

--- a/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
@@ -419,9 +419,47 @@ namespace Azure.Core.Tests.Identity
             AccessToken token = await credential.GetTokenAsync(context, default);
 
             Assert.AreEqual(ExpectedToken, token.Token);
+            Assert.IsFalse(mockMsal.FirstEnableMtlsPopForClientCreation);
             Assert.IsFalse(mockMsal.LastEnableMtlsPopForClientCreation);
             Assert.IsTrue(mockTransport.Requests.Any(request =>
                 request.Uri.ToString().StartsWith(EnvironmentVariables.IdentityEndpoint)));
+        }
+
+        [Test]
+        public async Task ChainedImdsRequestPreservesKeyGuardCapabilityAfterProbe()
+        {
+            using var environment = new TestEnvVar(new()
+            {
+                { "MSI_ENDPOINT", null },
+                { "MSI_SECRET", null },
+                { "IDENTITY_ENDPOINT", null },
+                { "IDENTITY_HEADER", null },
+                { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null }
+            });
+            var mockTransport = new MockImdsManagedIdentityTransport(CreateSuccessResponse(ExpectedToken));
+            MockMsalManagedIdentityClient mockMsal = null;
+            var credential = BuildManagedIdentityCredential(
+                new TokenCredentialOptions { Transport = mockTransport, IsChainedCredential = true },
+                ManagedIdentityId.SystemAssigned,
+                configureMockMsal: mock =>
+                {
+                    mockMsal = mock;
+                    mock.GetManagedIdentityCapabilitiesFactory = (_, _) =>
+                        MockMsalManagedIdentityClient.CreateCapabilities(
+                            Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.Imds,
+                            MtlsBindingStrength.KeyGuard);
+                    mock.AcquireTokenForManagedIdentityAsyncFactory = (_, _) =>
+                        AuthenticationResultFactory.Create(ExpectedToken);
+                    mock.OverrideAttestationSupport = true;
+                    mock.AttestationSupport = builder => builder;
+                });
+            var context = new TokenRequestContext(MockScopes.Default, isProofOfPossessionEnabled: true);
+
+            AccessToken token = await credential.GetTokenAsync(context, default);
+
+            Assert.AreEqual(ExpectedToken, token.Token);
+            Assert.IsTrue(mockMsal.FirstEnableMtlsPopForClientCreation);
+            Assert.IsTrue(mockMsal.LastIsTokenBindingAvailable);
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
@@ -17,6 +17,7 @@ using Azure.Identity;
 using Microsoft.Identity.Client;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using MtlsBindingStrength = Microsoft.Identity.Client.AppConfig.MtlsBindingStrength;
 namespace Azure.Core.Tests.Identity
 {
     [NonParallelizable]
@@ -346,6 +347,65 @@ namespace Azure.Core.Tests.Identity
             var ex = Assert.ThrowsAsync<AuthenticationFailedException>(
                 async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             Assert.IsNotInstanceOf<CredentialUnavailableException>(ex);
+        }
+
+        [TestCase(MtlsBindingStrength.None, false)]
+        [TestCase(MtlsBindingStrength.Software, false)]
+        [TestCase(MtlsBindingStrength.KeyGuard, true)]
+        [TestCase((MtlsBindingStrength)4, true)]
+        public async Task ManagedIdentityMtlsPopRequiresKeyGuard(MtlsBindingStrength maxSupportedBindingStrength, bool expectedTokenBindingAvailable)
+        {
+            MockMsalManagedIdentityClient mockMsal = null;
+            var credential = BuildManagedIdentityCredential(
+                new TokenCredentialOptions(),
+                ManagedIdentityId.SystemAssigned,
+                configureMockMsal: mock =>
+                {
+                    mockMsal = mock;
+                    mock.GetManagedIdentityCapabilitiesFactory = (_, _) =>
+                        MockMsalManagedIdentityClient.CreateCapabilities(
+                            Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.None,
+                            maxSupportedBindingStrength);
+                    mock.AcquireTokenForManagedIdentityAsyncFactory = (_, _) =>
+                        AuthenticationResultFactory.Create(ExpectedToken);
+                });
+            var context = new TokenRequestContext(MockScopes.Default, isProofOfPossessionEnabled: true);
+
+            // ClientTestBase runs this through GetToken for the synchronous fixture.
+            AccessToken token = await credential.GetTokenAsync(context, default);
+
+            Assert.AreEqual(ExpectedToken, token.Token);
+            Assert.AreEqual(expectedTokenBindingAvailable, mockMsal.LastIsTokenBindingAvailable);
+        }
+
+        [Test]
+        public void ManagedIdentityMinStrengthNotMetDoesNotFallback()
+        {
+            int acquisitionCount = 0;
+            var failure = new MsalClientException(MsalError.MinStrengthNotMet, "The host cannot satisfy the requested minimum binding strength.");
+            var credential = BuildManagedIdentityCredential(
+                new TokenCredentialOptions(),
+                ManagedIdentityId.SystemAssigned,
+                configureMockMsal: mock =>
+                {
+                    mock.GetManagedIdentityCapabilitiesFactory = (_, _) =>
+                        MockMsalManagedIdentityClient.CreateCapabilities(
+                            Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.None,
+                            MtlsBindingStrength.KeyGuard);
+                    mock.AcquireTokenForManagedIdentityAsyncFactory = (_, _) =>
+                    {
+                        acquisitionCount++;
+                        throw failure;
+                    };
+                });
+            var context = new TokenRequestContext(MockScopes.Default, isProofOfPossessionEnabled: true);
+
+            // ClientTestBase runs this through GetToken for the synchronous fixture.
+            AuthenticationFailedException exception =
+                Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(context, default));
+
+            Assert.AreSame(failure, exception.InnerException);
+            Assert.AreEqual(1, acquisitionCount);
         }
 
         [NonParallelizable]

--- a/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/ManagedIdentityCredentialTests.cs
@@ -69,7 +69,8 @@ namespace Azure.Core.Tests.Identity
             bool isForceRefreshEnabled = true,
             bool isManagedIdentityPipeline = false,
             bool preserveTransport = true,
-            Action<MockMsalManagedIdentityClient> configureMockMsal = null)
+            Action<MockMsalManagedIdentityClient> configureMockMsal = null,
+            bool disableMtlsProofOfPossession = false)
         {
             var pipeline = CredentialPipeline.GetInstance(options, isManagedIdentityPipeline);
             var clientOptions = new ManagedIdentityClientOptions
@@ -78,7 +79,8 @@ namespace Azure.Core.Tests.Identity
                 ManagedIdentityId = managedIdentityId,
                 IsForceRefreshEnabled = isForceRefreshEnabled,
                 PreserveTransport = preserveTransport,
-                Options = options
+                Options = options,
+                DisableMtlsProofOfPossession = disableMtlsProofOfPossession
             };
             // Inject a mock MSAL client that:
             // 1. Uses the static GetManagedIdentitySource() for source detection (no network probe)
@@ -376,6 +378,50 @@ namespace Azure.Core.Tests.Identity
 
             Assert.AreEqual(ExpectedToken, token.Token);
             Assert.AreEqual(expectedTokenBindingAvailable, mockMsal.LastIsTokenBindingAvailable);
+        }
+
+        [TestCase(false, false, true)]
+        [TestCase(true, true, true)]
+        [TestCase(true, false, false)]
+        public async Task KeyGuardBearerRequestsUseConfiguredTransport(
+            bool isProofOfPossessionEnabled,
+            bool disableMtlsProofOfPossession,
+            bool attestationSupportAvailable)
+        {
+            using var environment = new TestEnvVar(new()
+            {
+                { "MSI_ENDPOINT", null },
+                { "MSI_SECRET", null },
+                { "IDENTITY_ENDPOINT", "https://identity.endpoint/" },
+                { "IDENTITY_HEADER", "mock-identity-header" },
+                { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null }
+            });
+            var mockTransport = new MockTransport(CreateSuccessResponse(ExpectedToken));
+            MockMsalManagedIdentityClient mockMsal = null;
+            var credential = BuildManagedIdentityCredential(
+                new TokenCredentialOptions { Transport = mockTransport },
+                ManagedIdentityId.SystemAssigned,
+                configureMockMsal: mock =>
+                {
+                    mockMsal = mock;
+                    mock.GetManagedIdentityCapabilitiesFactory = (_, _) =>
+                        MockMsalManagedIdentityClient.CreateCapabilities(
+                            Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.AppService,
+                            MtlsBindingStrength.KeyGuard);
+                    mock.OverrideAttestationSupport = true;
+                    mock.AttestationSupport = attestationSupportAvailable ? builder => builder : null;
+                },
+                disableMtlsProofOfPossession: disableMtlsProofOfPossession);
+            var context = new TokenRequestContext(
+                MockScopes.Default,
+                isProofOfPossessionEnabled: isProofOfPossessionEnabled);
+
+            AccessToken token = await credential.GetTokenAsync(context, default);
+
+            Assert.AreEqual(ExpectedToken, token.Token);
+            Assert.IsFalse(mockMsal.LastEnableMtlsPopForClientCreation);
+            Assert.IsTrue(mockTransport.Requests.Any(request =>
+                request.Uri.ToString().StartsWith(EnvironmentVariables.IdentityEndpoint)));
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockManagedIdentityClient.cs
@@ -30,7 +30,7 @@ namespace Azure.Core.Tests.Identity.Mock
 
         public ManagedIdentitySource ManagedIdentitySourceOverride { get; set; }
 
-        public override ValueTask<AccessToken> AuthenticateCoreAsync(bool async, TokenRequestContext context, CancellationToken cancellationToken)
+        public override ValueTask<AccessToken> AuthenticateCoreAsync(bool async, TokenRequestContext context, bool isKeyGuardAvailable, CancellationToken cancellationToken)
               => TokenFactory != null ? new ValueTask<AccessToken>(TokenFactory()) : AuthenticateAsync(async, context, cancellationToken);
     }
 }

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
@@ -18,6 +18,7 @@ namespace Azure.Core.Tests.Identity.Mock
     {
         public Func<CancellationToken, IManagedIdentityApplication> ClientAppFactory { get; set; }
         public Func<TokenRequestContext, CancellationToken, AuthenticationResult> AcquireTokenForManagedIdentityAsyncFactory { get; set; }
+        public bool? LastIsTokenBindingAvailable { get; private set; }
 
         /// <summary>
         /// When set, this is invoked by <see cref="GetManagedIdentityCapabilitiesAsync"/> to produce the
@@ -54,6 +55,8 @@ namespace Azure.Core.Tests.Identity.Mock
 
         public override ValueTask<AuthenticationResult> AcquireTokenForManagedIdentityAsyncCore(bool async, TokenRequestContext requestContext, bool isTokenBindingAvailable, CancellationToken cancellationToken)
         {
+            LastIsTokenBindingAvailable = isTokenBindingAvailable;
+
             if (AcquireTokenForManagedIdentityAsyncFactory != null)
             {
                 return new ValueTask<AuthenticationResult>(AcquireTokenForManagedIdentityAsyncFactory(requestContext, cancellationToken));
@@ -98,10 +101,14 @@ namespace Azure.Core.Tests.Identity.Mock
         /// Tests use this with <see cref="GetManagedIdentityCapabilitiesFactory"/> to drive the credential down a
         /// specific code path (for example, <c>None</c> to reach the token-acquisition call).
         /// </summary>
-        internal static ManagedIdentityCapabilities CreateCapabilities(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source)
-            => CreateManagedIdentityCapabilities(source);
+        internal static ManagedIdentityCapabilities CreateCapabilities(
+            Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source,
+            Microsoft.Identity.Client.AppConfig.MtlsBindingStrength maxSupportedBindingStrength = Microsoft.Identity.Client.AppConfig.MtlsBindingStrength.None)
+            => CreateManagedIdentityCapabilities(source, maxSupportedBindingStrength);
 
-        private static ManagedIdentityCapabilities CreateManagedIdentityCapabilities(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source)
+        private static ManagedIdentityCapabilities CreateManagedIdentityCapabilities(
+            Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source,
+            Microsoft.Identity.Client.AppConfig.MtlsBindingStrength maxSupportedBindingStrength = Microsoft.Identity.Client.AppConfig.MtlsBindingStrength.None)
         {
             ConstructorInfo ctor = typeof(ManagedIdentityCapabilities).GetConstructor(
                 BindingFlags.Instance | BindingFlags.NonPublic,
@@ -116,7 +123,7 @@ namespace Azure.Core.Tests.Identity.Mock
                     "The MSAL library version may have changed its internal API. Update the reflection call to match the current constructor signature.");
             }
 
-            return (ManagedIdentityCapabilities)ctor.Invoke([source, Microsoft.Identity.Client.AppConfig.MtlsBindingStrength.None, null]);
+            return (ManagedIdentityCapabilities)ctor.Invoke([source, maxSupportedBindingStrength, null]);
         }
 
         private AuthenticationResult SendDirectImdsRequest(TokenRequestContext requestContext, CancellationToken cancellationToken)

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
@@ -19,6 +19,9 @@ namespace Azure.Core.Tests.Identity.Mock
         public Func<CancellationToken, IManagedIdentityApplication> ClientAppFactory { get; set; }
         public Func<TokenRequestContext, CancellationToken, AuthenticationResult> AcquireTokenForManagedIdentityAsyncFactory { get; set; }
         public bool? LastIsTokenBindingAvailable { get; private set; }
+        public bool? LastEnableMtlsPopForClientCreation { get; private set; }
+        public bool OverrideAttestationSupport { get; set; }
+        public Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> AttestationSupport { get; set; }
 
         /// <summary>
         /// When set, this is invoked by <see cref="GetManagedIdentityCapabilitiesAsync"/> to produce the
@@ -43,11 +46,13 @@ namespace Azure.Core.Tests.Identity.Mock
             _azureManagedIdentityId = options.ManagedIdentityId;
         }
 
-        protected override ValueTask<IManagedIdentityApplication> CreateClientCoreAsync(bool async, bool enableCae, bool isTokenBindingAvailable, CancellationToken cancellationToken)
+        protected override ValueTask<IManagedIdentityApplication> CreateClientCoreAsync(bool async, bool enableCae, bool enableMtlsPop, CancellationToken cancellationToken)
         {
+            LastEnableMtlsPopForClientCreation = enableMtlsPop;
+
             if (ClientAppFactory == null)
             {
-                return base.CreateClientCoreAsync(async, enableCae, isTokenBindingAvailable, cancellationToken);
+                return base.CreateClientCoreAsync(async, enableCae, enableMtlsPop, cancellationToken);
             }
 
             return new ValueTask<IManagedIdentityApplication>(ClientAppFactory(cancellationToken));
@@ -95,6 +100,9 @@ namespace Azure.Core.Tests.Identity.Mock
 #pragma warning restore CS0618
             return new ValueTask<ManagedIdentityCapabilities>(CreateManagedIdentityCapabilities(_detectedSource));
         }
+
+        protected override Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> GetAttestationSupport() =>
+            OverrideAttestationSupport ? AttestationSupport : base.GetAttestationSupport();
 
         /// <summary>
         /// Builds a <see cref="ManagedIdentityCapabilities"/> reporting the given <paramref name="source"/>.

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalManagedIdentityClient.cs
@@ -19,6 +19,7 @@ namespace Azure.Core.Tests.Identity.Mock
         public Func<CancellationToken, IManagedIdentityApplication> ClientAppFactory { get; set; }
         public Func<TokenRequestContext, CancellationToken, AuthenticationResult> AcquireTokenForManagedIdentityAsyncFactory { get; set; }
         public bool? LastIsTokenBindingAvailable { get; private set; }
+        public bool? FirstEnableMtlsPopForClientCreation { get; private set; }
         public bool? LastEnableMtlsPopForClientCreation { get; private set; }
         public bool OverrideAttestationSupport { get; set; }
         public Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> AttestationSupport { get; set; }
@@ -48,6 +49,7 @@ namespace Azure.Core.Tests.Identity.Mock
 
         protected override ValueTask<IManagedIdentityApplication> CreateClientCoreAsync(bool async, bool enableCae, bool enableMtlsPop, CancellationToken cancellationToken)
         {
+            FirstEnableMtlsPopForClientCreation ??= enableMtlsPop;
             LastEnableMtlsPopForClientCreation = enableMtlsPop;
 
             if (ClientAppFactory == null)
@@ -83,7 +85,10 @@ namespace Azure.Core.Tests.Identity.Mock
             return base.AcquireTokenForManagedIdentityAsyncCore(async, requestContext, isTokenBindingAvailable, cancellationToken);
         }
 
-        public override ValueTask<ManagedIdentityCapabilities> GetManagedIdentityCapabilitiesAsync(TokenRequestContext context, CancellationToken cancellationToken)
+        protected override ValueTask<ManagedIdentityCapabilities> GetManagedIdentityCapabilitiesFromClientAsync(
+            IManagedIdentityApplication client,
+            TokenRequestContext context,
+            CancellationToken cancellationToken)
         {
             if (GetManagedIdentityCapabilitiesFactory != null)
             {
@@ -101,8 +106,8 @@ namespace Azure.Core.Tests.Identity.Mock
             return new ValueTask<ManagedIdentityCapabilities>(CreateManagedIdentityCapabilities(_detectedSource));
         }
 
-        protected override Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> GetAttestationSupport() =>
-            OverrideAttestationSupport ? AttestationSupport : base.GetAttestationSupport();
+        protected override Func<AcquireTokenForManagedIdentityParameterBuilder, AcquireTokenForManagedIdentityParameterBuilder> ResolveAttestationSupport() =>
+            OverrideAttestationSupport ? AttestationSupport : base.ResolveAttestationSupport();
 
         /// <summary>
         /// Builds a <see cref="ManagedIdentityCapabilities"/> reporting the given <paramref name="source"/>.

--- a/sdk/core/Azure.Core/tests/Identity/MsalManagedIdentityClientReflectionTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalManagedIdentityClientReflectionTests.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Reflection;
+using Azure.Core.TestFramework;
+using Azure.Core.Tests.Identity.Mock;
 using Azure.Identity;
 using Microsoft.Identity.Client;
 using NUnit.Framework;
+using MtlsBindingStrength = Microsoft.Identity.Client.AppConfig.MtlsBindingStrength;
 
 namespace Azure.Core.Tests.Identity
 {
@@ -26,6 +30,92 @@ namespace Azure.Core.Tests.Identity
                     Assert.IsNull(withAttestationSupport, "Delegate must be null when reflection contract is unavailable.");
                 }
             });
+        }
+
+        [TestCase(false, true, true, true)]
+        [TestCase(false, false, true, false)]
+        [TestCase(false, true, false, false)]
+        [TestCase(true, true, true, false)]
+        public void ShouldAttemptMtlsPopHonorsCallerIntentAndOptOut(
+            bool disableMtlsProofOfPossession,
+            bool isProofOfPossessionEnabled,
+            bool isTokenBindingAvailable,
+            bool expected)
+        {
+            var client = new MsalManagedIdentityClient(
+                new ManagedIdentityClientOptions
+                {
+                    ManagedIdentityId = ManagedIdentityId.SystemAssigned,
+                    DisableMtlsProofOfPossession = disableMtlsProofOfPossession
+                });
+            var context = new TokenRequestContext(
+                MockScopes.Default,
+                isProofOfPossessionEnabled: isProofOfPossessionEnabled);
+
+            Assert.AreEqual(expected, client.ShouldAttemptMtlsPop(context, isTokenBindingAvailable));
+        }
+
+        [Test]
+        public void ConfigureMtlsPopWithoutAttestationSupportLeavesBearerRequest()
+        {
+            AcquireTokenForManagedIdentityParameterBuilder builder = CreateTokenBuilder();
+
+            AcquireTokenForManagedIdentityParameterBuilder configuredBuilder =
+                MsalManagedIdentityClient.ConfigureMtlsPop(builder, withAttestationSupport: null);
+
+            Assert.AreSame(builder, configuredBuilder);
+            Assert.IsFalse(GetCommonParameter<bool>(configuredBuilder, "IsMtlsPopRequested"));
+            Assert.AreEqual(MtlsBindingStrength.None, GetCommonParameter<MtlsBindingStrength>(configuredBuilder, "MtlsPopMinStrength"));
+        }
+
+        [Test]
+        [RunOnlyOnPlatforms(Windows = true)]
+#if NETFRAMEWORK
+        [Ignore("Managed identity mTLS proof-of-possession is not supported on .NET Framework.")]
+#endif
+        public void ConfigureMtlsPopRequiresKeyGuardBeforeAttestation()
+        {
+            AcquireTokenForManagedIdentityParameterBuilder builder = CreateTokenBuilder();
+            bool attestationConfigured = false;
+
+            AcquireTokenForManagedIdentityParameterBuilder configuredBuilder =
+                MsalManagedIdentityClient.ConfigureMtlsPop(
+                    builder,
+                    candidate =>
+                    {
+                        Assert.IsTrue(GetCommonParameter<bool>(candidate, "IsMtlsPopRequested"));
+                        Assert.AreEqual(MtlsBindingStrength.KeyGuard, GetCommonParameter<MtlsBindingStrength>(candidate, "MtlsPopMinStrength"));
+                        attestationConfigured = true;
+                        return candidate;
+                    });
+
+            Assert.AreSame(builder, configuredBuilder);
+            Assert.IsTrue(attestationConfigured);
+        }
+
+        private static AcquireTokenForManagedIdentityParameterBuilder CreateTokenBuilder()
+        {
+            IManagedIdentityApplication application = ManagedIdentityApplicationBuilder
+                .Create(Microsoft.Identity.Client.AppConfig.ManagedIdentityId.SystemAssigned)
+                .Build();
+            return application.AcquireTokenForManagedIdentity("https://vault.azure.net/.default");
+        }
+
+        private static T GetCommonParameter<T>(AcquireTokenForManagedIdentityParameterBuilder builder, string propertyName)
+        {
+            Type type = builder.GetType();
+            PropertyInfo commonParametersProperty = null;
+            while (type != null && commonParametersProperty == null)
+            {
+                commonParametersProperty = type.GetProperty("CommonParameters", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                type = type.BaseType;
+            }
+
+            Assert.NotNull(commonParametersProperty);
+            object commonParameters = commonParametersProperty.GetValue(builder);
+            PropertyInfo property = commonParameters.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(property);
+            return (T)property.GetValue(commonParameters);
         }
     }
 }


### PR DESCRIPTION
## Description

- Require `MtlsBindingStrength.KeyGuard` or stronger before enabling managed identity mTLS PoP.
- Enforce `PoPOptions.MinStrength = MtlsBindingStrength.KeyGuard` before applying attestation support.
- Update Microsoft.Identity.Client from 4.84.2 to 4.88.0.
- Cover capability strengths, caller intent, opt-out, missing attestation support, attestation ordering, and `MinStrengthNotMet` propagation.

Fixes #62585

## Testing

- Azure.Core managed identity tests on net10.0: 485 passed
- Azure.Core managed identity tests on net462: 484 passed, 30 skipped
- Focused KeyGuard tests on net8.0: 27 passed
- Azure.Core build across netstandard2.0, net8.0, net10.0, net462, and net472