### PR TITLE
[Key Vault] Enable managed identity mTLS PoP and retry binding failures

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 4.9.0-beta.3 (Unreleased)
+## 4.9.0-beta.2 (Unreleased)
 
 ### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ### Breaking Changes
 
@@ -13,12 +15,6 @@
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 
 ### Other Changes
-
-## 4.9.0-beta.2 (2026-06-10)
-
-### Features Added
-
-- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.9.0-beta.1 (2026-06-04)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0-beta.2 (Unreleased)
+## 4.9.0-beta.3 (Unreleased)
 
 ### Features Added
 
@@ -12,6 +12,12 @@
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 
 ### Other Changes
+
+## 4.9.0-beta.2 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.9.0-beta.1 (2026-06-04)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed intermittent authentication failures by retrying requests rejected because the mTLS Proof-of-Possession certificate did not match the token binding.
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Release History
 
-## 4.9.0-beta.2 (Unreleased)
+## 4.9.0-beta.3 (Unreleased)
 
 ### Features Added
-
-- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ### Breaking Changes
 
@@ -15,6 +13,12 @@
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 
 ### Other Changes
+
+## 4.9.0-beta.2 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.9.0-beta.1 (2026-06-04)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
@@ -3,7 +3,7 @@
 <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Administration client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Administration client library</AssemblyTitle>
-    <Version>4.9.0-beta.2</Version>
+    <Version>4.9.0-beta.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.8.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Administration;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
@@ -3,7 +3,7 @@
 <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Administration client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Administration client library</AssemblyTitle>
-    <Version>4.9.0-beta.3</Version>
+    <Version>4.9.0-beta.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.8.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Administration;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAccessControlClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAccessControlClient.cs
@@ -61,8 +61,12 @@ namespace Azure.Security.KeyVault.Administration
             options ??= new KeyVaultAdministrationClientOptions();
             string apiVersion = options.GetVersionString();
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _diagnostics = new ClientDiagnostics(options, true);
             ClientDiagnostics = _diagnostics;

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultEkmClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultEkmClient.cs
@@ -46,7 +46,10 @@ namespace Azure.Security.KeyVault.Administration
             ClientDiagnostics = new ClientDiagnostics(options, true);
             Pipeline = HttpPipelineBuilder.Build(
                 options,
-                new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
             _endpoint = vaultUri;
             _apiVersion = options.GetVersionString();
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultRestClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultRestClient.cs
@@ -38,8 +38,12 @@ namespace Azure.Security.KeyVault.Administration
             options ??= new KeyVaultAdministrationClientOptions();
 
             ClientDiagnostics = new ClientDiagnostics(options, true);
-            Pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            Pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
             _endpoint = endpoint;
             _apiVersion = options.GetVersionString();
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -73,6 +75,30 @@ namespace Azure.Security.KeyVault.Tests
             Assert.That(credential.LastRequestContext.ResourceRequestMethod, Is.EqualTo(RequestMethod.Get.ToString()));
             Assert.That(credential.LastRequestContext.ResourceRequestUri, Is.EqualTo(new Uri("https://myvault.vault.azure.net/")));
         }
+
+#if NET8_0_OR_GREATER
+        [Test]
+        public async Task AppliesBindingCertificateForMtlsPoPToken()
+        {
+            using RSA key = RSA.Create(2048);
+            CertificateRequest request = new("CN=KeyVaultPoPTest", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            using X509Certificate2 certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddMinutes(1));
+            MockCredentialThrowsWithNoScopes credential = new(MtlsPoPTokenType, certificate);
+            ChallengeBasedAuthenticationPolicy policy = new(credential, false);
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(200));
+
+            Response response = await SendGetRequest(transport, policy, uri: new Uri("https://myvault.vault.azure.net"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.TransportUpdates, Has.Count.EqualTo(1));
+            Assert.That(transport.TransportUpdates[0].ClientCertificates, Has.Count.EqualTo(1));
+            Assert.That(transport.TransportUpdates[0].ClientCertificates[0], Is.SameAs(certificate));
+            Assert.That(transport.Requests[1].Headers.TryGetValue("x-ms-tokenboundauth", out string headerValue), Is.True);
+            Assert.That(headerValue, Is.EqualTo("true"));
+        }
+#endif
 
         [Test]
         public async Task DoesNotAddTokenBoundAuthHeaderForBearerToken()
@@ -163,7 +189,7 @@ namespace Azure.Security.KeyVault.Tests
         }
 
         [Test]
-        public async Task RetriesTokenBindingValidationFailureWithCustomNonErrorClassifier()
+        public async Task PreservesCustomNonErrorClassifierForTokenBindingValidationFailure()
         {
             MockTransport transport = CreateMockTransport(
                 new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
@@ -172,8 +198,27 @@ namespace Azure.Security.KeyVault.Tests
 
             Response response = await SendGetRequestWithRetry(transport, new UnauthorizedIsNotErrorClassifier());
 
-            Assert.That(response.Status, Is.EqualTo(200));
-            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task TokenBindingValidationChallengeHonorsConfiguredRetryLimit()
+        {
+            MockTransport warmupTransport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(200));
+            _ = await SendGetRequest(warmupTransport, _policy, uri: new Uri("https://myvault.vault.azure.net"));
+
+            MockTransport transport = CreateMockTransport(
+                CreateTokenBindingValidationFailure()
+                    .WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport, maxRetries: 0);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -369,7 +414,8 @@ namespace Azure.Security.KeyVault.Tests
         private async Task<Response> SendGetRequestWithRetry(
             MockTransport transport,
             ResponseClassifier responseClassifier = null,
-            bool bufferResponse = true)
+            bool bufferResponse = true,
+            int maxRetries = 1)
         {
             // ResponseBodyPolicy leaves seekable test streams unchanged, while production HTTP response
             // streams are buffered into MemoryStream before the retry classifier runs.
@@ -378,7 +424,7 @@ namespace Azure.Security.KeyVault.Tests
             {
                 Transport = transport,
             };
-            options.Retry.MaxRetries = 1;
+            options.Retry.MaxRetries = maxRetries;
             options.Retry.Delay = TimeSpan.Zero;
             ChallengeBasedAuthenticationPolicy policy = new(new MockCredentialThrowsWithNoScopes(MtlsPoPTokenType), false);
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options, policy);
@@ -433,10 +479,12 @@ namespace Azure.Security.KeyVault.Tests
         public class MockCredentialThrowsWithNoScopes : TokenCredential
         {
             private readonly string _tokenType;
+            private readonly X509Certificate2 _bindingCertificate;
 
-            public MockCredentialThrowsWithNoScopes(string tokenType = "Bearer")
+            public MockCredentialThrowsWithNoScopes(string tokenType = "Bearer", X509Certificate2 bindingCertificate = null)
             {
                 _tokenType = tokenType;
+                _bindingCertificate = bindingCertificate;
             }
 
             public TokenRequestContext LastRequestContext { get; private set; }
@@ -454,7 +502,9 @@ namespace Azure.Security.KeyVault.Tests
                 }
 
                 LastRequestContext = requestContext;
-                return new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue, refreshOn: null, tokenType: _tokenType);
+                return _bindingCertificate is null
+                    ? new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue, refreshOn: null, tokenType: _tokenType)
+                    : new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue, refreshOn: null, tokenType: _tokenType, bindingCertificate: _bindingCertificate);
             }
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -16,6 +16,7 @@ namespace Azure.Security.KeyVault.Tests
     public class ChallengeBasedAuthenticationPolicyTests : SyncAsyncPolicyTestBase
     {
         internal ChallengeBasedAuthenticationPolicy _policy;
+        private const string MtlsPoPTokenType = "mtls_pop";
         private const string KeyVaultChallenge = "Bearer authorization=\"https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\", resource=\"https://vault.azure.net\"";
         public ChallengeBasedAuthenticationPolicyTests(bool isAsync) : base(isAsync)
         {
@@ -27,6 +28,7 @@ namespace Azure.Security.KeyVault.Tests
         {
             // Clear the cache to ensure the test starts with an empty cache.
             ChallengeBasedAuthenticationPolicy.ClearCache();
+            _policy = new ChallengeBasedAuthenticationPolicy(new MockCredentialThrowsWithNoScopes(), false);
         }
 
         [Test]
@@ -47,6 +49,69 @@ namespace Azure.Security.KeyVault.Tests
             response = await SendGetRequest(transport, _policy, uri: new Uri("https://myvault.vault.azure.net"));
 
             Assert.That(response.Status, Is.EqualTo(200));
+        }
+
+        [Test]
+        public async Task AddsTokenBoundAuthHeaderForMtlsPoPToken()
+        {
+            MockCredentialThrowsWithNoScopes credential = new(MtlsPoPTokenType);
+            ChallengeBasedAuthenticationPolicy policy = new(credential, false);
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(200));
+
+            Response response = await SendGetRequest(transport, policy, uri: new Uri("https://myvault.vault.azure.net"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests[1].Headers.TryGetValue("x-ms-tokenboundauth", out string headerValue), Is.True);
+            Assert.That(headerValue, Is.EqualTo("true"));
+            Assert.That(credential.LastRequestContext.IsProofOfPossessionEnabled, Is.True);
+            Assert.That(credential.LastRequestContext.ResourceRequestMethod, Is.EqualTo(RequestMethod.Get.ToString()));
+            Assert.That(credential.LastRequestContext.ResourceRequestUri, Is.EqualTo(new Uri("https://myvault.vault.azure.net/")));
+        }
+
+        [Test]
+        public async Task DoesNotAddTokenBoundAuthHeaderForBearerToken()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(200));
+
+            Response response = await SendGetRequest(transport, _policy, uri: new Uri("https://myvault.vault.azure.net"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests[1].Headers.Contains("x-ms-tokenboundauth"), Is.False);
+        }
+
+        [Test]
+        public async Task RemovesTokenBoundAuthHeaderWhenCaeReauthorizationReturnsBearer()
+        {
+            string caeChallenge = string.Concat(
+                "Be", "arer ",
+                "authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\", ",
+                "error=\"insufficient_claims\", ",
+                "claims=\"eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiY3AxIn19fQ==\"");
+
+            Queue<MockResponse> responses = new(
+            [
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401).WithHeader("WWW-Authenticate", caeChallenge),
+                new MockResponse(200),
+            ]);
+            List<bool> tokenBoundHeaders = [];
+            MockTransport transport = new(request =>
+            {
+                tokenBoundHeaders.Add(request.Headers.Contains("x-ms-tokenboundauth"));
+                return responses.Dequeue();
+            });
+            SequentialTokenCredential credential = new(MtlsPoPTokenType, "Bearer");
+            ChallengeBasedAuthenticationPolicy policy = new(credential, false);
+
+            Response response = await SendGetRequest(transport, policy, uri: new Uri("https://myvault.vault.azure.net"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+            Assert.That(tokenBoundHeaders, Is.EqualTo(new[] { false, true, false }));
         }
 
         [TestCaseSource(nameof(VerifyChallengeResourceData))]
@@ -93,6 +158,15 @@ namespace Azure.Security.KeyVault.Tests
 
         public class MockCredentialThrowsWithNoScopes : TokenCredential
         {
+            private readonly string _tokenType;
+
+            public MockCredentialThrowsWithNoScopes(string tokenType = "Bearer")
+            {
+                _tokenType = tokenType;
+            }
+
+            public TokenRequestContext LastRequestContext { get; private set; }
+
             public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
             {
                 return new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
@@ -104,8 +178,29 @@ namespace Azure.Security.KeyVault.Tests
                 {
                     Assert.Fail("TokenRequestContext contained no scopes.");
                 }
-                return new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue);
+
+                LastRequestContext = requestContext;
+                return new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue, refreshOn: null, tokenType: _tokenType);
             }
+        }
+
+        private class SequentialTokenCredential : TokenCredential
+        {
+            private readonly Queue<string> _tokenTypes;
+
+            public SequentialTokenCredential(params string[] tokenTypes)
+            {
+                _tokenTypes = new Queue<string>(tokenTypes);
+            }
+
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                Assert.That(_tokenTypes, Is.Not.Empty);
+                return new AccessToken("TEST TOKEN", DateTimeOffset.MaxValue, refreshOn: null, tokenType: _tokenTypes.Dequeue());
+            }
+
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+                => new(GetToken(requestContext, cancellationToken));
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -232,6 +232,27 @@ namespace Azure.Security.KeyVault.Tests
             Assert.That(transport.Requests, Has.Count.EqualTo(2));
         }
 
+        [TestCase("[]")]
+        [TestCase("\"Access denied.\"")]
+        [TestCase("null")]
+        [TestCase("42")]
+        [TestCase("true")]
+        public async Task DoesNotRetryNonObjectJsonResponse(string content)
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401)
+                {
+                    ContentStream = new MemoryStream(Encoding.UTF8.GetBytes(content)),
+                },
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
         [Test]
         public async Task DoesNotRetryMalformedUnauthorizedResponse()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -3,10 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -114,6 +118,191 @@ namespace Azure.Security.KeyVault.Tests
             Assert.That(tokenBoundHeaders, Is.EqualTo(new[] { false, true, false }));
         }
 
+        [Test]
+        public async Task RetriesTokenBindingValidationFailure()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(nonSeekable: true),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+            Assert.That(transport.Requests[2].Headers.TryGetValue("x-ms-tokenboundauth", out string headerValue), Is.True);
+            Assert.That(headerValue, Is.EqualTo("true"));
+        }
+
+        [Test]
+        public async Task RetriesTokenBindingValidationFailureFromSeekableStream()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(bufferedStream: true),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task RetriesNonBufferedTokenBindingValidationFailure()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(nonSeekable: true),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport, bufferResponse: false);
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task RetriesTokenBindingValidationFailureWithCustomNonErrorClassifier()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport, new UnauthorizedIsNotErrorClassifier());
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task StopsRetryingTokenBindingValidationFailureAtConfiguredLimit()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                CreateTokenBindingValidationFailure(),
+                CreateTokenBindingValidationFailure());
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task DoesNotRetryOtherUnauthorizedResponses()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401).WithJson("""
+                {
+                    "error": {
+                        "code": "Unauthorized",
+                        "message": "Access denied."
+                    }
+                }
+                """));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task DoesNotRetryWhenMarkerIsOutsideErrorMessage()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401).WithJson("""
+                {
+                    "error": {
+                        "code": "Unauthorized",
+                        "message": "Access denied.",
+                        "details": "[MtlsCnfClaimRequestDataValidationFailed]"
+                    }
+                }
+                """),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task DoesNotRetryMalformedUnauthorizedResponse()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401)
+                {
+                    ContentStream = new MemoryStream(Encoding.UTF8.GetBytes("{")),
+                },
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task DoesNotRetryTokenBindingValidationFailureWithoutBoundHeader()
+        {
+            MockTransport transport = CreateMockTransport(
+                CreateTokenBindingValidationFailure(),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(transport.Requests, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task PreservesSeekableResponsePosition()
+        {
+            byte[] content = Encoding.UTF8.GetBytes("""
+            {
+                "error": {
+                    "code": "Unauthorized",
+                    "message": "Access denied."
+                }
+            }
+            """);
+            BufferedStream contentStream = new(new MemoryStream(content));
+            contentStream.Position = 5;
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(401).WithHeader("WWW-Authenticate", KeyVaultChallenge),
+                new MockResponse(401)
+                {
+                    ContentStream = contentStream,
+                });
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(401));
+            Assert.That(response.ContentStream, Is.SameAs(contentStream));
+            Assert.That(response.ContentStream.Position, Is.EqualTo(5));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public async Task PreservesStandardRetryClassification()
+        {
+            MockTransport transport = CreateMockTransport(
+                new MockResponse(500),
+                new MockResponse(200));
+
+            Response response = await SendGetRequestWithRetry(transport);
+
+            Assert.That(response.Status, Is.EqualTo(200));
+            Assert.That(transport.Requests, Has.Count.EqualTo(2));
+        }
+
         [TestCaseSource(nameof(VerifyChallengeResourceData))]
         public async Task VerifyChallengeResource(Uri uri, bool disableVerification)
         {
@@ -154,6 +343,70 @@ namespace Azure.Security.KeyVault.Tests
 
             InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await SendGetRequest(transport, policy, uri: uri));
             Assert.That(ex.Message, Is.EqualTo("The challenge contains invalid scope 'invalid-uri/.default'."));
+        }
+
+        private async Task<Response> SendGetRequestWithRetry(
+            MockTransport transport,
+            ResponseClassifier responseClassifier = null,
+            bool bufferResponse = true)
+        {
+            // ResponseBodyPolicy leaves seekable test streams unchanged, while production HTTP response
+            // streams are buffered into MemoryStream before the retry classifier runs.
+            transport.ExpectSyncPipeline = null;
+            TestClientOptions options = new()
+            {
+                Transport = transport,
+            };
+            options.Retry.MaxRetries = 1;
+            options.Retry.Delay = TimeSpan.Zero;
+            ChallengeBasedAuthenticationPolicy policy = new(new MockCredentialThrowsWithNoScopes(MtlsPoPTokenType), false);
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, policy);
+
+            return await SendRequestAsync(
+                pipeline,
+                message =>
+                {
+                    message.Request.Method = RequestMethod.Get;
+                    message.Request.Uri.Reset(new Uri("https://myvault.vault.azure.net"));
+                    if (responseClassifier != null)
+                    {
+                        message.ResponseClassifier = responseClassifier;
+                    }
+                },
+                bufferResponse);
+        }
+
+        private static MockResponse CreateTokenBindingValidationFailure(bool nonSeekable = false, bool bufferedStream = false)
+        {
+            byte[] content = Encoding.UTF8.GetBytes("""
+            {
+                "error": {
+                    "code": "Unauthorized",
+                    "message": "[MtlsCnfClaimRequestDataValidationFailed] Could not validate token."
+                }
+            }
+            """);
+
+            Stream contentStream = nonSeekable
+                ? new NonSeekableMemoryStream(content)
+                : bufferedStream
+                    ? new BufferedStream(new MemoryStream(content))
+                    : new MemoryStream(content);
+
+            return new MockResponse(401)
+            {
+                ContentStream = contentStream,
+            };
+        }
+
+        private class TestClientOptions : ClientOptions
+        {
+        }
+
+        private class UnauthorizedIsNotErrorClassifier : ResponseClassifier
+        {
+            public override bool IsErrorResponse(HttpMessage message)
+                => message.Response.Status != (int)HttpStatusCode.Unauthorized && base.IsErrorResponse(message);
         }
 
         public class MockCredentialThrowsWithNoScopes : TokenCredential

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 4.10.0-beta.3 (Unreleased)
+## 4.10.0-beta.2 (Unreleased)
 
 ### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ### Breaking Changes
 
@@ -15,12 +17,6 @@
 ### Other Changes
 
 - Internal: the `CertificateClient` transport now delegates to a TypeSpec-generated implementation. All public method signatures, return types, exception contracts, default service version, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are unchanged for existing callers. `CertificateClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end into the new pipeline. A small set of additive types from the new transport layer (`AzureSecurityKeyVaultCertificatesContext`, `KeyVaultCertificatesModelFactory`, and `IJsonModel<PlatformManaged>` / `IPersistableModel<PlatformManaged>` on `PlatformManaged`) appears on the public surface; these are net additions that existing customer code is unaffected by — same pattern as `Azure.Security.KeyVault.Administration`.
-
-## 4.10.0-beta.2 (2026-06-10)
-
-### Features Added
-
-- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.10.0-beta.1 (2026-06-04)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.10.0-beta.2 (Unreleased)
+## 4.10.0-beta.3 (Unreleased)
 
 ### Features Added
 
@@ -14,6 +14,13 @@
 ### Other Changes
 
 - Internal: the `CertificateClient` transport now delegates to a TypeSpec-generated implementation. All public method signatures, return types, exception contracts, default service version, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are unchanged for existing callers. `CertificateClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end into the new pipeline. A small set of additive types from the new transport layer (`AzureSecurityKeyVaultCertificatesContext`, `KeyVaultCertificatesModelFactory`, and `IJsonModel<PlatformManaged>` / `IPersistableModel<PlatformManaged>` on `PlatformManaged`) appears on the public surface; these are net additions that existing customer code is unaffected by — same pattern as `Azure.Security.KeyVault.Administration`.
+
+## 4.10.0-beta.2 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
+
 ## 4.10.0-beta.1 (2026-06-04)
 
 ### Features Added

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Release History
 
-## 4.10.0-beta.2 (Unreleased)
+## 4.10.0-beta.3 (Unreleased)
 
 ### Features Added
-
-- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ### Breaking Changes
 
@@ -17,6 +15,12 @@
 ### Other Changes
 
 - Internal: the `CertificateClient` transport now delegates to a TypeSpec-generated implementation. All public method signatures, return types, exception contracts, default service version, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are unchanged for existing callers. `CertificateClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end into the new pipeline. A small set of additive types from the new transport layer (`AzureSecurityKeyVaultCertificatesContext`, `KeyVaultCertificatesModelFactory`, and `IJsonModel<PlatformManaged>` / `IPersistableModel<PlatformManaged>` on `PlatformManaged`) appears on the public surface; these are net additions that existing customer code is unaffected by — same pattern as `Azure.Security.KeyVault.Administration`.
+
+## 4.10.0-beta.2 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.10.0-beta.1 (2026-06-04)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed intermittent authentication failures by retrying requests rejected because the mTLS Proof-of-Possession certificate did not match the token binding.
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Certificates client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Certificates client library</AssemblyTitle>
-    <Version>4.10.0-beta.2</Version>
+    <Version>4.10.0-beta.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.9.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Certificates;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Certificates client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Certificates client library</AssemblyTitle>
-    <Version>4.10.0-beta.3</Version>
+    <Version>4.10.0-beta.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.9.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Certificates;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
@@ -105,7 +105,12 @@ namespace Azure.Security.KeyVault.Certificates
             // flow through automatically. No field-by-field copy is needed - future
             // additions to ClientOptions are picked up for free.
             var authPolicy = new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification);
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, authPolicy);
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [authPolicy],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _generated = new KeyVaultCertificatesClient(vaultUri, MapApiVersion(options.Version), pipeline, _diagnostics);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed intermittent authentication failures by retrying requests rejected because the mTLS Proof-of-Possession certificate did not match the token binding.
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
@@ -56,8 +56,12 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
 
             _apiVersion = options.GetVersionString();
 
-            _pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            _pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _clientDiagnostics = new ClientDiagnostics(options);
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RemoteCryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RemoteCryptographyClient.cs
@@ -29,8 +29,12 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             options ??= new CryptographyClientOptions();
             string apiVersion = options.GetVersionString();
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             Pipeline = new KeyVaultPipeline(keyId, apiVersion, pipeline, new ClientDiagnostics(options));
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -69,8 +69,12 @@ namespace Azure.Security.KeyVault.Keys
             options ??= new KeyClientOptions();
             string apiVersion = options.GetVersionString();
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification)],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _clientDiagnostics = new ClientDiagnostics(options);
             _pipeline = new KeyVaultPipeline(vaultUri, apiVersion, pipeline, _clientDiagnostics);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.12.0-beta.1 (Unreleased)
+## 4.12.0-beta.2 (Unreleased)
 
 ### Features Added
 
@@ -14,6 +14,12 @@
 ### Other Changes
 
 - Internal: the `SecretClient` transport now delegates to a TypeSpec-generated implementation. Public API surface, default service version, exception contracts, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are all unchanged. `SecretClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end. The TypeSpec emitter incidentally adds one additive public type (`AzureSecurityKeyVaultSecretsContext`, the `ModelReaderWriterContext` required for AOT-friendly `ModelReaderWriter` round-trip), matching the sibling `Azure.Security.KeyVault.Administration` package convention.
+
+## 4.12.0-beta.1 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.11.0 (2026-05-05)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Release History
 
-## 4.12.0-beta.1 (Unreleased)
+## 4.12.0-beta.2 (Unreleased)
 
 ### Features Added
-
-- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ### Breaking Changes
 
@@ -17,6 +15,12 @@
 ### Other Changes
 
 - Internal: the `SecretClient` transport now delegates to a TypeSpec-generated implementation. Public API surface, default service version, exception contracts, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are all unchanged. `SecretClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end. The TypeSpec emitter incidentally adds one additive public type (`AzureSecurityKeyVaultSecretsContext`, the `ModelReaderWriterContext` required for AOT-friendly `ModelReaderWriter` round-trip), matching the sibling `Azure.Security.KeyVault.Administration` package convention.
+
+## 4.12.0-beta.1 (2026-06-10)
+
+### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.11.0 (2026-05-05)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 4.12.0-beta.2 (Unreleased)
+## 4.12.0-beta.1 (Unreleased)
 
 ### Features Added
+
+- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ### Breaking Changes
 
@@ -15,12 +17,6 @@
 ### Other Changes
 
 - Internal: the `SecretClient` transport now delegates to a TypeSpec-generated implementation. Public API surface, default service version, exception contracts, on-the-wire requests, and OpenTelemetry / `DiagnosticListener` activity names are all unchanged. `SecretClientOptions` (custom retry, transport, diagnostics allow-lists, `AddPolicy` entries) continues to flow end-to-end. The TypeSpec emitter incidentally adds one additive public type (`AzureSecurityKeyVaultSecretsContext`, the `ModelReaderWriterContext` required for AOT-friendly `ModelReaderWriter` round-trip), matching the sibling `Azure.Security.KeyVault.Administration` package convention.
-
-## 4.12.0-beta.1 (2026-06-10)
-
-### Features Added
-
-- Added support for Proof-of-Possession (PoP) token binding in the Key Vault authentication policy.
 
 ## 4.11.0 (2026-05-05)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- Fixed intermittent authentication failures by retrying requests rejected because the mTLS Proof-of-Possession certificate did not match the token binding.
 - Fixed a `NullReferenceException` in the challenge-based authentication policy that could occur when a Continuous Access Evaluation (CAE) claims challenge was received for an authority that had not yet been cached.
 - Fixed an issue in the challenge-based authentication policy where a cached authentication challenge, and the access token acquired for it, could be reused for a request to a different Key Vault or Managed HSM endpoint. The policy now resolves the challenge per request endpoint, ensuring a token acquired for one vault is never attached to a request to another.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Secrets client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Secrets client library</AssemblyTitle>
-    <Version>4.12.0-beta.1</Version>
+    <Version>4.12.0-beta.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.11.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Secrets;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Secrets client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Secrets client library</AssemblyTitle>
-    <Version>4.12.0-beta.2</Version>
+    <Version>4.12.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>4.11.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Key Vault Secrets;$(PackageCommonTags)</PackageTags>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -68,7 +68,12 @@ namespace Azure.Security.KeyVault.Secrets
             var authPolicy = new ChallengeBasedAuthenticationPolicy(
                 credential, options.DisableChallengeResourceVerification);
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, authPolicy);
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(
+                options,
+                perCallPolicies: Array.Empty<HttpPipelinePolicy>(),
+                perRetryPolicies: [authPolicy],
+                transportOptions: new HttpPipelineTransportOptions(),
+                responseClassifier: null);
 
             _generated = new KeyVaultSecretsClient(
                 vaultUri,

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ContinousAccessEvaluationTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/ContinousAccessEvaluationTests.cs
@@ -134,7 +134,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
 
                 new MockResponse(200)
                 {
-                    ContentStream = new KeyVaultSecret("test-secret2", "secret-value").ToStream(),
+                    ContentStream = new KeyVaultSecret("test-secret", "secret-value").ToStream(),
                 },
             });
 
@@ -147,7 +147,8 @@ namespace Azure.Security.KeyVault.Secrets.Tests
                 });
 
             _ = client.GetSecret("test-secret");
-            _ = client.GetSecret("test-secret2");
+            // Keep the PoP request target unchanged so only the CAE claims challenge invalidates the token.
+            _ = client.GetSecret("test-secret");
 
             Assert.IsTrue(transport.Requests[2].Headers.TryGetValue("Authorization", out string authorizationValue));
             Assert.AreEqual("Bearer TOKEN_1", authorizationValue);

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
-using Azure.Core.Pipeline;
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
+using System.IO;
 using System.Net;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
 
 namespace Azure.Security.KeyVault
 {
@@ -16,6 +18,7 @@ namespace Azure.Security.KeyVault
         private const string KeyVaultStashedContentKey = "KeyVaultContent";
         private const string TokenBoundAuthHeaderName = "x-ms-tokenboundauth";
         private const string MtlsPoPTokenTypePrefix = "mtls_pop ";
+        private const string TokenBindingValidationFailure = "[MtlsCnfClaimRequestDataValidationFailed]";
         private readonly bool _verifyChallengeResource;
 
         /// <summary>
@@ -236,6 +239,11 @@ namespace Azure.Security.KeyVault
 
         private async ValueTask ProcessAsyncInternal(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
+            if (message.ResponseClassifier is not TokenBindingResponseClassifier)
+            {
+                message.ResponseClassifier = new TokenBindingResponseClassifier(message.ResponseClassifier);
+            }
+
             if (message.Request.Uri.Scheme != Uri.UriSchemeHttps)
             {
                 throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
@@ -294,6 +302,107 @@ namespace Azure.Security.KeyVault
                     }
                 }
                 // If we get a second CAE challenge, an unlikely scenario, we do not attempt to re-authenticate.
+            }
+
+            await BufferTokenBindingFailureResponseAsync(message, async).ConfigureAwait(false);
+        }
+
+        private static async ValueTask BufferTokenBindingFailureResponseAsync(HttpMessage message, bool async)
+        {
+            if (message.Response.Status != (int)HttpStatusCode.Unauthorized
+                || !message.Request.Headers.Contains(TokenBoundAuthHeaderName)
+                || message.Response.ContentStream is not { CanSeek: false } content)
+            {
+                return;
+            }
+
+            MemoryStream buffered = new();
+            try
+            {
+                if (async)
+                {
+                    await content.CopyToAsync(buffered, 81920, message.CancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    content.CopyTo(buffered);
+                }
+
+                buffered.Position = 0;
+                message.Response.ContentStream = buffered;
+            }
+            catch
+            {
+                buffered.Dispose();
+                throw;
+            }
+            finally
+            {
+                content.Dispose();
+            }
+        }
+
+        private sealed class TokenBindingResponseClassifier : ResponseClassifier
+        {
+            private readonly ResponseClassifier _inner;
+
+            public TokenBindingResponseClassifier(ResponseClassifier inner)
+            {
+                _inner = inner;
+            }
+
+            public override bool IsRetriableResponse(HttpMessage message)
+            {
+                if (IsTokenBindingValidationFailure(message))
+                {
+                    return true;
+                }
+
+                return _inner.IsRetriableResponse(message);
+            }
+
+            public override bool IsRetriableException(Exception exception)
+                => _inner.IsRetriableException(exception);
+
+            public override bool IsRetriable(HttpMessage message, Exception exception)
+                => _inner.IsRetriable(message, exception);
+
+            public override bool IsErrorResponse(HttpMessage message)
+                // The transport classifies the response before a non-seekable body can be buffered.
+                // Exact body matching in IsRetriableResponse still controls whether this 401 is retried.
+                => message.Response.Status == (int)HttpStatusCode.Unauthorized
+                    && message.Request.Headers.Contains(TokenBoundAuthHeaderName)
+                    || _inner.IsErrorResponse(message);
+
+            private static bool IsTokenBindingValidationFailure(HttpMessage message)
+            {
+                if (message.Response.Status != (int)HttpStatusCode.Unauthorized
+                    || !message.Request.Headers.Contains(TokenBoundAuthHeaderName)
+                    || message.Response.ContentStream is not { CanSeek: true } content)
+                {
+                    return false;
+                }
+
+                long position = content.Position;
+                try
+                {
+                    content.Position = 0;
+                    using JsonDocument document = JsonDocument.Parse(content);
+
+                    return document.RootElement.TryGetProperty("error", out JsonElement error)
+                        && error.ValueKind == JsonValueKind.Object
+                        && error.TryGetProperty("message", out JsonElement errorMessage)
+                        && errorMessage.ValueKind == JsonValueKind.String
+                        && errorMessage.GetString()?.IndexOf(TokenBindingValidationFailure, StringComparison.Ordinal) >= 0;
+                }
+                catch (JsonException)
+                {
+                    return false;
+                }
+                finally
+                {
+                    content.Position = position;
+                }
             }
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -389,7 +389,8 @@ namespace Azure.Security.KeyVault
                     content.Position = 0;
                     using JsonDocument document = JsonDocument.Parse(content);
 
-                    return document.RootElement.TryGetProperty("error", out JsonElement error)
+                    return document.RootElement.ValueKind == JsonValueKind.Object
+                        && document.RootElement.TryGetProperty("error", out JsonElement error)
                         && error.ValueKind == JsonValueKind.Object
                         && error.TryGetProperty("message", out JsonElement errorMessage)
                         && errorMessage.ValueKind == JsonValueKind.String

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -260,6 +260,14 @@ namespace Azure.Security.KeyVault
                 ProcessNext(message, pipeline);
             }
 
+            await BufferTokenBindingFailureResponseAsync(message, async).ConfigureAwait(false);
+            if (TokenBindingResponseClassifier.IsTokenBindingValidationFailure(message))
+            {
+                // Let the outer RetryPolicy enforce the configured retry count and delay instead of
+                // treating the binding failure as an authentication challenge and resending here.
+                return;
+            }
+
             // Check if we have received a challenge or we have not yet issued the first request.
             if (message.Response.Status == (int)HttpStatusCode.Unauthorized && message.Response.Headers.Contains(HttpHeader.Names.WwwAuthenticate))
             {
@@ -368,13 +376,9 @@ namespace Azure.Security.KeyVault
                 => _inner.IsRetriable(message, exception);
 
             public override bool IsErrorResponse(HttpMessage message)
-                // The transport classifies the response before a non-seekable body can be buffered.
-                // Exact body matching in IsRetriableResponse still controls whether this 401 is retried.
-                => message.Response.Status == (int)HttpStatusCode.Unauthorized
-                    && message.Request.Headers.Contains(TokenBoundAuthHeaderName)
-                    || _inner.IsErrorResponse(message);
+                => _inner.IsErrorResponse(message);
 
-            private static bool IsTokenBindingValidationFailure(HttpMessage message)
+            internal static bool IsTokenBindingValidationFailure(HttpMessage message)
             {
                 if (message.Response.Status != (int)HttpStatusCode.Unauthorized
                     || !message.Request.Headers.Contains(TokenBoundAuthHeaderName)

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -14,6 +14,8 @@ namespace Azure.Security.KeyVault
     internal class ChallengeBasedAuthenticationPolicy : BearerTokenAuthenticationPolicy
     {
         private const string KeyVaultStashedContentKey = "KeyVaultContent";
+        private const string TokenBoundAuthHeaderName = "x-ms-tokenboundauth";
+        private const string MtlsPoPTokenTypePrefix = "mtls_pop ";
         private readonly bool _verifyChallengeResource;
 
         /// <summary>
@@ -50,7 +52,14 @@ namespace Azure.Security.KeyVault
             if (s_challengeCache.TryGetValue(authority, out ChallengeParameters challenge))
             {
                 // We fetched the challenge from the cache, but we have not initialized the Scopes in the base yet.
-                var context = new TokenRequestContext(challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: challenge.TenantId, isCaeEnabled: true);
+                var context = new TokenRequestContext(
+                    challenge.Scopes,
+                    parentRequestId: message.Request.ClientRequestId,
+                    tenantId: challenge.TenantId,
+                    isCaeEnabled: true,
+                    isProofOfPossessionEnabled: true,
+                    requestUri: message.Request.Uri.ToUri(),
+                    requestMethod: message.Request.Method.ToString());
                 if (async)
                 {
                     await AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);
@@ -60,6 +69,7 @@ namespace Azure.Security.KeyVault
                     AuthenticateAndAuthorizeRequest(message, context);
                 }
 
+                UpdateTokenBoundAuthHeader(message);
                 return;
             }
 
@@ -177,7 +187,15 @@ namespace Azure.Security.KeyVault
                 s_challengeCache[authority] = challenge;
             }
 
-            var context = new TokenRequestContext(challenge.Scopes, parentRequestId: message.Request.ClientRequestId, tenantId: challenge.TenantId, isCaeEnabled: true, claims: claims);
+            var context = new TokenRequestContext(
+                challenge.Scopes,
+                parentRequestId: message.Request.ClientRequestId,
+                tenantId: challenge.TenantId,
+                isCaeEnabled: true,
+                claims: claims,
+                isProofOfPossessionEnabled: true,
+                requestUri: message.Request.Uri.ToUri(),
+                requestMethod: message.Request.Method.ToString());
             if (async)
             {
                 await AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);
@@ -187,7 +205,21 @@ namespace Azure.Security.KeyVault
                 AuthenticateAndAuthorizeRequest(message, context);
             }
 
+            UpdateTokenBoundAuthHeader(message);
             return true;
+        }
+
+        private static void UpdateTokenBoundAuthHeader(HttpMessage message)
+        {
+            if (message.Request.Headers.TryGetValue(HttpHeader.Names.Authorization, out string authorization)
+                && authorization.StartsWith(MtlsPoPTokenTypePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                message.Request.Headers.SetValue(TokenBoundAuthHeaderName, "true");
+            }
+            else
+            {
+                message.Request.Headers.Remove(TokenBoundAuthHeaderName);
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Description

Enables Key Vault managed identity mTLS Proof-of-Possession support on current `main` for Administration, Certificates, Keys, and Secrets, and adds a bounded retry for certificate-binding validation failures.

### PoP integration

- Requests PoP tokens with the request URI and HTTP method so Azure.Core can invalidate target-bound cached tokens correctly.
- Sends `x-ms-tokenboundauth` only when the credential returns an actual `mtls_pop` token, and removes a stale header if CAE reauthorization returns a bearer token.
- Uses update-capable default transports across all current Key Vault client entry points, including `KeyVaultEkmClient`.
- Adds the PoP feature under **Features Added** and the retry fix under **Bugs Fixed** in each package's existing unreleased release section; package versions are unchanged.

### Bounded retry

A request is retried only when:

- the response status is HTTP 401;
- the request carries `x-ms-tokenboundauth`;
- the JSON response contains `[MtlsCnfClaimRequestDataValidationFailed]` in `error.message`;
- the configured Azure.Core retry policy permits another attempt.

The retry implementation:

- routes a matching response to the configured retry policy before ordinary `WWW-Authenticate` challenge replay;
- preserves existing response and exception classification, including custom classifiers;
- buffers non-seekable 401 bodies, including when `BufferResponse` is false;
- preserves the position of seekable response streams;
- treats malformed and valid non-object JSON as non-matching responses;
- uses the configured retry count and delay;
- adds no public API.

Per-request certificate/transport affinity remains the long-term work tracked by #62546.

### Deliberately deferred limitations

- The bounded retry mitigates transient shared-transport races; it does not provide per-request certificate affinity.
- A custom transport that cannot apply certificate updates, including `HttpClientTransport(HttpClient)`, can exhaust the configured retries rather than recover. #62546 is the authoritative fix for transport capability and affinity.
- The update-capable default transport lives for the lifetime of the Key Vault client. Replaced `HttpClient` instances are reference-counted and released by `HttpClientTransport.Update`; adding `IDisposable` to the existing GA Key Vault clients is intentionally outside this PR because it would change their public API and lifetime guidance.

### Release sequencing

The per-request certificate/transport-affinity work tracked by #62546 is not a blocker for the initial 1P GA; the bounded retry in this PR is the current reliability mitigation.

#61654 is already merged in Azure.Core. Final Azure.Core and MSAL package versions will be aligned through the normal release process. #62619 is tracked as separate KeyGuard hardening and is not declared as a merge or GA prerequisite by this PR.

Repository project-reference tests use the current Azure.Core source; packed-package dependency validation will be completed during release preparation.

## Testing

- Latest-head `net - pullrequest` matrix passed: 71 successful checks, 1 expected skip, and no failures.
- Administration, Certificates, Keys, and Secrets built across all target frameworks with API compatibility checks.
- WebJobs `CanInjectKeyVaultClient` playback passed on `net8.0`.
- Search `CreateDoubleEncryptedIndex` playback passed with its expected skip on `net8.0`.
- `eng/scripts/CodeChecks.ps1 -ServiceDirectory keyvault` passed with no generated, snippet, or API-listing drift.
- Added review coverage for binding-certificate transport updates, `MaxRetries = 0` with `WWW-Authenticate`, and custom non-error classifier preservation.
- The complete stack also passed the policy matrix and all four package builds when combined with #62619.

---

- [x] REST specification changes are not applicable.
- [x] I have read the contribution guidelines.
- [x] The pull request does not introduce breaking changes or public API changes.
- [x] The title is clear and informative.
- [x] The pull request has a small number of focused commits.
- [x] The pull request includes test coverage for the included changes.
- [x] SDK regeneration inputs are unchanged.
