### PR TITLE
[Storage] Add code coverage for error cases in PartitionedDownloader, Decryptor/Encryptor and StorageRequestFailedParser

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobExtensions.cs
@@ -1399,35 +1399,6 @@ namespace Azure.Storage.Blobs
         }
 
         internal static void ValidateConditionsNotPresent(
-            this BlobLeaseRequestConditions requestConditions,
-            BlobRequestConditionProperty invalidConditions,
-            string operationName,
-            string parameterName)
-        {
-            if (CompatSwitches.DisableRequestConditionsValidation)
-            {
-                return;
-            }
-
-            if (requestConditions == null)
-            {
-                return;
-            }
-
-            List<string> invalidList = null;
-            requestConditions.ValidateConditionsNotPresent(
-                invalidConditions, ref invalidList);
-
-            if (invalidList?.Count > 0)
-            {
-                string unsupportedString = string.Join(", ", invalidList);
-                throw new ArgumentException(
-                    $"{operationName} does not support the {unsupportedString} condition(s).",
-                    parameterName);
-            }
-        }
-
-        internal static void ValidateConditionsNotPresent(
             this AppendBlobRequestConditions requestConditions,
             BlobRequestConditionProperty invalidConditions,
             string operationName,

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -327,8 +327,6 @@ namespace Azure.Storage.Blobs
             BlobRequestConditions conditionsWithEtag,
             CancellationToken cancellationToken)
         {
-            BlobErrors.VerifyParallelismGreaterThanOne(parallel);
-
             Queue<Task<BufferedDownloadResult>> bufferedTasks = new();
 
             // Easiest to rent whether or not we need it. It's just 8 bytes.

--- a/sdk/storage/Azure.Storage.Blobs/src/Shared/BlobClientConfiguration.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Shared/BlobClientConfiguration.cs
@@ -100,28 +100,6 @@ namespace Azure.Storage.Blobs
         }
 
         /// <summary>
-        /// Create a <see cref="BlobClientConfiguration"/> without authentication,
-        /// or with SAS that was provided as part of the URL.
-        /// </summary>
-
-        public BlobClientConfiguration(
-            HttpPipeline pipeline,
-            ClientDiagnostics clientDiagnostics,
-            BlobClientOptions.ServiceVersion version,
-            CustomerProvidedKey? customerProvidedKey,
-            TransferValidationOptions transferValidation,
-            string encryptionScope,
-            bool trimBlobNameSlashes)
-            : base(pipeline, clientDiagnostics)
-        {
-            Version = version;
-            CustomerProvidedKey = customerProvidedKey;
-            TransferValidation = transferValidation;
-            EncryptionScope = encryptionScope;
-            TrimBlobNameSlashes = trimBlobNameSlashes;
-        }
-
-        /// <summary>
         /// Used for internal Client Constructors that accept multiple types of authentication.
         /// </summary>
         internal BlobClientConfiguration(

--- a/sdk/storage/Azure.Storage.Blobs/src/Shared/BlobErrors.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Shared/BlobErrors.cs
@@ -35,14 +35,6 @@ namespace Azure.Storage.Blobs
             }
         }
 
-        public static void VerifyParallelismGreaterThanOne(int parallelism)
-        {
-            if (parallelism <= 1)
-            {
-                throw new ArgumentException("Parallel must be greater than 1 for parallel download.", nameof(parallelism));
-            }
-        }
-
         public static void VerifyNoExtraData(int extraDataLength)
         {
             if (extraDataLength > 0)

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobWriteStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobWriteStreamTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using NUnit.Framework;
+
+namespace Azure.Storage.Blobs.Tests
+{
+    public class AppendBlobWriteStreamTests
+    {
+        private static readonly UploadTransferValidationOptions s_validationOptions = new UploadTransferValidationOptions
+        {
+            ChecksumAlgorithm = StorageChecksumAlgorithm.None
+        };
+
+        [TestCase(0)]
+        [TestCase(Constants.Blob.Append.MaxAppendBlockBytes + 1)]
+        public void ConstructorRejectsInvalidBufferSize(long bufferSize)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => CreateStream(bufferSize));
+        }
+
+        [Test]
+        public void FlushWithEmptyBufferDoesNotAppend()
+        {
+            var transport = new MockTransport(_ => throw new AssertionException("The empty buffer should not be appended."));
+            AppendBlobWriteStream stream = CreateStream(1024, transport, position: 5);
+
+            stream.Flush();
+
+            Assert.AreEqual(5, stream.Position);
+        }
+
+        [Test]
+        public void FlushAppendsBufferAndUpdatesConditions()
+        {
+            const string expectedEtag = "\"etag\"";
+            var transport = new MockTransport(_ => new MockResponse(201)
+                .WithHeader("ETag", expectedEtag)
+                .WithHeader("x-ms-blob-committed-block-count", "1"));
+            var conditions = new AppendBlobRequestConditions();
+            AppendBlobWriteStream stream = CreateStream(1024, transport, conditions: conditions);
+
+            stream.Write(new byte[] { 1, 2, 3 }, 0, 3);
+            stream.Flush();
+
+            Assert.AreEqual(3, stream.Position);
+            Assert.AreEqual(expectedEtag, conditions.IfMatch.ToString());
+        }
+
+        private static AppendBlobWriteStream CreateStream(
+            long bufferSize,
+            MockTransport transport = null,
+            long position = 0,
+            AppendBlobRequestConditions conditions = null)
+        {
+            var options = new BlobClientOptions();
+            options.Transport = transport ?? new MockTransport(_ => new MockResponse(201)
+                .WithHeader("ETag", "\"etag\"")
+                .WithHeader("x-ms-blob-committed-block-count", "1"));
+            var client = new AppendBlobClient(new Uri("https://account.blob.core.windows.net/container/blob"), options);
+            return new AppendBlobWriteStream(client, bufferSize, position, conditions, progressHandler: null, s_validationOptions);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientSideDecryptorTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientSideDecryptorTests.cs
@@ -3,7 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Cryptography;
+using Azure.Storage.Cryptography;
 using Azure.Storage.Cryptography.Models;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Storage.Blobs.Test
@@ -11,351 +17,168 @@ namespace Azure.Storage.Blobs.Test
     [TestFixture]
     public class BlobClientSideDecryptorTests
     {
-        #region GetAndValidateEncryptionDataOrDefault
+        #region DecryptInternal
 
         [Test]
-        public void GetAndValidateEncryptionDataOrDefault_NullMetadata_ReturnsDefault()
+        public async Task DecryptInternal_NoEncryptionMetadata_TrimsStream()
         {
-            var result = BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(null);
-            Assert.IsNull(result);
-        }
-
-        [Test]
-        public void GetAndValidateEncryptionDataOrDefault_NoEncryptionKey_ReturnsDefault()
-        {
-            var metadata = new Dictionary<string, string> { { "somekey", "somevalue" } };
-            var result = BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(metadata);
-            Assert.IsNull(result);
-        }
-
-        [Test]
-        public void GetAndValidateEncryptionDataOrDefault_V1_MissingIV_Throws()
-        {
-            var encryptionData = new EncryptionData
-            {
-                EncryptionMode = Constants.ClientSideEncryption.EncryptionMode,
-                EncryptionAgent = new EncryptionAgent
-                {
-#pragma warning disable CS0618 // obsolete
-                    EncryptionVersion = ClientSideEncryptionVersionInternal.V1_0,
-#pragma warning restore CS0618 // obsolete
-                    EncryptionAlgorithm = ClientSideEncryptionAlgorithm.AesCbc256,
-                },
-                WrappedContentKey = new KeyEnvelope
-                {
-                    KeyId = "keyId",
-                    EncryptedKey = new byte[] { 1, 2, 3 },
-                    Algorithm = "algo"
-                },
-                ContentEncryptionIV = null,
-                KeyWrappingMetadata = new Dictionary<string, string>
-                {
-                    { Constants.ClientSideEncryption.AgentMetadataKey, "1.0" }
-                }
-            };
-
+            var decryptor = new BlobClientSideDecryptor(CreateDecryptor());
+            using var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
             var metadata = new Dictionary<string, string>
             {
-                { Constants.ClientSideEncryption.EncryptionDataKey, EncryptionDataSerializer.Serialize(encryptionData) }
+                { "otherKey", "otherValue" }
             };
 
-            Assert.Throws<InvalidOperationException>(() =>
-                BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(metadata));
+            var result = await decryptor.DecryptInternal(
+                stream,
+                metadata,
+                new HttpRange(2, 3),
+                "bytes 0-4/5",
+                0,
+                async: false,
+                CancellationToken.None);
+
+            var actual = await ReadAllBytesAsync(result);
+            CollectionAssert.AreEqual(new byte[] { 3, 4, 5 }, actual);
         }
 
         [Test]
-        public void GetAndValidateEncryptionDataOrDefault_V1_Valid_ReturnsData()
+        public async Task DecryptInternal_WithEncryptionMetadata_DecryptsAndTrims()
         {
-            var encryptionData = new EncryptionData
+            var plaintext = new byte[] { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
+            var (ciphertext, metadata) = await CreateEncryptedPayloadAsync(plaintext);
+            var decryptor = new BlobClientSideDecryptor(CreateDecryptor());
+
+            var result = await decryptor.DecryptInternal(
+                ciphertext,
+                metadata,
+                new HttpRange(3, 5),
+                "bytes 0-9/10",
+                0,
+                async: false,
+                CancellationToken.None);
+
+            var actual = await ReadAllBytesAsync(result);
+            CollectionAssert.AreEqual(new byte[] { 13, 14, 15, 16, 17 }, actual);
+        }
+
+        [Test]
+        public async Task DecryptWholeBlobWriteInternal_NoEncryptionMetadata_ReturnsOriginalStream()
+        {
+            var decryptor = new BlobClientSideDecryptor(CreateDecryptor());
+            var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+
+            var result = await decryptor.DecryptWholeBlobWriteInternal(
+                stream,
+                new Dictionary<string, string> { { "otherKey", "otherValue" } },
+                async: false,
+                CancellationToken.None);
+
+            Assert.AreSame(stream, result);
+        }
+
+        [Test]
+        public async Task DecryptWholeBlobWriteInternal_WithEncryptionMetadata_DecryptsToDestination()
+        {
+            var plaintext = new byte[] { 20, 21, 22, 23, 24 };
+            var (ciphertext, metadata) = await CreateEncryptedPayloadAsync(plaintext);
+            var decryptor = new BlobClientSideDecryptor(CreateDecryptor());
+            var destination = new MemoryStream();
+
+            using (Stream result = await decryptor.DecryptWholeBlobWriteInternal(
+                destination,
+                metadata,
+                async: false,
+                CancellationToken.None))
             {
-                EncryptionMode = Constants.ClientSideEncryption.EncryptionMode,
-                EncryptionAgent = new EncryptionAgent
-                {
-#pragma warning disable CS0618 // obsolete
-                    EncryptionVersion = ClientSideEncryptionVersionInternal.V1_0,
-#pragma warning restore CS0618 // obsolete
-                    EncryptionAlgorithm = ClientSideEncryptionAlgorithm.AesCbc256,
-                },
-                WrappedContentKey = new KeyEnvelope
-                {
-                    KeyId = "keyId",
-                    EncryptedKey = new byte[] { 1, 2, 3 },
-                    Algorithm = "algo"
-                },
-                ContentEncryptionIV = new byte[16],
-                KeyWrappingMetadata = new Dictionary<string, string>
-                {
-                    { Constants.ClientSideEncryption.AgentMetadataKey, "1.0" }
-                }
-            };
+                Assert.IsNotNull(result);
+                ciphertext.Position = 0;
+                await result.WriteAsync(await ReadAllBytesAsync(ciphertext), 0, (int)ciphertext.Length);
+                result.Flush();
+            }
 
-            var metadata = new Dictionary<string, string>
-            {
-                { Constants.ClientSideEncryption.EncryptionDataKey, EncryptionDataSerializer.Serialize(encryptionData) }
-            };
-
-            var result = BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(metadata);
-
-            Assert.IsNotNull(result);
-#pragma warning disable CS0618 // obsolete
-            Assert.AreEqual(ClientSideEncryptionVersionInternal.V1_0, result.EncryptionAgent.EncryptionVersion);
-#pragma warning restore CS0618 // obsolete
-        }
-
-        [Test]
-        public void GetAndValidateEncryptionDataOrDefault_V2_MissingRegionInfo_Throws()
-        {
-            var encryptionData = new EncryptionData
-            {
-                EncryptionMode = Constants.ClientSideEncryption.EncryptionMode,
-                EncryptionAgent = new EncryptionAgent
-                {
-                    EncryptionVersion = ClientSideEncryptionVersionInternal.V2_0,
-                    EncryptionAlgorithm = ClientSideEncryptionAlgorithm.AesGcm256,
-                },
-                WrappedContentKey = new KeyEnvelope
-                {
-                    KeyId = "keyId",
-                    EncryptedKey = new byte[] { 1, 2, 3 },
-                    Algorithm = "algo"
-                },
-                EncryptedRegionInfo = null,
-                KeyWrappingMetadata = new Dictionary<string, string>
-                {
-                    { Constants.ClientSideEncryption.AgentMetadataKey, "2.0" }
-                }
-            };
-
-            var metadata = new Dictionary<string, string>
-            {
-                { Constants.ClientSideEncryption.EncryptionDataKey, EncryptionDataSerializer.Serialize(encryptionData) }
-            };
-
-            Assert.Throws<InvalidOperationException>(() =>
-                BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(metadata));
-        }
-
-        [Test]
-        public void GetAndValidateEncryptionDataOrDefault_V2_Valid_ReturnsData()
-        {
-            var encryptionData = CreateV2EncryptionData();
-
-            var metadata = new Dictionary<string, string>
-            {
-                { Constants.ClientSideEncryption.EncryptionDataKey, EncryptionDataSerializer.Serialize(encryptionData) }
-            };
-
-            var result = BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(metadata);
-
-            Assert.IsNotNull(result);
-            Assert.AreEqual(ClientSideEncryptionVersionInternal.V2_0, result.EncryptionAgent.EncryptionVersion);
-        }
-
-        [Test]
-        public void GetAndValidateEncryptionDataOrDefault_MissingEncryptedKey_Throws()
-        {
-            // Construct a valid V2 encryption data, serialize it, then manipulate the JSON
-            // to remove the EncryptedKey value to simulate missing key scenario.
-            var encryptionData = CreateV2EncryptionData();
-            string serialized = EncryptionDataSerializer.Serialize(encryptionData);
-            // Replace the base64-encoded key with null in JSON
-            var json = Newtonsoft.Json.Linq.JObject.Parse(serialized);
-            json["WrappedContentKey"]["EncryptedKey"] = null;
-            serialized = json.ToString(Newtonsoft.Json.Formatting.None);
-
-            var metadata = new Dictionary<string, string>
-            {
-                { Constants.ClientSideEncryption.EncryptionDataKey, serialized }
-            };
-
-            Assert.That(() =>
-                BlobClientSideDecryptor.GetAndValidateEncryptionDataOrDefault(metadata),
-                Throws.InstanceOf<ArgumentNullException>());
-        }
-
-        #endregion
-
-        #region GetEncryptedBlobRange
-
-        [Test]
-        public void GetEncryptedBlobRange_DefaultEncryptionData_ReturnsSameRange()
-        {
-            var originalRange = new HttpRange(100, 200);
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, default(EncryptionData));
-            Assert.AreEqual(originalRange, result.BlobRange);
-        }
-
-        [Test]
-        public void GetEncryptedBlobRange_V1_ZeroOffset_NoAdjustment()
-        {
-            var encryptionData = CreateV1EncryptionData();
-            var originalRange = new HttpRange(0, 32);
-
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, encryptionData);
-
-            Assert.AreEqual(0, result.BlobRange.Offset);
-            Assert.AreEqual(32, result.BlobRange.Length);
-        }
-
-        [Test]
-        public void GetEncryptedBlobRange_V1_OffsetLessThanBlockSize_AlignsToBlockBoundary()
-        {
-            var encryptionData = CreateV1EncryptionData();
-            // Offset 5, within first block (blocksize=16), no IV needed
-            var originalRange = new HttpRange(5, 10);
-
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, encryptionData);
-
-            // offset adjusted back by 5 (diff from block boundary), so offset=0
-            Assert.AreEqual(0, result.BlobRange.Offset);
-            // count adjusted: 10 + 5 = 15, rounded up to block boundary = 16
-            Assert.AreEqual(16, result.BlobRange.Length);
-        }
-
-        [Test]
-        public void GetEncryptedBlobRange_V1_OffsetBeyondBlockSize_IncludesIV()
-        {
-            var encryptionData = CreateV1EncryptionData();
-            // Offset 20 (>16), diff from block boundary = 20%16 = 4
-            var originalRange = new HttpRange(20, 10);
-
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, encryptionData);
-
-            // offset = 20 - 4(diff) - 16(IV) = 0
-            Assert.AreEqual(0, result.BlobRange.Offset);
-            // count = 10 + 4(diff) + 16(IV) = 30, rounded up to 32
-            Assert.AreEqual(32, result.BlobRange.Length);
-        }
-
-        [Test]
-        public void GetEncryptedBlobRange_V1_NullLength_ReturnsNullLength()
-        {
-            var encryptionData = CreateV1EncryptionData();
-            var originalRange = new HttpRange(0, null);
-
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, encryptionData);
-
-            Assert.AreEqual(0, result.BlobRange.Offset);
-            Assert.IsNull(result.BlobRange.Length);
-        }
-
-        [Test]
-        public void GetEncryptedBlobRange_V2_ZeroOffset_NoAdjustment()
-        {
-            var encryptionData = CreateV2EncryptionData();
-            int totalRegionSize = Constants.ClientSideEncryption.V2.NonceSize
-                + Constants.ClientSideEncryption.V2.EncryptionRegionDataSize
-                + Constants.ClientSideEncryption.V2.TagSize;
-            var originalRange = new HttpRange(0, 100);
-
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, encryptionData);
-
-            Assert.AreEqual(0, result.BlobRange.Offset);
-            // end is in region 0, so count = 1 * totalRegionSize
-            Assert.AreEqual(totalRegionSize, result.BlobRange.Length);
-        }
-
-        [Test]
-        public void GetEncryptedBlobRange_V2_OffsetInSecondRegion()
-        {
-            var encryptionData = CreateV2EncryptionData();
-            int dataSize = Constants.ClientSideEncryption.V2.EncryptionRegionDataSize;
-            int totalRegionSize = Constants.ClientSideEncryption.V2.NonceSize
-                + dataSize
-                + Constants.ClientSideEncryption.V2.TagSize;
-
-            // Offset in second region
-            var originalRange = new HttpRange(dataSize + 100, 50);
-
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, encryptionData);
-
-            // Region 1 start
-            Assert.AreEqual(1 * totalRegionSize, result.BlobRange.Offset);
-            // End is also in region 1, so count = 2 * totalRegionSize - 1 * totalRegionSize = totalRegionSize
-            Assert.AreEqual(totalRegionSize, result.BlobRange.Length);
-        }
-
-        [Test]
-        public void GetEncryptedBlobRange_V2_NullLength_ReturnsNullLength()
-        {
-            var encryptionData = CreateV2EncryptionData();
-            var originalRange = new HttpRange(0, null);
-
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, encryptionData);
-
-            Assert.AreEqual(0, result.BlobRange.Offset);
-            Assert.IsNull(result.BlobRange.Length);
-        }
-
-        [Test]
-        public void GetEncryptedBlobRange_StringOverload_Works()
-        {
-            var encryptionData = CreateV2EncryptionData();
-            string rawEncryptionData = EncryptionDataSerializer.Serialize(encryptionData);
-            var originalRange = new HttpRange(0, 100);
-
-            var result = BlobClientSideDecryptor.GetEncryptedBlobRange(originalRange, rawEncryptionData);
-
-            Assert.AreEqual(0, result.BlobRange.Offset);
-            Assert.IsTrue(result.BlobRange.Length > 100);
+            CollectionAssert.AreEqual(plaintext, destination.ToArray());
         }
 
         #endregion
 
         #region Helpers
 
-        private static EncryptionData CreateV1EncryptionData()
+        private static ClientSideDecryptor CreateDecryptor()
         {
-            return new EncryptionData
+            const string keyId = "keyId";
+            const string keyWrapAlgorithm = "some algorithm name";
+            var key = new Mock<IKeyEncryptionKey>(MockBehavior.Strict);
+            key.SetupGet(k => k.KeyId).Returns(keyId);
+            key.Setup(k => k.WrapKey(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => contents.ToArray());
+            key.Setup(k => k.UnwrapKey(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => contents.ToArray());
+            key.Setup(k => k.WrapKeyAsync(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => Task.FromResult(contents.ToArray()));
+            key.Setup(k => k.UnwrapKeyAsync(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => Task.FromResult(contents.ToArray()));
+
+            var resolver = new Mock<IKeyEncryptionKeyResolver>(MockBehavior.Strict);
+            resolver.Setup(r => r.Resolve(keyId, It.IsAny<CancellationToken>())).Returns(key.Object);
+            resolver.Setup(r => r.ResolveAsync(keyId, It.IsAny<CancellationToken>())).ReturnsAsync(key.Object);
+
+            var options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0)
             {
-                EncryptionMode = Constants.ClientSideEncryption.EncryptionMode,
-                EncryptionAgent = new EncryptionAgent
-                {
-#pragma warning disable CS0618 // obsolete
-                    EncryptionVersion = ClientSideEncryptionVersionInternal.V1_0,
-#pragma warning restore CS0618 // obsolete
-                    EncryptionAlgorithm = ClientSideEncryptionAlgorithm.AesCbc256,
-                },
-                WrappedContentKey = new KeyEnvelope
-                {
-                    KeyId = "keyId",
-                    EncryptedKey = new byte[] { 1, 2, 3 },
-                    Algorithm = "algo"
-                },
-                ContentEncryptionIV = new byte[16],
-                KeyWrappingMetadata = new Dictionary<string, string>
-                {
-                    { Constants.ClientSideEncryption.AgentMetadataKey, "1.0" }
-                }
+                KeyEncryptionKey = key.Object,
+                KeyResolver = resolver.Object,
+                KeyWrapAlgorithm = keyWrapAlgorithm,
             };
+
+            return new ClientSideDecryptor(options);
         }
 
-        private static EncryptionData CreateV2EncryptionData()
+        private static async Task<(MemoryStream Ciphertext, Dictionary<string, string> Metadata)> CreateEncryptedPayloadAsync(byte[] plaintext)
         {
-            return new EncryptionData
+            const string keyId = "keyId";
+            const string keyWrapAlgorithm = "some algorithm name";
+            var key = new Mock<IKeyEncryptionKey>(MockBehavior.Strict);
+            key.SetupGet(k => k.KeyId).Returns(keyId);
+            key.Setup(k => k.WrapKey(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => contents.ToArray());
+            key.Setup(k => k.UnwrapKey(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => contents.ToArray());
+            key.Setup(k => k.WrapKeyAsync(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => Task.FromResult(contents.ToArray()));
+            key.Setup(k => k.UnwrapKeyAsync(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => Task.FromResult(contents.ToArray()));
+
+            var resolver = new Mock<IKeyEncryptionKeyResolver>(MockBehavior.Strict);
+            resolver.Setup(r => r.Resolve(keyId, It.IsAny<CancellationToken>())).Returns(key.Object);
+            resolver.Setup(r => r.ResolveAsync(keyId, It.IsAny<CancellationToken>())).ReturnsAsync(key.Object);
+
+            var options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0)
             {
-                EncryptionMode = Constants.ClientSideEncryption.EncryptionMode,
-                EncryptionAgent = new EncryptionAgent
-                {
-                    EncryptionVersion = ClientSideEncryptionVersionInternal.V2_0,
-                    EncryptionAlgorithm = ClientSideEncryptionAlgorithm.AesGcm256,
-                },
-                WrappedContentKey = new KeyEnvelope
-                {
-                    KeyId = "keyId",
-                    EncryptedKey = new byte[] { 1, 2, 3 },
-                    Algorithm = "algo"
-                },
-                EncryptedRegionInfo = new EncryptedRegionInfo
-                {
-                    DataLength = Constants.ClientSideEncryption.V2.EncryptionRegionDataSize,
-                    NonceLength = Constants.ClientSideEncryption.V2.NonceSize
-                },
-                KeyWrappingMetadata = new Dictionary<string, string>
-                {
-                    { Constants.ClientSideEncryption.AgentMetadataKey, "2.0" }
-                }
+                KeyEncryptionKey = key.Object,
+                KeyResolver = resolver.Object,
+                KeyWrapAlgorithm = keyWrapAlgorithm,
             };
+
+            var encryptor = new ClientSideEncryptorV2_0(options);
+            var (ciphertext, encryptionData) = await encryptor.BufferedEncryptInternal(new MemoryStream(plaintext), async: false, CancellationToken.None);
+            var metadata = new Dictionary<string, string>
+            {
+                { Constants.ClientSideEncryption.EncryptionDataKey, EncryptionDataSerializer.Serialize(encryptionData) }
+            };
+
+            return (new MemoryStream(ciphertext), metadata);
+        }
+
+        private static async Task<byte[]> ReadAllBytesAsync(Stream stream)
+        {
+            using var memory = new MemoryStream();
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+
+            await stream.CopyToAsync(memory).ConfigureAwait(false);
+            return memory.ToArray();
         }
 
         #endregion

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientSideEncryptorTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientSideEncryptorTests.cs
@@ -46,62 +46,30 @@ namespace Azure.Storage.Blobs.Test
         #region ClientSideEncryptInternal
 
         [Test]
-        public async Task ClientSideEncryptInternal_ReturnsEncryptedStreamAndMetadata()
+        public async Task ClientSideEncryptInternal_NullMetadata_CreatesNewMetadata()
         {
-            // Arrange
             var expectedCiphertext = new MemoryStream(new byte[] { 10, 20, 30 });
             var expectedEncryptionData = CreateTestEncryptionData();
-
             var mockEncryptor = new Mock<IClientSideEncryptor>();
             mockEncryptor
                 .Setup(e => e.EncryptInternal(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((expectedCiphertext, expectedEncryptionData));
 
             var encryptor = new BlobClientSideEncryptor(mockEncryptor.Object);
-            var plaintext = new MemoryStream(new byte[] { 1, 2, 3 });
-
-            // Act
             var (ciphertext, metadata) = await encryptor.ClientSideEncryptInternal(
-                plaintext,
+                new MemoryStream(new byte[] { 1, 2, 3 }),
                 null,
                 async: true,
                 CancellationToken.None);
 
-            // Assert
             Assert.AreSame(expectedCiphertext, ciphertext);
-            Assert.IsNotNull(metadata);
-            Assert.IsTrue(metadata.ContainsKey(Constants.ClientSideEncryption.EncryptionDataKey));
-        }
-
-        [Test]
-        public async Task ClientSideEncryptInternal_NullMetadata_CreatesNewMetadata()
-        {
-            // Arrange
-            var expectedEncryptionData = CreateTestEncryptionData();
-            var mockEncryptor = new Mock<IClientSideEncryptor>();
-            mockEncryptor
-                .Setup(e => e.EncryptInternal(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((new MemoryStream(), expectedEncryptionData));
-
-            var encryptor = new BlobClientSideEncryptor(mockEncryptor.Object);
-
-            // Act
-            var (_, metadata) = await encryptor.ClientSideEncryptInternal(
-                new MemoryStream(),
-                null,
-                async: true,
-                CancellationToken.None);
-
-            // Assert
-            Assert.IsNotNull(metadata);
             Assert.AreEqual(1, metadata.Count);
             Assert.IsTrue(metadata.ContainsKey(Constants.ClientSideEncryption.EncryptionDataKey));
         }
 
         [Test]
-        public async Task ClientSideEncryptInternal_ExistingMetadata_PreservesAndAddsEncryptionData()
+        public async Task ClientSideEncryptInternal_ExistingMetadata_CopiesAndOverwritesEncryptionData()
         {
-            // Arrange
             var expectedEncryptionData = CreateTestEncryptionData();
             var mockEncryptor = new Mock<IClientSideEncryptor>();
             mockEncryptor
@@ -111,153 +79,20 @@ namespace Azure.Storage.Blobs.Test
             var encryptor = new BlobClientSideEncryptor(mockEncryptor.Object);
             var existingMetadata = new Dictionary<string, string>
             {
-                { "existingKey", "existingValue" }
-            };
-
-            // Act
-            var (_, metadata) = await encryptor.ClientSideEncryptInternal(
-                new MemoryStream(),
-                existingMetadata,
-                async: true,
-                CancellationToken.None);
-
-            // Assert
-            Assert.AreEqual(2, metadata.Count);
-            Assert.AreEqual("existingValue", metadata["existingKey"]);
-            Assert.IsTrue(metadata.ContainsKey(Constants.ClientSideEncryption.EncryptionDataKey));
-        }
-
-        [Test]
-        public async Task ClientSideEncryptInternal_ExistingEncryptionMetadata_OverwritesPrevious()
-        {
-            // Arrange
-            var expectedEncryptionData = CreateTestEncryptionData();
-            var mockEncryptor = new Mock<IClientSideEncryptor>();
-            mockEncryptor
-                .Setup(e => e.EncryptInternal(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((new MemoryStream(), expectedEncryptionData));
-
-            var encryptor = new BlobClientSideEncryptor(mockEncryptor.Object);
-            var existingMetadata = new Dictionary<string, string>
-            {
+                { "existingKey", "existingValue" },
                 { Constants.ClientSideEncryption.EncryptionDataKey, "oldValue" }
             };
 
-            // Act
             var (_, metadata) = await encryptor.ClientSideEncryptInternal(
                 new MemoryStream(),
                 existingMetadata,
                 async: true,
                 CancellationToken.None);
 
-            // Assert
-            Assert.AreEqual(1, metadata.Count);
+            Assert.AreEqual(2, metadata.Count);
+            Assert.AreEqual("existingValue", metadata["existingKey"]);
             Assert.AreNotEqual("oldValue", metadata[Constants.ClientSideEncryption.EncryptionDataKey]);
-        }
-
-        [Test]
-        public async Task ClientSideEncryptInternal_DoesNotMutateOriginalMetadata()
-        {
-            // Arrange
-            var expectedEncryptionData = CreateTestEncryptionData();
-            var mockEncryptor = new Mock<IClientSideEncryptor>();
-            mockEncryptor
-                .Setup(e => e.EncryptInternal(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((new MemoryStream(), expectedEncryptionData));
-
-            var encryptor = new BlobClientSideEncryptor(mockEncryptor.Object);
-            var originalMetadata = new Dictionary<string, string>
-            {
-                { "key1", "value1" }
-            };
-
-            // Act
-            await encryptor.ClientSideEncryptInternal(
-                new MemoryStream(),
-                originalMetadata,
-                async: true,
-                CancellationToken.None);
-
-            // Assert - original metadata should not be modified
-            Assert.AreEqual(1, originalMetadata.Count);
-            Assert.IsFalse(originalMetadata.ContainsKey(Constants.ClientSideEncryption.EncryptionDataKey));
-        }
-
-        [Test]
-        public async Task ClientSideEncryptInternal_Sync_CallsEncryptorCorrectly()
-        {
-            // Arrange
-            var expectedEncryptionData = CreateTestEncryptionData();
-            var mockEncryptor = new Mock<IClientSideEncryptor>();
-            mockEncryptor
-                .Setup(e => e.EncryptInternal(It.IsAny<Stream>(), false, It.IsAny<CancellationToken>()))
-                .ReturnsAsync((new MemoryStream(), expectedEncryptionData));
-
-            var encryptor = new BlobClientSideEncryptor(mockEncryptor.Object);
-
-            // Act
-            await encryptor.ClientSideEncryptInternal(
-                new MemoryStream(),
-                null,
-                async: false,
-                CancellationToken.None);
-
-            // Assert
-            mockEncryptor.Verify(
-                e => e.EncryptInternal(It.IsAny<Stream>(), false, It.IsAny<CancellationToken>()),
-                Times.Once);
-        }
-
-        [Test]
-        public async Task ClientSideEncryptInternal_PassesCancellationToken()
-        {
-            // Arrange
-            var expectedEncryptionData = CreateTestEncryptionData();
-            var cts = new CancellationTokenSource();
-            var token = cts.Token;
-
-            var mockEncryptor = new Mock<IClientSideEncryptor>();
-            mockEncryptor
-                .Setup(e => e.EncryptInternal(It.IsAny<Stream>(), It.IsAny<bool>(), token))
-                .ReturnsAsync((new MemoryStream(), expectedEncryptionData));
-
-            var encryptor = new BlobClientSideEncryptor(mockEncryptor.Object);
-
-            // Act
-            await encryptor.ClientSideEncryptInternal(
-                new MemoryStream(),
-                null,
-                async: true,
-                token);
-
-            // Assert
-            mockEncryptor.Verify(
-                e => e.EncryptInternal(It.IsAny<Stream>(), true, token),
-                Times.Once);
-        }
-
-        [Test]
-        public async Task ClientSideEncryptInternal_MetadataKeysAreCaseInsensitive()
-        {
-            // Arrange
-            var expectedEncryptionData = CreateTestEncryptionData();
-            var mockEncryptor = new Mock<IClientSideEncryptor>();
-            mockEncryptor
-                .Setup(e => e.EncryptInternal(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((new MemoryStream(), expectedEncryptionData));
-
-            var encryptor = new BlobClientSideEncryptor(mockEncryptor.Object);
-
-            // Act
-            var (_, metadata) = await encryptor.ClientSideEncryptInternal(
-                new MemoryStream(),
-                null,
-                async: true,
-                CancellationToken.None);
-
-            // Assert - metadata should be case insensitive
-            string key = Constants.ClientSideEncryption.EncryptionDataKey;
-            Assert.IsTrue(metadata.ContainsKey(key.ToUpperInvariant()));
+            Assert.AreEqual("oldValue", existingMetadata[Constants.ClientSideEncryption.EncryptionDataKey]);
         }
 
         #endregion

--- a/sdk/storage/Azure.Storage.Blobs/tests/PartitionedDownloaderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PartitionedDownloaderTests.cs
@@ -7,10 +7,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core.Cryptography;
 using Azure.Core.TestFramework;
 using Azure.Storage;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Cryptography;
+using Azure.Storage.Cryptography.Models;
 using Moq;
 using NUnit.Framework;
 
@@ -69,6 +72,173 @@ namespace Azure.Storage.Blobs.Test
         }
 
         /// <summary>
+        /// Verifies that the PartitionedDownloader constructor enforces the requirement
+        /// that AutoValidateChecksum must be true. The downloader performs distributed
+        /// checksum composition and cannot defer validation to the caller.
+        /// </summary>
+        [Test]
+        public void ThrowsWhenAutoValidateChecksumIsFalse()
+        {
+            Mock<BlobBaseClient> blockClient = CreateMockBlobClient();
+            DownloadTransferValidationOptions validationOptions = new DownloadTransferValidationOptions()
+            {
+                AutoValidateChecksum = false,
+                ChecksumAlgorithm = StorageChecksumAlgorithm.StorageCrc64
+            };
+
+            ArgumentException thrown = Assert.Throws<ArgumentException>(() =>
+                new PartitionedDownloader(blockClient.Object, transferValidation: validationOptions));
+
+            Assert.That(thrown.Message, Does.Contain("Cannot defer"));
+        }
+
+        /// <summary>
+        /// Verifies the defensive guard that rejects a retry after InvalidRange when the
+        /// retry without a range header still returns a non-empty blob while checksum
+        /// validation is enabled.
+        /// </summary>
+        [Test]
+        public async Task ThrowsWhenRetryingInvalidRangeReturnsNonEmptyBlob()
+        {
+            MemoryStream stream = new MemoryStream();
+            Mock<BlobBaseClient> blockClient = CreateMockBlobClient();
+            DownloadTransferValidationOptions validationOptions = new DownloadTransferValidationOptions()
+            {
+                AutoValidateChecksum = true,
+                ChecksumAlgorithm = StorageChecksumAlgorithm.StorageCrc64
+            };
+
+            blockClient.Setup(c => c.DownloadStreamingInternal(
+                It.Is<HttpRange>(r => !r.Equals(default(HttpRange))),
+                It.IsAny<BlobRequestConditions>(),
+                It.Is<DownloadTransferValidationOptions>(options =>
+                    options != null && options.ChecksumAlgorithm != StorageChecksumAlgorithm.None && !options.AutoValidateChecksum),
+                It.IsAny<IProgress<long>>(),
+                $"{nameof(BlobBaseClient)}.{nameof(BlobBaseClient.DownloadStreaming)}",
+                _async,
+                s_cancellationToken))
+            .ThrowsAsync(new RequestFailedException(
+                status: 416,
+                errorCode: BlobErrorCode.InvalidRange.ToString(),
+                message: "The specified range is invalid.",
+                innerException: null));
+
+            blockClient.Setup(c => c.DownloadStreamingInternal(
+                It.Is<HttpRange>(r => r.Equals(default(HttpRange))),
+                It.IsAny<BlobRequestConditions>(),
+                It.Is<DownloadTransferValidationOptions>(options =>
+                    options != null && options.ChecksumAlgorithm == StorageChecksumAlgorithm.None),
+                It.IsAny<IProgress<long>>(),
+                $"{nameof(BlobBaseClient)}.{nameof(BlobBaseClient.DownloadStreaming)}",
+                _async,
+                s_cancellationToken))
+            .Returns<HttpRange, BlobRequestConditions, DownloadTransferValidationOptions, IProgress<long>, string, bool, CancellationToken>(
+                (range, conditions, validation, progress, operationName, async, cancellation) =>
+                {
+                    Response<BlobDownloadStreamingResult> response = CreateMockResponse(new HttpRange(0, 1), new MemoryStream(new byte[] { 1 }), 1);
+                    return async
+                        ? new ValueTask<Response<BlobDownloadStreamingResult>>(response)
+                        : new ValueTask<Response<BlobDownloadStreamingResult>>(response);
+                });
+
+            PartitionedDownloader downloader = new PartitionedDownloader(
+                blockClient.Object,
+                transferValidation: validationOptions);
+
+            RequestFailedException thrown = Assert.ThrowsAsync<RequestFailedException>(async () => await InvokeDownloadToAsync(downloader, stream));
+
+            Assert.AreEqual("Invalid range exception during ranged download despite non-empty blob", thrown.Message);
+        }
+
+        /// <summary>
+        /// Verifies the client-side encryption download wiring end-to-end: when the
+        /// blob's metadata contains encryption data, the downloader constructs a
+        /// <see cref="BlobClientSideDecryptor"/>, wraps the destination stream so
+        /// ciphertext is decrypted as it's written, and flushes the final
+        /// authenticated region (<see cref="AuthenticatedRegionCryptoStream.FlushFinalInternal"/>)
+        /// so the last block/auth-tag is not lost. A one-shot (single-response)
+        /// download is used so this exercises HandleOneShotDownload -> FinalizeDownloadInternal
+        /// -> FlushFinalIfNecessaryInternal. If the flush were skipped, the final
+        /// authenticated region would not be released, and this assertion would fail
+        /// or throw.
+        /// </summary>
+        [Test]
+        public async Task DecryptsClientSideEncryptedBlobAndFlushesFinalBlock()
+        {
+            byte[] plaintext = new byte[] { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
+
+            const string keyId = "keyId";
+            const string keyWrapAlgorithm = "some algorithm name";
+            Mock<IKeyEncryptionKey> key = new Mock<IKeyEncryptionKey>(MockBehavior.Strict);
+            key.SetupGet(k => k.KeyId).Returns(keyId);
+            key.Setup(k => k.WrapKey(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => contents.ToArray());
+            key.Setup(k => k.UnwrapKey(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => contents.ToArray());
+            key.Setup(k => k.WrapKeyAsync(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => Task.FromResult(contents.ToArray()));
+            key.Setup(k => k.UnwrapKeyAsync(keyWrapAlgorithm, It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, ReadOnlyMemory<byte> contents, CancellationToken _) => Task.FromResult(contents.ToArray()));
+
+            Mock<IKeyEncryptionKeyResolver> resolver = new Mock<IKeyEncryptionKeyResolver>(MockBehavior.Strict);
+            resolver.Setup(r => r.Resolve(keyId, It.IsAny<CancellationToken>())).Returns(key.Object);
+            resolver.Setup(r => r.ResolveAsync(keyId, It.IsAny<CancellationToken>())).ReturnsAsync(key.Object);
+
+            ClientSideEncryptionOptions options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V2_0)
+            {
+                KeyEncryptionKey = key.Object,
+                KeyResolver = resolver.Object,
+                KeyWrapAlgorithm = keyWrapAlgorithm,
+            };
+
+            ClientSideEncryptorV2_0 encryptor = new ClientSideEncryptorV2_0(options);
+            (byte[] ciphertext, EncryptionData encryptionData) = await encryptor.BufferedEncryptInternal(
+                new MemoryStream(plaintext), async: false, CancellationToken.None);
+            Dictionary<string, string> encryptionMetadata = new Dictionary<string, string>
+            {
+                { Constants.ClientSideEncryption.EncryptionDataKey, EncryptionDataSerializer.Serialize(encryptionData) }
+            };
+
+            Mock<BlobBaseClient> blockClient = new Mock<BlobBaseClient>(MockBehavior.Strict, new Uri("http://mock"), new BlobClientOptions());
+            blockClient.SetupGet(c => c.ClientConfiguration).CallBase();
+            blockClient.SetupGet(c => c.UsingClientSideEncryption).Returns(true);
+            blockClient.SetupGet(c => c.ClientSideEncryption).Returns(options);
+
+            blockClient.Setup(c => c.DownloadStreamingInternal(
+                It.IsAny<HttpRange>(),
+                It.IsAny<BlobRequestConditions>(),
+                It.IsAny<DownloadTransferValidationOptions>(),
+                It.IsAny<IProgress<long>>(),
+                $"{nameof(BlobBaseClient)}.{nameof(BlobBaseClient.DownloadStreaming)}",
+                _async,
+                s_cancellationToken))
+            .Returns<HttpRange, BlobRequestConditions, DownloadTransferValidationOptions, IProgress<long>, string, bool, CancellationToken>(
+                (range, conditions, validation, progress, operationName, async, cancellation) =>
+                {
+                    BlobDownloadDetails details = CreateMockDetails(range, ciphertext.Length, totalBlobLength: ciphertext.Length);
+                    details.Metadata = encryptionMetadata;
+                    Response<BlobDownloadStreamingResult> response = Response.FromValue(
+                        new BlobDownloadStreamingResult()
+                        {
+                            Content = new MemoryStream(ciphertext),
+                            Details = details,
+                        },
+                        new MockResponse(200));
+                    return new ValueTask<Response<BlobDownloadStreamingResult>>(response);
+                });
+
+            PartitionedDownloader downloader = new PartitionedDownloader(
+                blockClient.Object,
+                transferValidation: s_validationOptions);
+
+            MemoryStream destination = new MemoryStream();
+            Response result = await InvokeDownloadToAsync(downloader, destination);
+
+            Assert.NotNull(result);
+            CollectionAssert.AreEqual(plaintext, destination.ToArray());
+        }
+
+        /// <summary>
         /// Verifies that a blob smaller than the initial transfer size is downloaded
         /// in a single request (one-shot path) and the destination stream contains
         /// the correct bytes.
@@ -90,6 +260,56 @@ namespace Azure.Storage.Blobs.Test
 
             AssertContent(10, stream);
             Assert.NotNull(result);
+        }
+
+        /// <summary>
+        /// Verifies that when the initial response has no Content-Range header
+        /// (e.g. due to transit encoding stripping it), the downloader treats
+        /// totalLength as 0, which causes GetRanges to yield no further segments.
+        /// This exercises the fallback branch (initialLength = ContentLength,
+        /// totalLength = 0) and confirms the single response is downloaded in
+        /// full without requesting additional ranges or throwing.
+        /// </summary>
+        [Test]
+        public async Task HandlesMissingContentRangeHeader()
+        {
+            MemoryStream stream = new MemoryStream();
+            Mock<BlobBaseClient> blockClient = CreateMockBlobClient();
+            int requestCount = 0;
+
+            blockClient.Setup(c => c.DownloadStreamingInternal(
+                It.IsAny<HttpRange>(),
+                It.IsAny<BlobRequestConditions>(),
+                It.IsAny<DownloadTransferValidationOptions>(),
+                It.IsAny<IProgress<long>>(),
+                $"{nameof(BlobBaseClient)}.{nameof(BlobBaseClient.DownloadStreaming)}",
+                _async,
+                s_cancellationToken))
+            .Returns<HttpRange, BlobRequestConditions, DownloadTransferValidationOptions, IProgress<long>, string, bool, CancellationToken>(
+                (range, conditions, validation, progress, operationName, async, cancellation) =>
+                {
+                    Interlocked.Increment(ref requestCount);
+                    byte[] data = new byte[] { 1, 2, 3, 4, 5 };
+                    Response<BlobDownloadStreamingResult> response = Response.FromValue(
+                        new BlobDownloadStreamingResult()
+                        {
+                            Content = new MemoryStream(data),
+                            Details = CreateMockDetails(range, data.Length, totalBlobLength: data.Length),
+                        },
+                        new MockResponse(200));
+                    response.Value.Details.ContentRange = null;
+                    return new ValueTask<Response<BlobDownloadStreamingResult>>(response);
+                });
+
+            PartitionedDownloader downloader = new PartitionedDownloader(
+                blockClient.Object,
+                transferValidation: s_validationOptions);
+
+            Response result = await InvokeDownloadToAsync(downloader, stream);
+
+            Assert.NotNull(result);
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5 }, stream.ToArray());
+            Assert.AreEqual(1, requestCount, "No additional range requests should be made when Content-Range is missing.");
         }
 
         /// <summary>
@@ -521,6 +741,129 @@ namespace Azure.Storage.Blobs.Test
         }
 
         /// <summary>
+        /// Verifies that a per-partition checksum mismatch is detected and surfaced
+        /// when the initial response is streamed directly to the destination
+        /// (CopyToInternal), rather than buffered. Uses a single small blob so the
+        /// download completes as a one-shot streamed copy. The response omits the
+        /// x-ms-content-crc64 header entirely, so the locally computed hash will
+        /// never match the (empty) expected checksum.
+        /// </summary>
+        [Test]
+        public void ThrowsOnChecksumMismatchInStreamedPath()
+        {
+            MemoryStream destination = new MemoryStream();
+            MockDataSource dataSource = new MockDataSource(10);
+            Mock<BlobBaseClient> blockClient = CreateMockBlobClient();
+            SetupDownload(blockClient, dataSource);
+
+            DownloadTransferValidationOptions checksumValidation = new DownloadTransferValidationOptions()
+            {
+                AutoValidateChecksum = true,
+                ChecksumAlgorithm = StorageChecksumAlgorithm.StorageCrc64,
+            };
+
+            PartitionedDownloader downloader = new PartitionedDownloader(
+                blockClient.Object,
+                transferValidation: checksumValidation);
+
+            Assert.ThrowsAsync<InvalidDataException>(async () => await InvokeDownloadToAsync(downloader, destination));
+        }
+
+        /// <summary>
+        /// Verifies that a per-partition checksum mismatch is detected and surfaced
+        /// for a later range downloaded via the buffered (parallel worker) path,
+        /// BufferResponseAsync, as opposed to the streamed initial-response path.
+        /// Only applies to the async fixture, since the buffered path is only used
+        /// when downloading with multiple concurrent workers.
+        /// </summary>
+        [Test]
+        public void ThrowsOnChecksumMismatchInBufferedPath()
+        {
+            if (!_async)
+            {
+                Assert.Ignore("The buffered download path only exists in the async/multi-worker fixture");
+            }
+
+            MemoryStream destination = new MemoryStream();
+            Mock<BlobBaseClient> blockClient = CreateMockBlobClient();
+
+            SetupDownloadStreaming(blockClient, (range, conditions, validation, progress, async, cancellation) =>
+            {
+                // First (initial) request: valid, matching CRC so the streamed initial
+                // segment passes validation and the download proceeds to later ranges.
+                // Later requests: correct data, but an intentionally wrong CRC header,
+                // so BufferResponseAsync's independent hash comparison fails.
+                Response<BlobDownloadStreamingResult> response = range.Offset == 0
+                    ? CreateResponseWithCrc64(range, 30)
+                    : CreateResponseWithMismatchedCrc64(range, 30);
+                return new ValueTask<Response<BlobDownloadStreamingResult>>(response);
+            });
+
+            DownloadTransferValidationOptions checksumValidation = new DownloadTransferValidationOptions()
+            {
+                AutoValidateChecksum = true,
+                ChecksumAlgorithm = StorageChecksumAlgorithm.StorageCrc64,
+            };
+
+            PartitionedDownloader downloader = CreateDownloader(blockClient.Object, validation: checksumValidation);
+
+            Assert.CatchAsync<InvalidDataException>(async () => await InvokeDownloadToAsync(downloader, destination));
+        }
+
+        /// <summary>
+        /// Verifies the master CRC64 validation in ValidateFinalCrc: even when a
+        /// structured-message response's per-chunk decoding "trusts" the declared
+        /// ContentCrc without independently hashing (see CopyToInternal/BufferResponseAsync
+        /// structuredMessage branches), the master CRC calculator independently hashes
+        /// the actual bytes written to the destination. If the declared ContentCrc is
+        /// wrong, the composed CRC (built from the untrusted per-chunk values) will not
+        /// match the independently-calculated master hash, and the download must fail
+        /// rather than silently accept corrupted data.
+        /// </summary>
+        [Test]
+        public void ThrowsOnMasterCrcMismatchWhenStructuredMessageCrcIsForged()
+        {
+            byte[] data = new byte[] { 1, 2, 3, 4, 5 };
+            MemoryStream destination = new MemoryStream();
+            Mock<BlobBaseClient> blockClient = CreateMockBlobClient();
+
+            blockClient.Setup(c => c.DownloadStreamingInternal(
+                It.IsAny<HttpRange>(),
+                It.IsAny<BlobRequestConditions>(),
+                It.IsAny<DownloadTransferValidationOptions>(),
+                It.IsAny<IProgress<long>>(),
+                $"{nameof(BlobBaseClient)}.{nameof(BlobBaseClient.DownloadStreaming)}",
+                _async,
+                s_cancellationToken))
+            .Returns<HttpRange, BlobRequestConditions, DownloadTransferValidationOptions, IProgress<long>, string, bool, CancellationToken>(
+                (range, conditions, validation, progress, operationName, async, cancellation) =>
+                {
+                    Response<BlobDownloadStreamingResult> response = CreateMockResponse(
+                        range,
+                        new MemoryStream(data),
+                        data.Length,
+                        CreateStructuredMessageResponse(),
+                        totalBlobLength: data.Length);
+                    // Forge an incorrect ContentCrc; the real content bytes are correct,
+                    // but the declared checksum used for master-crc composition is not.
+                    response.Value.Details.ContentCrc = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+                    return new ValueTask<Response<BlobDownloadStreamingResult>>(response);
+                });
+
+            DownloadTransferValidationOptions checksumValidation = new DownloadTransferValidationOptions()
+            {
+                AutoValidateChecksum = true,
+                ChecksumAlgorithm = StorageChecksumAlgorithm.StorageCrc64,
+            };
+
+            PartitionedDownloader downloader = new PartitionedDownloader(
+                blockClient.Object,
+                transferValidation: checksumValidation);
+
+            Assert.ThrowsAsync<InvalidDataException>(async () => await InvokeDownloadToAsync(downloader, destination));
+        }
+
+        /// <summary>
         /// Verifies that all ArrayPool buffers are returned after a fully successful
         /// multi-partition download. Locks the invariant that the buffered (async) path's
         /// happy case is balanced w.r.t. ArrayPool rent/return, not just the error paths.
@@ -924,6 +1267,24 @@ namespace Azure.Storage.Blobs.Test
 
             MockResponse mockResponse = new MockResponse(200);
             mockResponse.AddHeader("x-ms-content-crc64", Convert.ToBase64String(crcHash));
+
+            return CreateMockResponse(range, new MemoryStream(data), contentLength, mockResponse, totalBlobLength: totalLength);
+        }
+
+        /// <summary>
+        /// Creates a response with correct data but a deliberately incorrect CRC64
+        /// header, to exercise per-partition checksum mismatch detection.
+        /// </summary>
+        private static Response<BlobDownloadStreamingResult> CreateResponseWithMismatchedCrc64(HttpRange range, int totalLength)
+        {
+            int contentLength = (int)Math.Min(range.Length ?? 0, totalLength);
+
+            byte[] data = new byte[contentLength];
+            for (int i = 0; i < contentLength; i++)
+                data[i] = (byte)(range.Offset + i);
+
+            MockResponse mockResponse = new MockResponse(200);
+            mockResponse.AddHeader("x-ms-content-crc64", Convert.ToBase64String(new byte[8]));
 
             return CreateMockResponse(range, new MemoryStream(data), contentLength, mockResponse, totalBlobLength: totalLength);
         }

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="$(AzureStorageSharedSources)StructuredMessageDecodingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StructuredMessageEncodingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StructuredMessagePrecalculatedCrcWrapperStream.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StorageRequestFailedDetailsParser.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)WindowStream.cs" LinkBase="Shared" />
   </ItemGroup>
   <!-- Ensure an empty TestConfigurations.xml is always present so the build can copy it -->

--- a/sdk/storage/Azure.Storage.Common/tests/StorageRequestFailedDetailsParserTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageRequestFailedDetailsParserTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Storage.Tests
+{
+    public class StorageRequestFailedDetailsParserTests
+    {
+        private readonly StorageRequestFailedDetailsParser _parser = new StorageRequestFailedDetailsParser();
+
+        [Test]
+        public void TryParseXml()
+        {
+            var response = new MockResponse(400)
+                .WithHeader("Content-Type", "application/xml")
+                .WithContent("<Error><Code>AuthenticationFailed</Code><Message>Invalid authentication</Message><Detail>More information</Detail></Error>");
+            response.ContentStream.Position = 3;
+
+            bool result = _parser.TryParse(response, out ResponseError error, out IDictionary<string, string> data);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("AuthenticationFailed", error.Code);
+            Assert.AreEqual("Invalid authentication", error.Message);
+            Assert.AreEqual("More information", data["Detail"]);
+            Assert.AreEqual(3, response.ContentStream.Position);
+        }
+
+        [Test]
+        public void TryParseXmlWithLowercaseProperties()
+        {
+            var response = CreateResponse("application/xml", "<Error><code>InvalidHeaderValue</code><message>Invalid version</message></Error>");
+
+            bool result = _parser.TryParse(response, out ResponseError error, out IDictionary<string, string> data);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("InvalidHeaderValue", error.Code);
+            Assert.AreEqual("Invalid version", error.Message);
+            Assert.AreEqual("InvalidHeaderValue", data["code"]);
+            Assert.AreEqual("Invalid version", data["message"]);
+        }
+
+        [Test]
+        public void TryParseXmlWithInvalidVersionHeader()
+        {
+            var response = CreateResponse("application/xml", "<Error><Code>InvalidHeaderValue</Code><Message>Original message</Message><HeaderName>x-ms-version</HeaderName></Error>");
+
+            bool result = _parser.TryParse(response, out ResponseError error, out _);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("InvalidHeaderValue", error.Code);
+            Assert.AreEqual(Constants.Errors.InvalidVersionHeaderMessage, error.Message);
+        }
+
+        [TestCase("{\"error\":{\"code\":\"BadRequest\",\"message\":\"Invalid request\",\"detail\":{\"target\":\"name\"}}}", "name")]
+        [TestCase("{\"error\":{\"code\":\"BadRequest\",\"message\":\"Invalid request\",\"detail\":\"not an object\"}}", null)]
+        public void TryParseJson(string content, string expectedDetail)
+        {
+            var response = CreateResponse("application/json", content);
+
+            bool result = _parser.TryParse(response, out ResponseError error, out IDictionary<string, string> data);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("BadRequest", error.Code);
+            Assert.AreEqual("Invalid request", error.Message);
+            if (expectedDetail is null)
+            {
+                Assert.IsNull(data);
+            }
+            else
+            {
+                Assert.AreEqual(expectedDetail, data["target"]);
+            }
+        }
+
+        [Test]
+        public void TryParseWithoutSeekableContentStream()
+        {
+            var response = CreateResponse("application/json", "{\"error\":{\"code\":\"BadRequest\",\"message\":\"Invalid request\"}}");
+            response.ContentStream = new NonSeekableStream(response.ContentStream);
+
+            bool result = _parser.TryParse(response, out ResponseError error, out _);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("BadRequest", error.Code);
+        }
+
+        [Test]
+        public void TryParseHeaderOnlyResponse()
+        {
+            var response = new MockResponse(400).WithHeader(Constants.HeaderNames.ErrorCode, "BadRequest");
+
+            bool result = _parser.TryParse(response, out ResponseError error, out IDictionary<string, string> data);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("BadRequest", error.Code);
+            Assert.IsNull(error.Message);
+            Assert.IsNull(data);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TryParseUnsupportedOrMissingResponse(bool includeContent)
+        {
+            var response = includeContent
+                ? CreateResponse("text/plain", "not an error document")
+                : new MockResponse(400);
+
+            bool result = _parser.TryParse(response, out ResponseError error, out IDictionary<string, string> data);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(error);
+            Assert.IsNull(data);
+        }
+
+        private static MockResponse CreateResponse(string contentType, string content)
+        {
+            return new MockResponse(400)
+                .WithHeader("Content-Type", contentType)
+                .WithContent(content);
+        }
+
+        private sealed class NonSeekableStream : Stream
+        {
+            private readonly Stream _inner;
+
+            public NonSeekableStream(Stream inner) => _inner = inner;
+
+            public override bool CanRead => _inner.CanRead;
+            public override bool CanSeek => false;
+            public override bool CanWrite => _inner.CanWrite;
+            public override long Length => _inner.Length;
+            public override long Position { get => _inner.Position; set => _inner.Position = value; }
+            public override void Flush() => _inner.Flush();
+            public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+            public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+            public override void SetLength(long value) => _inner.SetLength(value);
+            public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Internal.Avro/tests/AvroReaderTests.cs
+++ b/sdk/storage/Azure.Storage.Internal.Avro/tests/AvroReaderTests.cs
@@ -94,6 +94,45 @@ namespace Azure.Storage.Internal.Avro.Tests
         }
 
         [Test]
+        public async Task ReadBoolAsync_ReturnsFalseAndTrue()
+        {
+            using MemoryStream stream = new MemoryStream(new byte[] { 0, 1 });
+
+            Assert.IsFalse(await AvroParser.ReadBoolAsync(stream, async: true, default));
+            Assert.IsTrue(await AvroParser.ReadBoolAsync(stream, async: true, default));
+        }
+
+        [Test]
+        public async Task ReadFloatAsync_ReturnsFloat()
+        {
+            float expected = 1234.5f;
+            using MemoryStream stream = new MemoryStream(BitConverter.GetBytes(expected));
+
+            float result = await AvroParser.ReadFloatAsync(stream, async: true, default);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task ReadMapAsync_NegativeBlockCount_ReadsBlockSizeAndItems()
+        {
+            byte[] payload = new byte[]
+            {
+                0x01,       // block count -1
+                0x06,       // block byte size 3
+                0x02, 0x61, // key "a"
+                0x0E,       // value 7
+                0x00        // end of map
+            };
+            using MemoryStream stream = new MemoryStream(payload);
+
+            Dictionary<string, int> result = await AvroParser.ReadMapAsync(stream, AvroParser.ReadIntAsync, async: true, default);
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(7, result["a"]);
+        }
+
+        [Test]
         public void ReadFixedBytesAsync_NegativeLength_ThrowsInvalidDataException()
         {
             using MemoryStream stream = new MemoryStream(new byte[10]);


### PR DESCRIPTION
See title.

Also I removed more dead code (unreachable code), and removed alot of overtesting I did for decryptor and encryptor.