### PR TITLE
[Key Vault] Retry mTLS PoP certificate-binding failures

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0-beta.2 (Unreleased)
+## 4.9.0-beta.3 (Unreleased)
 
 ### Features Added
 
@@ -12,6 +12,12 @@
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 
 ### Other Changes
+
+## 4.9.0-beta.2 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.9.0-beta.1 (2026-06-04)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed intermittent authentication failures by retrying requests rejected because the mTLS Proof-of-Possession certificate did not match the token binding.
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
@@ -3,7 +3,7 @@
 <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Administration client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Administration client library</AssemblyTitle>
-    <Version>4.9.0-beta.2</Version>
+    <Version>4.9.0-beta.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.8.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Administration;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAccessControlClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAccessControlClient.cs
@@ -61,8 +61,12 @@ namespace Azure.Security.KeyVault.Administration
             options ??= new KeyVaultAdministrationClientOptions();
             string apiVersion = options.GetVersionString();
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _diagnostics = new ClientDiagnostics(options, true);
             ClientDiagnostics = _diagnostics;

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultEkmClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultEkmClient.cs
@@ -46,7 +46,10 @@ namespace Azure.Security.KeyVault.Administration
             ClientDiagnostics = new ClientDiagnostics(options, true);
             Pipeline = HttpPipelineBuilder.Build(
                 options,
-                new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
             _endpoint = vaultUri;
             _apiVersion = options.GetVersionString();
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultRestClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultRestClient.cs
@@ -38,8 +38,12 @@ namespace Azure.Security.KeyVault.Administration
             options ??= new KeyVaultAdministrationClientOptions();
 
             ClientDiagnostics = new ClientDiagnostics(options, true);
-            Pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            Pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
             _endpoint = endpoint;
             _apiVersion = options.GetVersionString();
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -16,6 +16,7 @@ namespace Azure.Security.KeyVault.Tests
     public class ChallengeBasedAuthenticationPolicyTests : SyncAsyncPolicyTestBase
     {
         internal ChallengeBasedAuthenticationPolicy _policy;
+        private const string MtlsPoPTokenType = "mtls_pop";
         private const string KeyVaultChallenge = "Bearer authorization=\"https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\", resource=\"https://vault.azure.net\"";
         public ChallengeBasedAuthenticationPolicyTests(bool isAsync) : base(isAsync)
         {
@@ -27,6 +28,7 @@ namespace Azure.Security.KeyVault.Tests
         {
             // Clear the cache to ensure the test starts with an empty cache.
             ChallengeBasedAuthenticationPolicy.ClearCache();
+            _policy = new ChallengeBasedAuthenticationPolicy(new MockCredentialThrowsWithNoScopes(), false);
         }
 
         [Test]
@@ -47,6 +49,69 @@ namespace Azure.Security.KeyVault.Tests
             response = await SendGetRequest(transport, _policy, uri: new Uri("https://myvault.vault.azure.net"));
 
             Assert.That(response.Status, Is.EqualTo(200));
+        }
+
+        [Test]
+        public async Task AddsTokenBoundAuthHeaderForMtlsPoPToken()
+        {
+            MockCredentialThrowsWithNoScopes credential = new(MtlsPoPTokenType);
+            ChallengeBasedAuthenticationPolicy policy = new(credential, false);
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(200));
+
+            Response response = await SendGetRequest(transport, policy, uri: new Uri("https://myvault.vault.azure.net"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests[1].Headers.TryGetValue("x-ms-tokenboundauth", out string headerValue), Is.True);
+            Assert.That(headerValue, Is.EqualTo("true"));
+            Assert.That(credential.LastRequestContext.IsProofOfPossessionEnabled, Is.True);
+            Assert.That(credential.LastRequestContext.ResourceRequestMethod, Is.EqualTo(RequestMethod.Get.ToString()));
+            Assert.That(credential.LastRequestContext.ResourceRequestUri, Is.EqualTo(new Uri("https://myvault.vault.azure.net/")));
+        }
+
+        [Test]
+        public async Task DoesNotAddTokenBoundAuthHeaderForBearerToken()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(200));
+
+            Response response = await SendGetRequest(transport, _policy, uri: new Uri("https://myvault.vault.azure.net"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests[1].Headers.Contains("x-ms-tokenboundauth"), Is.False);
+        }
+
+        [Test]
+        public async Task RemovesTokenBoundAuthHeaderWhenCaeReauthorizationReturnsBearer()
+        {
+            string caeChallenge = string.Concat(
+                "Be", "arer ",
+                "authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\", ",
+                "error=\"insufficient_claims\", ",
+                "claims=\"eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiY3AxIn19fQ==\"");
+
+            Queue<MockResponse> responses = new(
+            [
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401).WithHeader("WWW-Authenticate", caeChallenge),
+                new MockResponse(200),
+            ]);
+            List<bool> tokenBoundHeaders = [];
+            MockTransport transport = new(request =>
+            {
+                tokenBoundHeaders.Add(request.Headers.Contains("x-ms-tokenboundauth"));
+                return responses.Dequeue();
+            });
+            SequentialTokenCredential credential = new(MtlsPoPTokenType, "Bearer");
+            ChallengeBasedAuthenticationPolicy policy = new(credential, false);
+
+            Response response = await SendGetRequest(transport, policy, uri: new Uri("https://myvault.vault.azure.net"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+            Assert.That(tokenBoundHeaders, Is.EqualTo(new[] { false, true, false }));
         }
 
         [TestCaseSource(nameof(VerifyChallengeResourceData))]
@@ -93,6 +158,15 @@ namespace Azure.Security.KeyVault.Tests
 
         public class MockCredentialThrowsWithNoScopes : TokenCredential
         {
+            private readonly string _tokenType;
+
+            public MockCredentialThrowsWithNoScopes(string tokenType = "Bearer")
+            {
+                _tokenType = tokenType;
+            }
+
+            public TokenRequestContext LastRequestContext { get; private set; }
+
             public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
             {
                 return new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
@@ -104,8 +178,29 @@ namespace Azure.Security.KeyVault.Tests
                 {
                     Assert.Fail("TokenRequestContext contained no scopes.");
                 }
-                return new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue);
+
+                LastRequestContext = requestContext;
+                return new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue, refreshOn: null, tokenType: _tokenType);
             }
+        }
+
+        private class SequentialTokenCredential : TokenCredential
+        {
+            private readonly Queue<string> _tokenTypes;
+
+            public SequentialTokenCredential(params string[] tokenTypes)
+            {
+                _tokenTypes = new Queue<string>(tokenTypes);
+            }
+
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                Assert.That(_tokenTypes, Is.Not.Empty);
+                return new AccessToken("TEST TOKEN", DateTimeOffset.MaxValue, refreshOn: null, tokenType: _tokenTypes.Dequeue());
+            }
+
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+                => new(GetToken(requestContext, cancellationToken));
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -232,6 +232,27 @@ namespace Azure.Security.KeyVault.Tests
             Assert.That(transport.Requests, Has.Count.EqualTo(2));
         }
 
+        [TestCase("[]")]
+        [TestCase("\"Access denied.\"")]
+        [TestCase("null")]
+        [TestCase("42")]
+        [TestCase("true")]
+        public async Task DoesNotRetryNonObjectJsonResponse(string content)
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401)
+                {
+                    ContentStream = new MemoryStream(Encoding.UTF8.GetBytes(content)),
+                },
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
         [Test]
         public async Task DoesNotRetryMalformedUnauthorizedResponse()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -3,10 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -114,6 +118,191 @@ namespace Azure.Security.KeyVault.Tests
             Assert.That(tokenBoundHeaders, Is.EqualTo(new[] { false, true, false }));
         }
 
+        [Test]
+        public async Task RetriesTokenBindingValidationFailure()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(nonSeekable: true),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+            Assert.That(transport.Requests[2].Headers.TryGetValue("x-ms-tokenboundauth", out string headerValue), Is.True);
+            Assert.That(headerValue, Is.EqualTo("true"));
+        }
+
+        [Test]
+        public async Task RetriesTokenBindingValidationFailureFromSeekableStream()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(bufferedStream: true),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task RetriesNonBufferedTokenBindingValidationFailure()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(nonSeekable: true),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport, bufferResponse: false);
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task RetriesTokenBindingValidationFailureWithCustomNonErrorClassifier()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport, new UnauthorizedIsNotErrorClassifier());
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task StopsRetryingTokenBindingValidationFailureAtConfiguredLimit()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(),
+                CreateTokenBindingValidationFailure());
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task DoesNotRetryOtherUnauthorizedResponses()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401).WithJson("""
+                {
+                    "error": {
+                        "code": "Unauthorized",
+                        "message": "Access denied."
+                    }
+                }
+                """));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task DoesNotRetryWhenMarkerIsOutsideErrorMessage()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401).WithJson("""
+                {
+                    "error": {
+                        "code": "Unauthorized",
+                        "message": "Access denied.",
+                        "details": "[MtlsCnfClaimRequestDataValidationFailed]"
+                    }
+                }
+                """),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task DoesNotRetryMalformedUnauthorizedResponse()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401)
+                {
+                    ContentStream = new MemoryStream(Encoding.UTF8.GetBytes("{")),
+                },
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task DoesNotRetryTokenBindingValidationFailureWithoutBoundHeader()
+        {
+            MockTransport transport = CreateMockTransport(
+                CreateTokenBindingValidationFailure(),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task PreservesSeekableResponsePosition()
+        {
+            byte[] content = Encoding.UTF8.GetBytes("""
+            {
+                "error": {
+                    "code": "Unauthorized",
+                    "message": "Access denied."
+                }
+            }
+            """);
+            BufferedStream contentStream = new(new MemoryStream(content));
+            contentStream.Position = 5;
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401)
+                {
+                    ContentStream = contentStream,
+                });
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(response.ContentStream, Is.SameAs(contentStream));
+            Assert.That(response.ContentStream.Position, Is.EqualTo(5));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task PreservesStandardRetryClassification()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(500),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
         [TestCaseSource(nameof(VerifyChallengeResourceData))]
         public async Task VerifyChallengeResource(Uri uri, bool disableVerification)
         {
@@ -154,6 +343,70 @@ namespace Azure.Security.KeyVault.Tests
 
             InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await SendGetRequest(transport, policy, uri: uri));
             Assert.That(ex.Message, Is.EqualTo("The challenge contains invalid scope 'invalid-uri/.default'."));
+        }
+
+        private async Task<Response> SendGetRequestWithRetry(
+            MockTransport transport,
+            ResponseClassifier responseClassifier = null,
+            bool bufferResponse = true)
+        {
+            // ResponseBodyPolicy leaves seekable test streams unchanged, while production HTTP response
+            // streams are buffered into MemoryStream before the retry classifier runs.
+            transport.ExpectSyncPipeline = null;
+            TestClientOptions options = new()
+            {
+                Transport = transport,
+            };
+            options.Retry.MaxRetries = 1;
+            options.Retry.Delay = TimeSpan.Zero;
+            ChallengeBasedAuthenticationPolicy policy = new(new MockCredentialThrowsWithNoScopes(MtlsPoPTokenType), false);
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, policy);
+
+            return await SendRequestAsync(
+                pipeline,
+                message =>
+                {
+                    message.Request.Method = RequestMethod.Get;
+                    message.Request.Uri.Reset(new Uri("https://myvault.vault.azure.net"));
+                    if (responseClassifier != null)
+                    {
+                        message.ResponseClassifier = responseClassifier;
+                    }
+                },
+                bufferResponse);
+        }
+
+        private static MockResponse CreateTokenBindingValidationFailure(bool nonSeekable = false, bool bufferedStream = false)
+        {
+            byte[] content = Encoding.UTF8.GetBytes("""
+            {
+                "error": {
+                    "code": "Unauthorized",
+                    "message": "[MtlsCnfClaimRequestDataValidationFailed] Could not validate token."
+                }
+            }
+            """);
+
+            Stream contentStream = nonSeekable
+                ? new NonSeekableMemoryStream(content)
+                : bufferedStream
+                    ? new BufferedStream(new MemoryStream(content))
+                    : new MemoryStream(content);
+
+            return new MockResponse(401)
+            {
+                ContentStream = contentStream,
+            };
+        }
+
+        private class TestClientOptions : ClientOptions
+        {
+        }
+
+        private class UnauthorizedIsNotErrorClassifier : ResponseClassifier
+        {
+            public override bool IsErrorResponse(HttpMessage message)
+                => message.Response.Status != (int)HttpStatusCode.Unauthorized && base.IsErrorResponse(message);
         }
 
         public class MockCredentialThrowsWithNoScopes : TokenCredential

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.10.0-beta.2 (Unreleased)
+## 4.10.0-beta.3 (Unreleased)
 
 ### Features Added
 
@@ -14,6 +14,13 @@
 ### Other Changes
 
 - Internal: the `CertificateClient` transport now delegates to a TypeSpec-generated implementation. All public method signatures, return types, exception contracts, default service version, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are unchanged for existing callers. `CertificateClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end into the new pipeline. A small set of additive types from the new transport layer (`AzureSecurityKeyVaultCertificatesContext`, `KeyVaultCertificatesModelFactory`, and `IJsonModel<PlatformManaged>` / `IPersistableModel<PlatformManaged>` on `PlatformManaged`) appears on the public surface; these are net additions that existing customer code is unaffected by — same pattern as `Azure.Security.KeyVault.Administration`.
+
+## 4.10.0-beta.2 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
+
 ## 4.10.0-beta.1 (2026-06-04)
 
 ### Features Added

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed intermittent authentication failures by retrying requests rejected because the mTLS Proof-of-Possession certificate did not match the token binding.
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Certificates client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Certificates client library</AssemblyTitle>
-    <Version>4.10.0-beta.2</Version>
+    <Version>4.10.0-beta.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.9.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Certificates;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
@@ -105,7 +105,12 @@ namespace Azure.Security.KeyVault.Certificates
             // flow through automatically. No field-by-field copy is needed - future
             // additions to ClientOptions are picked up for free.
             var authPolicy = new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification);
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, authPolicy);
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [authPolicy],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _generated = new KeyVaultCertificatesClient(vaultUri, MapApiVersion(options.Version), pipeline, _diagnostics);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed intermittent authentication failures by retrying requests rejected because the mTLS Proof-of-Possession certificate did not match the token binding.
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
@@ -56,8 +56,12 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
 
             _apiVersion = options.GetVersionString();
 
-            _pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            _pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _clientDiagnostics = new ClientDiagnostics(options);
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RemoteCryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RemoteCryptographyClient.cs
@@ -29,8 +29,12 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             options ??= new CryptographyClientOptions();
             string apiVersion = options.GetVersionString();
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             Pipeline = new KeyVaultPipeline(keyId, apiVersion, pipeline, new ClientDiagnostics(options));
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -69,8 +69,12 @@ namespace Azure.Security.KeyVault.Keys
             options ??= new KeyClientOptions();
             string apiVersion = options.GetVersionString();
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _clientDiagnostics = new ClientDiagnostics(options);
             _pipeline = new KeyVaultPipeline(vaultUri, apiVersion, pipeline, _clientDiagnostics);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.12.0-beta.1 (Unreleased)
+## 4.12.0-beta.2 (Unreleased)
 
 ### Features Added
 
@@ -14,6 +14,12 @@
 ### Other Changes
 
 - Internal: the `SecretClient` transport now delegates to a TypeSpec-generated implementation. Public API surface, default service version, exception contracts, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are all unchanged. `SecretClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end. The TypeSpec emitter incidentally adds one additive public type (`AzureSecurityKeyVaultSecretsContext`, the `ModelReaderWriterContext` required for AOT-friendly `ModelReaderWriter` round-trip), matching the sibling `Azure.Security.KeyVault.Administration` package convention.
+
+## 4.12.0-beta.1 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.11.0 (2026-05-05)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed intermittent authentication failures by retrying requests rejected because the mTLS Proof-of-Possession certificate did not match the token binding.
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Secrets client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Secrets client library</AssemblyTitle>
-    <Version>4.12.0-beta.1</Version>
+    <Version>4.12.0-beta.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.11.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Secrets;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -68,7 +68,12 @@ namespace Azure.Security.KeyVault.Secrets
             var authPolicy = new ChallengeBasedAuthenticationPolicy(
                 credential, options.DisableChallengeResourceVerification);
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, authPolicy);
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [authPolicy],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _generated = new KeyVaultSecretsClient(
                 vaultUri,

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
-using Azure.Core.Pipeline;
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
+using System.IO;
 using System.Net;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
 
 namespace Azure.Security.KeyVault
 {
@@ -16,6 +18,7 @@ namespace Azure.Security.KeyVault
         private const string KeyVaultStashedContentKey = "KeyVaultContent";
         private const string TokenBoundAuthHeaderName = "x-ms-tokenboundauth";
         private const string MtlsPoPTokenTypePrefix = "mtls_pop ";
+        private const string TokenBindingValidationFailure = "[MtlsCnfClaimRequestDataValidationFailed]";
         private readonly bool _verifyChallengeResource;
 
         /// <summary>
@@ -236,6 +239,11 @@ namespace Azure.Security.KeyVault
 
         private async ValueTask ProcessAsyncInternal(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
+            if (message.ResponseClassifier is not TokenBindingResponseClassifier)
+            {
+                message.ResponseClassifier = new TokenBindingResponseClassifier(message.ResponseClassifier);
+            }
+
             if (message.Request.Uri.Scheme != Uri.UriSchemeHttps)
             {
                 throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
@@ -294,6 +302,107 @@ namespace Azure.Security.KeyVault
                     }
                 }
                 // If we get a second CAE challenge, an unlikely scenario, we do not attempt to re-authenticate.
+            }
+
+            await BufferTokenBindingFailureResponseAsync(message, async).ConfigureAwait(false);
+        }
+
+        private static async ValueTask BufferTokenBindingFailureResponseAsync(HttpMessage message, bool async)
+        {
+            if (message.Response.Status != (int)HttpStatusCode.Unauthorized
+                || !message.Request.Headers.Contains(TokenBoundAuthHeaderName)
+                || message.Response.ContentStream is not { CanSeek: false } content)
+            {
+                return;
+            }
+
+            MemoryStream buffered = new();
+            try
+            {
+                if (async)
+                {
+                    await content.CopyToAsync(buffered, 81920, message.CancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    content.CopyTo(buffered);
+                }
+
+                buffered.Position = 0;
+                message.Response.ContentStream = buffered;
+            }
+            catch
+            {
+                buffered.Dispose();
+                throw;
+            }
+            finally
+            {
+                content.Dispose();
+            }
+        }
+
+        private sealed class TokenBindingResponseClassifier : ResponseClassifier
+        {
+            private readonly ResponseClassifier _inner;
+
+            public TokenBindingResponseClassifier(ResponseClassifier inner)
+            {
+                _inner = inner;
+            }
+
+            public override bool IsRetriableResponse(HttpMessage message)
+            {
+                if (IsTokenBindingValidationFailure(message))
+                {
+                    return true;
+                }
+
+                return _inner.IsRetriableResponse(message);
+            }
+
+            public override bool IsRetriableException(Exception exception)
+                => _inner.IsRetriableException(exception);
+
+            public override bool IsRetriable(HttpMessage message, Exception exception)
+                => _inner.IsRetriable(message, exception);
+
+            public override bool IsErrorResponse(HttpMessage message)
+                // The transport classifies the response before a non-seekable body can be buffered.
+                // Exact body matching in IsRetriableResponse still controls whether this 401 is retried.
+                => message.Response.Status == (int)HttpStatusCode.Unauthorized
+                    && message.Request.Headers.Contains(TokenBoundAuthHeaderName)
+                    || _inner.IsErrorResponse(message);
+
+            private static bool IsTokenBindingValidationFailure(HttpMessage message)
+            {
+                if (message.Response.Status != (int)HttpStatusCode.Unauthorized
+                    || !message.Request.Headers.Contains(TokenBoundAuthHeaderName)
+                    || message.Response.ContentStream is not { CanSeek: true } content)
+                {
+                    return false;
+                }
+
+                long position = content.Position;
+                try
+                {
+                    content.Position = 0;
+                    using JsonDocument document = JsonDocument.Parse(content);
+
+                    return document.RootElement.TryGetProperty("error", out JsonElement error)
+                        && error.ValueKind == JsonValueKind.Object
+                        && error.TryGetProperty("message", out JsonElement errorMessage)
+                        && errorMessage.ValueKind == JsonValueKind.String
+                        && errorMessage.GetString()?.IndexOf(TokenBindingValidationFailure, StringComparison.Ordinal) >= 0;
+                }
+                catch (JsonException)
+                {
+                    return false;
+                }
+                finally
+                {
+                    content.Position = position;
+                }
             }
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -389,7 +389,8 @@ namespace Azure.Security.KeyVault
                     content.Position = 0;
                     using JsonDocument document = JsonDocument.Parse(content);
 
-                    return document.RootElement.TryGetProperty("error", out JsonElement error)
+                    return document.RootElement.ValueKind == JsonValueKind.Object
+                        && document.RootElement.TryGetProperty("error", out JsonElement error)
                         && error.ValueKind == JsonValueKind.Object
                         && error.TryGetProperty("message", out JsonElement errorMessage)
                         && errorMessage.ValueKind == JsonValueKind.String

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -14,6 +14,8 @@ namespace Azure.Security.KeyVault
     internal class ChallengeBasedAuthenticationPolicy : BearerTokenAuthenticationPolicy
     {
         private const string KeyVaultStashedContentKey = "KeyVaultContent";
+        private const string TokenBoundAuthHeaderName = "x-ms-tokenboundauth";
+        private const string MtlsPoPTokenTypePrefix = "mtls_pop ";
         private readonly bool _verifyChallengeResource;
 
         /// <summary>
@@ -50,7 +52,14 @@ namespace Azure.Security.KeyVault
             if (s_challengeCache.TryGetValue(authority, out ChallengeParameters challenge))
             {
                 // We fetched the challenge from the cache, but we have not initialized the Scopes in the base yet.
-                var context = new TokenRequestContext(challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: challenge.TenantId, isCaeEnabled: true);
+                var context = new TokenRequestContext(
+                    challenge.Scopes,
+                    parentRequestId: message.Request.ClientRequestId,
+                    tenantId: challenge.TenantId,
+                    isCaeEnabled: true,
+                    isProofOfPossessionEnabled: true,
+                    requestUri: message.Request.Uri.ToUri(),
+                    requestMethod: message.Request.Method.ToString());
                 if (async)
                 {
                     await AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);
@@ -60,6 +69,7 @@ namespace Azure.Security.KeyVault
                     AuthenticateAndAuthorizeRequest(message, context);
                 }
 
+                UpdateTokenBoundAuthHeader(message);
                 return;
             }
 
@@ -177,7 +187,15 @@ namespace Azure.Security.KeyVault
                 s_challengeCache[authority] = challenge;
             }
 
-            var context = new TokenRequestContext(challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: challenge.TenantId, isCaeEnabled: true, claims: claims);
+            var context = new TokenRequestContext(
+                challenge.Scopes,
+                parentRequestId: message.Request.ClientRequestId,
+                tenantId: challenge.TenantId,
+                isCaeEnabled: true,
+                claims: claims,
+                isProofOfPossessionEnabled: true,
+                requestUri: message.Request.Uri.ToUri(),
+                requestMethod: message.Request.Method.ToString());
             if (async)
             {
                 await AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);
@@ -187,7 +205,21 @@ namespace Azure.Security.KeyVault
                 AuthenticateAndAuthorizeRequest(message, context);
             }
 
+            UpdateTokenBoundAuthHeader(message);
             return true;
+        }
+
+        private static void UpdateTokenBoundAuthHeader(HttpMessage message)
+        {
+            if (message.Request.Headers.TryGetValue(HttpHeader.Names.Authorization, out string authorization)
+                && authorization.StartsWith(MtlsPoPTokenTypePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                message.Request.Headers.SetValue(TokenBoundAuthHeaderName, "true");
+            }
+            else
+            {
+                message.Request.Headers.Remove(TokenBoundAuthHeaderName);
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Description

Retries a Key Vault request when the service returns HTTP 401 and all of the following are true:

- the request carries `x-ms-tokenboundauth`;
- the JSON response contains `[MtlsCnfClaimRequestDataValidationFailed]` in `error.message`;
- the configured Azure.Core retry policy still permits another attempt.

The authentication policy decorates the existing response classifier. Existing response and exception classification is delegated unchanged, except that a token-bound 401 must enter the error path so its buffered body can be evaluated. Other 401 responses are not made retriable by this policy.

The implementation also:

- buffers non-seekable 401 bodies, including when `BufferResponse` is false;
- preserves the position of seekable response streams;
- treats malformed and valid non-object JSON as non-matching responses;
- uses the configured retry count and delay;
- adds no public API and does not change package versions.

This draft is stacked on #62756. Until #62756 merges, GitHub will also show that integration commit; the retry-specific commits are `ce82ff8cc7` and `c250da787b`.

Per-request certificate/transport affinity remains the long-term work tracked by #62546.

### Release dependency

GA remains blocked until an Azure.Core release containing #61654 and #62619 is available and the Key Vault package dependency floor is updated.

## Testing

- `ChallengeBasedAuthenticationPolicyTests`: 46/46 passed on `net8.0`, `net10.0`, and `net462`.
- Administration, Certificates, Keys, and Secrets built across all target frameworks with API compatibility checks.
- WebJobs `CanInjectKeyVaultClient` playback: 2/2 passed on `net8.0`.
- Search `CreateDoubleEncryptedIndex` playback: 1 passed and 1 expected skip on `net8.0`.
- Full `eng/scripts/CodeChecks.ps1 -ServiceDirectory keyvault` passed with no generated, snippet, or API-listing drift.
- The complete stack also passed the policy matrix and all four package builds when combined with #62619.

---

- [x] REST specification changes are not applicable.
- [x] I have read the contribution guidelines.
- [x] The pull request does not introduce breaking changes or public API changes.
- [x] The title is clear and informative.
- [x] The pull request has a small number of focused commits.
- [x] The pull request includes test coverage for the included changes.
- [x] SDK regeneration inputs are unchanged.