### PR TITLE
Add shared skill eval pipeline probe

### DIFF
--- a/eng/pipelines/skill-eval.yml
+++ b/eng/pipelines/skill-eval.yml
@@ -1,0 +1,30 @@
+# Manual probe for running the synced shared skill evals through the common Vally archetype.
+# This starts with one deterministic mock suite; it is report-only and has no CI or PR trigger.
+
+trigger: none
+
+pr: none
+
+resources:
+  repositories:
+    - repository: azure-sdk-tools
+      type: github
+      name: Azure/azure-sdk-tools
+      endpoint: Azure
+      ref: refs/heads/main
+
+variables:
+  - template: /eng/pipelines/templates/variables/image.yml
+  - group: AzSDK_Eval_Variable_group
+
+extends:
+  template: /eng/common/pipelines/templates/stages/archetype-eval.yml
+  parameters:
+    mcpSetupTemplate: /eng/common/pipelines/templates/steps/eval-mcp-setup.yml
+    TestType: mock
+    toolsRepo: azure-sdk-tools
+    vallyRoot: .github/skills
+    evalGlobs:
+      - 'azsdk-common-generate-sdk-locally/evals/eval.yaml'
+    failOnFailedTests: false
+    shardTimeoutInMinutes: 20

--- a/eng/pipelines/skill-eval.yml
+++ b/eng/pipelines/skill-eval.yml
@@ -1,5 +1,5 @@
 # Manual probe for running the synced shared skill evals through the common Vally archetype.
-# This starts with one deterministic mock suite; it is report-only and has no CI or PR trigger.
+# This runs all synced shared-skill suites against the mock MCP; it is report-only and has no CI or PR trigger.
 
 trigger: none
 
@@ -25,6 +25,7 @@ extends:
     toolsRepo: azure-sdk-tools
     vallyRoot: .github/skills
     evalGlobs:
-      - 'azsdk-common-generate-sdk-locally/evals/eval.yaml'
+      - 'azsdk-common-*/evals/eval.yaml'
+      - 'azsdk-common-*/evals/*.eval.yaml'
     failOnFailedTests: false
     shardTimeoutInMinutes: 20


### PR DESCRIPTION
Manual-only, Mock-only, report-only probe. Uses the common archetype and a protected, pinned Azure SDK Tools resource, and executes only `azsdk-common-generate-sdk-locally`. Validation passed YAML assertions, the matrix matched one eval, and `git diff --check`.