### PR TITLE
[Key Vault] Secrets 4.11.1: resolve challenge auth per request endpoint

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.11.1 (2026-09-02)
+
+### Bugs Fixed
+
+- Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
+
 ## 4.11.0 (2026-05-05)
 
 ### Other Changes

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Secrets client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Secrets client library</AssemblyTitle>
-    <Version>4.11.0</Version>
+    <Version>4.11.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.10.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Secrets;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -24,6 +25,8 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         private const string VaultHost = "test.vault.azure.net";
 
         private static Uri VaultUri => new Uri("https://" + VaultHost);
+
+        private static string Base64(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
 
         [SetUp]
         public void Setup()
@@ -237,6 +240,168 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.AreEqual(200, response.GetRawResponse().Status);
             Assert.AreEqual("secret-value", response.Value.Value);
             Assert.AreEqual(expectedTenantId, capturedTenantId);
+        }
+
+        // Regression test: a single ChallengeBasedAuthenticationPolicy instance must not reuse a challenge
+        // (or the token acquired for its scope and tenant) that was cached for one endpoint on a request to a
+        // different endpoint. Before the fix, the second request's pre-challenge fast path reused the first
+        // endpoint's sticky challenge, attaching the first vault's token to a request bound for the second.
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task DoesNotReuseTokenAcrossAuthorities(bool async)
+        {
+            const string hostA = "a.vault.azure.net";
+            const string hostB = "b.vault.azure.net";
+            const string tenantA = "11111111-1111-1111-1111-111111111111";
+            const string tenantB = "22222222-2222-2222-2222-222222222222";
+            string tokenA = Base64(tenantA);
+            string tokenB = Base64(tenantB);
+
+            List<string> authHeadersSentToHostB = new();
+
+            MockResponse Challenge(string tenant)
+            {
+                MockResponse response = new(401, "Unauthorized");
+                response.AddHeader(new HttpHeader("WWW-Authenticate", @$"Bearer authorization=""https://login.windows.net/{tenant}"", resource=""https://vault.azure.net"""));
+                return response;
+            }
+
+            MockTransport transport = new(request =>
+            {
+                string auth = request.Headers.TryGetValue("Authorization", out string value) ? value : null;
+                switch (request.Uri.Host)
+                {
+                    case hostA:
+                        return auth == $"Bearer {tokenA}"
+                            ? new MockResponse(200, "OK")
+                            : Challenge(tenantA);
+
+                    case hostB:
+                        if (auth != null)
+                        {
+                            authHeadersSentToHostB.Add(auth);
+                        }
+                        return auth == $"Bearer {tokenB}"
+                            ? new MockResponse(200, "OK")
+                            : Challenge(tenantB);
+
+                    default:
+                        throw new AssertionException($"Unexpected request: {request}");
+                }
+            });
+
+            // The credential honors the tenant from the challenge and mints a token unique to that tenant.
+            CallbackTokenCredential credential = new((requestContext, _) =>
+                new AccessToken(Base64(requestContext.TenantId), DateTimeOffset.UtcNow.AddHours(1)));
+
+            ChallengeBasedAuthenticationPolicy policy = new(credential, disableChallengeResourceVerification: false);
+            HttpPipeline pipeline = new(transport, new HttpPipelinePolicy[] { policy });
+
+            async Task SendAsync(string host)
+            {
+                Request request = pipeline.CreateRequest();
+                request.Method = RequestMethod.Get;
+                request.Uri.Reset(new Uri($"https://{host}/secrets/test?api-version=7.4"));
+                Response response = async
+                    ? await pipeline.SendRequestAsync(request, default)
+                    : pipeline.SendRequest(request, default);
+                Assert.AreEqual(200, response.Status);
+            }
+
+            // First, authenticate against host A. This populates the shared challenge cache and the base
+            // policy's token cache for tenant A.
+            await SendAsync(hostA);
+
+            // Then reuse the same policy instance for a different host. Host A's token must not be attached.
+            await SendAsync(hostB);
+
+            CollectionAssert.DoesNotContain(
+                authHeadersSentToHostB,
+                $"Bearer {tokenA}",
+                "The first endpoint's token was reused on a request to a different endpoint.");
+            CollectionAssert.Contains(
+                authHeadersSentToHostB,
+                $"Bearer {tokenB}",
+                "The second endpoint was never authenticated with its own token.");
+        }
+
+        // Regression test for the concurrent variant: interleaved requests to two endpoints on a single policy
+        // instance must each be authorized with their own endpoint's token. Because no challenge is memoized on
+        // the policy instance, a request bound for one endpoint can never observe the other endpoint's challenge.
+        [TestCase(10, 0, 0)]
+        [TestCase(10, 20, 200)]
+        public async Task DoesNotReuseTokenAcrossAuthoritiesConcurrently(int requestsPerHost, int minDelay, int maxDelay)
+        {
+            const string hostA = "a.vault.azure.net";
+            const string hostB = "b.vault.azure.net";
+            const string tenantA = "11111111-1111-1111-1111-111111111111";
+            const string tenantB = "22222222-2222-2222-2222-222222222222";
+            string tokenA = Base64(tenantA);
+            string tokenB = Base64(tenantB);
+
+            Random rand = new();
+
+            MockResponse Challenge(string tenant)
+            {
+                MockResponse response = new(401, "Unauthorized");
+                response.AddHeader(new HttpHeader("WWW-Authenticate", @$"Bearer authorization=""https://login.windows.net/{tenant}"", resource=""https://vault.azure.net"""));
+                return response;
+            }
+
+            // Assert on every authenticated request as it is processed: a request to one host must never carry
+            // the other host's token.
+            MockTransport transport = new(request =>
+            {
+                int delay;
+                lock (rand)
+                {
+                    delay = rand.Next(minDelay, maxDelay);
+                }
+
+                if (delay > 0)
+                {
+                    Thread.Sleep(delay);
+                }
+
+                string auth = request.Headers.TryGetValue("Authorization", out string value) ? value : null;
+                switch (request.Uri.Host)
+                {
+                    case hostA:
+                        Assert.AreNotEqual($"Bearer {tokenB}", auth, "Host B's token was attached to a host A request.");
+                        return auth == $"Bearer {tokenA}" ? new MockResponse(200, "OK") : Challenge(tenantA);
+
+                    case hostB:
+                        Assert.AreNotEqual($"Bearer {tokenA}", auth, "Host A's token was attached to a host B request.");
+                        return auth == $"Bearer {tokenB}" ? new MockResponse(200, "OK") : Challenge(tenantB);
+
+                    default:
+                        throw new AssertionException($"Unexpected request: {request}");
+                }
+            });
+
+            CallbackTokenCredential credential = new((requestContext, _) =>
+                new AccessToken(Base64(requestContext.TenantId), DateTimeOffset.UtcNow.AddHours(1)));
+
+            ChallengeBasedAuthenticationPolicy policy = new(credential, disableChallengeResourceVerification: false);
+            HttpPipeline pipeline = new(transport, new HttpPipelinePolicy[] { policy });
+
+            async Task SendAsync(string host)
+            {
+                Request request = pipeline.CreateRequest();
+                request.Method = RequestMethod.Get;
+                request.Uri.Reset(new Uri($"https://{host}/secrets/test?api-version=7.4"));
+                Response response = await pipeline.SendRequestAsync(request, default);
+                Assert.AreEqual(200, response.Status);
+            }
+
+            Task[] tasks = new Task[requestsPerHost * 2];
+            for (int i = 0; i < requestsPerHost; i++)
+            {
+                tasks[2 * i] = Task.Run(() => SendAsync(hostA));
+                tasks[2 * i + 1] = Task.Run(() => SendAsync(hostB));
+            }
+
+            await Task.WhenAll(tasks);
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -20,7 +20,6 @@ namespace Azure.Security.KeyVault
         /// Challenges are cached using the Key Vault or Managed HSM endpoint URI authority as the key.
         /// </summary>
         private static readonly ConcurrentDictionary<string, ChallengeParameters> s_challengeCache = new();
-        private ChallengeParameters _challenge;
 
         public ChallengeBasedAuthenticationPolicy(TokenCredential credential, bool disableChallengeResourceVerification) : base(credential, Array.Empty<string>())
         {
@@ -42,17 +41,16 @@ namespace Azure.Security.KeyVault
                 throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
             }
 
-            // If this policy doesn't have challenge parameters cached try to get it from the static challenge cache.
-            if (_challenge == null)
-            {
-                string authority = GetRequestAuthority(message.Request);
-                s_challengeCache.TryGetValue(authority, out _challenge);
-            }
-
-            if (_challenge != null)
+            // Resolve the challenge for the current request's authority from the static cache, which is keyed
+            // by authority. A challenge (and the token acquired for its scope and tenant) cached for one
+            // endpoint is therefore never applied to a request bound for a different endpoint. No challenge is
+            // memoized on the policy instance, so concurrent requests to different authorities on the same
+            // instance cannot observe each other's challenge.
+            string authority = GetRequestAuthority(message.Request);
+            if (s_challengeCache.TryGetValue(authority, out ChallengeParameters challenge))
             {
                 // We fetched the challenge from the cache, but we have not initialized the Scopes in the base yet.
-                var context = new TokenRequestContext(_challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: _challenge.TenantId, isCaeEnabled: true);
+                var context = new TokenRequestContext(challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: challenge.TenantId, isCaeEnabled: true);
                 if (async)
                 {
                     await AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);
@@ -129,17 +127,18 @@ namespace Azure.Security.KeyVault
             }
 
             // Handle CAE Challenges
+            ChallengeParameters challenge = null;
             string claims = getDecodedClaimsParameter(error, message.Response);
             if (claims != null)
             {
                 // Get the scope from the cache
-                s_challengeCache.TryGetValue(authority, out _challenge);
-                scope = _challenge.Scopes[0];
+                s_challengeCache.TryGetValue(authority, out challenge);
+                scope = challenge.Scopes[0];
             }
 
             if (scope is null)
             {
-                if (s_challengeCache.TryGetValue(authority, out _challenge))
+                if (s_challengeCache.TryGetValue(authority, out challenge))
                 {
                     return false;
                 }
@@ -171,11 +170,11 @@ namespace Azure.Security.KeyVault
                     throw new UriFormatException($"The challenge authorization URI '{authorization}' is invalid.");
                 }
 
-                _challenge = new ChallengeParameters(authorizationUri, new string[] { scope });
-                s_challengeCache[authority] = _challenge;
+                challenge = new ChallengeParameters(authorizationUri, new string[] { scope });
+                s_challengeCache[authority] = challenge;
             }
 
-            var context = new TokenRequestContext(_challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: _challenge.TenantId, isCaeEnabled: true, claims: claims);
+            var context = new TokenRequestContext(challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: challenge.TenantId, isCaeEnabled: true, claims: claims);
             if (async)
             {
                 await AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);


### PR DESCRIPTION
Servicing backport of the shared `ChallengeBasedAuthenticationPolicy` fix (main: #62617) to the **4.11.0** GA line, targeting `hotfix/secrets`.

## Description
The policy cached the parsed authentication challenge in a per-instance field and only re-read the authority-keyed cache when that field was null. Once populated for the first endpoint, the same challenge — and the token acquired for its scope and tenant — could be reused for later requests on that policy instance without checking the request's endpoint, so a token acquired for one vault could be attached to a request bound for a different vault. The per-instance field is removed; the challenge is now resolved per request from the authority-keyed `ConcurrentDictionary` using locals, so a challenge (and token) acquired for one endpoint is never applied to a request bound for another, including under concurrent multi-endpoint use.

This is a minimal, security-only backport: it intentionally does not include the separate CAE `NullReferenceException` hardening that `main` carries, keeping the servicing diff scoped to the fix.

- Bumped `Version` to 4.11.1 and added a dated CHANGELOG `Bugs Fixed` entry.
- Added cross-endpoint token-isolation regression tests (sync + async) plus a concurrent variant to the existing `ChallengeBasedAuthenticationPolicyTests`; the full class (12 cases) passes on the 4.11.0 base.

## Validation
- No public API change (`ChallengeParameters` is internal; ApiCompat passes).
- `eng/common/scripts/Verify-ChangeLog.ps1 -ForRelease` passes.

---
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).
- [x] The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).