### PR TITLE
[mgmt generator] Honor the ApiCompat baseline when restoring model factory overloads

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Generator.Management.Primitives;
+using Microsoft.TypeSpec.Generator;
 using Microsoft.TypeSpec.Generator.ClientModel;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
@@ -70,6 +71,7 @@ namespace Azure.Generator.Management.Visitors
                 var returnType = previousMethod.Signature.ReturnType;
                 if (returnType is null
                     || KnownManagementTypes.IsKnownManagementType(returnType)
+                    || IsRemovalAcceptedInBaseline(modelFactory, previousMethod.Signature)
                     || updatedMethods.Any(method => HasSameCSharpSignature(method.Signature, previousMethod.Signature))
                     || customMethods.Any(method => HasSameCSharpSignature(method.Signature, previousMethod.Signature))
                     || !ModelFactoryBackwardCompatHelper.TryCreateBackwardCompatMethod(previousMethod, modelFactory, out var restoredMethod))
@@ -79,6 +81,32 @@ namespace Azure.Generator.Management.Visitors
 
                 updatedMethods.Add(restoredMethod);
             }
+        }
+
+        /// <summary>
+        /// Determines whether a previously shipped model factory overload must stay removed. An overload is left out
+        /// when the ApiCompat baseline records its removal, or when its return type or any parameter type refers to a
+        /// type whose removal the baseline already accepted. Without the second check the generator would resurrect an
+        /// overload whose signature names a type that is no longer generated, producing code that does not compile.
+        /// </summary>
+        private static bool IsRemovalAcceptedInBaseline(ModelFactoryProvider modelFactory, MethodSignature previousSignature)
+        {
+            var baseline = CodeModelGenerator.Instance.SourceInputModel?.ApiCompatBaseline;
+            if (baseline is null || baseline.IsEmpty)
+            {
+                return false;
+            }
+
+            if (baseline.IsMethodRemovalSuppressed(
+                    modelFactory.Type.FullyQualifiedName,
+                    previousSignature.Name,
+                    [.. previousSignature.Parameters.Select(parameter => parameter.Type)]))
+            {
+                return true;
+            }
+
+            return baseline.ReferencesSuppressedType(previousSignature.ReturnType)
+                || previousSignature.Parameters.Any(parameter => baseline.ReferencesSuppressedType(parameter.Type));
         }
 
         private bool IsModelType(CSharpType type) => ContainsModelType(ModelTypes, type.WithNullable(false));

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -8,6 +8,7 @@ using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Statements;
 using NUnit.Framework;
 using System.Reflection;
@@ -322,6 +323,85 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         [Test]
+        public void DoesNotRestoreLastContractFactoryMethodsSuppressedByApiCompatBaseline()
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("value", InputPrimitiveType.String)]);
+
+            var baseline = ApiCompatBaseline.Parse(
+            [
+                $"MembersMustExist : Member '{ResolveModelFactoryFullName(inputModel)}.TestModel(System.String)' does not exist in the implementation but it does exist in the contract."
+            ]);
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [inputModel],
+                apiCompatBaseline: baseline);
+            var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+            var previousSignature = new MethodSignature(
+                "TestModel",
+                $"Creates a test model.",
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                model.Type,
+                $"A test model.",
+                [new ParameterProvider("value", $"Value description", typeof(string))]);
+            var lastContractView = new TestModelFactoryView(modelFactory.Name);
+            lastContractView.MethodsToBuild = [new MethodProvider(previousSignature, MethodBodyStatement.Empty, lastContractView)];
+            ModelTestHelper.SetLastContractView(modelFactory, lastContractView);
+            modelFactory.Update(methods: []);
+
+            var visitType = typeof(Management.Visitors.ModelFactoryVisitor).GetMethod(
+                "VisitType",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(visitType, Is.Not.Null);
+
+            visitType!.Invoke(new Management.Visitors.ModelFactoryVisitor(), [modelFactory]);
+
+            Assert.That(modelFactory.Methods, Is.Empty);
+        }
+
+        [Test]
+        public void DoesNotRestoreLastContractFactoryMethodsReferencingSuppressedTypes()
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("value", InputPrimitiveType.String)]);
+
+            var baseline = ApiCompatBaseline.Parse(
+            [
+                "TypesMustExist : Type 'Samples.Models.RemovedModel' does not exist in the implementation but it does exist in the contract."
+            ]);
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [inputModel],
+                apiCompatBaseline: baseline);
+            var model = plugin.Object.TypeFactory.CreateModel(inputModel)!;
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+            var removedType = new CSharpType(typeof(global::Samples.Models.RemovedModel));
+            var previousSignature = new MethodSignature(
+                "TestModel",
+                $"Creates a test model.",
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                model.Type,
+                $"A test model.",
+                [new ParameterProvider("removed", $"A parameter typed with a removed model.", removedType)]);
+            var lastContractView = new TestModelFactoryView(modelFactory.Name);
+            lastContractView.MethodsToBuild = [new MethodProvider(previousSignature, MethodBodyStatement.Empty, lastContractView)];
+            ModelTestHelper.SetLastContractView(modelFactory, lastContractView);
+            modelFactory.Update(methods: []);
+
+            var visitType = typeof(Management.Visitors.ModelFactoryVisitor).GetMethod(
+                "VisitType",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(visitType, Is.Not.Null);
+
+            visitType!.Invoke(new Management.Visitors.ModelFactoryVisitor(), [modelFactory]);
+
+            Assert.That(modelFactory.Methods, Is.Empty);
+        }
+
+        [Test]
         public void RebuildsPrimaryFactoryBodyFromCurrentConstructor()
         {
             var inputModel = InputFactory.Model(
@@ -612,6 +692,16 @@ namespace Azure.Generator.Mgmt.Tests
             }
 
             return builder.ToString().Replace("\r\n", "\n");
+        }
+
+        /// <summary>
+        /// Loads the mock plugin once purely to discover the fully-qualified name the model factory will be given,
+        /// so a baseline entry can be written for it before the plugin is reloaded with that baseline attached.
+        /// </summary>
+        private static string ResolveModelFactoryFullName(InputModelType inputModel)
+        {
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => [inputModel]);
+            return plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single().Type.FullyQualifiedName;
         }
 
         private class TestModelFactoryView : TypeProvider

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/TestHelpers/ManagementMockHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/TestHelpers/ManagementMockHelpers.cs
@@ -37,7 +37,8 @@ namespace Azure.Generator.Management.Tests.TestHelpers
             string? primaryNamespace = null,
             IEnumerable<string>? customizationSources = null,
             Func<Compilation?>? customizationCompilation = null,
-            Func<Compilation?>? lastContractCompilation = null)
+            Func<Compilation?>? lastContractCompilation = null,
+            ApiCompatBaseline? apiCompatBaseline = null)
         {
             IReadOnlyList<string> inputNsApiVersions = apiVersions?.Invoke() ?? ["2023-01-01"];
             IReadOnlyList<InputLiteralType> inputNsLiterals = inputLiterals?.Invoke() ?? [];
@@ -84,7 +85,7 @@ namespace Azure.Generator.Management.Tests.TestHelpers
                     ? null
                     : Helpers.BuildCompilation(customizationSources.Select((source, index) => ($"Customization{index}.cs", source))));
             var lastContract = lastContractCompilation?.Invoke();
-            var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(customizationCompilationResult, lastContract)) { CallBase = true };
+            var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(customizationCompilationResult, lastContract, apiCompatBaseline ?? ApiCompatBaseline.Empty)) { CallBase = true };
             mockPluginInstance.Setup(p => p.SourceInputModel).Returns(sourceInputModel.Object);
             var configureMethod = typeof(CodeModelGenerator).GetMethod(
                 "Configure",

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/TestHelpers/RemovedModel.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/TestHelpers/RemovedModel.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Samples.Models
+{
+    /// <summary>
+    /// Stand-in for a model that a previous contract exposed but the current generation no longer emits.
+    /// Used to verify that the model factory does not resurrect overloads referencing removed types.
+    /// </summary>
+    internal class RemovedModel
+    {
+    }
+}


### PR DESCRIPTION
Fixes a management generator bug where backward-compatibility model factory overloads are reintroduced even after their removal has been formally accepted, producing generated code that does not compile.

## Problem

`ModelFactoryVisitor.AddMissingLastContractModelMethods` resurrects every public model factory method found in the last released contract. It was the one back-compat path that never consulted `ApiCompatBaseline`.

When a service intentionally removes a model, the removal gets recorded in `eng/apicompatbaselines/<Package>.xml`. Every other back-compat path honors that — `BackCompatHelper.IsMethodRemovalAcceptedInBaseline` already gates the resource, collection and extension providers. The model factory did not, so it kept re-adding overloads whose signatures name types the current contract no longer defines.

The failure surfaces as a compile error on the *type*, not the method:

```
src/Generated/ArmProviderHubModelFactory.cs(1891,1120): error CS0234: The type or namespace name
'ServiceTreeInfo' does not exist in the namespace 'Azure.ResourceManager.ProviderHub.Models'
```

## Fix

Skip a last-contract overload when either:

1. the baseline records that method's removal as accepted, or
2. its return type or any parameter type refers to a type whose removal the baseline already accepted.

The second check is what actually matters here. A shim can be reintroduced under a name that is still perfectly valid while naming a removed type somewhere in its signature — which is why the error lands on the type rather than the method.

## Validation

- Two new unit tests: direct method suppression, and a suppressed type appearing in a parameter.
- Full generator suite passes: 343 + 12 tests.
- `eng/scripts/Generate.ps1` reproduces all test projects with **no drift**. This is a no-op for libraries that have no `eng/apicompatbaselines` entry.
- Verified end-to-end against a real library by packing this emitter locally, repointing the pin, and regenerating `Azure.ResourceManager.ProviderHub`: the output contains zero references to the removed types and compiles cleanly.

## Why this is split out

Azure/azure-sdk-for-net#62646 (ProviderHub) is blocked on this. That PR cannot go green on its own, because `Verify Generated Code` installs the pinned `@azure-typespec/http-client-csharp-mgmt` from npm rather than building the generator from source, and per `eng/packages/http-client-csharp-mgmt/ci.yml` that package only publishes from `refs/heads/main`.

Sequence to unblock it:

1. Merge this PR.
2. Run the mgmt emitter pipeline manually on `main` to publish an alpha containing this fix.
3. Bump the pin in `eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json` (and its lock) in #62646, then regenerate.
