### PR TITLE
Update SQL provisioning changelog

### DIFF
--- a/sdk/sqlmanagement/Azure.Provisioning.Sql/CHANGELOG.md
+++ b/sdk/sqlmanagement/Azure.Provisioning.Sql/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.2.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.0-beta.2 (2026-09-09)
 
 ### Other Changes
 


### PR DESCRIPTION
Updates the Azure.Provisioning.Sql 1.2.0-beta.2 changelog entry following #62529: sets the release date to 2026-09-09, retains the TypeSpec migration release note, and removes empty sections.