### PR TITLE
[VoiceLive] Remove redundant speech-start response cancellations

### DIFF
--- a/samples/voicelive/agent-voice-assistant/AgentVoiceAssistant.cs
+++ b/samples/voicelive/agent-voice-assistant/AgentVoiceAssistant.cs
@@ -106,7 +106,7 @@ public class AgentVoiceAssistant : IDisposable
         {
             await foreach (SessionUpdate update in _session!.GetUpdatesAsync(cancellationToken).ConfigureAwait(false))
             {
-                await HandleUpdateAsync(update, cancellationToken).ConfigureAwait(false);
+                await HandleUpdateAsync(update).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
@@ -115,7 +115,7 @@ public class AgentVoiceAssistant : IDisposable
         }
     }
 
-    private async Task HandleUpdateAsync(SessionUpdate update, CancellationToken cancellationToken)
+    private async Task HandleUpdateAsync(SessionUpdate update)
     {
         _logger.LogDebug("Received event: {EventType}", update.GetType().Name);
 
@@ -143,8 +143,6 @@ public class AgentVoiceAssistant : IDisposable
                 if (_audioProcessor != null)
                     await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
 
-                try { await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false); }
-                catch (Exception ex) { _logger.LogDebug(ex, "No response to cancel"); }
                 break;
 
             case SessionUpdateInputAudioBufferSpeechStopped:

--- a/samples/voicelive/basic-voice-assistant/BasicVoiceAssistant.cs
+++ b/samples/voicelive/basic-voice-assistant/BasicVoiceAssistant.cs
@@ -11,7 +11,6 @@ namespace Azure.AI.VoiceLive.Samples;
 /// <remarks>
 /// This sample now demonstrates some of the new convenience methods added to the VoiceLive SDK:
 /// - ClearStreamingAudioAsync() - Clears all input audio currently being streamed
-/// - CancelResponseAsync() - Cancels the current response generation (existing method)
 /// - ConfigureSessionAsync() - Configures session options (existing method)
 ///
 /// Additional convenience methods available but not shown in this sample:
@@ -206,16 +205,6 @@ public class BasicVoiceAssistant : IDisposable
                 if (_audioProcessor != null)
                 {
                     await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
-                }
-
-                // Cancel any ongoing response
-                try
-                {
-                    await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "No response to cancel");
                 }
 
                 // Demonstrate the new ClearStreamingAudio convenience method

--- a/samples/voicelive/basic-voice-assistant/README.md
+++ b/samples/voicelive/basic-voice-assistant/README.md
@@ -20,7 +20,6 @@ This sample now demonstrates some of the new convenience methods added to the Vo
 **Used in this sample:**
 - `ClearStreamingAudioAsync()` - Clears all input audio currently being streamed
 - `ConfigureSessionAsync()` - Configures conversation session options
-- `CancelResponseAsync()` - Cancels the current response generation
 - `SendInputAudioAsync()` - Sends audio data to the service
 
 **Additional convenience methods available:**

--- a/samples/voicelive/customer-service-bot/CustomerServiceBot.cs
+++ b/samples/voicelive/customer-service-bot/CustomerServiceBot.cs
@@ -413,15 +413,6 @@ public class CustomerServiceBot : IDisposable
                     await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
                 }
 
-                // Cancel any ongoing response
-                try
-                {
-                    await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "No response to cancel");
-                }
                 break;
 
             case SessionUpdateInputAudioBufferSpeechStopped speechStopped:

--- a/samples/voicelive/mcp-voice-assistant/MCPVoiceAssistant.cs
+++ b/samples/voicelive/mcp-voice-assistant/MCPVoiceAssistant.cs
@@ -205,8 +205,6 @@ public class MCPVoiceAssistant : IDisposable
                 if (_audioProcessor != null)
                     await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
 
-                try { await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false); }
-                catch (Exception ex) { _logger.LogDebug(ex, "No response to cancel"); }
                 break;
 
             case SessionUpdateInputAudioBufferSpeechStopped:

--- a/sdk/voicelive/Azure.AI.VoiceLive/tests/BasicVoiceAssistantLogicTests.cs
+++ b/sdk/voicelive/Azure.AI.VoiceLive/tests/BasicVoiceAssistantLogicTests.cs
@@ -101,7 +101,7 @@ namespace Azure.AI.VoiceLive.Tests
         }
 
         [Test]
-        public void SpeechStartedEvent_CancelsResponseAndClearsStreamingAudio()
+        public void SpeechStartedEvent_StopsPlaybackAndClearsStreaming()
         {
             // This test demonstrates how BasicVoiceAssistant.HandleSessionUpdateAsync would be tested
             // if the samples were accessible from the test project.
@@ -112,7 +112,7 @@ namespace Azure.AI.VoiceLive.Tests
                 "1. Add project reference to BasicVoiceAssistant sample in test project, OR " +
                 "2. Move BasicVoiceAssistant to the main SDK with dependency injection support. " +
                 "Expected behavior: SessionUpdateInputAudioBufferSpeechStarted should call " +
-                "CancelResponseAsync(), ClearStreamingAudioAsync(), and StopPlaybackAsync().");
+                "StopPlaybackAsync() and ClearStreamingAudioAsync(), but not CancelResponseAsync().");
         }
 
         [Test]


### PR DESCRIPTION
Remove explicit response cancellation on speech-start events from the basic, agent, MCP, and customer-service samples; Voice Live already handles this interruption. Preserve local playback stopping and existing audio-buffer behavior.

Remove cancellation-only error handling and an unused event-handler parameter, and align the basic sample README and test blueprint with the corrected behavior.