### PR TITLE
[AgentServer] Prepare Invocations 1.0.0-beta.7 release

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
@@ -1,16 +1,6 @@
 # Release History
 
-## 1.0.0-beta.7 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
-## 1.0.0-beta.6 (2026-08-12)
+## 1.0.0-beta.7 (2026-09-03)
 
 ### Features Added
 
@@ -24,6 +14,11 @@
   messages, and `AddVoice<THandler>()` / `VoiceServer.Run<THandler>()` reuse the
   existing `/invocations_ws` transport without owning application lifecycle state.
   Consumers acknowledge this preview surface with the `AAAS001` diagnostic.
+
+## 1.0.0-beta.6 (2026-08-12)
+
+### Features Added
+
 - AsyncAPI discovery endpoints — `InvocationHandler` now exposes two new
   virtual methods, `GetAsyncApiJsonAsync` and `GetAsyncApiYamlAsync`, served
   at `GET /invocations/docs/asyncapi.json` and `GET /invocations/docs/asyncapi.yaml`


### PR DESCRIPTION
## Purpose

Prepare `Azure.AI.AgentServer.Invocations` version `1.0.0-beta.7` for publication to NuGet.org.

This release makes the typed Voice Live Bridge over `invocations_ws` and application-owned Voice target-turn tracing available in a public NuGet package. These changes were merged after `1.0.0-beta.6` was published, so their release notes are moved to the correct `1.0.0-beta.7` entry.

This PR recreates #62673 from its commit on top of the latest `main`.

## Changes

- Set the `1.0.0-beta.7` release date to 2026-09-03.
- Attribute the typed Voice Live Bridge and Voice tracing features to `1.0.0-beta.7`.
- Restore the `1.0.0-beta.6` notes to the content actually shipped in that package.