### PR TITLE
Add standalone SDK ApiCompat change detection and PR reporting

### DIFF
--- a/.github/skills/mitigate-breaking-changes/SKILL.md
+++ b/.github/skills/mitigate-breaking-changes/SKILL.md
@@ -10,6 +10,34 @@ Patterns and techniques for mitigating breaking changes when regenerating Azure 
 
 Trigger phrases: "mitigate breaking changes", "fix breaking change", "customization patterns", "how to keep backward compat", "CodeGenType", "CodeGenSuppress", "markAsPageable", "hierarchyBuilding", "base type change".
 
+## Common breaking-change workflow
+
+When invoked from `azsdk-common-sdk-breaking-change`, use the
+[.NET pattern catalog](../../../doc/dev/SDKBreakingChanges.md) and the original
+`azsdk_package_detect_breaking_change` result. Preserve the ApiCompat diagnostics,
+previous signatures, additions, and `originBreaks`; a removal/addition pair is
+not proof of a rename.
+
+- For a user-selected `mitigation: generator` change, verify the documented
+  preconditions and matching previous contract. Reuse the management generator's
+  existing conditional-header and model-factory compatibility overload support.
+  Regenerate; do not write a second synthesizer or patch generated files.
+- For `mitigation: client customization`, use `azsdk_customized_code_update`
+  with the user's selected change and permitted edit scope. `CustomCode` cannot
+  edit TypeSpec inputs or change the pinned spec commit; `SpecChangeRequired`
+  requires a spec-owner handoff, not an automatic retry with broader scope.
+- For `mitigation: manual`, missing evidence, or unsupported generator output,
+  explain the decision needed and stop automatic mitigation.
+
+This skill's ARM patterns are management-specific. Do not apply resource
+hierarchy, ARM identifier, or conditional-header transformations to data-plane
+libraries without separately verified support.
+
+After a change, regenerate and compile fresh artifacts as needed, rerun the
+standalone detector, then run ordinary builds, analyzers, and tests separately.
+Do not treat a missing GA baseline, stale artifact, or detector failure as a
+compatibility pass. Never add suppressions without explicit owner approval.
+
 ## SDK-Side Customizations (in SDK repo)
 
 Use **Custom/*.cs** or **Customization/*.cs** partial classes (follow the package's existing structure) for .NET-side fixes.

--- a/doc/dev/SDKBreakingChanges.md
+++ b/doc/dev/SDKBreakingChanges.md
@@ -1,0 +1,333 @@
+# .NET SDK breaking change detection and mitigation
+
+This catalog is the .NET input to `azsdk_package_detect_breaking_change` and the
+shared `azsdk-common-sdk-breaking-change` workflow. It covers public APIs in
+both data-plane and management-plane libraries. ARM-specific mitigations below
+apply only to management-plane libraries.
+
+## Detection contract
+
+`eng/scripts/compatibility/Get-SdkChanges.ps1` compares current, already-built
+assemblies with the latest stable (GA) NuGet package. The pinned
+`ApiCompatVersion` is not proof that a version is the latest GA, and an absent
+property is not proof that a package has never shipped.
+
+The detector invokes the SDK-shipped
+`Microsoft.DotNet.ApiCompat.Task.ValidateAssembliesTask` independently of
+compilation and analyzer validation. It uses the repository's compatibility
+rules, attribute exclusions, and approved centralized suppressions. It does
+not generate suppressions or implement a second compatibility policy.
+Baseline packages and dependencies are restored using the SDK repository's
+`NuGet.Config`, including its approved Azure Artifacts feed.
+
+Run the common entry point from an SDK or local spec workflow:
+
+```text
+azsdk package detect-breaking-change --package-path <package-directory> --tsp-config-path <tspconfig.yaml>
+```
+
+Use `--changes-only` for deterministic detection without AI classification.
+Automation can call the configured script directly:
+
+```powershell
+.\eng\scripts\compatibility\Get-SdkChanges.ps1 `
+    -PackagePath <absolute-package-directory> `
+    -SdkRepoPath <absolute-sdk-repository> `
+    -OutputJsonFile <report.json>
+```
+
+Generate and compile current artifacts separately when needed. Matching
+portable or embedded PDBs are required to verify source checksums; build-input
+timestamps supplement that check. The PowerShell host must run on a .NET
+runtime compatible with the selected SDK's MSBuild diagnostic reader. For the
+current .NET 10 SDK, use PowerShell 7.6 or newer; installing an SDK alone does
+not upgrade PowerShell.
+
+The detector evaluates all declared target frameworks unless `TargetFramework`
+is set in the environment. `Configuration` must match the prepared artifacts:
+SDK PR packaging uses `Release`, while local builds commonly use `Debug`.
+For example, set `$env:Configuration = 'Release'` before detecting SDK PR
+artifacts. A deliberate `$env:TargetFramework = 'netstandard2.0'` comparison
+requires only that framework's artifacts, but is not full-package coverage;
+the report records the omitted frameworks. Clear the override for a complete
+multi-target comparison.
+
+A normal build
+or analyzer failure must be reported separately from compatibility results.
+Missing or stale assemblies, unresolved references, invalid reports, and
+failed baseline retrieval are detector errors, not evidence of compatibility.
+Native unresolved-reference diagnostics remain errors even on SDK versions
+that log them as informational messages instead of warnings.
+If the package has no GA release, the report explicitly identifies the missing
+baseline; that is not a successful compatibility comparison.
+
+The common result preserves `changes` and `hasBreakingChange`. Optional
+`details` retain `baselineVersion`, structured `apiChanges`, native
+`diagnostics`, and `limitations`. Classified results also retain that original
+evidence, including when AI classification fails.
+
+### SDK PR reports
+
+SDK PR build jobs collect native reports immediately after Release packaging,
+even when that build failed. Collection clears inherited target-framework
+overrides and records each selected package independently. Existing validation
+steps remain in place; the final compatibility assertion fails on detected
+breaks or detector errors, not merely on the extractor's exit code. No-GA
+packages are reported as not applicable, never compatible.
+
+The job publishes `sdk-api-changes_<job-name>` artifacts even after failure;
+the existing publisher adds `-FailedAttempt<attempt>` for failed jobs. Each
+artifact contains `summary.json` and per-project `result.json`, unchanged
+`sdk-changes.json`, and process logs. Detector failures instead include
+`error.json`; any incomplete raw output is named `failed-sdk-changes.json`
+and must not be replayed as a successful comparison.
+
+Use a successful collected `sdk-changes.json` with the common tool's
+`--sdk-change-json-file-path` option to classify and select mitigations.
+Retain its baseline, framework scope, and source revision when interpreting
+the result; replay does not refresh the original comparison. Do not combine
+that option with `--changes-only`, which requests fresh detection instead.
+
+The existing Compliance job runs the native and CI Pester suites on SDK PRs.
+To run the same suites locally from the repository root:
+
+```powershell
+Invoke-Pester -Path @(
+    '.\eng\scripts\compatibility\tests',
+    '.\eng\scripts\compatibility\ci-tests'
+) -Output Normal
+```
+
+### Supplemental extraction: additions, not a second compatibility checker
+
+ApiCompat's forward comparison is the authority for compatibility violations.
+Because it primarily reports violations, the detector also compares the same
+assemblies in reverse. Reverse `CP0001` and `CP0002` diagnostics supply added
+types and members for the `### Features Added` section. They do **not** set
+`hasBreakingChange`. Other reverse differences are not automatically additions
+or new breaking changes.
+
+A changed signature can appear as a removed overload and an added overload.
+A renamed type or property can appear as a removal and an addition. Preserve
+both entries and their signatures. Neither co-occurrence nor name similarity
+proves a rename: confirm the mapping using the TypeSpec source, existing client
+customizations, previous public contract, and affected call sites. Without
+that evidence, leave the violations separate and require manual review.
+
+ApiCompat cannot prove behavioral or wire compatibility. Serialization names,
+resource paths, paging behavior, defaults, and other runtime changes still
+require appropriate tests and owner judgment, even when the assemblies are
+compatible.
+
+## Classification and mitigation contract
+
+Use the common categories: `emitter change`, `conversion-by design`,
+`conversion-need resolve`, `spec change`, or `unknown`. A diagnostic identifies
+the API violation, not its root cause. Only choose a more specific category
+when the spec, emitter, and previous contract provide supporting evidence.
+An expected conversion is not permission to suppress a violation.
+
+Each classified .NET change includes a `mitigation` route:
+
+| Route | Preconditions and entry point |
+| --- | --- |
+| `generator` | A documented deterministic generator pattern below matches and its preconditions are verified. Invoke the SDK's existing [mitigate-breaking-changes skill](../../.github/skills/mitigate-breaking-changes/SKILL.md), then regenerate using the existing generator and matching previous contract. |
+| `client customization` | A verified client-layer change can preserve public and wire behavior. Use `azsdk_customized_code_update` with the selected change, local TypeSpec project, and approved edit scope. This is the current name of the tool previously called `azsdk_typespec_customized_code_update`. |
+| `manual` | The mapping, semantics, generator support, or owner decision is missing. Explain what must be established; do not apply an automatic fix. |
+
+Detection and classification are read-only. Present the changes and obtain the
+user's selection before mitigation. Do not edit generated files, automatically
+add suppressions, widen the permitted edit scope, or change a pinned spec
+commit. For SDK-only repair, `editScope: CustomCode` cannot change `client.tsp`
+or `tspconfig.yaml`; `SpecChangeRequired` is a handoff, not permission to retry
+with broader scope.
+
+After mitigation, regenerate and compile fresh artifacts as needed, rerun
+the same detector, and separately run ordinary build, analyzer, and test
+validation. Stop on unresolved or ambiguous changes rather than repeatedly
+applying speculative fixes.
+
+## Removed or renamed types
+
+**SDK change pattern:** Forward `CP0001` identifies an absent type; reverse
+`CP0001` may identify a new type. `CP0019` can indicate reduced visibility.
+
+**Breaking:** Existing type references, constructors, parameters, and returned
+models may no longer compile or load.
+
+**Reason:** Possible spec removal, changed client naming/accessibility, or
+emitter/conversion behavior. Confirm the canonical TypeSpec element before
+claiming a rename; retain `unknown` when the mapping is not established.
+
+**Resolution:** If the same service model and wire contract remain, restore
+the previous C# name/accessibility through a verified client customization
+(`@@clientName(..., "PreviousName", "csharp")` where appropriate). The management
+skill also documents `CodeGenType` for SDK-side customization when needed;
+its attribute argument is the original TypeSpec model name. Removed service
+functionality or an unproven mapping cannot be repaired by renaming another
+type. Route to `client customization` only with evidence; otherwise `manual`.
+
+## Removed members and changed signatures
+
+**SDK change pattern:** Forward `CP0002`, optionally paired with reverse
+`CP0002` for a property, constructor, method, accessor, or overload.
+
+**Breaking:** A callable signature or accessible member in the GA package is
+missing. Parameter/return-type changes can generate multiple related entries.
+
+**Reason:** Spec, naming, flattening, type conversion, or generator changes.
+Check old and new signatures, synchronous/asynchronous variants, overloads,
+requiredness, and custom code. Do not classify every removal/addition pair as
+a rename.
+
+**Resolution:** Use a verified naming customization only when the same API and
+wire semantics remain. Do not use `alternateType` to conceal a real service
+type change or introduce a lossy conversion. Check the deterministic
+management overload patterns below before considering custom forwarding
+members. Other signature changes require `manual` review.
+
+## Changed parameter names
+
+**SDK change pattern:** `CP0017` identifies a parameter name change; `CP0002`
+may additionally identify changed overloads.
+
+**Breaking:** Customer calls using named arguments no longer compile.
+
+**Reason:** A client-name customization, emitter naming convention, or spec
+parameter rename changed the C# name. A diagnostic alone does not distinguish
+these causes.
+
+**Resolution:** When the corresponding TypeSpec parameter and wire binding
+are verified, use `azsdk_customized_code_update` to restore the previous
+C# parameter name with a language-scoped client customization, for example
+`@@clientName(Operations.create::parameters.resource, "content", "csharp")`.
+Route to `client customization`; otherwise `manual`.
+
+## Management conditional-header compatibility overloads
+
+**SDK change pattern:** `CP0002` for an old public method with string ETag
+headers, alongside a current method using `ETag`, `MatchConditions`, or
+`RequestConditions`.
+
+**Breaking:** Callers of the old conditional-header signature lose their
+overload.
+
+**Reason:** A management generator transition may change the SDK's
+representation of unchanged HTTP conditional headers.
+
+**Resolution:** Route to `generator` only when the existing
+[BackCompatHelper](../../eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/BackCompatHelper.cs)
+can match the previous public method to a current method with the same name,
+return type, remaining parameters, and supported conditional-header
+transformation. Existing custom overloads and approved method removals must
+not be duplicated or resurrected. Invoke `mitigate-breaking-changes` and
+regenerate with the matching previous contract, rather than implementing a
+second overload synthesizer. If the generator reports that it cannot
+synthesize the overload, require `manual` review of a custom overload.
+
+## Management model-factory compatibility overloads
+
+**SDK change pattern:** `CP0002` for a previous model-factory overload after
+model flattening, constructor reordering, or added model properties.
+
+**Breaking:** Mocking and test code using the old factory signature no longer
+compiles; a superficially compatible overload can also incorrectly discard
+its input values.
+
+**Reason:** Model shape changes can invalidate old factory signatures or
+constructor argument positions.
+
+**Resolution:** The existing
+[ModelFactoryVisitor](../../eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs)
+and
+[ModelFactoryBackwardCompatHelper](../../eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryBackwardCompatHelper.cs)
+restore supported previous-contract methods and repair argument forwarding.
+Use `generator` only after verifying that the old types and parameters still
+map to the current model and that the removal was not approved. Invoke the
+existing skill, regenerate, and check that old input values are preserved in
+the resulting model. Unsupported/custom factory shapes require `manual`
+review, not guessed default values.
+
+## Enum types and values
+
+**SDK change pattern:** `CP0010` for an enum representation/type change,
+`CP0011` for a constant value change, or `CP0002` for removed members.
+Extensible enums represented as structs may produce member diagnostics
+instead of CLR enum diagnostics.
+
+**Breaking:** Customer code loses a named value or observes a different value.
+
+**Reason:** A spec value change, conversion, or naming change may be involved.
+Compare serialized values as well as C# names.
+
+**Resolution:** A verified name-only change retaining the same serialized
+value can use `client customization`. Do not automatically remap numeric
+values, seal an extensible enum, or claim that adding a differently valued
+member repairs a removal. Other cases require `manual` review.
+
+## Inheritance, virtual members, and resource hierarchy
+
+**SDK change pattern:** `CP0007`, `CP0008`, `CP0009`, `CP0012`, or `CP0013`.
+
+**Breaking:** Assignability, derivation, overriding, or dispatch changes for
+existing consumers.
+
+**Reason:** A client model, resource hierarchy, or generator change may have
+altered the public inheritance contract.
+
+**Resolution:** Default to `manual`. For ARM libraries, first verify resource
+hierarchy parity and repair structural TypeSpec resource-shape issues before
+considering SDK-side base-type customization. The existing management skill
+requires explicit owner approval for legacy `hierarchyBuilding`; do not
+automatically add it or use it for data-plane models.
+
+## Interface, abstract, visibility, and generic changes
+
+**SDK change pattern:** `CP0005`, `CP0006`, `CP0018`, `CP0019`, `CP0020`, or
+`CP0021`.
+
+**Breaking:** Existing implementers, derived types, generic instantiations,
+or source references may stop working. In particular, adding an interface or
+abstract member can be a forward compatibility violation even though the
+member is an addition.
+
+**Reason:** Public API design or generation constraints changed.
+
+**Resolution:** `manual`. Verify the affected implementations and API design;
+do not supply arbitrary implementations or weaken constraints just to pass
+compatibility. Preserve forward diagnostics even when the same added member
+also appears in reverse extraction.
+
+## Public attributes, including management WirePathAttribute
+
+**SDK change pattern:** `CP0014`, `CP0015`, or `CP0016` after applying the
+repository's existing attribute exclusions.
+
+**Breaking:** An attribute required by the compatibility policy was removed,
+changed, or added.
+
+**Reason:** The emitter configuration, generated metadata, or spec may have
+changed. Attribute differences are not all interchangeable.
+
+**Resolution:** For a verified management `WirePathAttribute` removal, the
+existing skill documents `enable-wire-path-attribute: true` in the management
+emitter options. Route that configuration change through
+`azsdk_customized_code_update` as `client customization`, then regenerate.
+Other attributes require pattern-specific evidence or `manual` review.
+Never automatically baseline unrelated errors or disable attribute checks.
+
+## Assembly identity, missing dependencies, and unknown diagnostics
+
+**SDK change pattern:** `CP0003`, `CP0004`, assembly-loading errors, or a
+diagnostic not covered by the catalog.
+
+**Breaking:** An identity change can break assembly consumers. A missing
+assembly/reference can instead mean that the detector did not complete.
+
+**Reason:** Package identity, target-framework coverage, baseline retrieval,
+reference resolution, or an unsupported compatibility case needs attention.
+
+**Resolution:** Preserve the native diagnostic and route to `manual`. Repair
+missing inputs or environment failures before declaring a comparison result.
+Do not guess a source customization or convert an incomplete run into
+`hasBreakingChange: false`.

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -215,6 +215,44 @@ jobs:
         - pwsh: ./eng/scripts/Test-NoWarnValidation.ps1
           displayName: Validate NoWarn enforcement targets
 
+        - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+          - task: NuGetAuthenticate@1
+
+          - task: UseDotNet@2
+            displayName: Use .NET 8 SDK for compatibility fixtures
+            retryCountOnTaskFailure: 3
+            inputs:
+              packageType: sdk
+              performMultiLevelLookup: true
+              version: "8.0.x"
+
+          - pwsh: |
+              . (Join-Path "$(Build.SourcesDirectory)" eng common scripts Helpers PSModule-Helpers.ps1)
+              Install-ModuleIfNotInstalled "powershell-yaml" "0.4.7" | Import-Module
+            displayName: Install compatibility test YAML dependency
+
+          - template: /eng/common/pipelines/templates/steps/run-pester-tests.yml
+            parameters:
+              TargetDirectory: eng/scripts/compatibility
+              CustomTestSteps:
+                - pwsh: |
+                    $config = New-PesterConfiguration
+                    $config.Run.Path = @('tests', 'ci-tests')
+                    $config.Run.PassThru = $true
+                    $config.Run.Exit = $true
+                    $config.TestResult.Enabled = $true
+                    $config.CodeCoverage.Enabled = $true
+                    $config.CodeCoverage.Path = @(
+                      'Get-SdkChanges.ps1',
+                      'Get-SdkChanges.Helpers.ps1',
+                      'Invoke-SdkChangesCI.ps1',
+                      'Assert-SdkChangesCI.ps1',
+                      'SdkChangesCI.Helpers.ps1'
+                    )
+                    Invoke-Pester -Configuration $config
+                  displayName: Test SDK API extraction and CI reporting
+                  workingDirectory: $(Build.SourcesDirectory)/eng/scripts/compatibility
+
     - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
       parameters:
         GenerateJobName: generate_target_service_test_matrix

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -155,6 +155,10 @@ steps:
         $(DiagnosticArguments)
       displayName: "Build and Package Service Directory"
 
+  - template: /eng/pipelines/templates/steps/sdk-api-changes.yml
+    parameters:
+      Mode: collect
+
   # save package properties again, this time honoring the dev version number
   - ${{ if ne(parameters.ServiceDirectory, 'auto') }}:
     - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -219,3 +223,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/validate-all-packages.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
+
+  - template: /eng/pipelines/templates/steps/sdk-api-changes.yml
+    parameters:
+      Mode: enforce

--- a/eng/pipelines/templates/steps/sdk-api-changes.yml
+++ b/eng/pipelines/templates/steps/sdk-api-changes.yml
@@ -1,0 +1,45 @@
+parameters:
+  - name: Mode
+    type: string
+    values:
+      - collect
+      - enforce
+
+steps:
+  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    - ${{ if eq(parameters.Mode, 'collect') }}:
+      - task: PowerShell@2
+        displayName: Collect standalone SDK API change reports
+        condition: succeededOrFailed()
+        # A collector startup failure must not skip the existing validations. The final assertion fails closed.
+        continueOnError: true
+        inputs:
+          pwsh: true
+          filePath: $(Build.SourcesDirectory)/eng/scripts/compatibility/Invoke-SdkChangesCI.ps1
+          arguments: >-
+            -SdkRepoPath "$(Build.SourcesDirectory)"
+            -PackageInfoDirectory "$(Build.ArtifactStagingDirectory)/PackageInfo"
+            -ProjectNames "$(ProjectNames)"
+            -ReportRoot "$(Agent.TempDirectory)/sdk-api-changes"
+            -ReportOnly
+          workingDirectory: $(Build.SourcesDirectory)
+        env:
+          Configuration: Release
+          TargetFramework: ''
+          TargetFrameworks: ''
+    - ${{ if eq(parameters.Mode, 'enforce') }}:
+      - task: PowerShell@2
+        displayName: Enforce standalone SDK API compatibility
+        condition: succeededOrFailed()
+        inputs:
+          pwsh: true
+          filePath: $(Build.SourcesDirectory)/eng/scripts/compatibility/Assert-SdkChangesCI.ps1
+          arguments: >-
+            -ReportDirectory "$(SdkChangesReportDirectory)"
+            -ProjectNames "$(ProjectNames)"
+          workingDirectory: $(Build.SourcesDirectory)
+      - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+        parameters:
+          ArtifactPath: $(SdkChangesReportDirectory)
+          ArtifactName: sdk-api-changes_$(System.JobName)
+          SbomEnabled: false

--- a/eng/scripts/compatibility/ApiCompat.proj
+++ b/eng/scripts/compatibility/ApiCompat.proj
@@ -1,0 +1,52 @@
+<Project DefaultTargets="CompareSdkAssemblies">
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <BaseIntermediateOutputPath>$(SdkChangesWorkDirectory)\obj\</BaseIntermediateOutputPath>
+    <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
+    <BaseOutputPath>$(SdkChangesWorkDirectory)\bin\</BaseOutputPath>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="$(SdkChangesInputFile)" Condition="'$(SdkChangesInputFile)' != ''" />
+
+  <Target Name="RejectSdkCompilation" BeforeTargets="Build;Rebuild;Compile;CoreCompile;RunAnalyzers;RunCodeAnalysis">
+    <Error Text="SDK change extraction must not compile or run analyzers." />
+  </Target>
+
+  <Target Name="CompareSdkAssemblies">
+    <Error Condition="!Exists('$(SdkChangesLeftAssembly)')" Text="The baseline assembly does not exist: $(SdkChangesLeftAssembly)" />
+    <Error Condition="!Exists('$(SdkChangesRightAssembly)')" Text="The current assembly does not exist: $(SdkChangesRightAssembly)" />
+    <Error Condition="!Exists('$(RoslynAssembliesPath)\Microsoft.CodeAnalysis.dll')" Text="The evaluated RoslynAssembliesPath is not available: $(RoslynAssembliesPath)" />
+    <ItemGroup>
+      <_SdkChangesLeftReferences Include="@(SdkChangesLeftReference, ',')" />
+      <_SdkChangesRightReferences Include="@(SdkChangesRightReference, ',')" />
+      <_SdkChangesAssemblyTransformation Include="^.%2A$">
+        <ReplacementString>$(SdkChangesAssemblyIdentity)</ReplacementString>
+      </_SdkChangesAssemblyTransformation>
+    </ItemGroup>
+    <!-- Keep native error events, but finish the target so a truncated/failed process is distinguishable. -->
+    <Microsoft.DotNet.ApiCompat.Task.ValidateAssembliesTask
+      RoslynAssembliesPath="$(RoslynAssembliesPath)"
+      LeftAssemblies="$(SdkChangesLeftAssembly)"
+      RightAssemblies="$(SdkChangesRightAssembly)"
+      LeftAssembliesReferences="@(_SdkChangesLeftReferences)"
+      RightAssembliesReferences="@(_SdkChangesRightReferences)"
+      LeftAssembliesTransformationPattern="@(_SdkChangesAssemblyTransformation)"
+      RightAssembliesTransformationPattern="@(_SdkChangesAssemblyTransformation)"
+      CreateWorkItemPerAssembly="true"
+      GenerateSuppressionFile="false"
+      PermitUnnecessarySuppressions="$(ApiCompatPermitUnnecessarySuppressions)"
+      SuppressionFiles="@(SdkChangesSuppressionFile)"
+      NoWarn="$(NoWarn)"
+      RespectInternals="$(ApiCompatRespectInternals)"
+      EnableRuleAttributesMustMatch="$(ApiCompatEnableRuleAttributesMustMatch)"
+      ExcludeAttributesFiles="@(SdkChangesExcludeAttributesFile)"
+      EnableRuleCannotChangeParameterName="$(ApiCompatEnableRuleCannotChangeParameterName)"
+      EnableStrictMode="$(ApiCompatStrictMode)"
+      ContinueOnError="ErrorAndContinue" />
+    <Message Text="SDK_CHANGES_API_COMPAT_COMPLETED" Importance="High" />
+  </Target>
+</Project>

--- a/eng/scripts/compatibility/Assert-SdkChangesCI.ps1
+++ b/eng/scripts/compatibility/Assert-SdkChangesCI.ps1
@@ -1,0 +1,24 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+Enforces collected native SDK API verdicts after existing CI validations and before report publication.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ReportDirectory,
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$ProjectNames
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3
+. (Join-Path $PSScriptRoot 'SdkChangesCI.Helpers.ps1')
+
+$verdict = Test-SdkChangesCIReports -ReportDirectory $ReportDirectory -ProjectNames $ProjectNames
+foreach ($errorMessage in $verdict.Errors) { LogError $errorMessage }
+LogInfo "SDK API result counts: $($verdict.Counts | ConvertTo-Json -Compress)"
+LogInfo "Job status before report collection: $($verdict.PreviousJobStatus). Existing validation failures are not replaced by API compatibility results."
+if ($verdict.Counts.notApplicable -gt 0) {
+    LogWarning "$($verdict.Counts.notApplicable) package(s) have no GA baseline; compatibility was not evaluated for those packages."
+}
+if ($verdict.Counts.selected -eq 0) { LogInfo 'No packages were selected for SDK API comparison in this job.' }
+if (!$verdict.Passed) { exit 1 }

--- a/eng/scripts/compatibility/Get-SdkChanges.Helpers.ps1
+++ b/eng/scripts/compatibility/Get-SdkChanges.Helpers.ps1
@@ -1,0 +1,981 @@
+#Requires -Version 7.0
+
+function Invoke-SdkChangeProcess {
+    param([string[]]$Arguments, [string]$WorkingDirectory)
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new('dotnet')
+    $startInfo.WorkingDirectory = $WorkingDirectory
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.Environment['DOTNET_CLI_UI_LANGUAGE'] = 'en'
+    $startInfo.Environment['VSLANG'] = '1033'
+    foreach ($argument in $Arguments) {
+        $startInfo.ArgumentList.Add($argument)
+    }
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        if (!$process.Start()) {
+            throw 'Could not start dotnet for SDK change extraction.'
+        }
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        if (!$process.WaitForExit(600000)) {
+            $process.Kill($true)
+            $process.WaitForExit()
+            throw 'SDK change extraction timed out while running dotnet.'
+        }
+        return @{
+            ExitCode = $process.ExitCode
+            StdOut = $stdout.GetAwaiter().GetResult()
+            StdErr = $stderr.GetAwaiter().GetResult()
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
+function Initialize-SdkChangeNativeLibraries {
+    param([string]$MSBuildToolsPath)
+
+    $framework = [System.Runtime.Versioning.FrameworkName]::new(
+        (Get-SdkChangeAssemblyInfo (Join-Path $MSBuildToolsPath 'Microsoft.Build.dll')).TargetFramework)
+    if ($framework.Identifier -eq '.NETCoreApp' -and [System.Environment]::Version.Major -lt $framework.Version.Major) {
+        throw "The selected SDK's diagnostic reader requires PowerShell running on .NET $($framework.Version.Major) or newer; this PowerShell host uses .NET $([System.Environment]::Version)."
+    }
+    foreach ($name in @('Microsoft.Build.Framework', 'Microsoft.Build', 'NuGet.Versioning', 'NuGet.Frameworks')) {
+        $path = Join-Path $MSBuildToolsPath "$name.dll"
+        if (!(Test-Path -LiteralPath $path -PathType Leaf)) {
+            throw "The selected .NET SDK is missing $path."
+        }
+        [void][System.Reflection.Assembly]::LoadFrom($path)
+    }
+}
+
+function Read-SdkChangeBuildLog {
+    param([string]$Path)
+
+    if (!(Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "MSBuild did not produce its diagnostic log: $Path"
+    }
+    $result = @{
+        Diagnostics = [System.Collections.Generic.List[object]]::new()
+        Imports = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        Targets = [System.Collections.Generic.List[string]]::new()
+        ReadErrors = [System.Collections.Generic.List[string]]::new()
+        Completed = $false
+        Finished = $false
+        Succeeded = $false
+    }
+    $reader = [Microsoft.Build.Logging.BinaryLogReplayEventSource]::new()
+    $reader.add_RecoverableReadError([System.Action[Microsoft.Build.Logging.BinaryLogReaderErrorEventArgs]]{
+        param($eventArgs)
+        $result.ReadErrors.Add($eventArgs.ToString())
+    })
+    $reader.add_AnyEventRaised([Microsoft.Build.Framework.AnyEventHandler]{
+        param($sender, $eventArgs)
+        if ($eventArgs -is [Microsoft.Build.Framework.BuildErrorEventArgs] -or
+            $eventArgs -is [Microsoft.Build.Framework.BuildWarningEventArgs]) {
+            $context = $eventArgs.BuildEventContext
+            $eventKey = [string]$eventArgs.Timestamp.Ticks
+            if ($null -ne $context) {
+                $eventKey += ":$($context.NodeId):$($context.ProjectContextId):$($context.TargetId):$($context.TaskId)"
+            }
+            $result.Diagnostics.Add(@{
+                Code = $eventArgs.Code
+                Message = $eventArgs.Message
+                IsError = $eventArgs -is [Microsoft.Build.Framework.BuildErrorEventArgs]
+                EventKey = $eventKey
+            })
+        }
+        elseif ($eventArgs -is [Microsoft.Build.Framework.ProjectImportedEventArgs] -and
+            !$eventArgs.ImportIgnored -and $eventArgs.ImportedProjectFile) {
+            [void]$result.Imports.Add($eventArgs.ImportedProjectFile)
+        }
+        elseif ($eventArgs -is [Microsoft.Build.Framework.TargetStartedEventArgs]) {
+            $result.Targets.Add($eventArgs.TargetName)
+        }
+        elseif ($eventArgs -is [Microsoft.Build.Framework.BuildFinishedEventArgs]) {
+            $result.Finished = $true
+            $result.Succeeded = $eventArgs.Succeeded
+        }
+        elseif ($eventArgs -is [Microsoft.Build.Framework.BuildMessageEventArgs] -and
+            $eventArgs.Message -eq 'SDK_CHANGES_API_COMPAT_COMPLETED') {
+            $result.Completed = $true
+        }
+        elseif ($eventArgs -is [Microsoft.Build.Framework.BuildMessageEventArgs] -and
+            $eventArgs.Message -cmatch "^Could not resolve reference '[^']+' directly or transitively referenced by .+ in any of the provided search directories\.$") {
+            # The SDK temporarily emits CP1002 as a message (dotnet/sdk#46236). It still
+            # means comparison inputs are incomplete, not that compatibility succeeded.
+            $result.Diagnostics.Add(@{
+                Code = 'CP1002'
+                Message = $eventArgs.Message
+                IsError = $true
+                EventKey = [string]$eventArgs.Timestamp.Ticks
+            })
+        }
+    })
+    $reader.Replay($Path)
+    if ($result.ReadErrors.Count -gt 0) {
+        throw "MSBuild's diagnostic log contains unreadable event records: $Path"
+    }
+    return $result
+}
+
+function Read-SdkChangeJson {
+    param([string]$Path)
+
+    if (!(Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "The expected JSON file was not produced: $Path"
+    }
+    return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable -Depth 100 -ErrorAction Stop)
+}
+
+function Get-SdkChangeProject {
+    param([string]$PackagePath, [string]$SdkRepoPath)
+
+    foreach ($path in @($PackagePath, $SdkRepoPath)) {
+        if (![System.IO.Path]::IsPathFullyQualified($path)) {
+            throw "An absolute path is required: $path"
+        }
+    }
+    $repo = (Resolve-Path -LiteralPath $SdkRepoPath -ErrorAction Stop).Path
+    $package = Get-Item -LiteralPath $PackagePath -ErrorAction Stop
+    $relative = [System.IO.Path]::GetRelativePath($repo, $package.FullName)
+    if ($relative -eq '..' -or $relative.StartsWith("..$([System.IO.Path]::DirectorySeparatorChar)") -or
+        [System.IO.Path]::IsPathFullyQualified($relative)) {
+        throw "PackagePath must be inside SdkRepoPath: $PackagePath"
+    }
+    if (!$package.PSIsContainer) {
+        if ($package.Extension -ne '.csproj') {
+            throw "PackagePath must identify a C# SDK source project: $PackagePath"
+        }
+        return $package.FullName
+    }
+    $source = Join-Path $package.FullName 'src'
+    if (!(Test-Path -LiteralPath $source -PathType Container)) {
+        $source = $package.FullName
+    }
+    $projects = @(Get-ChildItem -LiteralPath $source -Filter '*.csproj' -File)
+    if ($projects.Count -ne 1) {
+        throw "Expected exactly one SDK source project in $source; found $($projects.Count)."
+    }
+    return $projects[0].FullName
+}
+
+function Get-SdkChangeEvaluation {
+    param(
+        [string]$Project,
+        [string]$SdkRepoPath,
+        [string]$WorkDirectory,
+        [string]$TargetFramework,
+        [string]$Configuration
+    )
+
+    $id = [guid]::NewGuid().ToString('N')
+    $jsonPath = Join-Path $WorkDirectory "$id.json"
+    $logPath = Join-Path $WorkDirectory "$id.binlog"
+    $properties = @(
+        'PackageId', 'MSBuildProjectName', 'MSBuildProjectFullPath', 'MSBuildToolsPath',
+        'TargetFramework', 'TargetFrameworks', 'TargetFrameworkMoniker', 'RuntimeIdentifier',
+        'Configuration', 'TargetFileName', 'TargetPath', 'TargetRefPath', 'ProjectAssetsFile',
+        'IntermediateOutputPath', 'PdbFile', 'DebugType',
+        'MSBuildAllProjects', 'AssemblyName', 'NuGetPackageRoot', 'RoslynAssembliesPath',
+        'ApiCompatBaselineTargetFramework', 'ApiCompatVersion', 'ApiCompatRespectInternals',
+        'ApiCompatStrictMode', 'ApiCompatEnableRuleAttributesMustMatch',
+        'ApiCompatEnableRuleCannotChangeParameterName', 'ApiCompatPermitUnnecessarySuppressions',
+        'NoWarn', 'CompileUsingReferenceAssemblies',
+        'TargetFrameworkRootPath', 'TargetFrameworkFallbackSearchPaths',
+        'FrameworkPathOverride', 'BypassFrameworkInstallChecks'
+    )
+    $items = @(
+        'Compile', 'AdditionalFiles', 'EmbeddedResource', 'Reference', 'FrameworkReference',
+        'IntermediateAssembly', 'ApiCompatSuppressionFile', 'ApiCompatExcludeAttributesFile'
+    )
+    $arguments = @(
+        'msbuild', $Project, '-nologo', '-tl:off', '-nodeReuse:false',
+        "-getProperty:$($properties -join ',')", "-getItem:$($items -join ',')",
+        "-getResultOutputFile:$jsonPath", "-binaryLogger:$logPath;ProjectImports=None"
+    )
+    if ($TargetFramework) { $arguments += "-property:TargetFramework=$TargetFramework" }
+    if ($Configuration) { $arguments += "-property:Configuration=$Configuration" }
+    $process = Invoke-SdkChangeProcess -Arguments $arguments -WorkingDirectory $SdkRepoPath
+    if ($process.ExitCode -ne 0) {
+        throw "SDK project evaluation failed (exit $($process.ExitCode)).`n$($process.StdOut)`n$($process.StdErr)"
+    }
+    $evaluation = Read-SdkChangeJson $jsonPath
+    if (!$evaluation.Contains('Properties') -or !$evaluation.Contains('Items')) {
+        throw "MSBuild returned malformed project metadata for $Project."
+    }
+    Initialize-SdkChangeNativeLibraries $evaluation.Properties.MSBuildToolsPath
+    $log = Read-SdkChangeBuildLog $logPath
+    $evaluation.ImportedProjects = @($log.Imports)
+    $evaluation.RepositoryPath = $SdkRepoPath
+    return $evaluation
+}
+
+function Get-SdkChangeAssemblyInfo {
+    param([string]$Path, [switch]$IgnoreNonAssembly)
+
+    $stream = [System.IO.File]::OpenRead($Path)
+    $pe = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+    try {
+        if (!$pe.HasMetadata) {
+            if ($IgnoreNonAssembly) { return $null }
+            throw "Not a managed assembly: $Path"
+        }
+        $metadata = [System.Reflection.Metadata.PEReaderExtensions]::GetMetadataReader($pe)
+        if (!$metadata.IsAssembly) {
+            if ($IgnoreNonAssembly) { return $null }
+            throw "Not a managed assembly: $Path"
+        }
+        $definition = $metadata.GetAssemblyDefinition()
+        $targetFramework = $null
+        foreach ($handle in $definition.GetCustomAttributes()) {
+            $attribute = $metadata.GetCustomAttribute($handle)
+            if ($attribute.Constructor.Kind -ne [System.Reflection.Metadata.HandleKind]::MemberReference) { continue }
+            $constructor = $metadata.GetMemberReference($attribute.Constructor)
+            if ($constructor.Parent.Kind -ne [System.Reflection.Metadata.HandleKind]::TypeReference) { continue }
+            $type = $metadata.GetTypeReference($constructor.Parent)
+            if ($metadata.GetString($type.Namespace) -eq 'System.Runtime.Versioning' -and
+                $metadata.GetString($type.Name) -eq 'TargetFrameworkAttribute') {
+                $blob = $metadata.GetBlobReader($attribute.Value)
+                if ($blob.ReadUInt16() -ne 1) { throw "Invalid TargetFrameworkAttribute in $Path." }
+                $targetFramework = $blob.ReadSerializedString()
+            }
+        }
+        return @{
+            Name = $metadata.GetString($definition.Name)
+            TargetFramework = $targetFramework
+            References = @($metadata.AssemblyReferences | ForEach-Object {
+                $metadata.GetString($metadata.GetAssemblyReference($_).Name)
+            })
+        }
+    }
+    finally {
+        $pe.Dispose()
+        $stream.Dispose()
+    }
+}
+
+function Get-SdkChangeCompilationDocuments {
+    param([string]$Assembly, [hashtable]$Evaluation)
+
+    $stream = [System.IO.File]::OpenRead($Assembly)
+    $pe = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+    $provider = $null
+    $pdbStream = $null
+    try {
+        $entries = @($pe.ReadDebugDirectory())
+        $embedded = @($entries | Where-Object { $_.Type -eq 'EmbeddedPortablePdb' })
+        if ($embedded.Count -eq 1) {
+            $provider = $pe.ReadEmbeddedPortablePdbDebugDirectoryData($embedded[0])
+        }
+        else {
+            $pdb = if ($Evaluation.Properties.PdbFile) {
+                [System.IO.Path]::GetFullPath($Evaluation.Properties.PdbFile, (Split-Path $Evaluation.Properties.MSBuildProjectFullPath -Parent))
+            }
+            else { [System.IO.Path]::ChangeExtension($Assembly, '.pdb') }
+            if (!(Test-Path -LiteralPath $pdb -PathType Leaf)) {
+                throw "Current portable PDB is missing: $pdb. Build the current package with portable or embedded debug information to verify artifact freshness."
+            }
+            $pdbStream = [System.IO.File]::OpenRead($pdb)
+            $provider = [System.Reflection.Metadata.MetadataReaderProvider]::FromPortablePdbStream($pdbStream)
+        }
+        $metadata = $provider.GetMetadataReader()
+        $codeView = @($entries | Where-Object { $_.Type -eq 'CodeView' })
+        $id = [byte[]]$metadata.DebugMetadataHeader.Id
+        if ($codeView.Count -ne 1 -or $id.Length -ne 20 -or
+            $pe.ReadCodeViewDebugDirectoryData($codeView[0]).Guid -ne [guid]::new([byte[]]$id[0..15])) {
+            throw "Current PDB does not match the current assembly: $Assembly."
+        }
+        $sourceCount = $metadata.Documents.Count
+        foreach ($handle in $metadata.CustomDebugInformation) {
+            $info = $metadata.GetCustomDebugInformation($handle)
+            if ($info.Parent.Kind -eq 'ModuleDefinition' -and
+                $metadata.GetGuid($info.Kind) -eq [guid]'b5feec05-8cd0-4a83-96da-466284bb4bd8') {
+                $options = [System.Text.Encoding]::UTF8.GetString($metadata.GetBlobBytes($info.Value)).Split([char]0)
+                for ($i = 0; $i + 1 -lt $options.Length; $i += 2) {
+                    if ($options[$i] -eq 'source-file-count') { $sourceCount = [int]$options[$i + 1] }
+                }
+            }
+        }
+        if ($sourceCount -lt 0 -or $sourceCount -gt $metadata.Documents.Count) {
+            throw "The current PDB contains an invalid compilation source count: $Assembly."
+        }
+        $documents = [System.Collections.Generic.List[object]]::new()
+        $algorithms = @{
+            '8829d00f-11b8-4213-878b-770e8597ac16' = 'SHA256'
+            'ff1816ec-aa5e-4d10-87f7-6f4963833460' = 'SHA1'
+        }
+        foreach ($handle in $metadata.Documents) {
+            # Roslyn appends #line documents after its compilation source documents.
+            if ($documents.Count -eq $sourceCount) { break }
+            $document = $metadata.GetDocument($handle)
+            $documents.Add(@{
+                Name = $metadata.GetString($document.Name)
+                Algorithm = $algorithms[$metadata.GetGuid($document.HashAlgorithm).ToString()]
+                Hash = [System.Convert]::ToHexString($metadata.GetBlobBytes($document.Hash))
+            })
+        }
+        return @($documents)
+    }
+    finally {
+        if ($null -ne $provider) { $provider.Dispose() }
+        if ($null -ne $pdbStream) { $pdbStream.Dispose() }
+        $pe.Dispose()
+        $stream.Dispose()
+    }
+}
+
+function Assert-SdkChangeCompilationSources {
+    param([string]$Assembly, [hashtable]$Evaluation)
+
+    $documents = @(Get-SdkChangeCompilationDocuments -Assembly $Assembly -Evaluation $Evaluation)
+    $projectDirectory = Split-Path $Evaluation.Properties.MSBuildProjectFullPath -Parent
+    $intermediateDirectory = [System.IO.Path]::GetFullPath($Evaluation.Properties.IntermediateOutputPath, $projectDirectory).Replace('\', '/').TrimEnd('/') + '/'
+    $repoDirectory = $Evaluation.RepositoryPath.Replace('\', '/').TrimEnd('/') + '/'
+    $sources = @{}
+    $mappings = @{ $repoDirectory = $repoDirectory }
+    $projectPrefix = $projectDirectory.Replace('\', '/').TrimEnd('/') + '/'
+    $mappings[$projectPrefix] = $projectPrefix
+    foreach ($source in $Evaluation.Items.Compile) {
+        $path = $source.FullPath.Replace('\', '/')
+        $sources[$path] = $false
+        $relative = [System.IO.Path]::GetRelativePath($Evaluation.RepositoryPath, $source.FullPath).Replace('\', '/')
+        if ($relative.StartsWith('../')) { continue }
+        foreach ($document in $documents) {
+            $name = $document.Name.Replace('\', '/')
+            if ($name.EndsWith("/$relative", [System.StringComparison]::OrdinalIgnoreCase)) {
+                $prefix = $name.Substring(0, $name.Length - $relative.Length)
+                if ($mappings.Contains($prefix) -and $mappings[$prefix] -ne $repoDirectory) {
+                    throw "Ambiguous source path mapping in the current PDB: $($document.Name)"
+                }
+                $mappings[$prefix] = $repoDirectory
+            }
+        }
+    }
+    foreach ($document in $documents) {
+        $path = $document.Name.Replace('\', '/')
+        if (!$sources.Contains($path)) {
+            foreach ($prefix in ($mappings.Keys | Sort-Object Length -Descending)) {
+                if ($path.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $path = $mappings[$prefix] + $path.Substring($prefix.Length)
+                    break
+                }
+            }
+        }
+        if ($path.StartsWith($intermediateDirectory, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+        if (!$sources.Contains($path)) {
+            throw "Current assembly is stale or its PDB source mapping cannot be verified: '$($document.Name)' is not an evaluated Compile input. Build the current package first."
+        }
+        if (!$document.Algorithm -or !$document.Hash) {
+            throw "The current PDB has no supported source checksum for $path."
+        }
+        $actual = (Get-FileHash -LiteralPath $path -Algorithm $document.Algorithm).Hash
+        if ($actual -ne $document.Hash) {
+            throw "Current assembly is stale: the compiled checksum for $path differs from the current source. Build the current package first."
+        }
+        $sources[$path] = $true
+    }
+    foreach ($path in $sources.Keys) {
+        if (!$sources[$path]) {
+            throw "Current assembly is stale: the PDB does not contain the evaluated Compile input $path. Build the current package first."
+        }
+    }
+}
+
+function Assert-SdkChangeCurrentAssembly {
+    param([hashtable]$Evaluation)
+
+    $properties = $Evaluation.Properties
+    $assemblies = @($Evaluation.Items.IntermediateAssembly)
+    if ($assemblies.Count -ne 1 -or !$properties.TargetPath -or !$properties.TargetFramework) {
+        throw "Could not determine the current assembly/target framework for $($properties.MSBuildProjectFullPath)."
+    }
+    $assembly = $assemblies[0].FullPath
+    if (!(Test-Path -LiteralPath $assembly -PathType Leaf)) {
+        throw "Current assembly is missing for $($properties.TargetFramework): $assembly. Build the current package first."
+    }
+    $info = Get-SdkChangeAssemblyInfo $assembly
+    if ($info.Name -ne $properties.AssemblyName -or $info.TargetFramework -ne $properties.TargetFrameworkMoniker) {
+        throw "Current assembly identity/target framework does not match the evaluated project: $assembly."
+    }
+    $inputs = @($properties.MSBuildProjectFullPath, $properties.ProjectAssetsFile) +
+        @($properties.MSBuildAllProjects -split ';' | Where-Object { $_ }) + @($Evaluation.ImportedProjects)
+    $globalJson = Join-Path $Evaluation.RepositoryPath 'global.json'
+    if (Test-Path -LiteralPath $globalJson -PathType Leaf) { $inputs += $globalJson }
+    foreach ($itemType in @('Compile', 'AdditionalFiles', 'EmbeddedResource')) {
+        $inputs += @($Evaluation.Items[$itemType] | ForEach-Object { $_.FullPath })
+    }
+    $builtAt = (Get-Item -LiteralPath $assembly).LastWriteTimeUtc
+    foreach ($inputPath in ($inputs | Sort-Object -Unique)) {
+        if (!$inputPath -or !(Test-Path -LiteralPath $inputPath -PathType Leaf)) {
+            throw "A current build input is missing: $inputPath. Build the current package first."
+        }
+        if ((Get-Item -LiteralPath $inputPath).LastWriteTimeUtc -gt $builtAt) {
+            throw "Current assembly is stale for $($properties.TargetFramework): $inputPath is newer than $assembly. Build the current package first."
+        }
+    }
+    Assert-SdkChangeCompilationSources -Assembly $assembly -Evaluation $Evaluation
+    return $assembly
+}
+
+function Get-SdkChangeLatestGaVersion {
+    param([string]$PackageId)
+
+    if ($PackageId -notmatch '^[A-Za-z0-9_.-]+$') { throw "Invalid NuGet package ID: $PackageId" }
+    $uri = "https://api.nuget.org/v3-flatcontainer/$($PackageId.ToLowerInvariant())/index.json"
+    try {
+        $response = Invoke-RestMethod -Uri $uri -Method Get -TimeoutSec 60 -MaximumRetryCount 3 -RetryIntervalSec 2 -ErrorAction Stop
+    }
+    catch [Microsoft.PowerShell.Commands.HttpResponseException] {
+        if ($null -ne $_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 404) { return $null }
+        throw
+    }
+    if ($null -eq $response -or $null -eq $response.PSObject.Properties['versions'] -or
+        $response.versions -isnot [System.Collections.IList]) {
+        throw "NuGet returned a malformed version index for $PackageId."
+    }
+    $latest = $null
+    foreach ($text in $response.versions) {
+        if ($text -isnot [string]) {
+            throw "NuGet returned an invalid version for ${PackageId}: $text"
+        }
+        $version = [NuGet.Versioning.NuGetVersion]::new($text)
+        if (!$version.IsPrerelease -and
+            ($null -eq $latest -or [NuGet.Versioning.VersionComparer]::VersionRelease.Compare($version, $latest) -gt 0)) {
+            $latest = $version
+        }
+    }
+    if ($null -ne $latest) { return $latest.ToNormalizedString() }
+    return $null
+}
+
+function Write-SdkChangeInputs {
+    param(
+        [string]$Path,
+        [hashtable]$Properties,
+        [hashtable]$Items = @{},
+        [string[]]$RemoveItems = @()
+    )
+
+    $document = [System.Xml.XmlDocument]::new()
+    $root = $document.CreateElement('Project')
+    [void]$document.AppendChild($root)
+    $group = $document.CreateElement('PropertyGroup')
+    [void]$root.AppendChild($group)
+    foreach ($name in $Properties.Keys) {
+        $element = $document.CreateElement($name)
+        $element.InnerText = if ($name -eq 'NoWarn') {
+            ($Properties[$name] -split ';' | ForEach-Object { [Microsoft.Build.Evaluation.ProjectCollection]::Escape($_.Trim()) }) -join ';'
+        }
+        else {
+            [Microsoft.Build.Evaluation.ProjectCollection]::Escape([string]$Properties[$name])
+        }
+        [void]$group.AppendChild($element)
+    }
+    $group = $document.CreateElement('ItemGroup')
+    [void]$root.AppendChild($group)
+    foreach ($name in $RemoveItems) {
+        $element = $document.CreateElement($name)
+        $element.SetAttribute('Remove', "@($name)")
+        [void]$group.AppendChild($element)
+    }
+    foreach ($name in $Items.Keys) {
+        foreach ($item in $Items[$name]) {
+            $element = $document.CreateElement($name)
+            $identity = if ($item -is [string]) { $item } else { $item.Identity }
+            $element.SetAttribute('Include', [Microsoft.Build.Evaluation.ProjectCollection]::Escape($identity))
+            if ($item -isnot [string]) {
+                foreach ($key in $item.Keys | Where-Object { $_ -ne 'Identity' }) {
+                    $metadata = $document.CreateElement($key)
+                    $metadata.InnerText = [Microsoft.Build.Evaluation.ProjectCollection]::Escape([string]$item[$key])
+                    [void]$element.AppendChild($metadata)
+                }
+            }
+            [void]$group.AppendChild($element)
+        }
+    }
+    $document.Save($Path)
+}
+
+function Invoke-SdkChangeReferenceResolution {
+    param(
+        [string]$SdkRepoPath,
+        [string]$WorkDirectory,
+        [string]$TargetFramework,
+        [hashtable]$Properties,
+        [hashtable]$Items,
+        [switch]$Restore
+    )
+
+    [void][System.IO.Directory]::CreateDirectory($WorkDirectory)
+    $inputPath = Join-Path $WorkDirectory 'inputs.xml'
+    $jsonPath = Join-Path $WorkDirectory 'references.json'
+    $logPath = Join-Path $WorkDirectory 'references.binlog'
+    $removeItems = if ($Restore) { @() } else { @('Reference', 'FrameworkReference') }
+    Write-SdkChangeInputs -Path $inputPath -Properties $Properties -Items $Items -RemoveItems $removeItems
+    $arguments = @(
+        (Join-Path $PSScriptRoot 'SdkChangeReferences.proj'), '-nologo', '-tl:off', '-nodeReuse:false',
+        "-property:SdkChangesWorkDirectory=$WorkDirectory", "-property:SdkChangesInputFile=$inputPath",
+        "-property:TargetFramework=$TargetFramework"
+    )
+    if ($Restore) {
+        $nugetConfig = Join-Path $SdkRepoPath 'NuGet.Config'
+        if (!(Test-Path -LiteralPath $nugetConfig -PathType Leaf)) {
+            throw "The SDK repository NuGet configuration is missing: $nugetConfig"
+        }
+        $restoreResult = Invoke-SdkChangeProcess -WorkingDirectory $SdkRepoPath -Arguments (@('msbuild') + $arguments + @(
+            '-target:Restore', '-verbosity:minimal', "-property:RestoreConfigFile=$nugetConfig"
+        ))
+        if ($restoreResult.ExitCode -ne 0) {
+            throw "Could not restore the exact NuGet GA baseline (exit $($restoreResult.ExitCode)).`n$($restoreResult.StdOut)`n$($restoreResult.StdErr)"
+        }
+    }
+    $process = Invoke-SdkChangeProcess -WorkingDirectory $SdkRepoPath -Arguments (@('msbuild') + $arguments + @(
+        '-target:ResolveSdkChangeReferences', '-verbosity:minimal',
+        '-getProperty:ProjectAssetsFile,NuGetPackageRoot,TargetFrameworkDirectory', '-getItem:ReferencePathWithRefAssemblies',
+        "-getResultOutputFile:$jsonPath", "-binaryLogger:$logPath;ProjectImports=None"
+    ))
+    if ($process.ExitCode -ne 0) {
+        throw "Reference resolution failed (exit $($process.ExitCode)).`n$($process.StdOut)`n$($process.StdErr)"
+    }
+    $log = Read-SdkChangeBuildLog $logPath
+    if (!$log.Finished -or !$log.Succeeded -or $log.Diagnostics.Count -ne 0) {
+        throw "Reference resolution was incomplete or produced diagnostics: $($log.Diagnostics | ConvertTo-Json -Compress)"
+    }
+    $result = Read-SdkChangeJson $jsonPath
+    $references = @($result.Items.ReferencePathWithRefAssemblies | ForEach-Object { $_.FullPath } | Sort-Object -Unique)
+    if ($references.Count -eq 0) { throw 'No reference assemblies were resolved.' }
+    # Classic framework references can depend on framework assemblies not directly used by the SDK.
+    $referenceNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($reference in $references) { [void]$referenceNames.Add([System.IO.Path]::GetFileName($reference)) }
+    foreach ($directory in @($result.Properties.TargetFrameworkDirectory -split ';' | Where-Object { $_ } | Sort-Object -Unique)) {
+        if (!(Test-Path -LiteralPath $directory -PathType Container)) {
+            throw "A resolved framework reference directory is missing: $directory"
+        }
+        foreach ($file in Get-ChildItem -LiteralPath $directory -Filter '*.dll' -File) {
+            if (!$referenceNames.Contains($file.Name) -and
+                $null -ne (Get-SdkChangeAssemblyInfo -Path $file.FullName -IgnoreNonAssembly)) {
+                [void]$referenceNames.Add($file.Name)
+                $references += $file.FullName
+            }
+        }
+    }
+    return @{ References = $references; AssetsFile = $result.Properties.ProjectAssetsFile }
+}
+
+function Get-SdkChangeCurrentReferences {
+    param([hashtable]$Evaluation, [string]$SdkRepoPath, [string]$WorkDirectory)
+
+    [void][System.IO.Directory]::CreateDirectory($WorkDirectory)
+    $properties = $Evaluation.Properties
+    $assets = Read-SdkChangeJson $properties.ProjectAssetsFile
+    if (!$assets.Contains('targets') -or !$assets.Contains('libraries') -or !$assets.Contains('project') -or
+        [System.IO.Path]::GetFullPath($assets.project.restore.projectPath) -ne $properties.MSBuildProjectFullPath) {
+        throw "The existing NuGet assets do not belong to the evaluated project: $($properties.ProjectAssetsFile)"
+    }
+    $framework = [NuGet.Frameworks.NuGetFramework]::Parse($properties.TargetFramework)
+    $targetKeys = @($assets.targets.Keys | Where-Object {
+        !($_.Contains('/')) -and [NuGet.Frameworks.NuGetFramework]::Parse($_).Equals($framework)
+    })
+    if ($targetKeys.Count -ne 1) { throw "Existing NuGet assets do not contain $($properties.TargetFramework)." }
+    $references = [System.Collections.Generic.List[object]]::new()
+    foreach ($reference in $Evaluation.Items.Reference) {
+        $item = @{ Identity = $reference.Identity }
+        foreach ($name in @('HintPath', 'Aliases', 'EmbedInteropTypes', 'SpecificVersion', 'Private', 'ReferenceAssembly')) {
+            if ($reference.Contains($name) -and $reference[$name]) {
+                $value = $reference[$name]
+                if ($name -in @('HintPath', 'ReferenceAssembly')) {
+                    $value = [System.IO.Path]::GetFullPath($value, (Split-Path $properties.MSBuildProjectFullPath -Parent))
+                }
+                $item[$name] = $value
+            }
+        }
+        if ([System.IO.Path]::GetExtension($item.Identity) -eq '.dll') {
+            $item.Identity = [System.IO.Path]::GetFullPath($item.Identity, (Split-Path $properties.MSBuildProjectFullPath -Parent))
+        }
+        $references.Add($item)
+    }
+    $target = $assets.targets[$targetKeys[0]]
+    foreach ($key in $target.Keys) {
+        $library = $target[$key]
+        if ($library.type -ne 'project' -or !$library.Contains('compile')) { continue }
+        $project = [System.IO.Path]::GetFullPath($assets.libraries[$key].msbuildProject, (Split-Path $properties.MSBuildProjectFullPath -Parent))
+        $dependencyFramework = [NuGet.Frameworks.NuGetFramework]::Parse($library.framework).GetShortFolderName()
+        $dependency = Get-SdkChangeEvaluation -Project $project -SdkRepoPath $SdkRepoPath -WorkDirectory $WorkDirectory `
+            -TargetFramework $dependencyFramework -Configuration $properties.Configuration
+        $assembly = Assert-SdkChangeCurrentAssembly $dependency
+        # Use the existing compiler output, not a possibly stale copied project-reference assembly.
+        $references.Add(@{ Identity = $assembly; ReferenceAssembly = $assembly })
+    }
+    $frameworkReferences = @($Evaluation.Items.FrameworkReference | ForEach-Object {
+        $item = @{ Identity = $_.Identity }
+        foreach ($name in @('TargetingPackVersion', 'RuntimeFrameworkVersion', 'IsImplicitlyDefined', 'PrivateAssets')) {
+            if ($_.Contains($name) -and $_[$name]) { $item[$name] = $_[$name] }
+        }
+        $item
+    })
+    return (Invoke-SdkChangeReferenceResolution -SdkRepoPath $SdkRepoPath -WorkDirectory $WorkDirectory `
+        -TargetFramework $properties.TargetFramework -Properties @{
+            ProjectAssetsFile = $properties.ProjectAssetsFile
+            NuGetPackageRoot = $properties.NuGetPackageRoot
+            RuntimeIdentifier = $properties.RuntimeIdentifier
+            CompileUsingReferenceAssemblies = $properties.CompileUsingReferenceAssemblies
+            TargetFrameworkRootPath = $properties.TargetFrameworkRootPath
+            TargetFrameworkFallbackSearchPaths = $properties.TargetFrameworkFallbackSearchPaths
+            FrameworkPathOverride = $properties.FrameworkPathOverride
+            BypassFrameworkInstallChecks = $properties.BypassFrameworkInstallChecks
+        } -Items @{ Reference = @($references); FrameworkReference = $frameworkReferences }).References
+}
+
+function Get-SdkChangeBaseline {
+    param(
+        [string]$PackageId, [string]$Version, [string]$TargetFramework, [string]$TargetFileName,
+        [string]$SdkRepoPath, [string]$WorkDirectory
+    )
+
+    $resolved = Invoke-SdkChangeReferenceResolution -SdkRepoPath $SdkRepoPath -WorkDirectory $WorkDirectory `
+        -TargetFramework $TargetFramework -Properties @{ RestorePackagesPath = Join-Path $WorkDirectory 'packages' } -Items @{
+            PackageReference = @(@{ Identity = $PackageId; Version = "[$Version]" })
+        } -Restore
+    $assets = Read-SdkChangeJson $resolved.AssetsFile
+    $key = "$PackageId/$Version"
+    if (!$assets.libraries.Contains($key)) { throw "NuGet did not resolve the requested GA package $key." }
+    $packageDirectory = $null
+    foreach ($folder in $assets.packageFolders.Keys) {
+        $candidate = Join-Path $folder $assets.libraries[$key].path
+        if (Test-Path -LiteralPath $candidate -PathType Container) { $packageDirectory = $candidate; break }
+    }
+    if (!$packageDirectory) { throw "The restored GA package directory is missing: $key." }
+    $assembly = Join-Path $packageDirectory 'lib' $TargetFramework $TargetFileName
+    if (!(Test-Path -LiteralPath $assembly -PathType Leaf)) {
+        throw "The latest GA $key does not contain the evaluated baseline assembly lib/$TargetFramework/$TargetFileName. No older version or different framework was substituted."
+    }
+    return @{
+        Assembly = $assembly
+        References = @($resolved.References | Where-Object { [System.IO.Path]::GetFileName($_) -ne $TargetFileName })
+    }
+}
+
+function Assert-SdkChangeReferences {
+    param([string]$Assembly, [string[]]$References)
+
+    $paths = @($Assembly) + $References
+    $assemblies = @{}
+    foreach ($path in $paths | Sort-Object -Unique) {
+        if ($path.Contains(',') -or !(Test-Path -LiteralPath $path -PathType Leaf)) {
+            throw "A required assembly reference is missing or cannot be represented by ApiCompat: $path"
+        }
+        $info = Get-SdkChangeAssemblyInfo $path
+        $assemblies[$info.Name] = $info
+    }
+    # ApiCompat resolves API-reachable transitive references. A recursive PE closure would also
+    # require private framework implementation dependencies absent from reference-assembly packs.
+    $info = Get-SdkChangeAssemblyInfo $Assembly
+    foreach ($reference in $info.References) {
+        if (!$assemblies.Contains($reference)) {
+            throw "Missing assembly reference '$reference', required by '$($info.Name)'. API compatibility cannot be determined."
+        }
+    }
+}
+
+function Get-SdkChangeRules {
+    param([hashtable]$Evaluation, [string]$SdkRepoPath)
+
+    $properties = $Evaluation.Properties
+    $rules = @{}
+    $defaults = @{
+        ApiCompatRespectInternals = $false
+        ApiCompatStrictMode = $false
+        ApiCompatEnableRuleAttributesMustMatch = $true
+        ApiCompatEnableRuleCannotChangeParameterName = $true
+        ApiCompatPermitUnnecessarySuppressions = $true
+    }
+    foreach ($name in $defaults.Keys) {
+        $rules[$name] = if ($properties[$name]) { [bool]::Parse($properties[$name]) } else { $defaults[$name] }
+    }
+    $rules.NoWarn = $properties.NoWarn
+    $rules.RoslynAssembliesPath = $properties.RoslynAssembliesPath
+    $excludes = @($Evaluation.Items.ApiCompatExcludeAttributesFile | ForEach-Object { $_.FullPath })
+    if ($excludes.Count -eq 0) { $excludes = @(Join-Path $SdkRepoPath 'eng' 'ApiListing.exclude-attributes.txt') }
+    $suppressions = @($Evaluation.Items.ApiCompatSuppressionFile | ForEach-Object { $_.FullPath })
+    $central = Join-Path $SdkRepoPath 'eng' 'apicompatbaselines' "$($properties.MSBuildProjectName).xml"
+    if ((Test-Path -LiteralPath $central -PathType Leaf) -and $central -notin $suppressions) { $suppressions += $central }
+    foreach ($path in $excludes + $suppressions) {
+        if (!(Test-Path -LiteralPath $path -PathType Leaf)) { throw "ApiCompat configuration file is missing: $path" }
+    }
+    foreach ($name in @('ApiCompatBaseline.txt', "ApiCompatBaseline.$($properties.TargetFramework).txt", 'CompatibilitySuppressions.xml')) {
+        $path = Join-Path (Split-Path $properties.MSBuildProjectFullPath -Parent) $name
+        if (Test-Path -LiteralPath $path -PathType Leaf) { throw "Local ApiCompat suppressions are not supported; use $central instead of $path." }
+    }
+    return @{ Properties = $rules; Excludes = $excludes; Suppressions = $suppressions }
+}
+
+function Invoke-SdkChangeApiCompat {
+    param(
+        [string]$LeftAssembly, [string]$RightAssembly,
+        [string[]]$LeftReferences, [string[]]$RightReferences,
+        [hashtable]$Evaluation, [hashtable]$Rules,
+        [string]$SdkRepoPath, [string]$WorkDirectory
+    )
+
+    [void][System.IO.Directory]::CreateDirectory($WorkDirectory)
+    $inputPath = Join-Path $WorkDirectory 'inputs.xml'
+    $logPath = Join-Path $WorkDirectory 'apicompat.binlog'
+    $properties = @{} + $Rules.Properties
+    $properties.SdkChangesLeftAssembly = $LeftAssembly
+    $properties.SdkChangesRightAssembly = $RightAssembly
+    $properties.SdkChangesAssemblyIdentity = "lib/$($Evaluation.Properties.ApiCompatBaselineTargetFramework)/$($Evaluation.Properties.TargetFileName)"
+    Write-SdkChangeInputs -Path $inputPath -Properties $properties -Items @{
+        SdkChangesLeftReference = $LeftReferences
+        SdkChangesRightReference = $RightReferences
+        SdkChangesSuppressionFile = $Rules.Suppressions
+        SdkChangesExcludeAttributesFile = $Rules.Excludes
+    }
+    $process = Invoke-SdkChangeProcess -WorkingDirectory $SdkRepoPath -Arguments @(
+        'msbuild', (Join-Path $PSScriptRoot 'ApiCompat.proj'),
+        '-target:CompareSdkAssemblies', '-nologo', '-tl:off', '-nodeReuse:false', '-verbosity:minimal',
+        "-property:TargetFramework=$($Evaluation.Properties.TargetFramework)",
+        "-property:SdkChangesInputFile=$inputPath", "-property:SdkChangesWorkDirectory=$WorkDirectory",
+        "-binaryLogger:$logPath;ProjectImports=None"
+    )
+    $log = Read-SdkChangeBuildLog $logPath
+    $log.ExitCode = $process.ExitCode
+    $log.ProcessOutput = "$($process.StdOut)`n$($process.StdErr)"
+    $log.CompatibilityHeader = "API compatibility errors between '$($properties.SdkChangesAssemblyIdentity)' (left) and '$($properties.SdkChangesAssemblyIdentity)' (right):"
+    return $log
+}
+
+function ConvertFrom-SdkChangeApiCompat {
+    param([hashtable]$Log, [string]$TargetFramework, [switch]$Reverse)
+
+    if (!$Log.Finished -or !$Log.Completed -or $Log.ExitCode -notin @(0, 1)) {
+        throw "ApiCompat did not complete (exit $($Log.ExitCode)).`n$($Log.ProcessOutput)"
+    }
+    $changes = [System.Collections.Generic.List[object]]::new()
+    $diagnostics = [System.Collections.Generic.List[string]]::new()
+    $limitations = [System.Collections.Generic.List[string]]::new()
+    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    $compatibilityCount = 0
+    $direction = if ($Reverse) { 'reverse' } else { 'forward' }
+    foreach ($diagnostic in $Log.Diagnostics) {
+        $code = $diagnostic.Code
+        $message = $diagnostic.Message
+        $isNativeSummary = ($Log.Contains('CompatibilityHeader') -and $message -ceq $Log.CompatibilityHeader) -or
+            $message -ceq "API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'"
+        if (!$code -and $isNativeSummary) {
+            if ($seen.Add($message)) { $diagnostics.Add("[$direction][$TargetFramework] $message") }
+            continue
+        }
+        # CP0004 means an assembly could not be matched, not an API removal. Unknown codes fail closed.
+        if ($code -notmatch '^CP(000[12356789]|001[0-9]|002[01])$') {
+            throw "Unrecognized or fatal ApiCompat diagnostic ${code}: $message"
+        }
+        $eventKey = if ($diagnostic.Contains('EventKey')) { $diagnostic.EventKey } else { '' }
+        if (!$seen.Add("$eventKey`n$code`n$message")) { continue }
+        $compatibilityCount++
+        $diagnostics.Add("[$direction][$TargetFramework] ${code}: $message")
+        if ($Reverse -and $code -notin @('CP0001', 'CP0002')) {
+            $limitations.Add("Reverse $code is a structural difference, not evidence of an added API or a new breaking change.")
+            continue
+        }
+        $symbol = ''
+        if ($code -eq 'CP0003') {
+            if ($message -match "^(?<symbol>.+) assembly version '[^']+' should be equal to or higher than .+ version '[^']+'\.$") {
+                $symbol = $Matches.symbol
+            }
+        }
+        elseif ($code -in @('CP0014', 'CP0015', 'CP0016')) {
+            if ($message -match "^Cannot (?:change arguments of|add|remove) attribute '[^']+' (?:on|to|from) '(?<symbol>[^']+)'\.$") {
+                $symbol = $Matches.symbol
+            }
+        }
+        elseif ($code -eq 'CP0011') {
+            if ($message -match "^Value of field '(?<member>[^']+)' in enum '(?<enum>[^']+)' changed from '[^']*' to '[^']*'\.$") {
+                $symbol = "$($Matches.enum).$($Matches.member)"
+                $limitations.Add('ApiCompat CP0011 can provide unqualified enum/field names; identifying the namespace requires review.')
+            }
+        }
+        elseif ($message -match "'(?<symbol>[^']+)'") {
+            $symbol = $Matches.symbol
+        }
+        if (!$symbol) {
+            $limitations.Add("The symbol for $code could not be extracted; consult the original diagnostic description.")
+        }
+        $kind = if ($Reverse) { 'added' } elseif ($code -in @('CP0001', 'CP0002')) { 'removed' } else { 'changed' }
+        $changes.Add([ordered]@{
+            kind = $kind
+            symbol = $symbol
+            description = $message
+            isBreaking = !$Reverse
+            diagnosticId = $code
+            targetFramework = $TargetFramework
+        })
+    }
+    if (($Log.ExitCode -eq 1 -or !$Log.Succeeded) -and $compatibilityCount -eq 0) {
+        throw "ApiCompat failed without a recognized compatibility diagnostic.`n$($Log.ProcessOutput)"
+    }
+    return @{ Changes = @($changes); Diagnostics = @($diagnostics); Limitations = @($limitations) }
+}
+
+function New-SdkChangeReport {
+    param([AllowNull()][string]$BaselineVersion, [object[]]$Changes, [string[]]$Diagnostics, [string[]]$Limitations)
+
+    $breaking = @($Changes | Where-Object { $_.isBreaking })
+    $added = @($Changes | Where-Object { $_.kind -eq 'added' })
+    if (!$BaselineVersion) {
+        $text = '### Breaking Changes' + "`n" + 'Not applicable: no GA NuGet baseline exists; no comparison was performed.' +
+            "`n`n" + '### Features Added' + "`n" + 'Not determined without a GA baseline.'
+    }
+    else {
+        $sections = @()
+        foreach ($section in @(
+            @{ Heading = '### Breaking Changes'; Items = $breaking },
+            @{ Heading = '### Features Added'; Items = $added }
+        )) {
+            $lines = @($section.Items | ForEach-Object {
+                "- [$($_.diagnosticId)] $($_.description) (target framework: $($_.targetFramework))"
+            })
+            if ($lines.Count -eq 0) { $lines = @('None.') }
+            $sections += $section.Heading + "`n" + ($lines -join "`n")
+        }
+        $text = $sections -join "`n`n"
+    }
+    if (@($Changes | Where-Object { $_.kind -eq 'removed' }).Count -gt 0 -and $added.Count -gt 0) {
+        $Limitations += 'Removals and additions are independent evidence. Correlating changed signatures or renames requires review; no similarity matching was performed.'
+    }
+    return [ordered]@{
+        changes = $text
+        hasBreakingChange = $breaking.Count -gt 0
+        details = [ordered]@{
+            baselineVersion = $(if ($BaselineVersion) { $BaselineVersion } else { $null })
+            apiChanges = @($Changes)
+            diagnostics = @($Diagnostics | Sort-Object -Unique)
+            limitations = @($Limitations | Sort-Object -Unique)
+        }
+    }
+}
+
+function Get-SdkChangeTargetFrameworks {
+    param([hashtable]$Properties)
+
+    $frameworks = if ($Properties.TargetFramework) { @($Properties.TargetFramework) } else { $Properties.TargetFrameworks -split ';' }
+    return @($frameworks | Where-Object { $_ } | Sort-Object -Unique)
+}
+
+function Invoke-SdkChangeExtraction {
+    param([string]$PackagePath, [string]$SdkRepoPath, [string]$OutputJsonFile)
+
+    if (![System.IO.Path]::IsPathFullyQualified($OutputJsonFile)) {
+        throw "OutputJsonFile must be absolute: $OutputJsonFile"
+    }
+    if (Test-Path -LiteralPath $OutputJsonFile) {
+        if (!(Test-Path -LiteralPath $OutputJsonFile -PathType Leaf)) { throw "OutputJsonFile is not a file: $OutputJsonFile" }
+        Remove-Item -LiteralPath $OutputJsonFile -Force
+    }
+    $work = Join-Path ([System.IO.Path]::GetTempPath()) "sdk-changes-$([guid]::NewGuid().ToString('N'))"
+    [void][System.IO.Directory]::CreateDirectory($work)
+    try {
+        $project = Get-SdkChangeProject -PackagePath $PackagePath -SdkRepoPath $SdkRepoPath
+        $outer = Get-SdkChangeEvaluation -Project $project -SdkRepoPath $SdkRepoPath -WorkDirectory $work
+        $frameworks = @(Get-SdkChangeTargetFrameworks $outer.Properties)
+        if ($frameworks.Count -eq 0) { throw "No target frameworks were evaluated for $project." }
+        $current = @{}
+        foreach ($framework in $frameworks) {
+            $evaluation = Get-SdkChangeEvaluation -Project $project -SdkRepoPath $SdkRepoPath -WorkDirectory $work `
+                -TargetFramework $framework -Configuration $outer.Properties.Configuration
+            if ($evaluation.Properties.PackageId -ne $outer.Properties.PackageId -or
+                !$evaluation.Properties.ApiCompatBaselineTargetFramework) {
+                throw "Package identity or ApiCompat baseline framework is not consistent for $framework."
+            }
+            $assembly = Assert-SdkChangeCurrentAssembly $evaluation
+            $current[$framework] = @{
+                Evaluation = $evaluation
+                Assembly = $assembly
+                Hash = (Get-FileHash -LiteralPath $assembly).Hash
+            }
+        }
+        $version = Get-SdkChangeLatestGaVersion $outer.Properties.PackageId
+        $changes = @()
+        $diagnostics = @("Current artifact scope: Configuration=$($outer.Properties.Configuration); TargetFrameworks=$($frameworks -join ', ').")
+        $limitations = @(
+            'Metadata/API compatibility does not determine runtime behavior or wire-contract compatibility.',
+            'Freshness uses portable/embedded PDB source checksums and evaluated build-input timestamps. Build-time-generated inputs and timestamp-preserving changes to non-source build inputs require a fresh build.',
+            'Approved ApiCompat suppressions and NoWarn are honored; suppressed differences are not listed.'
+        )
+        $omittedFrameworks = @($outer.Properties.TargetFrameworks -split ';' | Where-Object { $_ -and $_ -notin $frameworks } | Sort-Object -Unique)
+        if ($omittedFrameworks.Count -gt 0) {
+            $limitations += "TargetFramework limits this extraction to $($frameworks -join ', '); declared frameworks not evaluated: $($omittedFrameworks -join ', '). This is not a full multi-target package comparison."
+        }
+        if (!$version) {
+            $limitations += "No GA NuGet release exists for $($outer.Properties.PackageId). Compatibility and additions are not applicable; no comparison was performed."
+        }
+        else {
+            $baselines = @{}
+            foreach ($framework in $frameworks) {
+                $entry = $current[$framework]
+                $evaluation = $entry.Evaluation
+                $properties = $evaluation.Properties
+                $baselineFramework = $properties.ApiCompatBaselineTargetFramework
+                $key = "$baselineFramework|$($properties.TargetFileName)"
+                if (!$baselines.Contains($key)) {
+                    $baselines[$key] = Get-SdkChangeBaseline -PackageId $properties.PackageId -Version $version `
+                        -TargetFramework $baselineFramework -TargetFileName $properties.TargetFileName `
+                        -SdkRepoPath $SdkRepoPath -WorkDirectory (Join-Path $work "baseline-$baselineFramework")
+                    Assert-SdkChangeReferences -Assembly $baselines[$key].Assembly -References $baselines[$key].References
+                }
+                $baseline = $baselines[$key]
+                $referenceDirectory = Join-Path $work "current-$framework"
+                [void][System.IO.Directory]::CreateDirectory($referenceDirectory)
+                $references = @(Get-SdkChangeCurrentReferences -Evaluation $evaluation -SdkRepoPath $SdkRepoPath -WorkDirectory $referenceDirectory)
+                Assert-SdkChangeReferences -Assembly $entry.Assembly -References $references
+                $rules = Get-SdkChangeRules -Evaluation $evaluation -SdkRepoPath $SdkRepoPath
+                $forward = Invoke-SdkChangeApiCompat -LeftAssembly $baseline.Assembly -RightAssembly $entry.Assembly `
+                    -LeftReferences $baseline.References -RightReferences $references -Evaluation $evaluation -Rules $rules `
+                    -SdkRepoPath $SdkRepoPath -WorkDirectory (Join-Path $work "forward-$framework")
+                $reverse = Invoke-SdkChangeApiCompat -LeftAssembly $entry.Assembly -RightAssembly $baseline.Assembly `
+                    -LeftReferences $references -RightReferences $baseline.References -Evaluation $evaluation -Rules $rules `
+                    -SdkRepoPath $SdkRepoPath -WorkDirectory (Join-Path $work "reverse-$framework")
+                foreach ($result in @(
+                    (ConvertFrom-SdkChangeApiCompat -Log $forward -TargetFramework $framework),
+                    (ConvertFrom-SdkChangeApiCompat -Log $reverse -TargetFramework $framework -Reverse)
+                )) {
+                    $changes += $result.Changes
+                    $diagnostics += $result.Diagnostics
+                    $limitations += $result.Limitations
+                }
+            }
+        }
+        $finalOuter = Get-SdkChangeEvaluation -Project $project -SdkRepoPath $SdkRepoPath -WorkDirectory $work
+        if ($finalOuter.Properties.PackageId -ne $outer.Properties.PackageId -or
+            (@(Get-SdkChangeTargetFrameworks $finalOuter.Properties) -join ';') -ne ($frameworks -join ';')) {
+            throw 'The package identity or target frameworks changed during extraction. Run extraction again.'
+        }
+        foreach ($framework in $frameworks) {
+            $finalEvaluation = Get-SdkChangeEvaluation -Project $project -SdkRepoPath $SdkRepoPath -WorkDirectory $work `
+                -TargetFramework $framework -Configuration $outer.Properties.Configuration
+            $assembly = Assert-SdkChangeCurrentAssembly $finalEvaluation
+            if ($assembly -ne $current[$framework].Assembly -or (Get-FileHash -LiteralPath $assembly).Hash -ne $current[$framework].Hash) {
+                throw "The current assembly changed during extraction for $framework. Run extraction again."
+            }
+        }
+        $report = New-SdkChangeReport -BaselineVersion $version -Changes $changes -Diagnostics $diagnostics -Limitations $limitations
+        $json = $report | ConvertTo-Json -Depth 10
+    }
+    finally {
+        Remove-Item -LiteralPath $work -Recurse -Force
+    }
+    [void][System.IO.Directory]::CreateDirectory((Split-Path $OutputJsonFile -Parent))
+    $temporaryOutput = "$OutputJsonFile.$([guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [System.IO.File]::WriteAllText($temporaryOutput, $json, [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::Move($temporaryOutput, $OutputJsonFile, $true)
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporaryOutput -PathType Leaf) { Remove-Item -LiteralPath $temporaryOutput -Force }
+    }
+}

--- a/eng/scripts/compatibility/Get-SdkChanges.ps1
+++ b/eng/scripts/compatibility/Get-SdkChanges.ps1
@@ -1,0 +1,27 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+Compares existing SDK assemblies with the latest stable NuGet release, without building the SDK.
+.DESCRIPTION
+PackagePath can identify a package directory, its src directory, or its source project.
+All paths must be absolute. Build the current package with portable/embedded PDBs before invoking this script.
+The PowerShell host runtime must support the selected .NET SDK's MSBuild diagnostic reader.
+Compatibility violations are a successful extraction; tool, reference, and stale-artifact errors are not.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackagePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SdkRepoPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputJsonFile
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3
+. (Join-Path $PSScriptRoot 'Get-SdkChanges.Helpers.ps1')
+
+Invoke-SdkChangeExtraction -PackagePath $PackagePath -SdkRepoPath $SdkRepoPath -OutputJsonFile $OutputJsonFile

--- a/eng/scripts/compatibility/Invoke-SdkChangesCI.ps1
+++ b/eng/scripts/compatibility/Invoke-SdkChangesCI.ps1
@@ -1,0 +1,34 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+Collects native SDK API change reports for the packages selected by this CI job.
+.DESCRIPTION
+ReportOnly defers enforcement until existing build validations have finished.
+Every invocation creates a new report directory; failed output is never replayable as a successful report.
+The summary records the executing PowerShell/runtime, prior job status, selection, and per-package outcomes.
+Each package has result.json and either an unchanged sdk-changes.json or error.json and optional quarantined output.
+CI publishes this directory even when Assert-SdkChangesCI.ps1 rejects breaking changes or detector errors.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$SdkRepoPath,
+    [Parameter(Mandatory = $true)][string]$PackageInfoDirectory,
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$ProjectNames,
+    [Parameter(Mandatory = $true)][string]$ReportRoot,
+    [ValidateRange(1, 3600)][int]$TimeoutSeconds = 300,
+    [switch]$ReportOnly
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3
+. (Join-Path $PSScriptRoot 'SdkChangesCI.Helpers.ps1')
+
+$result = Invoke-SdkChangesCICollection -SdkRepoPath $SdkRepoPath -PackageInfoDirectory $PackageInfoDirectory `
+    -ProjectNames $ProjectNames -ReportRoot $ReportRoot -TimeoutSeconds $TimeoutSeconds -PreviousJobStatus $env:AGENT_JOBSTATUS
+LogInfo "SDK API reports: $($result.Directory)"
+LogInfo "SDK API result counts: $($result.Summary.counts | ConvertTo-Json -Compress)"
+if (!$ReportOnly) {
+    $verdict = Test-SdkChangesCIReports -ReportDirectory $result.Directory -ProjectNames $ProjectNames
+    foreach ($errorMessage in $verdict.Errors) { LogError $errorMessage }
+    if (!$verdict.Passed) { exit 1 }
+}

--- a/eng/scripts/compatibility/SdkChangeReferences.proj
+++ b/eng/scripts/compatibility/SdkChangeReferences.proj
@@ -1,0 +1,33 @@
+<Project DefaultTargets="ResolveSdkChangeReferences">
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <BaseIntermediateOutputPath>$(SdkChangesWorkDirectory)\obj\</BaseIntermediateOutputPath>
+    <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
+    <BaseOutputPath>$(SdkChangesWorkDirectory)\bin\</BaseOutputPath>
+    <BuildProjectReferences>false</BuildProjectReferences>
+    <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
+    <RunAnalyzers>false</RunAnalyzers>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="$(SdkChangesInputFile)" Condition="'$(SdkChangesInputFile)' != ''" />
+  <PropertyGroup>
+    <!-- Only consume compile-time assets. Do not generate package content or resolve analyzers. -->
+    <ResolvePackageDependenciesForBuildDependsOn>ResolveLockFileReferences</ResolvePackageDependenciesForBuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="RejectSdkCompilation" BeforeTargets="Build;Rebuild;Compile;CoreCompile;RunAnalyzers;RunCodeAnalysis">
+    <Error Text="SDK change extraction must not compile or run analyzers." />
+  </Target>
+
+  <Target Name="ResolveSdkChangeReferences" DependsOnTargets="FindReferenceAssembliesForReferences">
+    <Error Condition="'@(ProjectReference)' != ''" Text="SDK change extraction requires existing assembly references, not project builds." />
+    <Error Condition="'@(ReferencePathWithRefAssemblies)' == ''" Text="No reference assemblies were resolved." />
+    <Error Condition="!Exists('%(ReferencePathWithRefAssemblies.FullPath)')" Text="A required reference assembly is missing: %(ReferencePathWithRefAssemblies.FullPath)" />
+  </Target>
+</Project>

--- a/eng/scripts/compatibility/SdkChangesCI.Helpers.ps1
+++ b/eng/scripts/compatibility/SdkChangesCI.Helpers.ps1
@@ -1,0 +1,434 @@
+#Requires -Version 7.0
+
+. (Join-Path $PSScriptRoot '..' '..' 'common' 'scripts' 'logging.ps1')
+
+function Read-SdkChangesCIJson {
+    param([string]$Path)
+
+    $text = [System.IO.File]::ReadAllText($Path)
+    $document = $null
+    try {
+        $options = [System.Text.Json.JsonDocumentOptions]::new()
+        $options.MaxDepth = 100
+        $document = [System.Text.Json.JsonDocument]::Parse($text, $options)
+        if ($document.RootElement.ValueKind -ne 'Object') {
+            throw [System.IO.InvalidDataException]::new("Expected a JSON object in $Path.")
+        }
+    }
+    catch [System.Text.Json.JsonException] {
+        throw [System.IO.InvalidDataException]::new("Invalid JSON in ${Path}: $($_.Exception.Message)", $_.Exception)
+    }
+    finally {
+        if ($null -ne $document) { $document.Dispose() }
+    }
+    return ($text | ConvertFrom-Json -AsHashtable -Depth 100 -ErrorAction Stop)
+}
+
+function Write-SdkChangesCIJson {
+    param([string]$Path, [object]$Value)
+
+    $temporary = "$Path.$([guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [System.IO.File]::WriteAllText($temporary, ($Value | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::Move($temporary, $Path, $true)
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporary -PathType Leaf) { Remove-Item -LiteralPath $temporary -Force }
+    }
+}
+
+function Get-SdkChangesCIProjectNames {
+    param([AllowEmptyString()][string]$ProjectNames)
+
+    $names = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in ($ProjectNames -split ',')) {
+        $name = $name.Trim()
+        if (!$name) { continue }
+        if ($name -notmatch '^[A-Za-z0-9_][A-Za-z0-9_.-]*$' -or $name -match '^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\.|$)') {
+            throw [System.IO.InvalidDataException]::new("Invalid or unresolved ProjectNames entry: '$name'.")
+        }
+        [void]$names.Add($name)
+    }
+    return @($names | Sort-Object)
+}
+
+function Resolve-SdkChangesCIPath {
+    param([string]$Root, [string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { throw [System.IO.InvalidDataException]::new('A required path is empty.') }
+    $absolute = [System.IO.Path]::GetFullPath($Path, $Root)
+    $relative = [System.IO.Path]::GetRelativePath($Root, $absolute)
+    if ($relative -eq '..' -or $relative.StartsWith("..$([System.IO.Path]::DirectorySeparatorChar)") -or
+        [System.IO.Path]::IsPathFullyQualified($relative)) {
+        throw [System.IO.InvalidDataException]::new("Path '$Path' is outside '$Root'.")
+    }
+    return $absolute
+}
+
+function Get-SdkChangesCISelection {
+    param([string]$SdkRepoPath, [string]$PackageInfoDirectory, [string[]]$ProjectNames)
+
+    if (!(Test-Path -LiteralPath $PackageInfoDirectory -PathType Container)) {
+        throw [System.IO.DirectoryNotFoundException]::new("PackageInfo directory is missing: $PackageInfoDirectory")
+    }
+    $metadata = @()
+    $warnings = @()
+    foreach ($file in (Get-ChildItem -LiteralPath $PackageInfoDirectory -Filter '*.json' -File -Recurse)) {
+        try {
+            $info = Read-SdkChangesCIJson $file.FullName
+            $metadata += @{ File = $file.FullName; Info = $info; Error = $null; FileName = $file.BaseName }
+        }
+        catch [System.IO.InvalidDataException], [System.IO.IOException], [System.UnauthorizedAccessException] {
+            $metadata += @{ File = $file.FullName; Info = @{}; Error = $_.Exception.Message; FileName = $file.BaseName }
+            if ($file.BaseName -notin $ProjectNames) {
+                $warnings += "Unselected PackageInfo file could not be read: $($file.FullName): $($_.Exception.Message)"
+            }
+        }
+    }
+    $packages = @()
+    foreach ($name in $ProjectNames) {
+        $matches = @($metadata | Where-Object {
+            $_.Info['Name'] -eq $name -or $_.Info['ArtifactName'] -eq $name -or ($_.Error -and $_.FileName -eq $name)
+        })
+        $entry = [ordered]@{ projectName = $name; packageName = $null; packagePath = $null; packageInfoFile = $null; error = $null }
+        if ($matches.Count -ne 1) {
+            $entry.error = "Expected one PackageInfo record for '$name'; found $($matches.Count)."
+        }
+        else {
+            $match = $matches[0]
+            $entry.packageInfoFile = $match.File
+            if ($match.Error) {
+                $entry.error = $match.Error
+            }
+            elseif ($match.Info['Name'] -isnot [string] -or !$match.Info['Name'] -or
+                $match.Info['DirectoryPath'] -isnot [string] -or !$match.Info['DirectoryPath']) {
+                $entry.error = "PackageInfo for '$name' must contain Name and DirectoryPath strings."
+            }
+            else {
+                $entry.packageName = $match.Info.Name
+                try {
+                    $entry.packagePath = Resolve-SdkChangesCIPath -Root $SdkRepoPath -Path $match.Info.DirectoryPath
+                    if (!(Test-Path -LiteralPath $entry.packagePath -PathType Container)) {
+                        $entry.error = "Selected package directory is missing: $($entry.packagePath)"
+                    }
+                }
+                catch [System.IO.InvalidDataException], [System.ArgumentException], [System.NotSupportedException] {
+                    $entry.error = $_.Exception.Message
+                }
+            }
+        }
+        $packages += $entry
+    }
+    return @{ Packages = $packages; Warnings = $warnings }
+}
+
+function Get-SdkChangesCIRuntime {
+    param([string]$SdkRepoPath)
+
+    $process = [System.Diagnostics.Process]::GetCurrentProcess()
+    try { $executable = $process.MainModule.FileName } finally { $process.Dispose() }
+    $runtime = [ordered]@{
+        powerShellVersion = $PSVersionTable.PSVersion.ToString()
+        runtimeVersion = [System.Environment]::Version.ToString()
+        executable = $executable
+        sdkVersion = $null
+        requiredRuntimeMajor = $null
+        supported = $false
+        error = $null
+    }
+    try {
+        $globalJson = Read-SdkChangesCIJson (Join-Path $SdkRepoPath 'global.json')
+        if ($globalJson['sdk'] -isnot [System.Collections.IDictionary] -or
+            $globalJson.sdk['version'] -isnot [string] -or $globalJson.sdk.version -notmatch '^(\d+)\.\d+\.\d+') {
+            throw [System.IO.InvalidDataException]::new('global.json must identify the .NET SDK version required by the detector.')
+        }
+        $runtime.sdkVersion = $globalJson.sdk.version
+        $runtime.requiredRuntimeMajor = [int]$Matches[1]
+        $runtime.supported = $PSVersionTable.PSEdition -eq 'Core' -and [System.Environment]::Version.Major -ge $runtime.requiredRuntimeMajor
+        if (!$runtime.supported) {
+            $runtime.error = "SDK $($runtime.sdkVersion) requires a PowerShell host on .NET $($runtime.requiredRuntimeMajor)+ for native diagnostics; this host is PowerShell $($runtime.powerShellVersion) on .NET $($runtime.runtimeVersion). Installing the .NET SDK does not upgrade pwsh."
+        }
+    }
+    catch [System.IO.InvalidDataException], [System.IO.IOException], [System.UnauthorizedAccessException] {
+        $runtime.error = $_.Exception.Message
+    }
+    return $runtime
+}
+
+function Invoke-SdkChangesCIProcess {
+    param(
+        [string]$PowerShellPath, [string]$DetectorPath, [string]$SdkRepoPath,
+        [string]$PackagePath, [string]$OutputJsonFile,
+        [ValidateRange(1, 3600)][int]$TimeoutSeconds = 300
+    )
+
+    $start = [System.Diagnostics.ProcessStartInfo]::new($PowerShellPath)
+    $start.WorkingDirectory = $SdkRepoPath
+    $start.UseShellExecute = $false
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    foreach ($key in @($start.Environment.Keys)) {
+        if ($key -in @('Configuration', 'TargetFramework', 'TargetFrameworks')) { [void]$start.Environment.Remove($key) }
+    }
+    $start.Environment['Configuration'] = 'Release'
+    foreach ($argument in @(
+        '-NoLogo', '-NoProfile', '-NonInteractive', '-File', $DetectorPath,
+        '-PackagePath', $PackagePath, '-SdkRepoPath', $SdkRepoPath, '-OutputJsonFile', $OutputJsonFile
+    )) {
+        $start.ArgumentList.Add($argument)
+    }
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $start
+    try {
+        if (!$process.Start()) { throw [System.InvalidOperationException]::new('Could not start the native SDK detector.') }
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        $timedOut = !$process.WaitForExit($TimeoutSeconds * 1000)
+        if ($timedOut) {
+            $process.Kill($true)
+            $process.WaitForExit()
+        }
+        return @{
+            ExitCode = $process.ExitCode
+            TimedOut = $timedOut
+            StdOut = $stdout.GetAwaiter().GetResult()
+            StdErr = $stderr.GetAwaiter().GetResult()
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
+function Get-SdkChangesCIRawStatus {
+    param([System.Collections.IDictionary]$Report)
+
+    if ($Report['changes'] -isnot [string] -or $Report['hasBreakingChange'] -isnot [bool] -or
+        $Report['details'] -isnot [System.Collections.IDictionary]) {
+        throw [System.IO.InvalidDataException]::new('The detector did not return the common changes/hasBreakingChange/details contract.')
+    }
+    $details = $Report.details
+    if (!$details.Contains('baselineVersion') -or
+        ($null -ne $details.baselineVersion -and ($details.baselineVersion -isnot [string] -or [string]::IsNullOrWhiteSpace($details.baselineVersion)))) {
+        throw [System.IO.InvalidDataException]::new('The detector baselineVersion must be a nonempty string or null.')
+    }
+    foreach ($name in @('apiChanges', 'diagnostics', 'limitations')) {
+        if ($details[$name] -isnot [array]) { throw [System.IO.InvalidDataException]::new("The detector details.$name must be an array.") }
+    }
+    foreach ($value in @($details.diagnostics) + @($details.limitations)) {
+        if ($value -isnot [string]) { throw [System.IO.InvalidDataException]::new('Detector diagnostics and limitations must contain strings.') }
+    }
+    foreach ($change in $details.apiChanges) {
+        if ($change -isnot [System.Collections.IDictionary] -or $change['kind'] -isnot [string] -or
+            $change['symbol'] -isnot [string] -or $change['description'] -isnot [string] -or $change['isBreaking'] -isnot [bool]) {
+            throw [System.IO.InvalidDataException]::new('The detector returned an invalid structured API change.')
+        }
+    }
+    if ($null -eq $details.baselineVersion) {
+        if ($Report.hasBreakingChange -or $details.apiChanges.Count -ne 0 -or
+            @($details.limitations | Where-Object { ![string]::IsNullOrWhiteSpace($_) }).Count -eq 0) {
+            throw [System.IO.InvalidDataException]::new('A no-GA report must explain why comparison is not applicable and contain no API verdicts.')
+        }
+        return 'not_applicable'
+    }
+    $hasBreakingApi = @($details.apiChanges | Where-Object { $_.isBreaking }).Count -gt 0
+    if ($Report.hasBreakingChange -ne $hasBreakingApi) {
+        throw [System.IO.InvalidDataException]::new('The detector hasBreakingChange contradicts its structured API changes.')
+    }
+    if ($Report.hasBreakingChange) { return 'breaking_changes' }
+    return 'compatible'
+}
+
+function Get-SdkChangesCICounts {
+    param([object[]]$Packages)
+
+    return [ordered]@{
+        selected = @($Packages).Count
+        compatible = @($Packages | Where-Object { $_.status -eq 'compatible' }).Count
+        breakingChanges = @($Packages | Where-Object { $_.status -eq 'breaking_changes' }).Count
+        notApplicable = @($Packages | Where-Object { $_.status -eq 'not_applicable' }).Count
+        detectorErrors = @($Packages | Where-Object { $_.status -eq 'detector_error' }).Count
+    }
+}
+
+function Invoke-SdkChangesCICollection {
+    param(
+        [string]$SdkRepoPath, [string]$PackageInfoDirectory, [AllowEmptyString()][string]$ProjectNames,
+        [string]$ReportRoot, [string]$PreviousJobStatus,
+        [ValidateRange(1, 3600)][int]$TimeoutSeconds = 300
+    )
+
+    if (![System.IO.Path]::IsPathFullyQualified($ReportRoot)) {
+        throw [System.ArgumentException]::new('ReportRoot must be absolute.')
+    }
+    $directory = Join-Path $ReportRoot ([guid]::NewGuid().ToString('N'))
+    [void][System.IO.Directory]::CreateDirectory($directory)
+    Set-PipelineVariable -Name 'SdkChangesReportDirectory' -Value $directory
+    $summary = [ordered]@{
+        schemaVersion = 1
+        generatedAt = [datetime]::UtcNow.ToString('o')
+        configuration = 'Release'
+        previousJobStatus = $(if ($PreviousJobStatus) { $PreviousJobStatus } else { 'Unknown' })
+        projectNames = @()
+        runtime = $null
+        selectionWarnings = @()
+        errors = @()
+        packages = @()
+        counts = $null
+    }
+    try {
+        if (![System.IO.Path]::IsPathFullyQualified($SdkRepoPath) -or !(Test-Path -LiteralPath $SdkRepoPath -PathType Container)) {
+            throw [System.IO.DirectoryNotFoundException]::new("SdkRepoPath must identify an existing absolute repository path: $SdkRepoPath")
+        }
+        $summary.projectNames = @(Get-SdkChangesCIProjectNames $ProjectNames)
+        $selection = Get-SdkChangesCISelection -SdkRepoPath $SdkRepoPath -PackageInfoDirectory $PackageInfoDirectory -ProjectNames $summary.projectNames
+        $summary.selectionWarnings = @($selection.Warnings)
+        foreach ($warning in $summary.selectionWarnings) { LogWarning $warning }
+        $summary.runtime = Get-SdkChangesCIRuntime $SdkRepoPath
+        $detector = Join-Path $SdkRepoPath 'eng' 'scripts' 'compatibility' 'Get-SdkChanges.ps1'
+        $prerequisiteError = if (!$summary.runtime.supported) { $summary.runtime.error } elseif (!(Test-Path -LiteralPath $detector -PathType Leaf)) {
+            "Native SDK detector script is missing: $detector"
+        } else { $null }
+        if ($prerequisiteError) { $summary.errors += $prerequisiteError }
+        foreach ($entry in $selection.Packages) {
+            $packageDirectory = Join-Path $directory $entry.projectName
+            [void][System.IO.Directory]::CreateDirectory($packageDirectory)
+            $rawPath = Join-Path $packageDirectory 'sdk-changes.json'
+            $result = [ordered]@{
+                projectName = $entry.projectName
+                packageName = $entry.packageName
+                packagePath = $(if ($entry.packagePath) { [System.IO.Path]::GetRelativePath($SdkRepoPath, $entry.packagePath).Replace('\', '/') } else { $null })
+                status = 'detector_error'
+                hasBreakingChange = $null
+                baselineVersion = $null
+                detectorExitCode = $null
+                timedOut = $false
+                reportFile = $null
+                reportSha256 = $null
+                errorFile = $null
+                failedReportFile = $null
+                error = $entry.error
+            }
+            if (!$result.error -and $prerequisiteError) { $result.error = $prerequisiteError }
+            if (!$result.error) {
+                try {
+                    $process = Invoke-SdkChangesCIProcess -PowerShellPath $summary.runtime.executable -DetectorPath $detector `
+                        -SdkRepoPath $SdkRepoPath -PackagePath $entry.packagePath -OutputJsonFile $rawPath -TimeoutSeconds $TimeoutSeconds
+                    [System.IO.File]::WriteAllText((Join-Path $packageDirectory 'detector.stdout.log'), $process.StdOut)
+                    [System.IO.File]::WriteAllText((Join-Path $packageDirectory 'detector.stderr.log'), $process.StdErr)
+                    $result.detectorExitCode = $process.ExitCode
+                    $result.timedOut = $process.TimedOut
+                    if ($process.TimedOut) {
+                        $result.error = "SDK change extraction timed out after $TimeoutSeconds seconds."
+                    }
+                    elseif ($process.ExitCode -ne 0) {
+                        $result.error = "SDK change extraction failed with exit code $($process.ExitCode). See detector.stdout.log and detector.stderr.log."
+                        $nativeError = if (![string]::IsNullOrWhiteSpace($process.StdErr)) { $process.StdErr.Trim() } else { $process.StdOut.Trim() }
+                        if ($nativeError) { $result.error += "`n$nativeError" }
+                    }
+                    elseif (!(Test-Path -LiteralPath $rawPath -PathType Leaf)) {
+                        $result.error = 'The detector exited successfully but did not produce SDK change JSON.'
+                    }
+                    else {
+                        $raw = Read-SdkChangesCIJson $rawPath
+                        $result.status = Get-SdkChangesCIRawStatus $raw
+                        $result.hasBreakingChange = $raw.hasBreakingChange
+                        $result.baselineVersion = $raw.details.baselineVersion
+                        $result.reportFile = [System.IO.Path]::GetRelativePath($directory, $rawPath).Replace('\', '/')
+                        $result.reportSha256 = (Get-FileHash -LiteralPath $rawPath -Algorithm SHA256).Hash
+                    }
+                }
+                catch [System.IO.InvalidDataException], [System.IO.IOException], [System.UnauthorizedAccessException],
+                    [System.ArgumentException], [System.InvalidOperationException], [System.ComponentModel.Win32Exception],
+                    [System.Management.Automation.ItemNotFoundException] {
+                    $result.error = $_.Exception.Message
+                }
+            }
+            if ($result.error) {
+                $result.status = 'detector_error'
+                $result.hasBreakingChange = $null
+                $result.baselineVersion = $null
+                $result.reportFile = $null
+                $result.reportSha256 = $null
+                if (Test-Path -LiteralPath $rawPath -PathType Leaf) {
+                    $failedPath = Join-Path $packageDirectory 'failed-sdk-changes.json'
+                    [System.IO.File]::Move($rawPath, $failedPath)
+                    $result.failedReportFile = [System.IO.Path]::GetRelativePath($directory, $failedPath).Replace('\', '/')
+                }
+                $errorPath = Join-Path $packageDirectory 'error.json'
+                Write-SdkChangesCIJson -Path $errorPath -Value @{
+                    status = 'detector_error'
+                    projectName = $entry.projectName
+                    message = $result.error
+                    detectorExitCode = $result.detectorExitCode
+                    timedOut = $result.timedOut
+                }
+                $result.errorFile = [System.IO.Path]::GetRelativePath($directory, $errorPath).Replace('\', '/')
+            }
+            Write-SdkChangesCIJson -Path (Join-Path $packageDirectory 'result.json') -Value $result
+            $summary.packages += $result
+            LogInfo "SDK API report: $($entry.projectName): $($result.status)"
+            if ($result.status -eq 'detector_error') { LogWarning "$($entry.projectName): $($result.error)" }
+            if ($result.status -eq 'not_applicable') { LogWarning "$($entry.projectName): no GA baseline; compatibility was not evaluated." }
+        }
+    }
+    catch [System.IO.InvalidDataException], [System.IO.IOException], [System.UnauthorizedAccessException],
+        [System.ArgumentException], [System.InvalidOperationException] {
+        $summary.errors += $_.Exception.Message
+        LogWarning "SDK API report collection error: $($_.Exception.Message)"
+    }
+    $summary.counts = Get-SdkChangesCICounts $summary.packages
+    Write-SdkChangesCIJson -Path (Join-Path $directory 'summary.json') -Value $summary
+    return @{ Directory = $directory; Summary = $summary }
+}
+
+function Test-SdkChangesCIReports {
+    param([string]$ReportDirectory, [AllowEmptyString()][string]$ProjectNames)
+
+    $summary = Read-SdkChangesCIJson (Join-Path $ReportDirectory 'summary.json')
+    if ($summary['schemaVersion'] -ne 1 -or $summary['configuration'] -ne 'Release' -or
+        $summary['packages'] -isnot [array] -or $summary['projectNames'] -isnot [array] -or $summary['errors'] -isnot [array]) {
+        throw [System.IO.InvalidDataException]::new('Invalid SDK API CI report summary.')
+    }
+    $expectedNames = @(Get-SdkChangesCIProjectNames $ProjectNames)
+    if (($expectedNames -join ',') -ine (@($summary.projectNames | Sort-Object) -join ',')) {
+        throw [System.IO.InvalidDataException]::new('The SDK API report does not match this job''s ProjectNames selection.')
+    }
+    $errors = @($summary.errors)
+    $actualNames = @($summary.packages | ForEach-Object { $_.projectName } | Sort-Object)
+    if (($actualNames -join ',') -ine ($expectedNames -join ',')) {
+        $errors += 'SDK API reports are missing or duplicated for selected projects.'
+    }
+    foreach ($package in $summary.packages) {
+        if ($package.status -eq 'detector_error') {
+            $errors += "$($package.projectName): detector error: $($package.error)"
+            continue
+        }
+        if ($package.status -notin @('compatible', 'breaking_changes', 'not_applicable') -or
+            $package.detectorExitCode -ne 0 -or $package.timedOut) {
+            $errors += "$($package.projectName): invalid detector result status."
+            continue
+        }
+        try {
+            $path = Resolve-SdkChangesCIPath -Root $ReportDirectory -Path $package.reportFile
+            if (!(Test-Path -LiteralPath $path -PathType Leaf)) {
+                throw [System.IO.FileNotFoundException]::new("Collected native SDK report is missing: $path", $path)
+            }
+            if ((Get-FileHash -LiteralPath $path -Algorithm SHA256 -ErrorAction Stop).Hash -ne $package.reportSha256) {
+                throw [System.IO.InvalidDataException]::new('The raw SDK change report was modified after collection.')
+            }
+            $raw = Read-SdkChangesCIJson $path
+            $status = Get-SdkChangesCIRawStatus $raw
+            if ($status -ne $package.status -or $raw.hasBreakingChange -ne $package.hasBreakingChange -or
+                $raw.details.baselineVersion -ne $package.baselineVersion) {
+                throw [System.IO.InvalidDataException]::new('The CI summary contradicts the authoritative native SDK report.')
+            }
+            if ($status -eq 'breaking_changes') { $errors += "$($package.projectName): native ApiCompat detected breaking changes." }
+        }
+        catch [System.IO.InvalidDataException], [System.IO.IOException], [System.UnauthorizedAccessException],
+            [System.ArgumentException], [System.Management.Automation.ItemNotFoundException] {
+            $errors += "$($package.projectName): $($_.Exception.Message)"
+        }
+    }
+    return @{ Passed = $errors.Count -eq 0; Errors = $errors; Counts = (Get-SdkChangesCICounts $summary.packages); PreviousJobStatus = $summary.previousJobStatus }
+}

--- a/eng/scripts/compatibility/ci-tests/SdkChangesCI.Pipeline.Tests.ps1
+++ b/eng/scripts/compatibility/ci-tests/SdkChangesCI.Pipeline.Tests.ps1
@@ -1,0 +1,139 @@
+#Requires -Version 7.0
+
+BeforeAll {
+    Set-StrictMode -Version 3
+    Import-Module powershell-yaml -MinimumVersion 0.4.7 -ErrorAction Stop
+    $repo = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..')).Path
+    $templatePath = Join-Path $repo 'eng' 'pipelines' 'templates' 'steps' 'sdk-api-changes.yml'
+    $buildPath = Join-Path $repo 'eng' 'pipelines' 'templates' 'steps' 'build.yml'
+    $template = Get-Content -LiteralPath $templatePath -Raw | ConvertFrom-Yaml
+    $build = Get-Content -LiteralPath $buildPath -Raw | ConvertFrom-Yaml
+    $publisher = Get-Content -LiteralPath (Join-Path $repo 'eng' 'common' 'pipelines' 'templates' 'steps' 'publish-1es-artifact.yml') -Raw | ConvertFrom-Yaml
+
+    function Get-YamlObjects {
+        param($Node)
+        if ($Node -is [System.Collections.IDictionary]) {
+            $Node
+            foreach ($value in $Node.Values) { Get-YamlObjects $value }
+        }
+        elseif ($Node -is [System.Collections.IEnumerable] -and $Node -isnot [string]) {
+            foreach ($value in $Node) { Get-YamlObjects $value }
+        }
+    }
+    $nodes = @(Get-YamlObjects $template)
+    $collect = @($nodes | Where-Object { $_['displayName'] -eq 'Collect standalone SDK API change reports' })[0]
+    $enforce = @($nodes | Where-Object { $_['displayName'] -eq 'Enforce standalone SDK API compatibility' })[0]
+    $publish = @($nodes | Where-Object { $_['template'] -eq '/eng/common/pipelines/templates/steps/publish-1es-artifact.yml' })[0]
+}
+
+Describe 'Automatic SDK PR YAML integration' -Tag 'UnitTest' {
+    It 'limits the new workflow to actual SDK pull requests' {
+        @($template.steps[0].Keys) | Should -Contain '${{ if eq(variables[''Build.Reason''], ''PullRequest'') }}'
+        @($template.parameters | Where-Object { $_.name -eq 'Mode' })[0].values | Should -Be @('collect', 'enforce')
+    }
+
+    It 'collects after both existing Release pack branches and before later artifact-mutating checks' {
+        $collectIndex = -1
+        $enforceIndex = -1
+        $aotIndex = -1
+        $packIndexes = @()
+        for ($i = 0; $i -lt $build.steps.Count; $i++) {
+            $step = $build.steps[$i]
+            if ($step['template'] -eq '/eng/pipelines/templates/steps/sdk-api-changes.yml') {
+                if ($step.parameters.Mode -eq 'collect') { $collectIndex = $i } else { $enforceIndex = $i }
+            }
+            if ($step['template'] -eq '/eng/pipelines/templates/steps/aot-compatibility.yml') { $aotIndex = $i }
+            if (@(Get-YamlObjects $step | Where-Object { $_['pwsh'] -is [string] -and $_.pwsh -match 'dotnet pack eng/service.proj' }).Count -gt 0) {
+                $packIndexes += $i
+            }
+        }
+        $packIndexes.Count | Should -Be 2
+        foreach ($index in $packIndexes) { $collectIndex | Should -BeGreaterThan $index }
+        $collectIndex | Should -BeLessThan $aotIndex
+        $enforceIndex | Should -Be ($build.steps.Count - 1)
+    }
+
+    It 'preserves the existing build-coupled ApiCompat gates and Release configuration' {
+        $packSteps = @(Get-YamlObjects $build | Where-Object { $_['pwsh'] -is [string] -and $_.pwsh -match 'dotnet pack eng/service.proj' })
+        $packSteps.Count | Should -Be 2
+        foreach ($step in $packSteps) {
+            $step.pwsh | Should -Match '/p:ValidateRunApiCompat=true'
+            $step.pwsh | Should -Match '/p:Configuration=Release'
+            $step.pwsh | Should -Not -Match '/p:RunApiCompat=false'
+        }
+    }
+
+    It 'runs collection and final assertion even if a previous build or analyzer gate failed' {
+        $collect.condition | Should -Be 'succeededOrFailed()'
+        $enforce.condition | Should -Be 'succeededOrFailed()'
+        $collect.continueOnError | Should -BeTrue
+        $collect.inputs.arguments | Should -Match '-ReportOnly'
+        $enforce.Contains('continueOnError') | Should -BeFalse
+    }
+
+    It 'uses the existing package selection and actual Release configuration, not public BuildConfiguration=Debug' {
+        $collect.inputs.arguments | Should -Match ([regex]::Escape('-ProjectNames "$(ProjectNames)"'))
+        $collect.inputs.arguments | Should -Match ([regex]::Escape('$(Build.ArtifactStagingDirectory)/PackageInfo'))
+        $collect.env.Configuration | Should -Be 'Release'
+        $collect.env.TargetFramework | Should -BeNullOrEmpty
+        $collect.env.TargetFrameworks | Should -BeNullOrEmpty
+        $collect.inputs.arguments | Should -Not -Match 'BuildConfiguration'
+    }
+
+    It 'does not add report files to the existing package artifact directory' {
+        $collect.inputs.arguments | Should -Match ([regex]::Escape('-ReportRoot "$(Agent.TempDirectory)/sdk-api-changes"'))
+        $publish.parameters.ArtifactPath | Should -Be '$(SdkChangesReportDirectory)'
+        $publish.parameters.ArtifactName | Should -Be 'sdk-api-changes_$(System.JobName)'
+    }
+
+    It 'establishes the API verdict before publication so failed attempts use retry-safe artifact names' {
+        $enforceBlock = @($nodes | Where-Object { $_.Keys -contains '${{ if eq(parameters.Mode, ''enforce'') }}' })[0]
+        $steps = $enforceBlock['${{ if eq(parameters.Mode, ''enforce'') }}']
+        $steps[0].displayName | Should -Be 'Enforce standalone SDK API compatibility'
+        $steps[1].template | Should -Be '/eng/common/pipelines/templates/steps/publish-1es-artifact.yml'
+        $publisher.steps[0].pwsh | Should -Match 'FailedAttempt'
+        $publisher.steps[1].condition | Should -Match 'succeededOrFailed'
+        foreach ($name in $publish.parameters.Keys) { $publisher.parameters.Contains($name) | Should -BeTrue }
+    }
+
+    It 'references existing runner scripts without requiring an unpublished CLI or additional permissions' {
+        foreach ($step in @($collect, $enforce)) {
+            $step.task | Should -Be 'PowerShell@2'
+            $step.inputs.pwsh | Should -BeTrue
+            $relative = $step.inputs.filePath.Replace('$(Build.SourcesDirectory)/', '').Replace('/', '\')
+            Test-Path -LiteralPath (Join-Path $repo $relative) -PathType Leaf | Should -BeTrue
+        }
+        $text = Get-Content -LiteralPath $templatePath -Raw
+        $text | Should -Not -Match 'azsdk.exe|detect-breaking-change|azureSubscription|SYSTEM_ACCESSTOKEN|RunApiCompat=false'
+    }
+
+    It 'is reached by both batched PR builds and ordinary service build jobs' {
+        foreach ($file in @('batched-build.yml', 'ci.yml')) {
+            $job = Get-Content -LiteralPath (Join-Path $repo 'eng' 'pipelines' 'templates' 'jobs' $file) -Raw | ConvertFrom-Yaml
+            @(Get-YamlObjects $job | Where-Object { $_['template'] -eq '/eng/pipelines/templates/steps/build.yml' }).Count |
+                Should -BeGreaterThan 0
+        }
+    }
+
+    It 'runs both native and CI regression suites in the existing Compliance job with nonzero failures' {
+        $jobs = Get-Content -LiteralPath (Join-Path $repo 'eng' 'pipelines' 'templates' 'jobs' 'ci.yml') -Raw | ConvertFrom-Yaml
+        $compliance = @(Get-YamlObjects $jobs | Where-Object { $_['job'] -eq 'Compliance' })[0]
+        $testTemplate = @(Get-YamlObjects $compliance | Where-Object { $_['template'] -eq '/eng/common/pipelines/templates/steps/run-pester-tests.yml' })[0]
+        $testTemplate.parameters.TargetDirectory | Should -Be 'eng/scripts/compatibility'
+        $step = $testTemplate.parameters.CustomTestSteps[0]
+        $step.pwsh | Should -Match ([regex]::Escape('$config.Run.Path = @(''tests'', ''ci-tests'')'))
+        $step.pwsh | Should -Match ([regex]::Escape('$config.Run.Exit = $true'))
+        $step.pwsh | Should -Match ([regex]::Escape('$config.TestResult.Enabled = $true'))
+        $step.pwsh | Should -Match 'Invoke-Pester -Configuration'
+    }
+
+    It 'prepares the existing YAML module and net8 targeting packs for native regression fixtures' {
+        $jobs = Get-Content -LiteralPath (Join-Path $repo 'eng' 'pipelines' 'templates' 'jobs' 'ci.yml') -Raw | ConvertFrom-Yaml
+        $compliance = @(Get-YamlObjects $jobs | Where-Object { $_['job'] -eq 'Compliance' })[0]
+        @(Get-YamlObjects $compliance | Where-Object { $_['task'] -eq 'NuGetAuthenticate@1' }).Count | Should -Be 1
+        @(Get-YamlObjects $compliance | Where-Object { $_['task'] -eq 'UseDotNet@2' -and $_.inputs['version'] -eq '8.0.x' }).Count | Should -Be 1
+        @(Get-YamlObjects $compliance | Where-Object {
+            $_['pwsh'] -is [string] -and $_.pwsh -match 'Install-ModuleIfNotInstalled "powershell-yaml" "0.4.7"'
+        }).Count | Should -Be 1
+    }
+}

--- a/eng/scripts/compatibility/ci-tests/SdkChangesCI.Tests.ps1
+++ b/eng/scripts/compatibility/ci-tests/SdkChangesCI.Tests.ps1
@@ -1,0 +1,578 @@
+#Requires -Version 7.0
+
+BeforeAll {
+    Set-StrictMode -Version 3
+    . (Join-Path $PSScriptRoot '..' 'SdkChangesCI.Helpers.ps1')
+    $fixtureDetector = Join-Path $PSScriptRoot 'fixtures' 'Detector.ps1'
+
+    function New-CIRepository {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $info = Join-Path $root 'PackageInfo'
+        $detector = Join-Path $root 'eng' 'scripts' 'compatibility' 'Get-SdkChanges.ps1'
+        [void][System.IO.Directory]::CreateDirectory($info)
+        [void][System.IO.Directory]::CreateDirectory((Split-Path $detector -Parent))
+        Copy-Item -LiteralPath $fixtureDetector -Destination $detector
+        [System.IO.File]::WriteAllText((Join-Path $root 'global.json'), '{"sdk":{"version":"10.0.400"}}')
+        return @{ Root = $root; Info = $info; ReportRoot = Join-Path $root 'reports'; Detector = $detector }
+    }
+
+    function New-CIPackage {
+        param([hashtable]$Repository, [string]$Name, [string]$ArtifactName = $Name, [bool]$Indirect = $false)
+        $relativePath = Join-Path 'sdk' 'fixture' $Name
+        [void][System.IO.Directory]::CreateDirectory((Join-Path $Repository.Root $relativePath))
+        $info = @{ Name = $Name; ArtifactName = $ArtifactName; DirectoryPath = $relativePath; IncludedForValidation = $Indirect }
+        Write-SdkChangesCIJson -Path (Join-Path $Repository.Info "$Name.json") -Value $info
+        return $info
+    }
+
+    function New-CIRawReport {
+        param([switch]$Breaking, [switch]$NoGa)
+        return [ordered]@{
+            changes = "### Breaking Changes`nFixture`n### Features Added`nNone."
+            hasBreakingChange = [bool]$Breaking
+            details = [ordered]@{
+                baselineVersion = $(if ($NoGa) { $null } else { '1.0.0' })
+                apiChanges = @($(if ($Breaking) {
+                    @{ kind = 'removed'; symbol = 'Example.Removed()'; description = 'Native removal'; isBreaking = $true; diagnosticId = 'CP0002'; targetFramework = 'net8.0' }
+                }))
+                diagnostics = @('Native diagnostic')
+                limitations = @($(if ($NoGa) { 'No GA baseline exists; no comparison was performed.' }))
+            }
+        }
+    }
+
+    function Invoke-CICollection {
+        param([hashtable]$Repository, [AllowEmptyString()][string]$Names, [string]$Previous = 'Succeeded')
+        Invoke-SdkChangesCICollection -SdkRepoPath $Repository.Root -PackageInfoDirectory $Repository.Info `
+            -ProjectNames $Names -ReportRoot $Repository.ReportRoot -PreviousJobStatus $Previous
+    }
+}
+
+Describe 'SDK CI package selection' -Tag 'UnitTest' {
+    BeforeEach { $repo = New-CIRepository }
+
+    It 'normalizes the existing comma-separated ProjectNames without selecting every PackageInfo file' {
+        New-CIPackage $repo 'Azure.One' | Out-Null
+        New-CIPackage $repo 'Azure.Two' | Out-Null
+        $names = @(Get-SdkChangesCIProjectNames ' Azure.One,Azure.One,azure.one, ')
+        $names | Should -Be @('Azure.One')
+        $selection = Get-SdkChangesCISelection $repo.Root $repo.Info $names
+        $selection.Packages.Count | Should -Be 1
+        $selection.Packages[0].packageName | Should -Be 'Azure.One'
+        $selection.Packages[0].error | Should -BeNullOrEmpty
+    }
+
+    It 'matches ArtifactName when it differs from Name' {
+        New-CIPackage $repo 'internal-name' 'Azure.Special' | Out-Null
+        $selection = Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.Special')
+        $selection.Packages[0].packageName | Should -Be 'internal-name'
+        $selection.Packages[0].error | Should -BeNullOrEmpty
+    }
+
+    It 'keeps indirect validation packages when the build selected them' {
+        New-CIPackage $repo 'Azure.Indirect' -Indirect $true | Out-Null
+        (Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.Indirect')).Packages.Count | Should -Be 1
+    }
+
+    It 'reports missing selected metadata rather than silently skipping the package' {
+        $entry = (Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.Missing')).Packages[0]
+        $entry.error | Should -Match 'found 0'
+    }
+
+    It 'reports ambiguous metadata rather than picking the first match' {
+        New-CIPackage $repo 'Azure.One' | Out-Null
+        $nested = Join-Path $repo.Info 'nested'
+        [void][System.IO.Directory]::CreateDirectory($nested)
+        Copy-Item -LiteralPath (Join-Path $repo.Info 'Azure.One.json') -Destination $nested
+        (Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.One')).Packages[0].error | Should -Match 'found 2'
+    }
+
+    It 'reports malformed selected metadata and continues selecting other packages' {
+        New-CIPackage $repo 'Azure.One' | Out-Null
+        [System.IO.File]::WriteAllText((Join-Path $repo.Info 'Azure.Bad.json'), '{invalid')
+        $selection = Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.One', 'Azure.Bad')
+        @($selection.Packages | Where-Object { $_.error }).Count | Should -Be 1
+        @($selection.Packages | Where-Object { !$_.error }).Count | Should -Be 1
+    }
+
+    It 'records unreadable unselected metadata without attributing its failure to a selected package' {
+        New-CIPackage $repo 'Azure.One' | Out-Null
+        [System.IO.File]::WriteAllText((Join-Path $repo.Info 'Other.json'), 'not-json')
+        $selection = Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.One')
+        $selection.Packages[0].error | Should -BeNullOrEmpty
+        $selection.Warnings.Count | Should -Be 1
+    }
+
+    It 'rejects missing package paths' {
+        $info = New-CIPackage $repo 'Azure.One'
+        $info.DirectoryPath = 'sdk\missing\Azure.One'
+        Write-SdkChangesCIJson (Join-Path $repo.Info 'Azure.One.json') $info
+        (Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.One')).Packages[0].error | Should -Match 'directory is missing'
+    }
+
+    It 'rejects metadata paths that escape the SDK checkout' {
+        $info = New-CIPackage $repo 'Azure.One'
+        $info.DirectoryPath = '..\outside'
+        Write-SdkChangesCIJson (Join-Path $repo.Info 'Azure.One.json') $info
+        (Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.One')).Packages[0].error | Should -Match 'outside'
+    }
+
+    It 'rejects missing DirectoryPath data' {
+        New-CIPackage $repo 'Azure.One' | Out-Null
+        Write-SdkChangesCIJson (Join-Path $repo.Info 'Azure.One.json') @{ Name = 'Azure.One' }
+        (Get-SdkChangesCISelection $repo.Root $repo.Info @('Azure.One')).Packages[0].error | Should -Match 'Name and DirectoryPath'
+    }
+
+    It 'fails explicitly if PackageInfo is unavailable' {
+        { Get-SdkChangesCISelection $repo.Root (Join-Path $repo.Root 'missing-info') @('Azure.One') } | Should -Throw '*PackageInfo directory is missing*'
+    }
+
+    It 'rejects unresolved or unsafe selection <Name>' -TestCases @(
+        @{ Name = '$(ProjectNames)' }, @{ Name = '..\outside' }, @{ Name = 'a/b' },
+        @{ Name = 'a;Write-Host bad' }, @{ Name = 'CON' }, @{ Name = 'NUL.json' }
+    ) {
+        param($Name)
+        { Get-SdkChangesCIProjectNames $Name } | Should -Throw '*Invalid or unresolved*'
+    }
+
+    It 'represents an empty selected package list explicitly' {
+        @(Get-SdkChangesCIProjectNames '').Count | Should -Be 0
+        (Get-SdkChangesCISelection $repo.Root $repo.Info @()).Packages.Count | Should -Be 0
+    }
+}
+
+Describe 'SDK CI runtime prerequisites' -Tag 'UnitTest' {
+    BeforeEach { $repo = New-CIRepository }
+
+    It 'records the actual PowerShell executable and runtime, not just the installed SDK' {
+        $runtime = Get-SdkChangesCIRuntime $repo.Root
+        $runtime.powerShellVersion | Should -Be $PSVersionTable.PSVersion.ToString()
+        $runtime.runtimeVersion | Should -Be ([System.Environment]::Version.ToString())
+        Test-Path -LiteralPath $runtime.executable -PathType Leaf | Should -BeTrue
+        $runtime.sdkVersion | Should -Be '10.0.400'
+        $runtime.supported | Should -Be ([System.Environment]::Version.Major -ge 10)
+    }
+
+    It 'explains an SDK/runtime mismatch instead of assuming UseDotNet upgraded pwsh' {
+        $major = [System.Environment]::Version.Major + 1
+        Write-SdkChangesCIJson (Join-Path $repo.Root 'global.json') @{ sdk = @{ version = "$major.0.100" } }
+        $runtime = Get-SdkChangesCIRuntime $repo.Root
+        $runtime.supported | Should -BeFalse
+        $runtime.error | Should -Match 'Installing the .NET SDK does not upgrade pwsh'
+    }
+
+    It 'reports missing or invalid SDK metadata' -TestCases @(
+        @{ Content = '{}' }, @{ Content = '{invalid' }, @{ Content = '{"sdk":{"version":"invalid"}}' }
+    ) {
+        param($Content)
+        [System.IO.File]::WriteAllText((Join-Path $repo.Root 'global.json'), $Content)
+        $runtime = Get-SdkChangesCIRuntime $repo.Root
+        $runtime.supported | Should -BeFalse
+        $runtime.error | Should -Not -BeNullOrEmpty
+    }
+}
+
+Describe 'SDK CI native report semantics' -Tag 'UnitTest' {
+    It 'distinguishes compatible, breaking, and no-GA outcomes' {
+        Get-SdkChangesCIRawStatus (New-CIRawReport) | Should -Be 'compatible'
+        Get-SdkChangesCIRawStatus (New-CIRawReport -Breaking) | Should -Be 'breaking_changes'
+        Get-SdkChangesCIRawStatus (New-CIRawReport -NoGa) | Should -Be 'not_applicable'
+    }
+
+    It 'rejects malformed common contract field <Field>' -TestCases @(
+        @{ Field = 'hasBreakingChange'; Value = 'false' },
+        @{ Field = 'changes'; Value = 1 },
+        @{ Field = 'details'; Value = @() }
+    ) {
+        param($Field, $Value)
+        $raw = New-CIRawReport
+        $raw[$Field] = $Value
+        { Get-SdkChangesCIRawStatus $raw } | Should -Throw '*common changes/hasBreakingChange/details contract*'
+    }
+
+    It 'rejects non-array details.<Field>' -TestCases @(
+        @{ Field = 'apiChanges' }, @{ Field = 'diagnostics' }, @{ Field = 'limitations' }
+    ) {
+        param($Field)
+        $raw = New-CIRawReport
+        $raw.details[$Field] = $null
+        { Get-SdkChangesCIRawStatus $raw } | Should -Throw '*must be an array*'
+    }
+
+    It 'rejects invalid baseline metadata' {
+        $raw = New-CIRawReport
+        $raw.details.baselineVersion = ' '
+        { Get-SdkChangesCIRawStatus $raw } | Should -Throw '*baselineVersion*'
+    }
+
+    It 'rejects a no-GA success-shaped report with a breaking verdict' {
+        $raw = New-CIRawReport -NoGa -Breaking
+        { Get-SdkChangesCIRawStatus $raw } | Should -Throw '*no-GA report*'
+    }
+
+    It 'requires no-GA limitations to explain that comparison was not performed' {
+        $raw = New-CIRawReport -NoGa
+        $raw.details.limitations = @()
+        { Get-SdkChangesCIRawStatus $raw } | Should -Throw '*no-GA report*'
+        $raw.details.limitations = @(' ')
+        { Get-SdkChangesCIRawStatus $raw } | Should -Throw '*no-GA report*'
+    }
+
+    It 'rejects a false top-level verdict contradicted by native breaking API evidence' {
+        $raw = New-CIRawReport -Breaking
+        $raw.hasBreakingChange = $false
+        { Get-SdkChangesCIRawStatus $raw } | Should -Throw '*contradicts*'
+    }
+
+    It 'rejects invalid structured changes' {
+        $raw = New-CIRawReport -Breaking
+        $raw.details.apiChanges[0].isBreaking = 'true'
+        { Get-SdkChangesCIRawStatus $raw } | Should -Throw '*invalid structured API change*'
+    }
+}
+
+Describe 'SDK CI multi-package collection and enforcement' -Tag 'UnitTest' {
+    BeforeEach {
+        $repo = New-CIRepository
+        Mock Set-PipelineVariable {}
+        Mock LogInfo {}
+        Mock LogWarning {}
+        Mock Get-SdkChangesCIRuntime {
+            @{ supported = $true; executable = (Get-Process -Id $PID).Path; error = $null; powerShellVersion = '7.6.5'; runtimeVersion = '10.0.11'; sdkVersion = '10.0.400' }
+        }
+        Mock Invoke-SdkChangesCIProcess {
+            param($PackagePath, $OutputJsonFile)
+            $name = Split-Path $PackagePath -Leaf
+            if ($name -eq 'Stale') { return @{ ExitCode = 12; TimedOut = $false; StdOut = ''; StdErr = 'Current assembly is stale.' } }
+            if ($name -eq 'MissingAssembly') { return @{ ExitCode = 14; TimedOut = $false; StdOut = ''; StdErr = 'Current assembly is missing.' } }
+            if ($name -eq 'Missing') { return @{ ExitCode = 0; TimedOut = $false; StdOut = ''; StdErr = '' } }
+            if ($name -eq 'Timeout') { return @{ ExitCode = 137; TimedOut = $true; StdOut = ''; StdErr = 'Timeout' } }
+            if ($name -eq 'Malformed') {
+                [System.IO.File]::WriteAllText($OutputJsonFile, '{invalid')
+            }
+            else {
+                Write-SdkChangesCIJson $OutputJsonFile (New-CIRawReport -Breaking:($name -in @('Breaking', 'Partial')) -NoGa:($name -eq 'NoGa'))
+            }
+            return @{ ExitCode = $(if ($name -eq 'Partial') { 13 } else { 0 }); TimedOut = $false; StdOut = 'Native output'; StdErr = '' }
+        }
+    }
+
+    It 'collects every selected package despite native failures and distinguishes all verdicts' {
+        $names = @('Compatible', 'Breaking', 'NoGa', 'Stale', 'Missing', 'Partial', 'Malformed', 'Timeout')
+        foreach ($name in $names) { New-CIPackage $repo $name | Out-Null }
+        $result = Invoke-CICollection $repo ($names -join ',') 'Failed'
+        $result.Summary.counts.selected | Should -Be 8
+        $result.Summary.counts.compatible | Should -Be 1
+        $result.Summary.counts.breakingChanges | Should -Be 1
+        $result.Summary.counts.notApplicable | Should -Be 1
+        $result.Summary.counts.detectorErrors | Should -Be 5
+        $result.Summary.previousJobStatus | Should -Be 'Failed'
+        Should -Invoke Invoke-SdkChangesCIProcess -Times 8 -Exactly
+        $verdict = Test-SdkChangesCIReports $result.Directory ($names -join ',')
+        $verdict.Passed | Should -BeFalse
+        $verdict.Errors.Count | Should -Be 6
+    }
+
+    It 'treats exit0 with hasBreakingChange=true as a failing compatibility verdict' {
+        New-CIPackage $repo 'Breaking' | Out-Null
+        $result = Invoke-CICollection $repo 'Breaking'
+        $result.Summary.packages[0].detectorExitCode | Should -Be 0
+        $result.Summary.packages[0].status | Should -Be 'breaking_changes'
+        (Test-SdkChangesCIReports $result.Directory 'Breaking').Passed | Should -BeFalse
+    }
+
+    It 'does not call no-GA compatible, but permits a first-release PR' {
+        New-CIPackage $repo 'NoGa' | Out-Null
+        $result = Invoke-CICollection $repo 'NoGa'
+        $result.Summary.packages[0].status | Should -Be 'not_applicable'
+        $verdict = Test-SdkChangesCIReports $result.Directory 'NoGa'
+        $verdict.Passed | Should -BeTrue
+        $verdict.Counts.compatible | Should -Be 0
+        $verdict.Counts.notApplicable | Should -Be 1
+        Should -Invoke LogWarning -Times 1 -ParameterFilter { "$args" -match 'compatibility was not evaluated' }
+    }
+
+    It 'preserves other failed validation gates independently from API compatibility' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible' 'Failed'
+        $result.Summary.packages[0].hasBreakingChange | Should -BeFalse
+        $result.Summary.previousJobStatus | Should -Be 'Failed'
+        $verdict = Test-SdkChangesCIReports $result.Directory 'Compatible'
+        $verdict.Passed | Should -BeTrue
+        $verdict.PreviousJobStatus | Should -Be 'Failed'
+    }
+
+    It 'preserves valid native JSON byte-for-byte, including additive details' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $raw = New-CIRawReport
+        $raw.details.additionalEvidence = @{ retained = $true }
+        $text = "`r`n" + ($raw | ConvertTo-Json -Depth 10) + "`r`n"
+        Mock Invoke-SdkChangesCIProcess {
+            param($OutputJsonFile)
+            [System.IO.File]::WriteAllText($OutputJsonFile, $text)
+            @{ ExitCode = 0; TimedOut = $false; StdOut = ''; StdErr = '' }
+        }
+        $result = Invoke-CICollection $repo 'Compatible'
+        $path = Join-Path $result.Directory $result.Summary.packages[0].reportFile
+        [System.IO.File]::ReadAllText($path) | Should -Be $text
+        (Read-SdkChangesCIJson $path).details.additionalEvidence.retained | Should -BeTrue
+    }
+
+    It 'records portable artifact paths for downstream replay while invoking the detector with absolute paths' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible'
+        $package = $result.Summary.packages[0]
+        $package.packagePath | Should -Be 'sdk/fixture/Compatible'
+        $package.reportFile | Should -Be 'Compatible/sdk-changes.json'
+        Should -Invoke Invoke-SdkChangesCIProcess -Times 1 -Exactly -ParameterFilter {
+            [System.IO.Path]::IsPathFullyQualified($PackagePath) -and
+            [System.IO.Path]::IsPathFullyQualified($SdkRepoPath) -and
+            [System.IO.Path]::IsPathFullyQualified($OutputJsonFile)
+        }
+    }
+
+    It 'quarantines partial reports from failed processes rather than publishing them as replayable native results' {
+        New-CIPackage $repo 'Partial' | Out-Null
+        $result = Invoke-CICollection $repo 'Partial'
+        $package = $result.Summary.packages[0]
+        $package.status | Should -Be 'detector_error'
+        $package.hasBreakingChange | Should -BeNullOrEmpty
+        $package.reportFile | Should -BeNullOrEmpty
+        Test-Path -LiteralPath (Join-Path $result.Directory 'Partial' 'sdk-changes.json') | Should -BeFalse
+        Test-Path -LiteralPath (Join-Path $result.Directory $package.failedReportFile) | Should -BeTrue
+        (Read-SdkChangesCIJson (Join-Path $result.Directory $package.errorFile)).detectorExitCode | Should -Be 13
+    }
+
+    It 'preserves <Package> diagnostics in per-package logs and error JSON' -TestCases @(
+        @{ Package = 'Stale'; Message = 'Current assembly is stale' },
+        @{ Package = 'MissingAssembly'; Message = 'Current assembly is missing' }
+    ) {
+        param($Package, $Message)
+        New-CIPackage $repo $Package | Out-Null
+        $result = Invoke-CICollection $repo $Package
+        Get-Content -LiteralPath (Join-Path $result.Directory $Package 'detector.stderr.log') -Raw | Should -Match $Message
+        $errorReport = Read-SdkChangesCIJson (Join-Path $result.Directory $Package 'error.json')
+        $errorReport.status | Should -Be 'detector_error'
+        $errorReport.message | Should -Match $Message
+    }
+
+    It 'records process start failures without skipping subsequent packages' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        New-CIPackage $repo 'Failure' | Out-Null
+        Mock Invoke-SdkChangesCIProcess { throw [System.ComponentModel.Win32Exception]::new('Cannot start pwsh') } `
+            -ParameterFilter { (Split-Path $PackagePath -Leaf) -eq 'Failure' }
+        $result = Invoke-CICollection $repo 'Failure,Compatible'
+        $result.Summary.counts.compatible | Should -Be 1
+        $result.Summary.counts.detectorErrors | Should -Be 1
+    }
+
+    It 'publishes explicit prerequisite errors and never invokes an incompatible PowerShell runtime' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        Mock Get-SdkChangesCIRuntime { @{ supported = $false; error = 'PowerShell uses .NET8; SDK requires .NET10'; executable = 'unused' } }
+        $result = Invoke-CICollection $repo 'Compatible'
+        $result.Summary.runtime.supported | Should -BeFalse
+        $result.Summary.packages[0].error | Should -Match 'SDK requires'
+        Test-Path -LiteralPath (Join-Path $result.Directory 'Compatible' 'error.json') | Should -BeTrue
+        Should -Invoke Invoke-SdkChangesCIProcess -Times 0 -Exactly
+        (Test-SdkChangesCIReports $result.Directory 'Compatible').Passed | Should -BeFalse
+    }
+
+    It 'reports a missing native script as a detector prerequisite failure' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        Remove-Item -LiteralPath $repo.Detector
+        $result = Invoke-CICollection $repo 'Compatible'
+        $result.Summary.errors -join ' ' | Should -Match 'detector script is missing'
+        Should -Invoke Invoke-SdkChangesCIProcess -Times 0 -Exactly
+    }
+
+    It 'writes a summary for a missing PackageInfo directory rather than returning compatible' {
+        $repo.Info = Join-Path $repo.Root 'missing'
+        $result = Invoke-CICollection $repo 'Compatible'
+        $result.Summary.errors.Count | Should -Be 1
+        (Test-SdkChangesCIReports $result.Directory 'Compatible').Passed | Should -BeFalse
+    }
+
+    It 'reports selected-package metadata errors and still processes other valid packages' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible,NoMetadata'
+        $result.Summary.counts.compatible | Should -Be 1
+        $result.Summary.counts.detectorErrors | Should -Be 1
+        Test-Path -LiteralPath (Join-Path $result.Directory 'NoMetadata' 'error.json') | Should -BeTrue
+        Should -Invoke Invoke-SdkChangesCIProcess -Times 1 -Exactly
+        (Test-SdkChangesCIReports $result.Directory 'Compatible,NoMetadata').Passed | Should -BeFalse
+    }
+
+    It 'publishes an explicit empty selection without inventing a compatibility result' {
+        $result = Invoke-CICollection $repo ''
+        $result.Summary.counts.selected | Should -Be 0
+        $result.Summary.counts.compatible | Should -Be 0
+        (Test-SdkChangesCIReports $result.Directory '').Passed | Should -BeTrue
+        Should -Invoke Invoke-SdkChangesCIProcess -Times 0 -Exactly
+    }
+
+    It 'uses a fresh report directory for every attempt and never reuses stale raw output' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $first = Invoke-CICollection $repo 'Compatible'
+        Mock Invoke-SdkChangesCIProcess { @{ ExitCode = 1; TimedOut = $false; StdOut = ''; StdErr = 'Failed' } }
+        $second = Invoke-CICollection $repo 'Compatible'
+        $second.Directory | Should -Not -Be $first.Directory
+        Test-Path -LiteralPath (Join-Path $second.Directory 'Compatible' 'sdk-changes.json') | Should -BeFalse
+        Should -Invoke Set-PipelineVariable -Times 1 -Exactly -ParameterFilter { $Value -eq $second.Directory }
+    }
+
+    It 'fails enforcement if the raw report was changed after collection' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible'
+        Write-SdkChangesCIJson (Join-Path $result.Directory 'Compatible' 'sdk-changes.json') (New-CIRawReport -Breaking)
+        $verdict = Test-SdkChangesCIReports $result.Directory 'Compatible'
+        $verdict.Passed | Should -BeFalse
+        $verdict.Errors -join ' ' | Should -Match 'modified after collection'
+    }
+
+    It 'fails enforcement if the summary contradicts the unchanged raw verdict' {
+        New-CIPackage $repo 'Breaking' | Out-Null
+        $result = Invoke-CICollection $repo 'Breaking'
+        $result.Summary.packages[0].status = 'compatible'
+        $result.Summary.packages[0].hasBreakingChange = $false
+        Write-SdkChangesCIJson (Join-Path $result.Directory 'summary.json') $result.Summary
+        $verdict = Test-SdkChangesCIReports $result.Directory 'Breaking'
+        $verdict.Passed | Should -BeFalse
+        $verdict.Errors -join ' ' | Should -Match 'contradicts'
+    }
+
+    It 'fails enforcement when collected raw evidence is missing' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible'
+        Remove-Item -LiteralPath (Join-Path $result.Directory 'Compatible' 'sdk-changes.json')
+        $verdict = Test-SdkChangesCIReports $result.Directory 'Compatible'
+        $verdict.Passed | Should -BeFalse
+        $verdict.Errors -join ' ' | Should -Match 'report is missing'
+    }
+
+    It 'does not read raw evidence outside the report directory' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible'
+        $result.Summary.packages[0].reportFile = '..\outside.json'
+        Write-SdkChangesCIJson (Join-Path $result.Directory 'summary.json') $result.Summary
+        $verdict = Test-SdkChangesCIReports $result.Directory 'Compatible'
+        $verdict.Passed | Should -BeFalse
+        $verdict.Errors -join ' ' | Should -Match 'outside'
+    }
+
+    It 'fails enforcement on unknown or unsuccessful recorded outcomes' -TestCases @(
+        @{ Status = 'unknown'; ExitCode = 0; TimedOut = $false },
+        @{ Status = 'compatible'; ExitCode = 1; TimedOut = $false },
+        @{ Status = 'compatible'; ExitCode = 0; TimedOut = $true }
+    ) {
+        param($Status, $ExitCode, $TimedOut)
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible'
+        $result.Summary.packages[0].status = $Status
+        $result.Summary.packages[0].detectorExitCode = $ExitCode
+        $result.Summary.packages[0].timedOut = $TimedOut
+        Write-SdkChangesCIJson (Join-Path $result.Directory 'summary.json') $result.Summary
+        (Test-SdkChangesCIReports $result.Directory 'Compatible').Passed | Should -BeFalse
+    }
+
+    It 'fails closed on missing or invalid summary files' {
+        { Test-SdkChangesCIReports $repo.ReportRoot 'Compatible' } | Should -Throw
+        [void][System.IO.Directory]::CreateDirectory($repo.ReportRoot)
+        Write-SdkChangesCIJson (Join-Path $repo.ReportRoot 'summary.json') @{ schemaVersion = 999 }
+        { Test-SdkChangesCIReports $repo.ReportRoot 'Compatible' } | Should -Throw '*Invalid SDK API CI report summary*'
+    }
+
+    It 'rejects a summary from a different package selection' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible'
+        { Test-SdkChangesCIReports $result.Directory 'Another' } | Should -Throw '*ProjectNames selection*'
+    }
+
+    It 'fails enforcement when a selected package report is missing from the summary' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $result = Invoke-CICollection $repo 'Compatible'
+        $result.Summary.packages = @()
+        Write-SdkChangesCIJson (Join-Path $result.Directory 'summary.json') $result.Summary
+        (Test-SdkChangesCIReports $result.Directory 'Compatible').Passed | Should -BeFalse
+    }
+}
+
+Describe 'SDK CI actual child process boundary' -Tag 'IntegrationTest' {
+    BeforeEach { $repo = New-CIRepository }
+
+    It 'preserves SDK NuGet configuration and inherited feed authentication/cache context' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $configPath = Join-Path $repo.Root 'NuGet.Config'
+        [System.IO.File]::WriteAllText($configPath, '<configuration><packageSources><clear /><add key="SDK feed" value="https://pkgs.dev.azure.com/example/sdk/_packaging/sdk/nuget/v3/index.json" /></packageSources></configuration>')
+        $configHash = (Get-FileHash -LiteralPath $configPath).Hash
+        $oldPackages = $env:NUGET_PACKAGES
+        $oldAuthentication = $env:VSS_NUGET_ACCESSTOKEN
+        try {
+            $env:NUGET_PACKAGES = Join-Path $repo.Root 'existing-package-cache'
+            $env:VSS_NUGET_ACCESSTOKEN = 'synthetic-ci-fixture-not-a-real-token'
+            $result = Invoke-CICollection $repo 'Compatible'
+            $raw = Read-SdkChangesCIJson (Join-Path $result.Directory 'Compatible' 'sdk-changes.json')
+            $raw.details.diagnostics | Should -Contain "WorkingDirectory=$($repo.Root)"
+            $raw.details.diagnostics | Should -Contain "NuGetPackages=$env:NUGET_PACKAGES"
+            $raw.details.diagnostics | Should -Contain 'NuGetAuthenticationPresent=True'
+            $raw.details.diagnostics -join "`n" | Should -Not -Match 'synthetic-ci-fixture'
+            (Get-FileHash -LiteralPath $configPath).Hash | Should -Be $configHash
+        }
+        finally {
+            $env:NUGET_PACKAGES = $oldPackages
+            $env:VSS_NUGET_ACCESSTOKEN = $oldAuthentication
+        }
+    }
+
+    It 'uses named absolute paths, Release, and no inherited single-TFM override' {
+        New-CIPackage $repo 'Compatible' | Out-Null
+        $oldConfiguration = $env:Configuration
+        $oldFramework = $env:TargetFramework
+        $oldFrameworks = $env:TargetFrameworks
+        try {
+            $env:Configuration = 'Debug'
+            $env:TargetFramework = 'net8.0'
+            $env:TargetFrameworks = 'net8.0;net10.0'
+            $result = Invoke-CICollection $repo 'Compatible'
+            $raw = Read-SdkChangesCIJson (Join-Path $result.Directory 'Compatible' 'sdk-changes.json')
+            $raw.details.diagnostics | Should -Contain 'Configuration=Release'
+            $raw.details.diagnostics | Should -Contain 'TargetFramework='
+            $raw.details.diagnostics | Should -Contain 'TargetFrameworks='
+            $raw.details.diagnostics | Should -Contain "SdkRepoPath=$($repo.Root)"
+            $env:Configuration | Should -Be 'Debug'
+            $env:TargetFramework | Should -Be 'net8.0'
+        }
+        finally {
+            $env:Configuration = $oldConfiguration
+            $env:TargetFramework = $oldFramework
+            $env:TargetFrameworks = $oldFrameworks
+        }
+    }
+
+    It 'enforces a real child-process timeout and records an explicit error' {
+        New-CIPackage $repo 'Timeout' | Out-Null
+        $result = Invoke-SdkChangesCICollection -SdkRepoPath $repo.Root -PackageInfoDirectory $repo.Info `
+            -ProjectNames 'Timeout' -ReportRoot $repo.ReportRoot -TimeoutSeconds 1
+        $result.Summary.packages[0].timedOut | Should -BeTrue
+        $result.Summary.packages[0].status | Should -Be 'detector_error'
+    }
+
+    It 'defers the collector exit code in ReportOnly mode but the final CI assertion rejects breaks' {
+        New-CIPackage $repo 'Breaking' | Out-Null
+        $collector = Join-Path $PSScriptRoot '..' 'Invoke-SdkChangesCI.ps1'
+        $assertion = Join-Path $PSScriptRoot '..' 'Assert-SdkChangesCI.ps1'
+        & pwsh -NoProfile -File $collector -SdkRepoPath $repo.Root -PackageInfoDirectory $repo.Info `
+            -ProjectNames Breaking -ReportRoot $repo.ReportRoot -ReportOnly | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        $directory = @(Get-ChildItem -LiteralPath $repo.ReportRoot -Directory)[0].FullName
+        (Read-SdkChangesCIJson (Join-Path $directory 'summary.json')).packages[0].status | Should -Be 'breaking_changes'
+        & pwsh -NoProfile -File $assertion -ReportDirectory $directory -ProjectNames Breaking | Out-Null
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It 'returns a failing exit code for direct runner use with detector errors' {
+        New-CIPackage $repo 'Stale' | Out-Null
+        & pwsh -NoProfile -File (Join-Path $PSScriptRoot '..' 'Invoke-SdkChangesCI.ps1') `
+            -SdkRepoPath $repo.Root -PackageInfoDirectory $repo.Info -ProjectNames Stale -ReportRoot $repo.ReportRoot | Out-Null
+        $LASTEXITCODE | Should -Be 1
+    }
+}

--- a/eng/scripts/compatibility/ci-tests/fixtures/Detector.ps1
+++ b/eng/scripts/compatibility/ci-tests/fixtures/Detector.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$PackagePath,
+    [Parameter(Mandatory = $true)][string]$SdkRepoPath,
+    [Parameter(Mandatory = $true)][string]$OutputJsonFile
+)
+
+$ErrorActionPreference = 'Stop'
+$name = Split-Path $PackagePath -Leaf
+if ($name -eq 'Missing') { exit 0 }
+if ($name -eq 'Stale') { [Console]::Error.WriteLine('Current assembly is stale.'); exit 12 }
+if ($name -eq 'MissingAssembly') { [Console]::Error.WriteLine('Current assembly is missing.'); exit 14 }
+if ($name -eq 'Timeout') { Start-Sleep -Seconds 30; exit 0 }
+if ($name -eq 'Malformed') { [System.IO.File]::WriteAllText($OutputJsonFile, '{invalid'); exit 0 }
+$breaking = $name -in @('Breaking', 'Partial')
+$report = [ordered]@{
+    changes = "### Breaking Changes`nNative fixture`n### Features Added`nNone."
+    hasBreakingChange = $breaking
+    details = [ordered]@{
+        baselineVersion = $(if ($name -eq 'NoGa') { $null } else { '1.0.0' })
+        apiChanges = @($(if ($breaking) {
+            @{ kind = 'removed'; symbol = 'Fixture.Removed()'; description = 'Removed member'; isBreaking = $true; diagnosticId = 'CP0002'; targetFramework = 'net8.0' }
+        }))
+        diagnostics = @(
+            "Configuration=$env:Configuration",
+            "TargetFramework=$env:TargetFramework",
+            "TargetFrameworks=$env:TargetFrameworks",
+            "PackagePath=$PackagePath",
+            "SdkRepoPath=$SdkRepoPath",
+            "WorkingDirectory=$((Get-Location).Path)",
+            "NuGetPackages=$env:NUGET_PACKAGES",
+            "NuGetAuthenticationPresent=$(![string]::IsNullOrEmpty($env:VSS_NUGET_ACCESSTOKEN))"
+        )
+        limitations = @($(if ($name -eq 'NoGa') { 'No GA release exists; compatibility was not evaluated.' }))
+    }
+}
+[System.IO.File]::WriteAllText($OutputJsonFile, ($report | ConvertTo-Json -Depth 10))
+if ($name -eq 'Partial') { [Console]::Error.WriteLine('Native process failed after writing partial output.'); exit 13 }

--- a/eng/scripts/compatibility/tests/Get-SdkChanges.Integration.Tests.ps1
+++ b/eng/scripts/compatibility/tests/Get-SdkChanges.Integration.Tests.ps1
@@ -1,0 +1,426 @@
+#Requires -Version 7.0
+
+BeforeAll {
+    Set-StrictMode -Version 3
+    . (Join-Path $PSScriptRoot '..' 'Get-SdkChanges.Helpers.ps1')
+    $repo = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..')).Path
+    $fixtureRoot = Join-Path $TestDrive 'native-fixture'
+    [void][System.IO.Directory]::CreateDirectory($fixtureRoot)
+    Copy-Item -LiteralPath (Join-Path $repo 'global.json') -Destination (Join-Path $fixtureRoot 'global.json')
+    [void][System.IO.Directory]::CreateDirectory((Join-Path $fixtureRoot 'eng'))
+    Copy-Item -LiteralPath (Join-Path $repo 'eng' 'ApiListing.exclude-attributes.txt') -Destination (Join-Path $fixtureRoot 'eng')
+    $emptyFeed = Join-Path $fixtureRoot 'empty-feed'
+    [void][System.IO.Directory]::CreateDirectory($emptyFeed)
+    $localFeed = Join-Path $fixtureRoot 'local-feed'
+    [void][System.IO.Directory]::CreateDirectory($localFeed)
+    [System.IO.File]::WriteAllText((Join-Path $fixtureRoot 'NuGet.Config'),
+        "<configuration><packageSources><clear /><add key=`"fixtures`" value=`"$([System.Security.SecurityElement]::Escape($localFeed))`" /></packageSources></configuration>")
+    $fixtures = @{}
+    foreach ($variant in @('Before', 'After', 'Additions', 'SourceGenerator', 'Embedded', 'Mapped', 'Standard', 'Framework', 'Release')) {
+        $root = Join-Path $fixtureRoot $variant
+        Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'fixtures') -Destination $root -Recurse
+        $project = Join-Path $root 'src' 'Azure.ResourceManager.CompatibilityFixture.csproj'
+        $debugType = if ($variant -eq 'Embedded') { '<DebugType>embedded</DebugType>' } else { '' }
+        $pathMap = if ($variant -eq 'Mapped') { "<PathMap>$([System.Security.SecurityElement]::Escape("$fixtureRoot\=/_/"))</PathMap>" } else { '' }
+        $standardProperties = if ($variant -eq 'Standard') {
+            '<TargetFrameworks>netstandard2.0</TargetFrameworks><LangVersion>latest</LangVersion><ApiCompatBaselineTargetFramework>netstandard2.0</ApiCompatBaselineTargetFramework><PackageId>Azure.Data.CompatibilityFixture</PackageId><IsMgmtLibrary>false</IsMgmtLibrary><IsClientLibrary>true</IsClientLibrary>'
+        } elseif ($variant -eq 'Framework') {
+            '<TargetFrameworks>net462</TargetFrameworks><LangVersion>latest</LangVersion><ApiCompatBaselineTargetFramework>net462</ApiCompatBaselineTargetFramework><PackageId>Azure.Data.FrameworkFixture</PackageId><IsMgmtLibrary>false</IsMgmtLibrary><IsClientLibrary>true</IsClientLibrary>'
+        } else { '' }
+        $extraArguments = if ($variant -eq 'Standard') {
+            @('-p:TargetFrameworks=netstandard2.0', '-p:LangVersion=latest', '-p:PackageVersion=1.0.1')
+        } elseif ($variant -eq 'Framework') {
+            @('-p:TargetFrameworks=net462', '-p:LangVersion=latest', '-p:PackageVersion=1.0.2')
+        } else { @() }
+        $configuration = if ($variant -eq 'Release') { 'Release' } else { 'Debug' }
+        [System.IO.File]::WriteAllText((Join-Path $root 'src' 'Fixture.props'),
+            "<Project><PropertyGroup><FixtureVariant>$variant</FixtureVariant>$debugType$pathMap$standardProperties</PropertyGroup></Project>")
+        $restored = Invoke-SdkChangeProcess -WorkingDirectory $root -Arguments (@(
+            'restore', $project, '--source', $emptyFeed, '--verbosity', 'quiet'
+        ) + $extraArguments)
+        if ($variant -in @('Standard', 'Framework') -and $restored.ExitCode -ne 0 -and
+            "$($restored.StdOut)`n$($restored.StdErr)" -match 'error NU1101:') {
+            # A cold cache needs the fixture's reference packages before offline comparisons.
+            $prepared = Invoke-SdkChangeProcess -WorkingDirectory $root -Arguments (@(
+                'restore', $project, '--configfile', (Join-Path $repo 'NuGet.Config'), '--verbosity', 'quiet'
+            ) + $extraArguments)
+            if ($prepared.ExitCode -ne 0) { throw "Fixture dependency preparation failed.`n$($prepared.StdOut)`n$($prepared.StdErr)" }
+            $restored = Invoke-SdkChangeProcess -WorkingDirectory $root -Arguments (@(
+                'restore', $project, '--source', $emptyFeed, '--verbosity', 'quiet'
+            ) + $extraArguments)
+        }
+        if ($restored.ExitCode -ne 0) { throw "Offline fixture restore failed.`n$($restored.StdOut)`n$($restored.StdErr)" }
+        $built = Invoke-SdkChangeProcess -WorkingDirectory $root -Arguments (@(
+            'build', $project, '--no-restore', '--configuration', $configuration,
+            '--verbosity', 'quiet', '-p:UseSharedCompilation=false', '-tl:off'
+        ) + $extraArguments)
+        if ($built.ExitCode -ne 0) { throw "Fixture setup compilation failed.`n$($built.StdOut)`n$($built.StdErr)" }
+        if ($variant -in @('Before', 'Standard', 'Framework')) {
+            foreach ($packProject in @((Join-Path $root 'dependency' 'Dependency.csproj'), $project)) {
+                $packed = Invoke-SdkChangeProcess -WorkingDirectory $root -Arguments (@(
+                    'pack', $packProject, '--no-build', '--no-restore', '--configuration', 'Debug',
+                    '--output', $localFeed, '--verbosity', 'quiet', '-p:PackageVersion=1.0.0'
+                ) + $extraArguments)
+                if ($packed.ExitCode -ne 0) { throw "Fixture package creation failed.`n$($packed.StdOut)`n$($packed.StdErr)" }
+            }
+        }
+        [System.IO.File]::WriteAllText((Join-Path $root 'src' 'do-not-build'), '')
+        [System.IO.File]::WriteAllText((Join-Path $root 'dependency' 'do-not-build'), '')
+        $work = Join-Path $root 'extraction'
+        [void][System.IO.Directory]::CreateDirectory($work)
+        $framework = if ($variant -eq 'Standard') { 'netstandard2.0' } elseif ($variant -eq 'Framework') { 'net462' } else { 'net8.0' }
+        $evaluation = Get-SdkChangeEvaluation -Project $project -SdkRepoPath $fixtureRoot -WorkDirectory $work `
+            -TargetFramework $framework -Configuration $configuration
+        if ($variant -in @('Standard', 'Framework')) {
+            $assets = Read-SdkChangeJson $evaluation.Properties.ProjectAssetsFile
+            foreach ($key in $assets.libraries.Keys) {
+                $library = $assets.libraries[$key]
+                if ($library.type -ne 'package') { continue }
+                $archiveName = ($key.Replace('/', '.') + '.nupkg').ToLowerInvariant()
+                $archives = @($assets.packageFolders.Keys | ForEach-Object {
+                    Join-Path $_ $library.path $archiveName
+                } | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf })
+                if ($archives.Count -eq 0) { throw "The offline fixture needs the already-restored NuGet archive for $key." }
+                Copy-Item -LiteralPath $archives[0] -Destination $localFeed -Force
+            }
+        }
+        $assembly = Assert-SdkChangeCurrentAssembly $evaluation
+        $references = @(Get-SdkChangeCurrentReferences -Evaluation $evaluation -SdkRepoPath $fixtureRoot -WorkDirectory (Join-Path $work 'references'))
+        Assert-SdkChangeReferences -Assembly $assembly -References $references
+        $fixtures[$variant] = @{
+            Root = $root; Project = $project; Evaluation = $evaluation; Assembly = $assembly; References = $references
+        }
+    }
+    $rules = Get-SdkChangeRules -Evaluation $fixtures.After.Evaluation -SdkRepoPath $repo
+    $forward = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.Before.Assembly -RightAssembly $fixtures.After.Assembly `
+        -LeftReferences $fixtures.Before.References -RightReferences $fixtures.After.References `
+        -Evaluation $fixtures.After.Evaluation -Rules $rules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'forward')
+    $reverse = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.After.Assembly -RightAssembly $fixtures.Before.Assembly `
+        -LeftReferences $fixtures.After.References -RightReferences $fixtures.Before.References `
+        -Evaluation $fixtures.After.Evaluation -Rules $rules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'reverse')
+}
+
+Describe 'Real offline SDK ApiCompat task' -Tag 'IntegrationTest' {
+    It 'captures exact native member/type removal events and keeps additions separate' {
+        $result = ConvertFrom-SdkChangeApiCompat -Log $forward -TargetFramework 'net8.0'
+        $forward.ExitCode | Should -Be 1
+        $forward.Completed | Should -BeTrue
+        @($result.Changes | Where-Object { $_.diagnosticId -eq 'CP0002' -and $_.symbol -eq 'void CompatibilityFixture.Widget.Removed()' }).Count | Should -Be 1
+        @($result.Changes | Where-Object { $_.diagnosticId -eq 'CP0001' -and $_.symbol -eq 'CompatibilityFixture.RemovedType' }).Count | Should -Be 1
+        @($result.Changes | Where-Object { $_.symbol -match 'AddedType' }).Count | Should -Be 0
+        $added = ConvertFrom-SdkChangeApiCompat -Log $reverse -TargetFramework 'net8.0' -Reverse
+        @($added.Changes | Where-Object { $_.diagnosticId -eq 'CP0001' -and $_.symbol -eq 'CompatibilityFixture.AddedType' }).Count | Should -Be 1
+        @($added.Changes | Where-Object { $_.isBreaking }).Count | Should -Be 0
+    }
+
+    It 'captures parameter names, attributes, interface requirements, enum and signature changes from the native engine' {
+        $ids = @($forward.Diagnostics.Code | Sort-Object -Unique)
+        foreach ($id in @('CP0002', 'CP0006', 'CP0010', 'CP0011', 'CP0012', 'CP0015', 'CP0017')) {
+            $ids | Should -Contain $id
+        }
+        $descriptions = $forward.Diagnostics.Message -join "`n"
+        $descriptions | Should -Match 'Signature'
+        $descriptions | Should -Match 'oldName'
+        $descriptions | Should -Match 'Marker'
+    }
+
+    It 'identifies the affected symbol in native <Code> diagnostics' -TestCases @(
+        @{ Code = 'CP0017'; Symbol = 'CompatibilityFixture.Widget.Parameter(string)' },
+        @{ Code = 'CP0015'; Symbol = 'CompatibilityFixture.Widget.AttributeChange()' },
+        @{ Code = 'CP0011'; Symbol = 'ValueOnly.Default' }
+    ) {
+        param($Code, $Symbol)
+        $changes = (ConvertFrom-SdkChangeApiCompat -Log $forward -TargetFramework 'net8.0').Changes
+        $change = @($changes | Where-Object { $_.diagnosticId -eq $Code -and ($Code -ne 'CP0011' -or $_.description -match "'ValueOnly'") })[0]
+        $change.symbol | Should -Be $Symbol -Because $change.description
+    }
+
+    It 'does not collapse separate enum changes when native messages omit their namespaces' {
+        $changes = (ConvertFrom-SdkChangeApiCompat -Log $forward -TargetFramework 'net8.0').Changes
+        @($changes | Where-Object { $_.diagnosticId -eq 'CP0011' -and $_.symbol -eq 'Ambiguous.Value' }).Count | Should -Be 2
+    }
+
+    It 'never executes compilation or analyzers in either standalone comparison' {
+        foreach ($log in @($forward, $reverse)) {
+            $log.Targets | Should -Contain 'CompareSdkAssemblies'
+            foreach ($target in @('Build', 'Compile', 'CoreCompile', 'RunAnalyzers', 'RunCodeAnalysis')) {
+                $log.Targets | Should -Not -Contain $target
+            }
+        }
+        $referenceLog = Read-SdkChangeBuildLog (Join-Path $fixtures.After.Root 'extraction' 'references' 'references.binlog')
+        foreach ($target in @('Build', 'Compile', 'CoreCompile', 'RunAnalyzers', 'RunCodeAnalysis', 'PoisonBuildAndAnalyzers')) {
+            $referenceLog.Targets | Should -Not -Contain $target
+        }
+    }
+
+    It 'rejects an omitted external dependency instead of treating it as compatible' {
+        $withoutDependency = @($fixtures.After.References | Where-Object { [System.IO.Path]::GetFileName($_) -ne 'Dependency.dll' })
+        { Assert-SdkChangeReferences -Assembly $fixtures.After.Assembly -References $withoutDependency } |
+            Should -Throw "*Missing assembly reference 'Dependency'*"
+    }
+
+    It 'uses native diagnostics to reject a missing API-reachable transitive dependency' {
+        (Get-SdkChangeAssemblyInfo $fixtures.Before.Assembly).References | Should -Not -Contain 'System.Data.Common'
+        $isolated = Join-Path $fixtureRoot 'incomplete-references'
+        [void][System.IO.Directory]::CreateDirectory($isolated)
+        $incomplete = @($fixtures.Before.References | Where-Object {
+            [System.IO.Path]::GetFileName($_) -ne 'System.Data.Common.dll'
+        } | ForEach-Object {
+            $copy = Join-Path $isolated ([System.IO.Path]::GetFileName($_))
+            Copy-Item -LiteralPath $_ -Destination $copy
+            $copy
+        })
+        { Assert-SdkChangeReferences -Assembly $fixtures.Before.Assembly -References $incomplete } | Should -Not -Throw
+        $log = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.Before.Assembly -RightAssembly $fixtures.Before.Assembly `
+            -LeftReferences $fixtures.Before.References -RightReferences $incomplete `
+            -Evaluation $fixtures.Before.Evaluation -Rules $rules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'missing-transitive')
+        @($log.Diagnostics | Where-Object { $_.Code -eq 'CP1002' -and $_.Message -match 'System.Data.Common' }).Count | Should -BeGreaterThan 0
+        { ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0' } | Should -Throw '*CP1002*'
+    }
+
+    It 'captures a real missing-assembly MSBuild error and fails extraction' {
+        $log = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.Before.Assembly -RightAssembly (Join-Path $fixtureRoot 'missing.dll') `
+            -LeftReferences $fixtures.Before.References -RightReferences $fixtures.After.References -Evaluation $fixtures.After.Evaluation `
+            -Rules $rules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'missing-assembly')
+        $log.ExitCode | Should -Be 1
+        { ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0' } | Should -Throw
+    }
+
+    It 'reports a genuinely clean comparison' {
+        $log = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.Before.Assembly -RightAssembly $fixtures.Before.Assembly `
+            -LeftReferences $fixtures.Before.References -RightReferences $fixtures.Before.References `
+            -Evaluation $fixtures.Before.Evaluation -Rules $rules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'clean')
+        $log.ExitCode | Should -Be 0
+        $result = ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0'
+        $result.Changes.Count | Should -Be 0
+    }
+
+    It 'reports additions without breaks from a real two-direction comparison' {
+        $forwardAdded = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.Before.Assembly -RightAssembly $fixtures.Additions.Assembly `
+            -LeftReferences $fixtures.Before.References -RightReferences $fixtures.Additions.References `
+            -Evaluation $fixtures.Additions.Evaluation -Rules $rules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'additions-forward')
+        $reverseAdded = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.Additions.Assembly -RightAssembly $fixtures.Before.Assembly `
+            -LeftReferences $fixtures.Additions.References -RightReferences $fixtures.Before.References `
+            -Evaluation $fixtures.Additions.Evaluation -Rules $rules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'additions-reverse')
+        $changes = (ConvertFrom-SdkChangeApiCompat -Log $forwardAdded -TargetFramework 'net8.0').Changes +
+            (ConvertFrom-SdkChangeApiCompat -Log $reverseAdded -TargetFramework 'net8.0' -Reverse).Changes
+        $report = New-SdkChangeReport -BaselineVersion '1.0.0' -Changes $changes -Diagnostics @() -Limitations @()
+        $report.hasBreakingChange | Should -BeFalse
+        $report.details.apiChanges.symbol | Should -Contain 'CompatibilityFixture.AddedType'
+    }
+
+    It 'honors central suppression paths after assembly identity transformations without modifying the file' {
+        $suppressionPath = Join-Path $fixtureRoot 'suppression.xml'
+        [System.IO.File]::WriteAllText($suppressionPath, @'
+<Suppressions>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:CompatibilityFixture.Widget.Removed</Target>
+    <Left>lib/net8.0/Azure.ResourceManager.CompatibilityFixture.dll</Left>
+    <Right>lib/net8.0/Azure.ResourceManager.CompatibilityFixture.dll</Right>
+  </Suppression>
+</Suppressions>
+'@)
+        $hash = (Get-FileHash -LiteralPath $suppressionPath).Hash
+        $suppressedRules = @{ Properties = $rules.Properties; Excludes = $rules.Excludes; Suppressions = @($suppressionPath) }
+        $log = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.Before.Assembly -RightAssembly $fixtures.After.Assembly `
+            -LeftReferences $fixtures.Before.References -RightReferences $fixtures.After.References `
+            -Evaluation $fixtures.After.Evaluation -Rules $suppressedRules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'suppressed')
+        $changes = (ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0').Changes
+        @($changes | Where-Object { $_.symbol -eq 'void CompatibilityFixture.Widget.Removed()' }).Count | Should -Be 0
+        (Get-FileHash -LiteralPath $suppressionPath).Hash | Should -Be $hash
+    }
+
+    It 'honors multiple NoWarn codes using the native task, without suppressing other changes' {
+        $properties = @{} + $rules.Properties
+        $properties.NoWarn = 'CP0015;CP0017'
+        $noWarnRules = @{ Properties = $properties; Excludes = $rules.Excludes; Suppressions = @() }
+        $log = Invoke-SdkChangeApiCompat -LeftAssembly $fixtures.Before.Assembly -RightAssembly $fixtures.After.Assembly `
+            -LeftReferences $fixtures.Before.References -RightReferences $fixtures.After.References `
+            -Evaluation $fixtures.After.Evaluation -Rules $noWarnRules -SdkRepoPath $repo -WorkDirectory (Join-Path $fixtureRoot 'no-warn')
+        $changes = (ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0').Changes
+        $changes.diagnosticId | Should -Not -Contain 'CP0015'
+        $changes.diagnosticId | Should -Not -Contain 'CP0017'
+        $changes.diagnosticId | Should -Contain 'CP0002'
+    }
+
+    It 'emits the complete JSON for all current TFMs without invoking poisoned source targets' {
+        Mock Get-SdkChangeLatestGaVersion { '1.0.0' }
+        Mock Get-SdkChangeBaseline { @{ Assembly = $fixtures.Before.Assembly; References = $fixtures.Before.References } }
+        $output = Join-Path $fixtureRoot 'report.json'
+        Invoke-SdkChangeExtraction -PackagePath (Split-Path $fixtures.After.Project -Parent) -SdkRepoPath $fixtureRoot -OutputJsonFile $output
+        $report = Read-SdkChangeJson $output
+        $report.hasBreakingChange | Should -BeTrue
+        @($report.details.apiChanges.targetFramework | Sort-Object -Unique) | Should -Be @('net10.0', 'net8.0')
+        $report.details.diagnostics | Should -Contain 'Current artifact scope: Configuration=Debug; TargetFrameworks=net10.0, net8.0.'
+        $report.details.limitations -join ' ' | Should -Not -Match 'not a full multi-target package comparison'
+        Should -Invoke Get-SdkChangeBaseline -Times 1 -Exactly -ParameterFilter { $TargetFramework -eq 'net8.0' }
+    }
+
+    It 'restores an exact baseline and its dependency graph from an offline NuGet feed without compiling' {
+        $work = Join-Path $fixtureRoot 'restored-baseline'
+        $baseline = Get-SdkChangeBaseline -PackageId 'Azure.ResourceManager.CompatibilityFixture' -Version '1.0.0' `
+            -TargetFramework 'net8.0' -TargetFileName 'Azure.ResourceManager.CompatibilityFixture.dll' -SdkRepoPath $fixtureRoot -WorkDirectory $work
+        Assert-SdkChangeReferences -Assembly $baseline.Assembly -References $baseline.References
+        $baseline.Assembly | Should -BeLike '*azure.resourcemanager.compatibilityfixture*1.0.0*lib*net8.0*'
+        @($baseline.References | ForEach-Object { [System.IO.Path]::GetFileName($_) }) | Should -Contain 'Dependency.dll'
+        (Read-SdkChangeBuildLog (Join-Path $work 'references.binlog')).Targets | Should -Not -Contain 'CoreCompile'
+    }
+
+    It 'extracts a data-plane netstandard2.0 package end to end with a real restored baseline' {
+        Mock Get-SdkChangeLatestGaVersion { '1.0.1' }
+        $output = Join-Path $fixtureRoot 'standard-report.json'
+        Invoke-SdkChangeExtraction -PackagePath (Split-Path $fixtures.Standard.Project -Parent) -SdkRepoPath $fixtureRoot -OutputJsonFile $output
+        $report = Read-SdkChangeJson $output
+        $report.hasBreakingChange | Should -BeFalse
+        $report.details.apiChanges.Count | Should -Be 0
+        $report.details.baselineVersion | Should -Be '1.0.1'
+        Should -Invoke Get-SdkChangeLatestGaVersion -Times 1 -Exactly -ParameterFilter {
+            $PackageId -eq 'Azure.Data.CompatibilityFixture'
+        }
+    }
+
+    It 'preserves NuGet-provided classic framework targeting paths and resolves transitive framework assemblies' {
+        $entry = $fixtures.Framework
+        $entry.Evaluation.Properties.TargetFrameworkRootPath | Should -Match 'microsoft.netframework.referenceassemblies'
+        @($entry.References | ForEach-Object { [System.IO.Path]::GetFileName($_) }) | Should -Contain 'System.Configuration.dll'
+        Assert-SdkChangeReferences -Assembly $entry.Assembly -References $entry.References
+    }
+
+    It 'extracts a classic .NET Framework package with a real offline baseline and complete framework references' {
+        Mock Get-SdkChangeLatestGaVersion { '1.0.2' }
+        $output = Join-Path $fixtureRoot 'framework-report.json'
+        Invoke-SdkChangeExtraction -PackagePath (Split-Path $fixtures.Framework.Project -Parent) -SdkRepoPath $fixtureRoot -OutputJsonFile $output
+        $report = Read-SdkChangeJson $output
+        $report.hasBreakingChange | Should -BeFalse
+        $report.details.baselineVersion | Should -Be '1.0.2'
+        $report.details.apiChanges.Count | Should -Be 0
+        $report.details.diagnostics | Should -Contain 'Current artifact scope: Configuration=Debug; TargetFrameworks=net462.'
+    }
+
+    It 'supports SDK PR Release artifacts through the same named-parameter contract and inherited Configuration' {
+        Mock Get-SdkChangeLatestGaVersion { '1.0.0' }
+        Mock Get-SdkChangeBaseline { @{ Assembly = $fixtures.Before.Assembly; References = $fixtures.Before.References } }
+        $previousConfiguration = $env:Configuration
+        $output = Join-Path $fixtureRoot 'release-report.json'
+        try {
+            $env:Configuration = $null
+            $defaultEvaluation = Get-SdkChangeEvaluation -Project $fixtures.Release.Project -SdkRepoPath $fixtureRoot `
+                -WorkDirectory (Join-Path $fixtures.Release.Root 'extraction') -TargetFramework 'net8.0'
+            { Assert-SdkChangeCurrentAssembly $defaultEvaluation } | Should -Throw '*Current assembly is missing*'
+
+            $env:Configuration = 'Release'
+            Invoke-SdkChangeExtraction -PackagePath (Split-Path $fixtures.Release.Project -Parent) `
+                -SdkRepoPath $fixtureRoot -OutputJsonFile $output
+            $report = Read-SdkChangeJson $output
+            $report.hasBreakingChange | Should -BeFalse
+            $report.details.baselineVersion | Should -Be '1.0.0'
+            $report.details.apiChanges.Count | Should -Be 0
+        }
+        finally {
+            $env:Configuration = $previousConfiguration
+        }
+    }
+
+    It 'explicitly scopes a common-script smoke when TargetFramework is inherited from the caller' {
+        Mock Get-SdkChangeLatestGaVersion { '1.0.0' }
+        Mock Get-SdkChangeBaseline { @{ Assembly = $fixtures.Before.Assembly; References = $fixtures.Before.References } }
+        $previousFramework = $env:TargetFramework
+        $output = Join-Path $fixtureRoot 'single-framework-report.json'
+        try {
+            $env:TargetFramework = 'net8.0'
+            Invoke-SdkChangeExtraction -PackagePath (Split-Path $fixtures.Before.Project -Parent) `
+                -SdkRepoPath $fixtureRoot -OutputJsonFile $output
+            $report = Read-SdkChangeJson $output
+            $report.hasBreakingChange | Should -BeFalse
+            $report.details.diagnostics | Should -Contain 'Current artifact scope: Configuration=Debug; TargetFrameworks=net8.0.'
+            $report.details.limitations -join ' ' | Should -Match 'declared frameworks not evaluated: net10.0'
+            $report.details.limitations -join ' ' | Should -Match 'not a full multi-target package comparison'
+        }
+        finally {
+            $env:TargetFramework = $previousFramework
+        }
+    }
+
+    It 'validates a real embedded PDB and does not require an external PDB file' {
+        $entry = $fixtures.Embedded
+        Test-Path -LiteralPath ([System.IO.Path]::ChangeExtension($entry.Assembly, '.pdb')) | Should -BeFalse
+        Assert-SdkChangeCurrentAssembly $entry.Evaluation | Should -Be $entry.Assembly
+    }
+
+    It 'validates source-generator output from the existing PDB without rerunning the generator' {
+        $entry = $fixtures.SourceGenerator
+        Assert-SdkChangeCurrentAssembly $entry.Evaluation | Should -Be $entry.Assembly
+        @(Get-SdkChangeCompilationDocuments -Assembly $entry.Assembly -Evaluation $entry.Evaluation).Name -join "`n" |
+            Should -Match 'JsonSourceGenerator'
+    }
+
+    It 'validates a real deterministic path-mapped PDB using sources in this checkout' {
+        $entry = $fixtures.Mapped
+        @(Get-SdkChangeCompilationDocuments -Assembly $entry.Assembly -Evaluation $entry.Evaluation).Name -join "`n" |
+            Should -Match '/_/Mapped/src/'
+        Assert-SdkChangeCurrentAssembly $entry.Evaluation | Should -Be $entry.Assembly
+    }
+
+    It 'uses the PDB compilation source count rather than treating #line documents as deleted inputs' {
+        $entry = $fixtures.Before
+        @(Get-SdkChangeCompilationDocuments -Assembly $entry.Assembly -Evaluation $entry.Evaluation).Name -join "`n" |
+            Should -Not -Match 'Logical.cs'
+        Assert-SdkChangeCurrentAssembly $entry.Evaluation | Should -Be $entry.Assembly
+    }
+
+    It 'detects a backdated change in a real enum-only source file' {
+        $entry = $fixtures.After
+        $source = Get-Item -LiteralPath (Join-Path $entry.Root 'src' 'EnumOnly.cs')
+        $original = [System.IO.File]::ReadAllBytes($source.FullName)
+        $time = $source.LastWriteTimeUtc
+        try {
+            [System.IO.File]::WriteAllText($source.FullName, 'namespace CompatibilityFixture; public enum UnchangedEnum { Changed }')
+            $source.LastWriteTimeUtc = $time
+            { Assert-SdkChangeCurrentAssembly $entry.Evaluation } | Should -Throw '*compiled checksum*'
+        }
+        finally {
+            [System.IO.File]::WriteAllBytes($source.FullName, $original)
+            $source.LastWriteTimeUtc = $time
+        }
+    }
+
+    It 'detects a deleted enum-only source that evaluation no longer includes' {
+        $entry = $fixtures.After
+        $evaluation = @{} + $entry.Evaluation
+        $evaluation.Items = @{} + $entry.Evaluation.Items
+        $evaluation.Items.Compile = @($evaluation.Items.Compile | Where-Object { $_.FullPath -notlike '*EnumOnly.cs' })
+        { Assert-SdkChangeCurrentAssembly $evaluation } | Should -Throw '*not an evaluated Compile input*'
+    }
+
+    It 'rejects an external PDB from a different compilation' {
+        $entry = $fixtures.After
+        $pdb = [System.IO.Path]::ChangeExtension($entry.Assembly, '.pdb')
+        $original = [System.IO.File]::ReadAllBytes($pdb)
+        try {
+            Copy-Item -LiteralPath ([System.IO.Path]::ChangeExtension($fixtures.Before.Assembly, '.pdb')) -Destination $pdb -Force
+            { Assert-SdkChangeCurrentAssembly $entry.Evaluation } | Should -Throw '*PDB does not match*'
+        }
+        finally {
+            [System.IO.File]::WriteAllBytes($pdb, $original)
+        }
+    }
+
+    It 'exits nonzero through the named-parameter entry point for stale artifacts and removes stale output' {
+        $source = Get-Item -LiteralPath (Join-Path $fixtures.After.Root 'src' 'After.cs')
+        $timestamp = $source.LastWriteTimeUtc
+        $output = Join-Path $fixtureRoot 'stale-report.json'
+        [System.IO.File]::WriteAllText($output, '{"hasBreakingChange":false}')
+        try {
+            $source.LastWriteTimeUtc = [datetime]::UtcNow.AddMinutes(1)
+            $messages = & pwsh -NoProfile -File (Join-Path $PSScriptRoot '..' 'Get-SdkChanges.ps1') `
+                -PackagePath (Split-Path $fixtures.After.Project -Parent) -SdkRepoPath $fixtureRoot -OutputJsonFile $output 2>&1
+            $LASTEXITCODE | Should -Not -Be 0
+            $messages -join "`n" | Should -Match 'Current assembly is stale'
+            Test-Path -LiteralPath $output | Should -BeFalse
+        }
+        finally {
+            $source.LastWriteTimeUtc = $timestamp
+        }
+    }
+}

--- a/eng/scripts/compatibility/tests/Get-SdkChanges.Tests.ps1
+++ b/eng/scripts/compatibility/tests/Get-SdkChanges.Tests.ps1
@@ -1,0 +1,713 @@
+#Requires -Version 7.0
+
+BeforeAll {
+    Set-StrictMode -Version 3
+    . (Join-Path $PSScriptRoot '..' 'Get-SdkChanges.Helpers.ps1')
+    $repo = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..')).Path
+    $nativeProject = Join-Path $PSScriptRoot '..' 'ApiCompat.proj'
+    $sdkPath = (& dotnet msbuild $nativeProject -nologo -getProperty:MSBuildToolsPath -tl:off).Trim()
+    if ($LASTEXITCODE -ne 0) { throw 'Could not evaluate the installed .NET SDK.' }
+    Initialize-SdkChangeNativeLibraries $sdkPath
+
+    function New-TestLog {
+        param([object[]]$Diagnostics = @(), [int]$ExitCode = 0)
+        return @{
+            Diagnostics = $Diagnostics
+            ExitCode = $ExitCode
+            Finished = $true
+            Completed = $true
+            Succeeded = $ExitCode -eq 0
+            ProcessOutput = ''
+        }
+    }
+
+    function New-TestDiagnostic {
+        param([string]$Code, [string]$Message = "Member 'Example.Client.Removed()' exists on the left but not on the right")
+        if (!$PSBoundParameters.ContainsKey('Message')) {
+            switch ($Code) {
+                'CP0003' { $Message = "lib/net8.0/Example.dll assembly version '1.0.0.0' should be equal to or higher than lib/net8.0/Example.dll version '2.0.0.0'." }
+                'CP0011' { $Message = "Value of field 'Default' in enum 'ValueOnly' changed from '1' to '2'." }
+                'CP0014' { $Message = "Cannot remove attribute 'Example.Attribute' from 'Example.Client.Removed()'." }
+                'CP0015' { $Message = "Cannot change arguments of attribute 'Example.Attribute' on 'Example.Client.Removed()'." }
+                'CP0016' { $Message = "Cannot add attribute 'Example.Attribute' to 'Example.Client.Removed()'." }
+            }
+        }
+        return @{ Code = $Code; Message = $Message; IsError = $true; EventKey = [guid]::NewGuid().ToString('N') }
+    }
+
+    function New-TestEvaluation {
+        param([string]$Root, [string]$Framework = 'net8.0', [string]$PackageId = 'Azure.ResourceManager.Example')
+        $project = Join-Path $Root 'src' "$PackageId.csproj"
+        $assembly = Join-Path $Root 'obj' $Framework "$PackageId.dll"
+        return @{
+            Properties = @{
+                MSBuildProjectFullPath = $project
+                MSBuildProjectName = $PackageId
+                MSBuildAllProjects = $project
+                AssemblyName = $PackageId
+                PackageId = $PackageId
+                TargetFramework = $Framework
+                TargetFrameworks = $Framework
+                TargetFrameworkMoniker = '.NETCoreApp,Version=v8.0'
+                TargetPath = Join-Path $Root 'bin' $Framework "$PackageId.dll"
+                TargetFileName = "$PackageId.dll"
+                ProjectAssetsFile = Join-Path $Root 'obj' 'project.assets.json'
+                IntermediateOutputPath = Join-Path $Root 'obj' $Framework
+                PdbFile = ''
+                Configuration = 'Debug'
+                ApiCompatBaselineTargetFramework = 'net8.0'
+                ApiCompatVersion = ''
+                RoslynAssembliesPath = Join-Path $sdkPath 'Roslyn' 'bincore'
+                ApiCompatRespectInternals = ''
+                ApiCompatStrictMode = ''
+                ApiCompatEnableRuleAttributesMustMatch = ''
+                ApiCompatEnableRuleCannotChangeParameterName = ''
+                ApiCompatPermitUnnecessarySuppressions = ''
+                NoWarn = ''
+                RuntimeIdentifier = ''
+                NuGetPackageRoot = ''
+                CompileUsingReferenceAssemblies = ''
+                TargetFrameworkRootPath = ''
+                TargetFrameworkFallbackSearchPaths = ''
+                FrameworkPathOverride = ''
+                BypassFrameworkInstallChecks = ''
+            }
+            Items = @{
+                IntermediateAssembly = @(@{ FullPath = $assembly })
+                Compile = @(@{ FullPath = Join-Path $Root 'src' 'Client.cs' })
+                AdditionalFiles = @()
+                EmbeddedResource = @()
+                Reference = @()
+                FrameworkReference = @()
+                ApiCompatSuppressionFile = @()
+                ApiCompatExcludeAttributesFile = @()
+            }
+            ImportedProjects = @()
+            RepositoryPath = $Root
+        }
+    }
+}
+
+Describe 'Latest stable NuGet baseline' -Tag 'UnitTest' {
+    It 'uses the actual public registry and orders stable NuGet versions numerically' {
+        Mock Invoke-RestMethod { [pscustomobject]@{ versions = @('1.9.0', '2.0.0-beta.9', '1.10.0', '1.10.0+metadata', '1.2.0') } }
+        Get-SdkChangeLatestGaVersion 'Azure.Example' | Should -Be '1.10.0'
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Uri -eq 'https://api.nuget.org/v3-flatcontainer/azure.example/index.json'
+        }
+    }
+
+    It 'does not treat stable 0.x versions as previews' {
+        Mock Invoke-RestMethod { [pscustomobject]@{ versions = @('0.2.0', '0.3.0-preview.1') } }
+        Get-SdkChangeLatestGaVersion 'Azure.Example' | Should -Be '0.2.0'
+    }
+
+    It 'accepts NuGet legacy four-part stable versions' {
+        Mock Invoke-RestMethod { [pscustomobject]@{ versions = @('1.2.3', '1.2.3.4') } }
+        Get-SdkChangeLatestGaVersion 'Azure.Example' | Should -Be '1.2.3.4'
+    }
+
+    It 'returns no baseline for <Name>' -TestCases @(
+        @{ Name = 'preview-only releases'; Versions = @('1.0.0-beta.1', '2.0.0-rc.1') },
+        @{ Name = 'an empty version index'; Versions = @() }
+    ) {
+        param($Versions)
+        Mock Invoke-RestMethod { [pscustomobject]@{ versions = $Versions } }
+        Get-SdkChangeLatestGaVersion 'Azure.Example' | Should -BeNullOrEmpty
+    }
+
+    It 'only treats an HTTP 404 as an absent package' {
+        Mock Invoke-RestMethod {
+            throw [Microsoft.PowerShell.Commands.HttpResponseException]::new(
+                'Not Found', [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::NotFound))
+        }
+        Get-SdkChangeLatestGaVersion 'Azure.Example' | Should -BeNullOrEmpty
+    }
+
+    It 'propagates HTTP <Status> rather than reporting first release' -TestCases @(
+        @{ Status = 401 }, @{ Status = 403 }, @{ Status = 429 }, @{ Status = 500 }
+    ) {
+        param($Status)
+        Mock Invoke-RestMethod {
+            throw [Microsoft.PowerShell.Commands.HttpResponseException]::new(
+                'Request failed', [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]$Status))
+        }
+        { Get-SdkChangeLatestGaVersion 'Azure.Example' } | Should -Throw '*Request failed*'
+    }
+
+    It 'propagates a connection failure' {
+        Mock Invoke-RestMethod { throw [System.Net.Http.HttpRequestException]::new('Network unavailable') }
+        { Get-SdkChangeLatestGaVersion 'Azure.Example' } | Should -Throw '*Network unavailable*'
+    }
+
+    It 'rejects malformed version indexes' -TestCases @(
+        @{ Response = [pscustomobject]@{ other = @() } },
+        @{ Response = [pscustomobject]@{ versions = '1.0.0' } },
+        @{ Response = [pscustomobject]@{ versions = @('1.0.0', 'not-a-version') } },
+        @{ Response = [pscustomobject]@{ versions = @(1) } },
+        @{ Response = $null }
+    ) {
+        param($Response)
+        Mock Invoke-RestMethod { $Response }
+        { Get-SdkChangeLatestGaVersion 'Azure.Example' } | Should -Throw
+    }
+}
+
+Describe 'Baseline restore configuration' -Tag 'UnitTest' {
+    BeforeEach {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        [void][System.IO.Directory]::CreateDirectory($root)
+        $config = Join-Path $root 'NuGet.Config'
+        [System.IO.File]::WriteAllText($config, '<configuration><packageSources><clear /></packageSources></configuration>')
+        Mock Invoke-SdkChangeProcess { @{ ExitCode = 0; StdOut = ''; StdErr = '' } }
+        Mock Read-SdkChangeBuildLog { @{ Finished = $true; Succeeded = $true; Diagnostics = @() } }
+        Mock Read-SdkChangeJson {
+            @{
+                Items = @{ ReferencePathWithRefAssemblies = @(@{ FullPath = 'reference.dll' }) }
+                Properties = @{ ProjectAssetsFile = 'project.assets.json'; TargetFrameworkDirectory = '' }
+            }
+        }
+    }
+
+    It 'uses the SDK repository feed configuration rather than adding a public download feed' {
+        $result = Invoke-SdkChangeReferenceResolution -SdkRepoPath $root -WorkDirectory (Join-Path $root 'work') `
+            -TargetFramework 'net8.0' -Properties @{} -Items @{} -Restore
+        $result.References | Should -Be @('reference.dll')
+        Should -Invoke Invoke-SdkChangeProcess -Times 1 -Exactly -ParameterFilter {
+            $Arguments -contains '-target:Restore' -and
+            $Arguments -contains "-property:RestoreConfigFile=$config" -and
+            @($Arguments | Where-Object { $_ -like '*RestoreSources=*' }).Count -eq 0
+        }
+    }
+
+    It 'rejects a missing repository configuration instead of using implicit feeds' {
+        Remove-Item -LiteralPath $config
+        {
+            Invoke-SdkChangeReferenceResolution -SdkRepoPath $root -WorkDirectory (Join-Path $root 'work') `
+                -TargetFramework 'net8.0' -Properties @{} -Items @{} -Restore
+        } | Should -Throw '*repository NuGet configuration is missing*'
+        Should -Invoke Invoke-SdkChangeProcess -Times 0 -Exactly
+    }
+
+    It 'does not resolve references after a failed configured-feed restore' {
+        Mock Invoke-SdkChangeProcess { @{ ExitCode = 1; StdOut = 'NU1301: Feed unavailable'; StdErr = '' } }
+        {
+            Invoke-SdkChangeReferenceResolution -SdkRepoPath $root -WorkDirectory (Join-Path $root 'work') `
+                -TargetFramework 'net8.0' -Properties @{} -Items @{} -Restore
+        } | Should -Throw '*Feed unavailable*'
+        Should -Invoke Invoke-SdkChangeProcess -Times 0 -Exactly -ParameterFilter {
+            $Arguments -contains '-target:ResolveSdkChangeReferences'
+        }
+    }
+
+    It 'adds framework dependencies and facades without replacing the compiler-selected reference' {
+        $framework = Join-Path $root 'framework'
+        $facades = Join-Path $framework 'Facades'
+        [void][System.IO.Directory]::CreateDirectory($facades)
+        foreach ($name in @('System.dll', 'System.Configuration.dll', 'System.xml', 'Native.dll')) {
+            [System.IO.File]::WriteAllText((Join-Path $framework $name), '')
+        }
+        Mock Get-SdkChangeAssemblyInfo {
+            if ([System.IO.Path]::GetFileName($Path) -eq 'Native.dll') { return $null }
+            return @{ Name = [System.IO.Path]::GetFileNameWithoutExtension($Path) }
+        } -ParameterFilter { $IgnoreNonAssembly }
+        [System.IO.File]::WriteAllText((Join-Path $facades 'System.Runtime.dll'), '')
+        $selected = Join-Path $root 'System.dll'
+        Mock Read-SdkChangeJson {
+            @{
+                Items = @{ ReferencePathWithRefAssemblies = @(@{ FullPath = $selected }) }
+                Properties = @{ ProjectAssetsFile = 'project.assets.json'; TargetFrameworkDirectory = "$framework;;$facades;" }
+            }
+        }
+        $result = Invoke-SdkChangeReferenceResolution -SdkRepoPath $root -WorkDirectory (Join-Path $root 'work') `
+            -TargetFramework 'net462' -Properties @{} -Items @{}
+        $result.References.Count | Should -Be 3
+        $result.References | Should -Contain $selected
+        $result.References | Should -Contain (Join-Path $framework 'System.Configuration.dll')
+        $result.References | Should -Contain (Join-Path $facades 'System.Runtime.dll')
+        $result.References | Should -Not -Contain (Join-Path $framework 'System.dll')
+    }
+
+    It 'fails explicitly if an evaluated framework directory is unavailable' {
+        Mock Read-SdkChangeJson {
+            @{
+                Items = @{ ReferencePathWithRefAssemblies = @(@{ FullPath = 'reference.dll' }) }
+                Properties = @{ ProjectAssetsFile = 'project.assets.json'; TargetFrameworkDirectory = (Join-Path $root 'missing') }
+            }
+        }
+        {
+            Invoke-SdkChangeReferenceResolution -SdkRepoPath $root -WorkDirectory (Join-Path $root 'work') `
+                -TargetFramework 'net462' -Properties @{} -Items @{}
+        } | Should -Throw '*framework reference directory is missing*'
+    }
+}
+
+Describe 'Assembly reference preflight' -Tag 'UnitTest' {
+    It 'does not require private implementation dependencies from reference-assembly packs' {
+        $assembly = Join-Path $TestDrive 'Current.dll'
+        $reference = Join-Path $TestDrive 'Framework.dll'
+        [System.IO.File]::WriteAllText($assembly, '')
+        [System.IO.File]::WriteAllText($reference, '')
+        Mock Get-SdkChangeAssemblyInfo {
+            if ($Path -eq $assembly) { return @{ Name = 'Current'; References = @('Framework') } }
+            return @{ Name = 'Framework'; References = @('Private.Implementation') }
+        }
+        { Assert-SdkChangeReferences -Assembly $assembly -References @($reference) } | Should -Not -Throw
+    }
+}
+
+Describe 'Structured native ApiCompat classification' -Tag 'UnitTest' {
+    It 'reports a clean comparison with no changes' {
+        $result = ConvertFrom-SdkChangeApiCompat -Log (New-TestLog) -TargetFramework 'net8.0'
+        $result.Changes.Count | Should -Be 0
+        $result.Diagnostics.Count | Should -Be 0
+    }
+
+    It 'classifies forward <Code> as <Kind>' -TestCases @(
+        @{ Code = 'CP0001'; Kind = 'removed' }, @{ Code = 'CP0002'; Kind = 'removed' },
+        @{ Code = 'CP0003'; Kind = 'changed' }, @{ Code = 'CP0005'; Kind = 'changed' },
+        @{ Code = 'CP0006'; Kind = 'changed' }, @{ Code = 'CP0007'; Kind = 'changed' },
+        @{ Code = 'CP0008'; Kind = 'changed' }, @{ Code = 'CP0009'; Kind = 'changed' },
+        @{ Code = 'CP0010'; Kind = 'changed' }, @{ Code = 'CP0011'; Kind = 'changed' },
+        @{ Code = 'CP0012'; Kind = 'changed' }, @{ Code = 'CP0013'; Kind = 'changed' },
+        @{ Code = 'CP0014'; Kind = 'changed' }, @{ Code = 'CP0015'; Kind = 'changed' },
+        @{ Code = 'CP0016'; Kind = 'changed' }, @{ Code = 'CP0017'; Kind = 'changed' },
+        @{ Code = 'CP0018'; Kind = 'changed' }, @{ Code = 'CP0019'; Kind = 'changed' },
+        @{ Code = 'CP0020'; Kind = 'changed' }, @{ Code = 'CP0021'; Kind = 'changed' }
+    ) {
+        param($Code, $Kind)
+        $log = New-TestLog -Diagnostics @((New-TestDiagnostic $Code)) -ExitCode 1
+        $result = ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'netstandard2.0'
+        $result.Changes.Count | Should -Be 1
+        $result.Changes[0].kind | Should -Be $Kind
+        $expectedSymbol = if ($Code -eq 'CP0011') { 'ValueOnly.Default' } elseif ($Code -eq 'CP0003') { 'lib/net8.0/Example.dll' } else { 'Example.Client.Removed()' }
+        $result.Changes[0].symbol | Should -Be $expectedSymbol
+        $result.Changes[0].isBreaking | Should -BeTrue
+        $result.Changes[0].diagnosticId | Should -Be $Code
+        $result.Changes[0].targetFramework | Should -Be 'netstandard2.0'
+    }
+
+    It 'deduplicates repeated events without collapsing distinct diagnostics for the same symbol' {
+        $one = New-TestDiagnostic 'CP0015'
+        $two = New-TestDiagnostic 'CP0017'
+        $log = New-TestLog -Diagnostics @($one, $one, $two, $two) -ExitCode 1
+        $result = ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0'
+        $result.Changes.Count | Should -Be 2
+        $result.Diagnostics.Count | Should -Be 2
+    }
+
+    It 'preserves distinct native events whose unqualified enum messages are identical' {
+        $log = New-TestLog -Diagnostics @((New-TestDiagnostic 'CP0011'), (New-TestDiagnostic 'CP0011')) -ExitCode 1
+        $result = ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0'
+        $result.Changes.Count | Should -Be 2
+        $result.Limitations -join ' ' | Should -Match 'unqualified enum/field'
+    }
+
+    It 'retains only type/member existence differences from the reverse comparison' {
+        $log = New-TestLog -Diagnostics @(
+            (New-TestDiagnostic 'CP0001'), (New-TestDiagnostic 'CP0002'),
+            (New-TestDiagnostic 'CP0006'), (New-TestDiagnostic 'CP0015')
+        ) -ExitCode 1
+        $result = ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0' -Reverse
+        $result.Changes.Count | Should -Be 2
+        @($result.Changes | Where-Object { $_.isBreaking }).Count | Should -Be 0
+        @($result.Changes | Where-Object { $_.kind -ne 'added' }).Count | Should -Be 0
+        $result.Diagnostics.Count | Should -Be 4
+        $result.Limitations.Count | Should -Be 2
+    }
+
+    It 'fails closed on unknown, missing-assembly, dependency, and noncompatibility diagnostic <Code>' -TestCases @(
+        @{ Code = 'CP0004' }, @{ Code = 'CP1002' }, @{ Code = 'CP9999' },
+        @{ Code = 'MSB4018' }, @{ Code = 'MSB3245' }, @{ Code = 'NU1101' }, @{ Code = '' }
+    ) {
+        param($Code)
+        $log = New-TestLog -Diagnostics @((New-TestDiagnostic $Code)) -ExitCode 1
+        { ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0' } | Should -Throw '*fatal*'
+    }
+
+    It 'does not mistake an unidentifiable symbol for a known symbol' {
+        $log = New-TestLog -Diagnostics @((New-TestDiagnostic 'CP0017' 'A diagnostic without a quoted symbol')) -ExitCode 1
+        $result = ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0'
+        $result.Changes[0].symbol | Should -Be ''
+        $result.Limitations[0] | Should -Match 'symbol.*could not be extracted'
+    }
+
+    It 'does not mistake an unknown assembly identity diagnostic value for an API symbol' {
+        $log = New-TestLog -Diagnostics @((New-TestDiagnostic 'CP0003' "Unsupported identity difference: version '1.0.0.0'.")) -ExitCode 1
+        $result = ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0'
+        $result.Changes[0].symbol | Should -Be ''
+        $result.Limitations[0] | Should -Match 'symbol.*could not be extracted'
+    }
+
+    It 'rejects partial output even when it includes valid compatibility violations' -TestCases @(
+        @{ ExitCode = 137; Finished = $true; Completed = $true },
+        @{ ExitCode = 1; Finished = $false; Completed = $true },
+        @{ ExitCode = 1; Finished = $true; Completed = $false }
+    ) {
+        param($ExitCode, $Finished, $Completed)
+        $log = New-TestLog -Diagnostics @((New-TestDiagnostic 'CP0002')) -ExitCode $ExitCode
+        $log.Finished = $Finished
+        $log.Completed = $Completed
+        { ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0' } | Should -Throw '*did not complete*'
+    }
+
+    It 'rejects an unsuccessful tool without compatibility errors' {
+        { ConvertFrom-SdkChangeApiCompat -Log (New-TestLog -ExitCode 1) -TargetFramework 'net8.0' } |
+            Should -Throw '*without a recognized compatibility diagnostic*'
+    }
+
+    It 'preserves the exact native header but does not count a header alone as a compatibility violation' {
+        $header = "API compatibility errors between 'lib/net8.0/Example.dll' (left) and 'lib/net8.0/Example.dll' (right):"
+        $log = New-TestLog -Diagnostics @((New-TestDiagnostic '' $header), (New-TestDiagnostic 'CP0002')) -ExitCode 1
+        $log.CompatibilityHeader = $header
+        $result = ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0'
+        $result.Changes.Count | Should -Be 1
+        $result.Diagnostics.Count | Should -Be 2
+        $log.Diagnostics = @((New-TestDiagnostic '' $header))
+        { ConvertFrom-SdkChangeApiCompat -Log $log -TargetFramework 'net8.0' } |
+            Should -Throw '*without a recognized compatibility diagnostic*'
+    }
+}
+
+Describe 'Common SDK change JSON contract' -Tag 'UnitTest' {
+    It 'emits only the common top-level fields and additive details, with real booleans and arrays' {
+        $result = New-SdkChangeReport -BaselineVersion '1.2.3' -Changes @() -Diagnostics @() -Limitations @()
+        $json = $result | ConvertTo-Json -Depth 10 | ConvertFrom-Json -AsHashtable
+        @($json.Keys) | Should -Be @('changes', 'hasBreakingChange', 'details')
+        @($json.details.Keys) | Should -Be @('baselineVersion', 'apiChanges', 'diagnostics', 'limitations')
+        $json.hasBreakingChange | Should -BeOfType [bool]
+        $json.hasBreakingChange | Should -BeFalse
+        $json.details.baselineVersion | Should -Be '1.2.3'
+        ($json.details.apiChanges -is [array]) | Should -BeTrue
+        $json.changes | Should -Be "### Breaking Changes`nNone.`n`n### Features Added`nNone."
+    }
+
+    It 'does not OR reverse failures into hasBreakingChange' {
+        $reverse = ConvertFrom-SdkChangeApiCompat -Log (New-TestLog -Diagnostics @((New-TestDiagnostic 'CP0001')) -ExitCode 1) `
+            -TargetFramework 'net8.0' -Reverse
+        $result = New-SdkChangeReport -BaselineVersion '1.2.3' -Changes $reverse.Changes -Diagnostics $reverse.Diagnostics -Limitations $reverse.Limitations
+        $result.hasBreakingChange | Should -BeFalse
+        $result.changes | Should -Match '### Features Added\n- \[CP0001\]'
+    }
+
+    It 'keeps a possible rename or changed signature as independent removal and addition evidence' {
+        $forward = ConvertFrom-SdkChangeApiCompat -Log (New-TestLog -Diagnostics @(
+            (New-TestDiagnostic 'CP0002' "Member 'Client.OldName()' does not exist on the right")
+        ) -ExitCode 1) -TargetFramework 'net8.0'
+        $reverse = ConvertFrom-SdkChangeApiCompat -Log (New-TestLog -Diagnostics @(
+            (New-TestDiagnostic 'CP0002' "Member 'Client.NewName()' does not exist on the right")
+        ) -ExitCode 1) -TargetFramework 'net8.0' -Reverse
+        $result = New-SdkChangeReport -BaselineVersion '1.0.0' -Changes ($forward.Changes + $reverse.Changes) -Diagnostics @() -Limitations @()
+        @($result.details.apiChanges.kind) | Should -Be @('removed', 'added')
+        $result.hasBreakingChange | Should -BeTrue
+        $result.details.limitations -join ' ' | Should -Match 'Correlating changed signatures or renames requires review'
+    }
+
+    It 'marks the absence of a GA baseline as not applicable, not a successful clean comparison' {
+        $result = New-SdkChangeReport -BaselineVersion $null -Changes @() -Diagnostics @() -Limitations @('No GA baseline exists.')
+        $result.details.baselineVersion | Should -BeNullOrEmpty
+        ($result | ConvertTo-Json -Depth 10) | Should -Match '"baselineVersion": null'
+        $result.changes | Should -Match 'no comparison was performed'
+    }
+}
+
+Describe 'Current artifact and configuration validation' -Tag 'UnitTest' {
+    BeforeEach {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $evaluation = New-TestEvaluation $root
+        $paths = @(
+            $evaluation.Properties.MSBuildProjectFullPath,
+            $evaluation.Properties.ProjectAssetsFile,
+            $evaluation.Items.Compile[0].FullPath,
+            $evaluation.Items.IntermediateAssembly[0].FullPath
+        )
+        foreach ($path in $paths) {
+            [void][System.IO.Directory]::CreateDirectory((Split-Path $path -Parent))
+            [System.IO.File]::WriteAllText($path, 'fixture')
+            (Get-Item -LiteralPath $path).LastWriteTimeUtc = [datetime]::UtcNow.AddMinutes(-10)
+        }
+        $assembly = $evaluation.Items.IntermediateAssembly[0].FullPath
+        (Get-Item -LiteralPath $assembly).LastWriteTimeUtc = [datetime]::UtcNow.AddMinutes(-5)
+        Mock Get-SdkChangeAssemblyInfo {
+            @{ Name = $evaluation.Properties.AssemblyName; TargetFramework = $evaluation.Properties.TargetFrameworkMoniker; References = @() }
+        }
+        Mock Assert-SdkChangeCompilationSources {}
+    }
+
+    It 'uses the evaluated intermediate assembly rather than a guessed package or bin path' {
+        Assert-SdkChangeCurrentAssembly $evaluation | Should -Be $assembly
+    }
+
+    It 'rejects a missing current artifact' {
+        Remove-Item -LiteralPath $assembly
+        { Assert-SdkChangeCurrentAssembly $evaluation } | Should -Throw '*Current assembly is missing*'
+    }
+
+    It 'rejects a newer <InputKind>' -TestCases @(
+        @{ InputKind = 'source' }, @{ InputKind = 'project' }, @{ InputKind = 'assets' }, @{ InputKind = 'import' }, @{ InputKind = 'resource' }
+    ) {
+        param($InputKind)
+        $path = switch ($InputKind) {
+            'source' { $evaluation.Items.Compile[0].FullPath }
+            'project' { $evaluation.Properties.MSBuildProjectFullPath }
+            'assets' { $evaluation.Properties.ProjectAssetsFile }
+            'import' {
+                $path = Join-Path $root 'Imported.props'
+                [System.IO.File]::WriteAllText($path, '<Project />')
+                $evaluation.ImportedProjects = @($path)
+                $path
+            }
+            'resource' {
+                $path = Join-Path $root 'Resource.resx'
+                [System.IO.File]::WriteAllText($path, 'resource')
+                $evaluation.Items.EmbeddedResource = @(@{ FullPath = $path })
+                $path
+            }
+        }
+        (Get-Item -LiteralPath $path).LastWriteTimeUtc = [datetime]::UtcNow
+        { Assert-SdkChangeCurrentAssembly $evaluation } | Should -Throw '*Current assembly is stale*'
+    }
+
+    It 'rejects a missing source or restore input' {
+        Remove-Item -LiteralPath $evaluation.Properties.ProjectAssetsFile
+        { Assert-SdkChangeCurrentAssembly $evaluation } | Should -Throw '*build input is missing*'
+    }
+
+    It 'rejects an assembly built for the wrong target framework' {
+        Mock Get-SdkChangeAssemblyInfo { @{ Name = $evaluation.Properties.AssemblyName; TargetFramework = '.NETCoreApp,Version=v10.0' } }
+        { Assert-SdkChangeCurrentAssembly $evaluation } | Should -Throw '*identity/target framework does not match*'
+    }
+
+    It 'rejects a misidentified assembly' {
+        Mock Get-SdkChangeAssemblyInfo { @{ Name = 'Wrong.Assembly'; TargetFramework = $evaluation.Properties.TargetFrameworkMoniker } }
+        { Assert-SdkChangeCurrentAssembly $evaluation } | Should -Throw '*identity/target framework does not match*'
+    }
+
+    It 'requires the package to be inside the supplied repository' {
+        $other = Join-Path $TestDrive 'other'
+        [void][System.IO.Directory]::CreateDirectory($other)
+        { Get-SdkChangeProject -PackagePath $root -SdkRepoPath $other } | Should -Throw '*inside SdkRepoPath*'
+    }
+
+    It 'accepts package, src, and project paths' {
+        foreach ($path in @($root, (Join-Path $root 'src'), $evaluation.Properties.MSBuildProjectFullPath)) {
+            Get-SdkChangeProject -PackagePath $path -SdkRepoPath $root | Should -Be $evaluation.Properties.MSBuildProjectFullPath
+        }
+    }
+
+    It 'rejects ambiguous source projects' {
+        [System.IO.File]::WriteAllText((Join-Path $root 'src' 'Another.csproj'), '<Project />')
+        { Get-SdkChangeProject -PackagePath $root -SdkRepoPath $root } | Should -Throw '*exactly one*'
+    }
+
+    It 'preserves central suppressions and default rules even without ApiCompatVersion' {
+        $excludes = Join-Path $root 'eng' 'ApiListing.exclude-attributes.txt'
+        $suppression = Join-Path $root 'eng' 'apicompatbaselines' "$($evaluation.Properties.MSBuildProjectName).xml"
+        [void][System.IO.Directory]::CreateDirectory((Split-Path $suppression -Parent))
+        [System.IO.File]::WriteAllText($excludes, 'T:System.ObsoleteAttribute')
+        [System.IO.File]::WriteAllText($suppression, '<Suppressions />')
+        $hash = (Get-FileHash -LiteralPath $suppression).Hash
+        $rules = Get-SdkChangeRules -Evaluation $evaluation -SdkRepoPath $root
+        $rules.Properties.ApiCompatEnableRuleAttributesMustMatch | Should -BeTrue
+        $rules.Properties.ApiCompatEnableRuleCannotChangeParameterName | Should -BeTrue
+        $rules.Properties.ApiCompatPermitUnnecessarySuppressions | Should -BeTrue
+        $rules.Suppressions | Should -Be @($suppression)
+        $rules.Excludes | Should -Be @($excludes)
+        (Get-FileHash -LiteralPath $suppression).Hash | Should -Be $hash
+    }
+
+    It 'preserves configured strictness, internals, rule disabling, and NoWarn' {
+        $excludes = Join-Path $root 'exclude.txt'
+        [System.IO.File]::WriteAllText($excludes, '')
+        $evaluation.Items.ApiCompatExcludeAttributesFile = @(@{ FullPath = $excludes })
+        $evaluation.Properties.ApiCompatRespectInternals = 'true'
+        $evaluation.Properties.ApiCompatStrictMode = 'true'
+        $evaluation.Properties.ApiCompatEnableRuleAttributesMustMatch = 'false'
+        $evaluation.Properties.ApiCompatEnableRuleCannotChangeParameterName = 'false'
+        $evaluation.Properties.NoWarn = 'CP0015;CP0017'
+        $rules = Get-SdkChangeRules -Evaluation $evaluation -SdkRepoPath $root
+        $rules.Properties.ApiCompatRespectInternals | Should -BeTrue
+        $rules.Properties.ApiCompatStrictMode | Should -BeTrue
+        $rules.Properties.ApiCompatEnableRuleAttributesMustMatch | Should -BeFalse
+        $rules.Properties.ApiCompatEnableRuleCannotChangeParameterName | Should -BeFalse
+        $rules.Properties.NoWarn | Should -Be 'CP0015;CP0017'
+    }
+}
+
+Describe 'Extraction orchestration and failure behavior' -Tag 'UnitTest' {
+    BeforeEach {
+        $evaluation = New-TestEvaluation -Root $TestDrive
+        $output = Join-Path $TestDrive 'result.json'
+        Mock Get-SdkChangeProject { $evaluation.Properties.MSBuildProjectFullPath }
+        Mock Get-SdkChangeEvaluation { $evaluation }
+        Mock Assert-SdkChangeCurrentAssembly { $evaluation.Items.IntermediateAssembly[0].FullPath }
+        Mock Get-FileHash { @{ Hash = 'fixture-assembly-hash' } }
+        Mock Get-SdkChangeLatestGaVersion { '9.1.0' }
+        Mock Get-SdkChangeBaseline { @{ Assembly = 'baseline.dll'; References = @('baseline-reference.dll') } }
+        Mock Get-SdkChangeCurrentReferences { @('current-reference.dll') }
+        Mock Assert-SdkChangeReferences {}
+        Mock Get-SdkChangeRules { @{ Properties = @{}; Excludes = @(); Suppressions = @() } }
+        Mock Invoke-SdkChangeApiCompat { New-TestLog }
+    }
+
+    It 'queries the latest GA independently of stale or missing ApiCompatVersion: <OldVersion>' -TestCases @(
+        @{ OldVersion = '' }, @{ OldVersion = '1.0.0' }, @{ OldVersion = '100.0.0-beta.1' }
+    ) {
+        param($OldVersion)
+        $evaluation.Properties.ApiCompatVersion = $OldVersion
+        Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output
+        (Read-SdkChangeJson $output).details.baselineVersion | Should -Be '9.1.0'
+        Should -Invoke Get-SdkChangeBaseline -Times 1 -Exactly -ParameterFilter { $Version -eq '9.1.0' }
+    }
+
+    It 'supports both planes and evaluated baseline frameworks: <PackageId>, <Framework>' -TestCases @(
+        @{ PackageId = 'Azure.ResourceManager.Example'; Framework = 'netstandard2.0' },
+        @{ PackageId = 'Azure.Storage.Example'; Framework = 'netstandard2.0' },
+        @{ PackageId = 'Azure.Data.Example'; Framework = 'net8.0' }
+    ) {
+        param($PackageId, $Framework)
+        $evaluation = New-TestEvaluation -Root $TestDrive -PackageId $PackageId -Framework $Framework
+        $evaluation.Properties.ApiCompatBaselineTargetFramework = $Framework
+        Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output
+        Should -Invoke Get-SdkChangeBaseline -Times 1 -Exactly -ParameterFilter {
+            $TargetFramework -eq $Framework -and $PackageId -eq $evaluation.Properties.PackageId
+        }
+    }
+
+    It 'writes a successful report for compatibility violations' {
+        Mock Invoke-SdkChangeApiCompat {
+            if ($LeftAssembly -eq 'baseline.dll') {
+                New-TestLog -Diagnostics @((New-TestDiagnostic 'CP0002')) -ExitCode 1
+            }
+            else { New-TestLog }
+        }
+        Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output
+        (Read-SdkChangeJson $output).hasBreakingChange | Should -BeTrue
+    }
+
+    It 'does not resolve a baseline or run ApiCompat when no GA exists' {
+        Mock Get-SdkChangeLatestGaVersion { $null }
+        Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output
+        $report = Read-SdkChangeJson $output
+        $report.details.baselineVersion | Should -BeNullOrEmpty
+        $report.details.limitations -join ' ' | Should -Match 'no comparison was performed'
+        Should -Invoke Get-SdkChangeBaseline -Times 0 -Exactly
+        Should -Invoke Invoke-SdkChangeApiCompat -Times 0 -Exactly
+    }
+
+    It 'records a narrowed framework scope without adding raw contract fields' {
+        $evaluation.Properties.TargetFrameworks = 'net8.0;net10.0'
+        Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output
+        $report = Read-SdkChangeJson $output
+        $report.details.diagnostics | Should -Contain 'Current artifact scope: Configuration=Debug; TargetFrameworks=net8.0.'
+        $report.details.limitations -join ' ' | Should -Match 'declared frameworks not evaluated: net10.0'
+        $report.details.limitations -join ' ' | Should -Match 'not a full multi-target package comparison'
+        @($report.details.Keys) | Should -Be @('baselineVersion', 'apiChanges', 'diagnostics', 'limitations')
+    }
+
+    It 'removes stale output on a registry failure' {
+        [System.IO.File]::WriteAllText($output, '{"hasBreakingChange":false}')
+        Mock Get-SdkChangeLatestGaVersion { throw 'Registry unavailable' }
+        { Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output } |
+            Should -Throw '*Registry unavailable*'
+        Test-Path -LiteralPath $output | Should -BeFalse
+    }
+
+    It 'removes stale output on a missing artifact, even for a first release' {
+        [System.IO.File]::WriteAllText($output, '{"hasBreakingChange":false}')
+        Mock Assert-SdkChangeCurrentAssembly { throw 'Current assembly is missing' }
+        Mock Get-SdkChangeLatestGaVersion { $null }
+        { Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output } |
+            Should -Throw '*Current assembly is missing*'
+        Test-Path -LiteralPath $output | Should -BeFalse
+        Should -Invoke Get-SdkChangeLatestGaVersion -Times 0 -Exactly
+    }
+
+    It 'leaves no success-shaped output on a partial native process failure' {
+        [System.IO.File]::WriteAllText($output, '{"hasBreakingChange":false}')
+        Mock Invoke-SdkChangeApiCompat {
+            $log = New-TestLog -Diagnostics @((New-TestDiagnostic 'CP0002')) -ExitCode 1
+            $log.Completed = $false
+            $log
+        }
+        { Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output } |
+            Should -Throw '*did not complete*'
+        Test-Path -LiteralPath $output | Should -BeFalse
+    }
+
+    It 'fails before comparison when a dependency cannot be loaded' {
+        [System.IO.File]::WriteAllText($output, '{"hasBreakingChange":false}')
+        Mock Assert-SdkChangeReferences { throw "Missing assembly reference 'Dependency'." }
+        { Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output } |
+            Should -Throw '*Missing assembly reference*'
+        Test-Path -LiteralPath $output | Should -BeFalse
+        Should -Invoke Invoke-SdkChangeApiCompat -Times 0 -Exactly
+    }
+
+    It 'does not publish a report if a concurrent build replaces the current assembly' {
+        $script:hashCalls = 0
+        Mock Get-FileHash {
+            $script:hashCalls++
+            @{ Hash = "assembly-$script:hashCalls" }
+        }
+        { Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile $output } |
+            Should -Throw '*assembly changed during extraction*'
+        Test-Path -LiteralPath $output | Should -BeFalse
+    }
+
+    It 'requires an absolute output path' {
+        { Invoke-SdkChangeExtraction -PackagePath $TestDrive -SdkRepoPath $TestDrive -OutputJsonFile 'result.json' } |
+            Should -Throw '*must be absolute*'
+    }
+}
+
+Describe 'Portable PDB compilation freshness' -Tag 'UnitTest' {
+    BeforeEach {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $evaluation = New-TestEvaluation $root
+        $source = $evaluation.Items.Compile[0].FullPath
+        [void][System.IO.Directory]::CreateDirectory((Split-Path $source -Parent))
+        [System.IO.File]::WriteAllText($source, 'public class Client {}')
+        $documents = @(@{ Name = $source; Algorithm = 'SHA256'; Hash = (Get-FileHash -LiteralPath $source).Hash })
+        Mock Get-SdkChangeCompilationDocuments { $documents }
+    }
+
+    It 'accepts matching physical source checksums' {
+        { Assert-SdkChangeCompilationSources -Assembly 'unused.dll' -Evaluation $evaluation } | Should -Not -Throw
+    }
+
+    It 'maps deterministic PDB paths to this checkout rather than reading a different checkout' {
+        $documents[0].Name = '/_/src/Client.cs'
+        { Assert-SdkChangeCompilationSources -Assembly 'unused.dll' -Evaluation $evaluation } | Should -Not -Throw
+    }
+
+    It 'ignores compiler-generated documents under the evaluated intermediate path' {
+        $documents += @{ Name = Join-Path $evaluation.Properties.IntermediateOutputPath 'Generator' 'Generated.cs'; Algorithm = ''; Hash = '' }
+        { Assert-SdkChangeCompilationSources -Assembly 'unused.dll' -Evaluation $evaluation } | Should -Not -Throw
+    }
+
+    It 'rejects changed source even if its timestamp was preserved' {
+        $time = (Get-Item -LiteralPath $source).LastWriteTimeUtc
+        [System.IO.File]::WriteAllText($source, 'public class RenamedClient {}')
+        (Get-Item -LiteralPath $source).LastWriteTimeUtc = $time
+        { Assert-SdkChangeCompilationSources -Assembly 'unused.dll' -Evaluation $evaluation } | Should -Throw '*compiled checksum*'
+    }
+
+    It 'rejects a deleted source that is no longer included by evaluation' {
+        $evaluation.Items.Compile = @()
+        Remove-Item -LiteralPath $source
+        { Assert-SdkChangeCompilationSources -Assembly 'unused.dll' -Evaluation $evaluation } | Should -Throw '*not an evaluated Compile input*'
+    }
+
+    It 'rejects an added compile input that is absent from the PDB' {
+        $newFile = Join-Path $root 'src' 'Added.cs'
+        [System.IO.File]::WriteAllText($newFile, 'public class Added {}')
+        $evaluation.Items.Compile += @{ FullPath = $newFile }
+        { Assert-SdkChangeCompilationSources -Assembly 'unused.dll' -Evaluation $evaluation } | Should -Throw '*does not contain the evaluated Compile input*'
+    }
+
+    It 'fails explicitly on an unsupported source checksum' {
+        $documents[0].Algorithm = ''
+        { Assert-SdkChangeCompilationSources -Assembly 'unused.dll' -Evaluation $evaluation } | Should -Throw '*no supported source checksum*'
+    }
+}

--- a/eng/scripts/compatibility/tests/fixtures/dependency/Dependency.csproj
+++ b/eng/scripts/compatibility/tests/fixtures/dependency/Dependency.csproj
@@ -1,0 +1,20 @@
+<Project>
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Target Name="PoisonBuildAndAnalyzers" BeforeTargets="Build;Compile;CoreCompile;RunAnalyzers;ResolveReferences"
+          Condition="Exists('do-not-build')">
+    <Error Text="Fixture dependencies must not be built during SDK change extraction." />
+  </Target>
+</Project>

--- a/eng/scripts/compatibility/tests/fixtures/dependency/Parent.cs
+++ b/eng/scripts/compatibility/tests/fixtures/dependency/Parent.cs
@@ -1,0 +1,6 @@
+namespace FixtureDependency;
+
+public class Parent : System.Data.DataTable
+{
+    public void BaseMember() { }
+}

--- a/eng/scripts/compatibility/tests/fixtures/src/Added.cs
+++ b/eng/scripts/compatibility/tests/fixtures/src/Added.cs
@@ -1,0 +1,6 @@
+namespace CompatibilityFixture;
+
+public class AddedType
+{
+    public void Added() { }
+}

--- a/eng/scripts/compatibility/tests/fixtures/src/After.cs
+++ b/eng/scripts/compatibility/tests/fixtures/src/After.cs
@@ -1,0 +1,16 @@
+namespace CompatibilityFixture;
+
+public class Widget : FixtureDependency.Parent
+{
+    public void NewName() { }
+    public string Signature() => "";
+    public void Parameter(string newName) { }
+    [Marker(2)]
+    public void AttributeChange() { }
+    public void Virtual() { }
+    public int Value { get; }
+}
+
+public interface IContract { void Required(); }
+public enum Flavor : int { Default = 2 }
+public enum ValueOnly { Default = 2 }

--- a/eng/scripts/compatibility/tests/fixtures/src/Azure.ResourceManager.CompatibilityFixture.csproj
+++ b/eng/scripts/compatibility/tests/fixtures/src/Azure.ResourceManager.CompatibilityFixture.csproj
@@ -1,0 +1,38 @@
+<Project>
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NuGetAudit>false</NuGetAudit>
+    <IsMgmtLibrary>true</IsMgmtLibrary>
+    <FixtureVariant>Before</FixtureVariant>
+    <ApiCompatBaselineTargetFramework>net8.0</ApiCompatBaselineTargetFramework>
+    <ApiCompatEnableRuleAttributesMustMatch>true</ApiCompatEnableRuleAttributesMustMatch>
+    <ApiCompatEnableRuleCannotChangeParameterName>true</ApiCompatEnableRuleCannotChangeParameterName>
+  </PropertyGroup>
+  <Import Project="Fixture.props" Condition="Exists('Fixture.props')" />
+  <ItemGroup>
+    <Compile Include="Shared.cs" />
+    <Compile Include="EnumOnly.cs" />
+    <Compile Include="Before.cs" Condition="'$(FixtureVariant)' != 'After'" />
+    <Compile Include="After.cs" Condition="'$(FixtureVariant)' == 'After'" />
+    <Compile Include="Enums.Before.cs" Condition="'$(FixtureVariant)' != 'After'" />
+    <Compile Include="Enums.After.cs" Condition="'$(FixtureVariant)' == 'After'" />
+    <Compile Include="Added.cs" Condition="'$(FixtureVariant)' == 'After' or '$(FixtureVariant)' == 'Additions'" />
+    <Compile Include="SourceGenerator.cs" Condition="'$(FixtureVariant)' == 'SourceGenerator'" />
+    <ProjectReference Include="..\dependency\Dependency.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Target Name="PoisonBuildAndAnalyzers" BeforeTargets="Build;Compile;CoreCompile;RunAnalyzers;ResolveReferences"
+          Condition="Exists('do-not-build')">
+    <Error Text="Fixture build/analyzer targets must never run during SDK change extraction." />
+  </Target>
+</Project>

--- a/eng/scripts/compatibility/tests/fixtures/src/Before.cs
+++ b/eng/scripts/compatibility/tests/fixtures/src/Before.cs
@@ -1,0 +1,18 @@
+namespace CompatibilityFixture;
+
+public class Widget : FixtureDependency.Parent
+{
+    public void Removed() { }
+    public void OldName() { }
+    public int Signature() => 0;
+    public void Parameter(string oldName) { }
+    [Marker(1)]
+    public void AttributeChange() { }
+    public virtual void Virtual() { }
+    public int Value { get; set; }
+}
+
+public interface IContract { }
+public enum Flavor : byte { Default = 1 }
+public enum ValueOnly { Default = 1 }
+public class RemovedType { }

--- a/eng/scripts/compatibility/tests/fixtures/src/EnumOnly.cs
+++ b/eng/scripts/compatibility/tests/fixtures/src/EnumOnly.cs
@@ -1,0 +1,3 @@
+namespace CompatibilityFixture;
+
+public enum UnchangedEnum { One, Two }

--- a/eng/scripts/compatibility/tests/fixtures/src/Enums.After.cs
+++ b/eng/scripts/compatibility/tests/fixtures/src/Enums.After.cs
@@ -1,0 +1,9 @@
+namespace FirstNamespace
+{
+    public enum Ambiguous { Value = 2 }
+}
+
+namespace SecondNamespace
+{
+    public enum Ambiguous { Value = 2 }
+}

--- a/eng/scripts/compatibility/tests/fixtures/src/Enums.Before.cs
+++ b/eng/scripts/compatibility/tests/fixtures/src/Enums.Before.cs
@@ -1,0 +1,9 @@
+namespace FirstNamespace
+{
+    public enum Ambiguous { Value = 1 }
+}
+
+namespace SecondNamespace
+{
+    public enum Ambiguous { Value = 1 }
+}

--- a/eng/scripts/compatibility/tests/fixtures/src/Shared.cs
+++ b/eng/scripts/compatibility/tests/fixtures/src/Shared.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace CompatibilityFixture;
+
+[AttributeUsage(AttributeTargets.All)]
+public sealed class MarkerAttribute : Attribute
+{
+#line 100 "Logical.cs"
+    public MarkerAttribute(int value) => Value = value;
+#line default
+    public int Value { get; }
+}

--- a/eng/scripts/compatibility/tests/fixtures/src/SourceGenerator.cs
+++ b/eng/scripts/compatibility/tests/fixtures/src/SourceGenerator.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace CompatibilityFixture;
+
+[JsonSerializable(typeof(Widget))]
+internal partial class FixtureJsonContext : JsonSerializerContext { }

--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -30,6 +30,10 @@
     "updateMetadataScript": {
       "path": "./eng/scripts/Export-API.ps1"
     },
+    "getSdkChangesScript": {
+      "path": "./eng/scripts/compatibility/Get-SdkChanges.ps1"
+    },
+    "sdkBreakingChangePatternFile": "doc/dev/SDKBreakingChanges.md",
     "buildFailedLabel": "auto-sdk-build-fix"
   }
 }


### PR DESCRIPTION
## Summary

Companion to Azure/azure-sdk-tools#16949 for Azure/azure-sdk-tools#16817.

- Add a standalone extractor that evaluates current assemblies, verifies portable/embedded PDB freshness, resolves the actual latest GA NuGet version, and restores the exact baseline through the repository's approved `NuGet.Config`.
- Invoke the SDK-shipped `ValidateAssembliesTask` without source compilation or analyzer targets. Preserve configured rules, attribute exclusions, central suppressions, native diagnostics, and framework-specific details; never generate suppressions.
- Supplement forward compatibility violations with reverse type/member additions. Keep possible renames/signature transformations as separate evidence, and fail explicitly on incomplete processes or missing references, including native CP1002 messages.
- Add the canonical .NET pattern catalog and connect common classifications to the existing management mitigation skill, deterministic generator helpers, client customizations, and manual review.
- Collect SDK PR reports immediately after Release packaging, independently of other failed gates. Preserve per-package JSON/errors, enforce actual native breaking flags, and publish artifacts on both success and failure. Existing build validations remain unchanged.
- Register native and CI regression suites in the existing Compliance job, using the existing Pester runner and authenticated dependency setup.

The common CLI/configuration/skill changes are in Azure/azure-sdk-tools#16949. Both PRs are required for the complete partner-facing integration.

## Coverage

207 Pester tests pass together with 91.86% command coverage of the five scripts, covering real SDK ApiCompat invocation, offline NuGet baseline restoration, management/data-plane and classic-framework fixtures, source/PDB freshness, native diagnostics, configuration preservation, process failures, selection, report integrity, and CI wiring.

A real Azure.Core comparison against GA 1.62.0 covers net10.0, net8.0, netstandard2.0, net462, and net472. All ten intermediate/bin assembly hashes and timestamps remain unchanged. The resulting report also round-trips through the common CLI with its original scope and diagnostics.

## Environment and CI notes

- PowerShell must host a runtime compatible with the SDK's MSBuild reader; the current .NET 10 SDK requires PowerShell 7.6+. The SDK PR image was checked, and the collector records/checks its actual runtime.
- Local `api.nuget.org` access fails TLS negotiation. The default detector correctly reports failure. The real-package smoke substituted only live metadata transport through NuGet's official v2 endpoint; baseline restoration and native comparison used the production implementation.
- Local tests used installed Pester 5.3.3. Restoring CI's minimum Pester 5.7.1 from the approved feed requires upstream-save authentication unavailable locally; CI uses the existing helper with `NuGetAuthenticate`.
- The new Azure DevOps YAML has not executed in a live PR build yet.
