### PR TITLE
[AgentServer] Prepare Core 1.0.0-beta.29 release

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.29 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.29 (2026-09-08)
 
 ### Other Changes
+
+- Released to provide the public `Azure.AI.AgentServer.Core` dependency required by `Azure.AI.AgentServer.Invocations` 1.0.0-beta.7.
 
 ## 1.0.0-beta.28 (2026-08-12)
 


### PR DESCRIPTION
## Summary

- mark `Azure.AI.AgentServer.Core` 1.0.0-beta.29 as released on 2026-09-08
- document that this release provides the public Core dependency required by `Azure.AI.AgentServer.Invocations` 1.0.0-beta.7

## Validation

- Azure SDK changelog validation
- `dotnet format sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj`
- `git diff --check`

This PR only prepares the Core package release; it does not trigger the release pipeline.