### PR TITLE
Update ServiceNetworking 1.2.0 release date

### DIFF
--- a/sdk/servicenetworking/Azure.ResourceManager.ServiceNetworking/CHANGELOG.md
+++ b/sdk/servicenetworking/Azure.ResourceManager.ServiceNetworking/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Release History
 
-## 1.2.0 (Unreleased)
-
+## 1.2.0 (2026-08-28)
 ### Features Added
 
 - Upgraded API version to `2026-03-01`.

--- a/sdk/servicenetworking/Azure.ResourceManager.ServiceNetworking/CHANGELOG.md
+++ b/sdk/servicenetworking/Azure.ResourceManager.ServiceNetworking/CHANGELOG.md
@@ -6,12 +6,6 @@
 - Upgraded API version to `2026-03-01`.
 - Added support for private frontends on Application Gateway for Containers, including the `PrivateEndpointConnectionResource` and `PrivateLinkResource` resources and the `PublicNetworkAccess` property (of type `TrafficControllerPublicNetworkAccess`) on `TrafficControllerFrontendData` and `FrontendUpdateProperties`.
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.2.0-beta.3 (2026-06-30)
 
 ### Other Changes


### PR DESCRIPTION
Updates the Azure.ResourceManager.ServiceNetworking 1.2.0 changelog release date to 2026-08-28.