### PR TITLE
Add benchmarks for multi-tenant export and the shared redirect policy

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
+    <ProjectReference Include="$(AzureCoreTestFramework)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/IngestionRedirectPolicyBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/IngestionRedirectPolicyBenchmarks.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Azure.Core;
 using Azure.Core.Pipeline;
@@ -28,10 +29,13 @@ The three cases below separate those costs:
   NoRedirectLearned  - the cache is empty. One volatile read, then straight through. This is what
                        the overwhelming majority of callers pay, because most ingestion endpoints
                        never issue a redirect.
-  RedirectLearned    - a redirect for this origin is cached. Pays the key materialization and the
-                       lock on every request.
-  RedirectLearnedOtherOrigin - a redirect is cached, but for a different origin. Worst case for the
-                       common path: full key cost and lock, and the lookup misses.
+  RedirectLearned    - a redirect for this origin is cached, so the request pays the key
+                       materialization, the lock, the trust check against the cached target, and the
+                       rewrite.
+  RedirectLearnedOtherOrigin - a redirect is cached, but for a different origin. Pays the key
+                       materialization and the lock, then misses and does no trust check. The gap
+                       between these two rows is therefore what the trust check and rewrite cost,
+                       and the gap from the baseline is what the key and lock cost.
 
 BuildRequestUri isolates the per-request builder allocation on its own.
 
@@ -43,18 +47,24 @@ Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 ph
 
 Job=MediumRun  IterationCount=15  LaunchCount=2  WarmupCount=10
 
-| Method                     | Mean      | Error     | StdDev     | Ratio | Gen0   | Allocated | Alloc Ratio |
-|--------------------------- |----------:|----------:|-----------:|------:|-------:|----------:|------------:|
-| NoRedirectLearned          | 465.50 ns | 44.309 ns |  66.320 ns |  1.02 | 0.0381 |     968 B |        1.00 |
-| RedirectLearned            | 925.80 ns | 69.305 ns | 101.586 ns |  2.02 | 0.0477 |    1216 B |        1.26 |
-| RedirectLearnedOtherOrigin | 615.15 ns | 30.883 ns |  45.268 ns |  1.34 | 0.0439 |    1112 B |        1.15 |
-| BuildRequestUri            |  55.98 ns |  2.447 ns |   3.587 ns |  0.12 | 0.0067 |     168 B |        0.17 |
+| Method                     | Mean        | Error      | StdDev     | Ratio | Gen0   | Allocated | Alloc Ratio |
+|--------------------------- |------------:|-----------:|-----------:|------:|-------:|----------:|------------:|
+| NoRedirectLearned          |   586.05 ns |  37.084 ns |  55.506 ns |  1.01 | 0.0467 |    1192 B |        1.00 |
+| RedirectLearned            | 1,145.17 ns | 114.137 ns | 170.835 ns |  1.97 | 0.0572 |    1440 B |        1.21 |
+| RedirectLearnedOtherOrigin |   759.45 ns |  77.354 ns | 115.780 ns |  1.31 | 0.0525 |    1336 B |        1.12 |
+| BuildRequestUri            |    64.72 ns |   5.728 ns |   8.395 ns |  0.11 | 0.0067 |     168 B |        0.14 |
 
 Reading these numbers: the transport is a no-op, so the whole of a real request is missing. An
-ingestion POST costs milliseconds. The 460 ns and 248 B that a learned redirect adds is therefore
-around 0.05% of a request that takes 1 ms, and the per-request builder that every caller pays
-regardless is 56 ns. Both are too small to be worth optimizing, which is the useful result: the
+ingestion POST costs milliseconds. The 559 ns and 248 B that a learned redirect adds is therefore
+around 0.06% of a request that takes 1 ms, and the per-request builder that every caller pays
+regardless is 65 ns. Both are too small to be worth optimizing, which is the useful result: the
 correctness fixes did not cost the single-tenant path anything that matters.
+
+Where that 559 ns goes is not where it first appears. RedirectLearnedOtherOrigin pays the key
+materialization and the lock in full and lands only 173 ns above the baseline, so the remaining
+386 ns belongs to IsTrustedIngestionRedirect and the rewrite, not to the lock. The trust check
+lower-cases two IdnHost values, which is also most of the 248 B. Anyone optimizing this should start
+there and not at the cache.
 
 One optimization was tried and rejected. The cache-hit path calls request.Uri.ToUri() twice, which
 looks like two Uri allocations. Hoisting it into a local left the allocated bytes byte-for-byte
@@ -121,19 +131,34 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 
         /// <summary>
         /// Drives one real 307 through the policy so the cache holds an entry for <paramref name="origin"/>,
-        /// rather than reaching into the cache directly.
+        /// rather than reaching into the cache directly. Whether the entry is written depends on
+        /// production trust and header-parsing rules, and when it is not the policy simply carries on,
+        /// so the result is verified instead of assumed: an unwarmed pipeline would silently turn two
+        /// of the rows below into duplicates of the baseline.
         /// </summary>
         private static void WarmRedirectCache(HttpPipeline pipeline, RedirectOnceTransport transport, string origin)
         {
-            transport.RedirectNextRequest = true;
+            transport.ArmRedirect();
 
-            using var message = pipeline.CreateMessage();
-            message.Request.Method = RequestMethod.Post;
-            message.Request.Uri.Reset(new Uri(origin));
+            using (var message = pipeline.CreateMessage())
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri(origin));
 
-            pipeline.Send(message, CancellationToken.None);
+                pipeline.Send(message, CancellationToken.None);
+            }
 
-            transport.RedirectNextRequest = false;
+            using var probe = pipeline.CreateMessage();
+            probe.Request.Method = RequestMethod.Post;
+            probe.Request.Uri.Reset(new Uri(origin));
+
+            pipeline.Send(probe, CancellationToken.None);
+
+            if (probe.Request.Uri.ToUri().AbsoluteUri != RedirectTarget)
+            {
+                throw new InvalidOperationException(
+                    $"Redirect cache was not warmed for {origin}: the probe was sent to {probe.Request.Uri} instead of {RedirectTarget}.");
+            }
         }
 
         private static HttpPipeline BuildPipeline(out RedirectOnceTransport transport)
@@ -144,17 +169,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         }
 
         /// <summary>
-        /// Answers 307 once when asked to, and 200 otherwise, so no socket is involved.
+        /// Answers 307 once when armed, and 200 otherwise, so no socket is involved.
         /// </summary>
         private sealed class RedirectOnceTransport : HttpPipelineTransport
         {
-            internal bool RedirectNextRequest;
+            private int _redirectsRemaining;
+
+            internal void ArmRedirect() => _redirectsRemaining = 1;
 
             public override Request CreateRequest() => new MockRequest();
 
             public override void Process(HttpMessage message) => message.Response = BuildResponse();
 
-            public override System.Threading.Tasks.ValueTask ProcessAsync(HttpMessage message)
+            public override ValueTask ProcessAsync(HttpMessage message)
             {
                 message.Response = BuildResponse();
 
@@ -163,16 +190,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 
             private MockResponse BuildResponse()
             {
-                if (!RedirectNextRequest)
+                if (_redirectsRemaining == 0)
                 {
-                    return new MockResponse(200);
+                    // Carries the cache directive because the policy reads it from the response that
+                    // completes the redirect, not from the 307 itself.
+                    var ok = new MockResponse(200);
+                    ok.AddHeader(new HttpHeader("Cache-Control", "max-age=3600"));
+
+                    return ok;
                 }
 
-                RedirectNextRequest = false;
+                _redirectsRemaining--;
 
                 var response = new MockResponse(307);
                 response.AddHeader(new HttpHeader("Location", RedirectTarget));
-                response.AddHeader(new HttpHeader("Cache-Control", "max-age=3600"));
 
                 return response;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/IngestionRedirectPolicyBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/IngestionRedirectPolicyBenchmarks.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+
+using BenchmarkDotNet.Attributes;
+
+/*
+Measures what a single request pays inside IngestionRedirectPolicy, which sits in the shared
+pipeline and therefore runs for single-tenant callers too.
+
+Multi-tenant export required two changes on this path, and both are now live for every caller
+whether or not the feature is switched on:
+
+  - CreateRequest builds a fresh RawRequestUriBuilder per request. It previously reused one
+    instance, which is what let a learned redirect permanently retarget every later request.
+  - Once any redirect has been learned, the policy materializes a Uri and a key string and takes
+    a lock on every request. Before the first redirect it does none of that.
+
+The three cases below separate those costs:
+
+  NoRedirectLearned  - the cache is empty. One volatile read, then straight through. This is what
+                       the overwhelming majority of callers pay, because most ingestion endpoints
+                       never issue a redirect.
+  RedirectLearned    - a redirect for this origin is cached. Pays the key materialization and the
+                       lock on every request.
+  RedirectLearnedOtherOrigin - a redirect is cached, but for a different origin. Worst case for the
+                       common path: full key cost and lock, and the lookup misses.
+
+BuildRequestUri isolates the per-request builder allocation on its own.
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2) (Hyper-V)
+Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.401
+  [Host]    : .NET 8.0.31 (8.0.31, 8.0.3126.42015), X64 RyuJIT x86-64-v4
+  MediumRun : .NET 8.0.31 (8.0.31, 8.0.3126.42015), X64 RyuJIT x86-64-v4
+
+Job=MediumRun  IterationCount=15  LaunchCount=2  WarmupCount=10
+
+| Method                     | Mean      | Error     | StdDev     | Ratio | Gen0   | Allocated | Alloc Ratio |
+|--------------------------- |----------:|----------:|-----------:|------:|-------:|----------:|------------:|
+| NoRedirectLearned          | 465.50 ns | 44.309 ns |  66.320 ns |  1.02 | 0.0381 |     968 B |        1.00 |
+| RedirectLearned            | 925.80 ns | 69.305 ns | 101.586 ns |  2.02 | 0.0477 |    1216 B |        1.26 |
+| RedirectLearnedOtherOrigin | 615.15 ns | 30.883 ns |  45.268 ns |  1.34 | 0.0439 |    1112 B |        1.15 |
+| BuildRequestUri            |  55.98 ns |  2.447 ns |   3.587 ns |  0.12 | 0.0067 |     168 B |        0.17 |
+
+Reading these numbers: the transport is a no-op, so the whole of a real request is missing. An
+ingestion POST costs milliseconds. The 460 ns and 248 B that a learned redirect adds is therefore
+around 0.05% of a request that takes 1 ms, and the per-request builder that every caller pays
+regardless is 56 ns. Both are too small to be worth optimizing, which is the useful result: the
+correctness fixes did not cost the single-tenant path anything that matters.
+
+One optimization was tried and rejected. The cache-hit path calls request.Uri.ToUri() twice, which
+looks like two Uri allocations. Hoisting it into a local left the allocated bytes byte-for-byte
+identical, because RequestUriBuilder already caches the Uri it builds and invalidates on mutation,
+so the second call was nearly free. The change was reverted rather than kept on an unmeasurable gain.
+*/
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class IngestionRedirectPolicyBenchmarks
+    {
+        private const string Origin = "https://westus2-1.in.applicationinsights.azure.com/v2.1/track";
+        private const string OtherOrigin = "https://eastus-2.in.applicationinsights.azure.com/v2.1/track";
+        private const string RedirectTarget = "https://westus2-1.in.applicationinsights.azure.com/v2.1/track/redirected";
+
+        private static readonly Uri s_trackUri = new(Origin);
+
+        private HttpPipeline _cold = null!;
+        private HttpPipeline _warmSameOrigin = null!;
+        private HttpPipeline _warmOtherOrigin = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _cold = BuildPipeline(out _);
+
+            _warmSameOrigin = BuildPipeline(out var sameOriginTransport);
+            WarmRedirectCache(_warmSameOrigin, sameOriginTransport, Origin);
+
+            _warmOtherOrigin = BuildPipeline(out var otherOriginTransport);
+            WarmRedirectCache(_warmOtherOrigin, otherOriginTransport, OtherOrigin);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void NoRedirectLearned() => Send(_cold);
+
+        [Benchmark]
+        public void RedirectLearned() => Send(_warmSameOrigin);
+
+        [Benchmark]
+        public void RedirectLearnedOtherOrigin() => Send(_warmOtherOrigin);
+
+        /// <summary>
+        /// The per-request builder on its own, with no policy around it.
+        /// </summary>
+        [Benchmark]
+        public RequestUriBuilder BuildRequestUri()
+        {
+            var uri = new RawRequestUriBuilder();
+            uri.Reset(s_trackUri);
+
+            return uri;
+        }
+
+        private static void Send(HttpPipeline pipeline)
+        {
+            using var message = pipeline.CreateMessage();
+            message.Request.Method = RequestMethod.Post;
+            message.Request.Uri.Reset(s_trackUri);
+
+            pipeline.Send(message, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Drives one real 307 through the policy so the cache holds an entry for <paramref name="origin"/>,
+        /// rather than reaching into the cache directly.
+        /// </summary>
+        private static void WarmRedirectCache(HttpPipeline pipeline, RedirectOnceTransport transport, string origin)
+        {
+            transport.RedirectNextRequest = true;
+
+            using var message = pipeline.CreateMessage();
+            message.Request.Method = RequestMethod.Post;
+            message.Request.Uri.Reset(new Uri(origin));
+
+            pipeline.Send(message, CancellationToken.None);
+
+            transport.RedirectNextRequest = false;
+        }
+
+        private static HttpPipeline BuildPipeline(out RedirectOnceTransport transport)
+        {
+            transport = new RedirectOnceTransport();
+
+            return new HttpPipeline(transport, new HttpPipelinePolicy[] { new IngestionRedirectPolicy() });
+        }
+
+        /// <summary>
+        /// Answers 307 once when asked to, and 200 otherwise, so no socket is involved.
+        /// </summary>
+        private sealed class RedirectOnceTransport : HttpPipelineTransport
+        {
+            internal bool RedirectNextRequest;
+
+            public override Request CreateRequest() => new MockRequest();
+
+            public override void Process(HttpMessage message) => message.Response = BuildResponse();
+
+            public override System.Threading.Tasks.ValueTask ProcessAsync(HttpMessage message)
+            {
+                message.Response = BuildResponse();
+
+                return default;
+            }
+
+            private MockResponse BuildResponse()
+            {
+                if (!RedirectNextRequest)
+                {
+                    return new MockResponse(200);
+                }
+
+                RedirectNextRequest = false;
+
+                var response = new MockResponse(307);
+                response.AddHeader(new HttpHeader("Location", RedirectTarget));
+                response.AddHeader(new HttpHeader("Cache-Control", "max-age=3600"));
+
+                return response;
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/IngestionRedirectPolicyBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/IngestionRedirectPolicyBenchmarks.cs
@@ -21,8 +21,8 @@ whether or not the feature is switched on:
 
   - CreateRequest builds a fresh RawRequestUriBuilder per request. It previously reused one
     instance, which is what let a learned redirect permanently retarget every later request.
-  - Once any redirect has been learned, the policy materializes a Uri and a key string and takes
-    a lock on every request. Before the first redirect it does none of that.
+  - Once any redirect has been learned, the policy builds a cache key string and takes a lock on
+    every request. Before the first redirect it does neither.
 
 The three cases below separate those costs:
 
@@ -47,24 +47,26 @@ Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 ph
 
 Job=MediumRun  IterationCount=15  LaunchCount=2  WarmupCount=10
 
-| Method                     | Mean        | Error      | StdDev     | Ratio | Gen0   | Allocated | Alloc Ratio |
-|--------------------------- |------------:|-----------:|-----------:|------:|-------:|----------:|------------:|
-| NoRedirectLearned          |   586.05 ns |  37.084 ns |  55.506 ns |  1.01 | 0.0467 |    1192 B |        1.00 |
-| RedirectLearned            | 1,145.17 ns | 114.137 ns | 170.835 ns |  1.97 | 0.0572 |    1440 B |        1.21 |
-| RedirectLearnedOtherOrigin |   759.45 ns |  77.354 ns | 115.780 ns |  1.31 | 0.0525 |    1336 B |        1.12 |
-| BuildRequestUri            |    64.72 ns |   5.728 ns |   8.395 ns |  0.11 | 0.0067 |     168 B |        0.14 |
+| Method                     | Mean      | Error    | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------------------------- |----------:|---------:|----------:|------:|--------:|-------:|----------:|------------:|
+| NoRedirectLearned          | 358.12 ns | 4.647 ns |  6.956 ns |  1.00 |    0.03 | 0.0381 |     968 B |        1.00 |
+| RedirectLearned            | 730.98 ns | 7.614 ns | 10.920 ns |  2.04 |    0.05 | 0.0477 |    1216 B |        1.26 |
+| RedirectLearnedOtherOrigin | 533.85 ns | 9.576 ns | 14.334 ns |  1.49 |    0.05 | 0.0439 |    1112 B |        1.15 |
+| BuildRequestUri            |  48.00 ns | 1.025 ns |  1.535 ns |  0.13 |    0.00 | 0.0067 |     168 B |        0.17 |
 
-Reading these numbers: the transport is a no-op, so the whole of a real request is missing. An
-ingestion POST costs milliseconds. The 559 ns and 248 B that a learned redirect adds is therefore
-around 0.06% of a request that takes 1 ms, and the per-request builder that every caller pays
-regardless is 65 ns. Both are too small to be worth optimizing, which is the useful result: the
-correctness fixes did not cost the single-tenant path anything that matters.
+1. A learned redirect adds 373 ns and 248 B per request, roughly doubling what the policy itself
+   costs. An ingestion POST costs milliseconds, so that is about 0.04% of a real request. The
+   per-request URI builder every caller pays regardless is 48 ns. Neither is worth optimizing, which
+   is the useful result: the correctness fixes did not cost the single-tenant path anything.
 
-Where that 559 ns goes is not where it first appears. RedirectLearnedOtherOrigin pays the key
-materialization and the lock in full and lands only 173 ns above the baseline, so the remaining
-386 ns belongs to IsTrustedIngestionRedirect and the rewrite, not to the lock. The trust check
-lower-cases two IdnHost values, which is also most of the 248 B. Anyone optimizing this should start
-there and not at the cache.
+2. That 373 ns splits about evenly. Building the cache key and taking the lock is 176 ns and 144 B,
+   which is what RedirectLearnedOtherOrigin pays before missing. The trust check and the rewrite are
+   the remaining 197 ns and 104 B. The 144 B is the origin key itself: GetLeftPart returns a 61
+   character string. Anyone optimizing this should look at both halves, not just the lock.
+
+3. The transport answers 200 with no headers in steady state. An earlier revision attached a cache
+   directive to every 200, which built a header inside the measured region and added 224 B to every
+   transport-using row.
 
 One optimization was tried and rejected. The cache-hit path calls request.Uri.ToUri() twice, which
 looks like two Uri allocations. Hoisting it into a local left the allocated bytes byte-for-byte
@@ -174,6 +176,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         private sealed class RedirectOnceTransport : HttpPipelineTransport
         {
             private int _redirectsRemaining;
+            private bool _completingRedirect;
 
             internal void ArmRedirect() => _redirectsRemaining = 1;
 
@@ -190,22 +193,31 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 
             private MockResponse BuildResponse()
             {
-                if (_redirectsRemaining == 0)
+                if (_redirectsRemaining > 0)
                 {
-                    // Carries the cache directive because the policy reads it from the response that
-                    // completes the redirect, not from the 307 itself.
-                    var ok = new MockResponse(200);
-                    ok.AddHeader(new HttpHeader("Cache-Control", "max-age=3600"));
+                    _redirectsRemaining--;
+                    _completingRedirect = true;
 
-                    return ok;
+                    var redirect = new MockResponse(307);
+                    redirect.AddHeader(new HttpHeader("Location", RedirectTarget));
+
+                    return redirect;
                 }
 
-                _redirectsRemaining--;
+                if (_completingRedirect)
+                {
+                    _completingRedirect = false;
 
-                var response = new MockResponse(307);
-                response.AddHeader(new HttpHeader("Location", RedirectTarget));
+                    // The policy reads the cache directive off the response that completes a redirect,
+                    // never off the 307, so it belongs only here. Putting it on every 200 would build
+                    // a header inside the measured region and inflate every row by that allocation.
+                    var completing = new MockResponse(200);
+                    completing.AddHeader(new HttpHeader("Cache-Control", "max-age=3600"));
 
-                return response;
+                    return completing;
+                }
+
+                return new MockResponse(200);
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/MultiTenantExportBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/MultiTenantExportBenchmarks.cs
@@ -17,21 +17,31 @@ using OpenTelemetry;
 Measures the routed conversion against the single-tenant one, and how the routed path scales with
 the number of distinct ingestion endpoints in a batch.
 
-Two things are being separated:
+There is no single honest way to compare the two conversions, because the routing attributes are
+custom dimensions to one path and consumed input to the other. Both baselines are therefore measured:
 
-  SingleTenant / MultiTenant at EndpointCount=1 answers what routing costs per Activity when there
-  is nothing to group. The routed path skips the resource envelope and the schema counter, and adds
-  routing tag recognition, route validation and endpoint normalization.
+  SingleTenant_NoRoutingTags   - single-tenant on a batch carrying no routing attributes. This is
+                                 how single-tenant actually runs, and is the number to quote for the
+                                 existing product.
+  SingleTenant_WithRoutingTags - single-tenant on the same batch the routed path is given. The two
+                                 extra attributes fall through to unmapped tags and are serialized as
+                                 custom dimensions, work the routed path does not do.
+  MultiTenant                  - the routed conversion on that same batch.
 
-  MultiTenant across EndpointCount 1, 3 and 25 answers whether the grouping strategy holds up.
-  EndpointRouteBatch.GetOrAdd does an ordinal linear scan over the groups opened so far, which is
-  documented as beating a hash at the handful of regions a process is expected to talk to. At 25
-  endpoints a 512-Activity batch performs up to ~12,800 string comparisons, so this is where that
-  assumption is tested rather than assumed.
+MultiTenant against SingleTenant_WithRoutingTags is an upper bound on what routing costs, not an
+isolated measurement of it: any gap includes two custom dimensions per Activity that only the
+baseline pays. The gap between the two baselines is what those two dimensions cost on their own.
 
-SingleTenant is the baseline. It does not vary with EndpointCount - the routing tags are simply
-carried as ordinary custom dimensions - so its rows should be flat, and a non-flat result means the
-measurement is picking up noise rather than signal.
+GroupOnly isolates EndpointRouteBatch.GetOrAdd, whose ordinal linear scan over the groups opened so
+far is documented as beating a hash at the handful of regions a process is expected to talk to. The
+endpoint strings are built once in setup and indexed rather than formatted in the loop: formatting
+512 strings per iteration costs more than the thing being measured and puts its own garbage in the
+allocation column. Indexing also reproduces production, where TenantRouting.NormalizeEndpoint
+memoizes and hands GetOrAdd the same instance every time, so the ordinal comparison short-circuits
+on reference equality.
+
+Both SingleTenant rows are independent of EndpointCount, so their spread across the three parameter
+values is this harness's noise floor. Read nothing from a difference smaller than that spread.
 
 BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2) (Hyper-V)
 Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
@@ -41,42 +51,46 @@ Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 ph
 
 Job=MediumRun  IterationCount=15  LaunchCount=2  WarmupCount=10   BatchSize=512
 
-| Method       | EndpointCount | Mean      | Error      | StdDev     | Ratio | Allocated | Alloc Ratio |
-|------------- |-------------- |----------:|-----------:|-----------:|------:|----------:|------------:|
-| SingleTenant | 1             | 864.32 us | 122.343 us | 175.461 us |  1.04 | 748.25 KB |        1.00 |
-| MultiTenant  | 1             | 643.26 us |  14.872 us |  22.260 us |  0.77 |    740 KB |        0.99 |
-| GroupOnly    | 1             |  37.10 us |   1.887 us |   2.707 us |  0.04 |     72 KB |        0.10 |
-| SingleTenant | 3             | 739.64 us |  25.741 us |  37.730 us |  1.00 | 748.25 KB |        1.00 |
-| MultiTenant  | 3             | 654.11 us |  17.335 us |  24.861 us |  0.89 |    740 KB |        0.99 |
-| GroupOnly    | 3             |  36.87 us |   0.844 us |   1.211 us |  0.05 |     72 KB |        0.10 |
-| SingleTenant | 25            | 704.66 us |  18.792 us |  28.126 us |  1.00 | 748.25 KB |        1.00 |
-| MultiTenant  | 25            | 760.19 us |  69.319 us | 101.607 us |  1.08 |    740 KB |        0.99 |
-| GroupOnly    | 25            |  56.13 us |   2.303 us |   3.303 us |  0.08 |  74.36 KB |        0.10 |
+| Method                       | EndpointCount | Mean         | Error        | Ratio | Allocated |
+|----------------------------- |-------------- |-------------:|-------------:|------:|----------:|
+| SingleTenant_NoRoutingTags   | 1             | 643,799.5 ns | 34,496.91 ns | 1.006 |  766208 B |
+| SingleTenant_WithRoutingTags | 1             | 726,850.7 ns | 35,138.94 ns | 1.136 |  766208 B |
+| MultiTenant                  | 1             | 765,342.8 ns | 97,410.61 ns | 1.196 |  757760 B |
+| GroupOnly                    | 1             |     998.2 ns |     34.32 ns | 0.002 |       0 B |
+| SingleTenant_NoRoutingTags   | 3             | 658,007.1 ns | 68,808.27 ns | 1.020 |  766208 B |
+| SingleTenant_WithRoutingTags | 3             | 703,885.8 ns | 31,395.07 ns | 1.092 |  766208 B |
+| MultiTenant                  | 3             | 686,400.9 ns | 40,725.12 ns | 1.064 |  757760 B |
+| GroupOnly                    | 3             |   2,522.1 ns |    111.31 ns | 0.004 |       0 B |
+| SingleTenant_NoRoutingTags   | 25            | 588,613.8 ns | 13,589.76 ns | 1.000 |  766208 B |
+| SingleTenant_WithRoutingTags | 25            | 690,046.4 ns | 18,759.69 ns | 1.170 |  766208 B |
+| MultiTenant                  | 25            | 818,049.2 ns | 60,325.65 ns | 1.390 |  757760 B |
+| GroupOnly                    | 25            |  16,216.6 ns |    733.30 ns | 0.030 |       0 B |
 
 Reading these numbers:
 
-The baseline is not flat - 864, 740, 705 us for identical work - so anything below roughly 20% at
-this scale is noise. The 864 us row is the first benchmark executed and carries an error of 175 us.
-Treat the SingleTenant against MultiTenant comparison as directional only.
+The noise floor is about 12%: SingleTenant_NoRoutingTags does identical work in all three rows and
+came out 644, 658 and 589 us. Nothing below that is a result.
 
-Routing does not cost more per Activity. If anything it is slightly cheaper at one to three
-endpoints, which is explainable rather than surprising: the routed path skips the resource metric
-envelope and the schema type counter that the single-tenant path emits. Allocations differ by about
-1%, which is the same story.
+Grouping is linear in the endpoint count and allocates nothing. 998 ns, 2.5 us and 16.2 us for 512
+lookups is roughly 2, 5 and 32 ns per lookup against 1, 3 and 25 open groups, which is the ordinal
+scan doing exactly what a scan does. The zero in the allocation column is the useful part: it is
+direct evidence that the group and list pooling holds, with no garbage per export. In absolute terms
+16.2 us against 818 us of conversion is about 2% of a routed export at 25 endpoints, and a linear
+extrapolation to the 64-partition cap gives roughly 40 us, or 5%. The scan is not worth replacing;
+a hash would add an allocation to the one-to-three endpoint case that every deployment pays.
 
-Grouping is where the endpoint count actually shows. GroupOnly is flat from 1 to 3 endpoints and
-then rises by roughly half at 25, with tight error bars, which is the ordinal linear scan in
-EndpointRouteBatch.GetOrAdd behaving exactly as its comment predicts. Allocation stays flat
-(72 to 74 KB), so the pooling holds.
+Routing is not cheaper than single-tenant. The two extra custom dimensions cost the baseline 7 to
+17% (SingleTenant_WithRoutingTags against SingleTenant_NoRoutingTags), and once that bias is
+accounted for MultiTenant is within noise of its like-for-like partner at 1 and 3 endpoints and
+about 19% slower at 25, where grouping and route validation have grown. Against the realistic
+single-tenant workload, which carries no routing attributes at all, the routed path costs 4 to 39%
+more depending on endpoint count.
 
-Even so, grouping at 25 endpoints is about 56 us against roughly 700 us of conversion, so under a
-tenth of the export. Replacing the scan with a dictionary would recover a fraction of that while
-adding an allocation to the one-to-three endpoint case that every deployment pays, so the current
-design is the right trade at the supported scale. The partition cap is 64; the scan cost grows
-linearly, so 64 endpoints would be around 2.5 times the 25-endpoint figure, and that is the point
-at which this is worth revisiting.
+The one stable non-time result is allocation: MultiTenant allocates 757,760 B against 766,208 B,
+about 1% less, identically in all three parameter rows. That is the routed path consuming the two
+routing attributes instead of serializing them as custom dimensions, and it is consistent enough
+across rows to be believed where the timings are not.
 */
-
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 {
     [MemoryDiagnoser]
@@ -91,8 +105,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
             serviceVersion: "1.0.0",
             monitorBaseData: null);
 
-        private Batch<Activity> _batch;
+        private Batch<Activity> _routedBatch;
+        private Batch<Activity> _plainBatch;
         private EndpointRouteBatch _routeBatch = null!;
+        private string[] _endpoints = null!;
 
         [Params(1, 3, 25)]
         public int EndpointCount { get; set; }
@@ -114,21 +130,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
+            _endpoints = new string[EndpointCount];
+
+            for (int i = 0; i < EndpointCount; i++)
+            {
+                _endpoints[i] = string.Format(CultureInfo.InvariantCulture, "https://region{0}.in.applicationinsights.azure.com/", i);
+            }
+
             _routeBatch = new EndpointRouteBatch();
-            _batch = CreateBatch(BatchSize, EndpointCount);
+            _routedBatch = CreateBatch(BatchSize, withRoutingTags: true);
+            _plainBatch = CreateBatch(BatchSize, withRoutingTags: false);
         }
 
         [Benchmark(Baseline = true)]
-        public int SingleTenant()
-        {
-            var (telemetryItems, _) = TraceHelper.OtelToAzureMonitorTrace(
-                _batch,
-                s_resource,
-                InstrumentationKey,
-                sampleRate: 100F);
+        public int SingleTenant_NoRoutingTags() => ConvertSingleTenant(_plainBatch);
 
-            return telemetryItems.Count;
-        }
+        [Benchmark]
+        public int SingleTenant_WithRoutingTags() => ConvertSingleTenant(_routedBatch);
 
         [Benchmark]
         public int MultiTenant()
@@ -136,7 +154,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
             _routeBatch.Reset();
 
             TraceHelper.OtelToAzureMonitorTraceMultiTenant(
-                _batch,
+                _routedBatch,
                 s_resource,
                 sampleRate: 100F,
                 _routeBatch);
@@ -144,10 +162,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
             return _routeBatch.Count;
         }
 
-        /// <summary>
-        /// Grouping on its own, with no conversion, so the linear scan is not hidden behind the
-        /// per-Activity conversion cost.
-        /// </summary>
         [Benchmark]
         public int GroupOnly()
         {
@@ -155,16 +169,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 
             for (int i = 0; i < BatchSize; i++)
             {
-                _routeBatch.GetOrAdd(EndpointFor(i % EndpointCount));
+                _routeBatch.GetOrAdd(_endpoints[i % EndpointCount]);
             }
 
             return _routeBatch.Count;
         }
 
-        private static string EndpointFor(int index)
-            => string.Format(CultureInfo.InvariantCulture, "https://region{0}.in.applicationinsights.azure.com/", index);
+        private static int ConvertSingleTenant(Batch<Activity> batch)
+        {
+            var (telemetryItems, _) = TraceHelper.OtelToAzureMonitorTrace(
+                batch,
+                s_resource,
+                InstrumentationKey,
+                sampleRate: 100F);
 
-        private static Batch<Activity> CreateBatch(int size, int endpointCount)
+            return telemetryItems.Count;
+        }
+
+        private Batch<Activity> CreateBatch(int size, bool withRoutingTags)
         {
             var activitySource = new ActivitySource(nameof(MultiTenantExportBenchmarks));
             var activities = new Activity[size];
@@ -181,12 +203,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
                     [SemanticConventions.AttributeHttpRoute] = "api/{id}",
                     [SemanticConventions.AttributeHttpResponseStatusCode] = 200,
                     ["custom.tenant"] = "contoso",
-
-                    // The routing contract. On the single-tenant path these are not recognized and
-                    // simply become custom dimensions, which is what makes the baseline comparable.
-                    [SemanticConventions.AttributeMicrosoftInstrumentationKey] = InstrumentationKey,
-                    [SemanticConventions.AttributeMicrosoftIngestionEndpoint] = EndpointFor(i % endpointCount),
                 };
+
+                if (withRoutingTags)
+                {
+                    tags[SemanticConventions.AttributeMicrosoftInstrumentationKey] = InstrumentationKey;
+                    tags[SemanticConventions.AttributeMicrosoftIngestionEndpoint] = _endpoints[i % EndpointCount];
+                }
 
                 var startTimestamp = DateTime.UtcNow;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/MultiTenantExportBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/MultiTenantExportBenchmarks.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.MultiTenant;
+
+using BenchmarkDotNet.Attributes;
+
+using OpenTelemetry;
+
+/*
+Measures the routed conversion against the single-tenant one, and how the routed path scales with
+the number of distinct ingestion endpoints in a batch.
+
+Two things are being separated:
+
+  SingleTenant / MultiTenant at EndpointCount=1 answers what routing costs per Activity when there
+  is nothing to group. The routed path skips the resource envelope and the schema counter, and adds
+  routing tag recognition, route validation and endpoint normalization.
+
+  MultiTenant across EndpointCount 1, 3 and 25 answers whether the grouping strategy holds up.
+  EndpointRouteBatch.GetOrAdd does an ordinal linear scan over the groups opened so far, which is
+  documented as beating a hash at the handful of regions a process is expected to talk to. At 25
+  endpoints a 512-Activity batch performs up to ~12,800 string comparisons, so this is where that
+  assumption is tested rather than assumed.
+
+SingleTenant is the baseline. It does not vary with EndpointCount - the routing tags are simply
+carried as ordinary custom dimensions - so its rows should be flat, and a non-flat result means the
+measurement is picking up noise rather than signal.
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2) (Hyper-V)
+Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.401
+  [Host]    : .NET 8.0.31 (8.0.31, 8.0.3126.42015), X64 RyuJIT x86-64-v4
+  MediumRun : .NET 8.0.31 (8.0.31, 8.0.3126.42015), X64 RyuJIT x86-64-v4
+
+Job=MediumRun  IterationCount=15  LaunchCount=2  WarmupCount=10   BatchSize=512
+
+| Method       | EndpointCount | Mean      | Error      | StdDev     | Ratio | Allocated | Alloc Ratio |
+|------------- |-------------- |----------:|-----------:|-----------:|------:|----------:|------------:|
+| SingleTenant | 1             | 864.32 us | 122.343 us | 175.461 us |  1.04 | 748.25 KB |        1.00 |
+| MultiTenant  | 1             | 643.26 us |  14.872 us |  22.260 us |  0.77 |    740 KB |        0.99 |
+| GroupOnly    | 1             |  37.10 us |   1.887 us |   2.707 us |  0.04 |     72 KB |        0.10 |
+| SingleTenant | 3             | 739.64 us |  25.741 us |  37.730 us |  1.00 | 748.25 KB |        1.00 |
+| MultiTenant  | 3             | 654.11 us |  17.335 us |  24.861 us |  0.89 |    740 KB |        0.99 |
+| GroupOnly    | 3             |  36.87 us |   0.844 us |   1.211 us |  0.05 |     72 KB |        0.10 |
+| SingleTenant | 25            | 704.66 us |  18.792 us |  28.126 us |  1.00 | 748.25 KB |        1.00 |
+| MultiTenant  | 25            | 760.19 us |  69.319 us | 101.607 us |  1.08 |    740 KB |        0.99 |
+| GroupOnly    | 25            |  56.13 us |   2.303 us |   3.303 us |  0.08 |  74.36 KB |        0.10 |
+
+Reading these numbers:
+
+The baseline is not flat - 864, 740, 705 us for identical work - so anything below roughly 20% at
+this scale is noise. The 864 us row is the first benchmark executed and carries an error of 175 us.
+Treat the SingleTenant against MultiTenant comparison as directional only.
+
+Routing does not cost more per Activity. If anything it is slightly cheaper at one to three
+endpoints, which is explainable rather than surprising: the routed path skips the resource metric
+envelope and the schema type counter that the single-tenant path emits. Allocations differ by about
+1%, which is the same story.
+
+Grouping is where the endpoint count actually shows. GroupOnly is flat from 1 to 3 endpoints and
+then rises by roughly half at 25, with tight error bars, which is the ordinal linear scan in
+EndpointRouteBatch.GetOrAdd behaving exactly as its comment predicts. Allocation stays flat
+(72 to 74 KB), so the pooling holds.
+
+Even so, grouping at 25 endpoints is about 56 us against roughly 700 us of conversion, so under a
+tenth of the export. Replacing the scan with a dictionary would recover a fraction of that while
+adding an allocation to the one-to-three endpoint case that every deployment pays, so the current
+design is the right trade at the supported scale. The partition cap is 64; the scan cost grows
+linearly, so 64 endpoints would be around 2.5 times the 25-endpoint figure, and that is the point
+at which this is worth revisiting.
+*/
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class MultiTenantExportBenchmarks
+    {
+        private const string InstrumentationKey = "00000000-0000-0000-0000-000000000000";
+        private const int BatchSize = 512;
+
+        private static readonly AzureMonitorResource s_resource = new(
+            roleName: "BenchmarkRole",
+            roleInstance: "BenchmarkInstance",
+            serviceVersion: "1.0.0",
+            monitorBaseData: null);
+
+        private Batch<Activity> _batch;
+        private EndpointRouteBatch _routeBatch = null!;
+
+        [Params(1, 3, 25)]
+        public int EndpointCount { get; set; }
+
+        static MultiTenantExportBenchmarks()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+            };
+
+            ActivitySource.AddActivityListener(listener);
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _routeBatch = new EndpointRouteBatch();
+            _batch = CreateBatch(BatchSize, EndpointCount);
+        }
+
+        [Benchmark(Baseline = true)]
+        public int SingleTenant()
+        {
+            var (telemetryItems, _) = TraceHelper.OtelToAzureMonitorTrace(
+                _batch,
+                s_resource,
+                InstrumentationKey,
+                sampleRate: 100F);
+
+            return telemetryItems.Count;
+        }
+
+        [Benchmark]
+        public int MultiTenant()
+        {
+            _routeBatch.Reset();
+
+            TraceHelper.OtelToAzureMonitorTraceMultiTenant(
+                _batch,
+                s_resource,
+                sampleRate: 100F,
+                _routeBatch);
+
+            return _routeBatch.Count;
+        }
+
+        /// <summary>
+        /// Grouping on its own, with no conversion, so the linear scan is not hidden behind the
+        /// per-Activity conversion cost.
+        /// </summary>
+        [Benchmark]
+        public int GroupOnly()
+        {
+            _routeBatch.Reset();
+
+            for (int i = 0; i < BatchSize; i++)
+            {
+                _routeBatch.GetOrAdd(EndpointFor(i % EndpointCount));
+            }
+
+            return _routeBatch.Count;
+        }
+
+        private static string EndpointFor(int index)
+            => string.Format(CultureInfo.InvariantCulture, "https://region{0}.in.applicationinsights.azure.com/", index);
+
+        private static Batch<Activity> CreateBatch(int size, int endpointCount)
+        {
+            var activitySource = new ActivitySource(nameof(MultiTenantExportBenchmarks));
+            var activities = new Activity[size];
+
+            for (int i = 0; i < size; i++)
+            {
+                var tags = new Dictionary<string, object?>
+                {
+                    [SemanticConventions.AttributeHttpRequestMethod] = "GET",
+                    [SemanticConventions.AttributeUrlScheme] = "https",
+                    [SemanticConventions.AttributeUrlPath] = "/api/items",
+                    [SemanticConventions.AttributeServerAddress] = "localhost",
+                    [SemanticConventions.AttributeServerPort] = 8080,
+                    [SemanticConventions.AttributeHttpRoute] = "api/{id}",
+                    [SemanticConventions.AttributeHttpResponseStatusCode] = 200,
+                    ["custom.tenant"] = "contoso",
+
+                    // The routing contract. On the single-tenant path these are not recognized and
+                    // simply become custom dimensions, which is what makes the baseline comparable.
+                    [SemanticConventions.AttributeMicrosoftInstrumentationKey] = InstrumentationKey,
+                    [SemanticConventions.AttributeMicrosoftIngestionEndpoint] = EndpointFor(i % endpointCount),
+                };
+
+                var startTimestamp = DateTime.UtcNow;
+
+                var activity = activitySource.StartActivity(
+                    "BenchmarkActivity",
+                    ActivityKind.Server,
+                    parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                    tags,
+                    links: null,
+                    startTime: startTimestamp);
+
+                activity!.SetStatus(ActivityStatusCode.Ok);
+                activity.SetEndTime(startTimestamp.AddMilliseconds(50));
+                activity.Stop();
+
+                activities[i] = activity;
+            }
+
+            return new Batch<Activity>(activities, size);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/MultiTenantExportBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/MultiTenantExportBenchmarks.cs
@@ -41,7 +41,9 @@ memoizes and hands GetOrAdd the same instance every time, so the ordinal compari
 on reference equality.
 
 Both SingleTenant rows are independent of EndpointCount, so their spread across the three parameter
-values is this harness's noise floor. Read nothing from a difference smaller than that spread.
+values is this harness's noise floor. It came out at about 12%, so each baseline is pooled across
+its three rows before any percentage below is computed; a per-row comparison would manufacture
+differences out of that spread.
 
 BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2) (Hyper-V)
 Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
@@ -49,47 +51,51 @@ Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 ph
   [Host]    : .NET 8.0.31 (8.0.31, 8.0.3126.42015), X64 RyuJIT x86-64-v4
   MediumRun : .NET 8.0.31 (8.0.31, 8.0.3126.42015), X64 RyuJIT x86-64-v4
 
-Job=MediumRun  IterationCount=15  LaunchCount=2  WarmupCount=10   BatchSize=512
+Job=MediumRun  IterationCount=15  LaunchCount=2  WarmupCount=10
 
-| Method                       | EndpointCount | Mean         | Error        | Ratio | Allocated |
-|----------------------------- |-------------- |-------------:|-------------:|------:|----------:|
-| SingleTenant_NoRoutingTags   | 1             | 643,799.5 ns | 34,496.91 ns | 1.006 |  766208 B |
-| SingleTenant_WithRoutingTags | 1             | 726,850.7 ns | 35,138.94 ns | 1.136 |  766208 B |
-| MultiTenant                  | 1             | 765,342.8 ns | 97,410.61 ns | 1.196 |  757760 B |
-| GroupOnly                    | 1             |     998.2 ns |     34.32 ns | 0.002 |       0 B |
-| SingleTenant_NoRoutingTags   | 3             | 658,007.1 ns | 68,808.27 ns | 1.020 |  766208 B |
-| SingleTenant_WithRoutingTags | 3             | 703,885.8 ns | 31,395.07 ns | 1.092 |  766208 B |
-| MultiTenant                  | 3             | 686,400.9 ns | 40,725.12 ns | 1.064 |  757760 B |
-| GroupOnly                    | 3             |   2,522.1 ns |    111.31 ns | 0.004 |       0 B |
-| SingleTenant_NoRoutingTags   | 25            | 588,613.8 ns | 13,589.76 ns | 1.000 |  766208 B |
-| SingleTenant_WithRoutingTags | 25            | 690,046.4 ns | 18,759.69 ns | 1.170 |  766208 B |
-| MultiTenant                  | 25            | 818,049.2 ns | 60,325.65 ns | 1.390 |  757760 B |
-| GroupOnly                    | 25            |  16,216.6 ns |    733.30 ns | 0.030 |       0 B |
+| Method                       | EndpointCount | Mean         | Error        | StdDev        | Ratio | RatioSD | Gen0    | Gen1    | Allocated | Alloc Ratio |
+|----------------------------- |-------------- |-------------:|-------------:|--------------:|------:|--------:|--------:|--------:|----------:|------------:|
+| SingleTenant_NoRoutingTags   | 1             | 643,799.5 ns | 34,496.91 ns |  51,633.35 ns | 1.006 |    0.11 | 30.2734 | 21.4844 |  766208 B |        1.00 |
+| SingleTenant_WithRoutingTags | 1             | 726,850.7 ns | 35,138.94 ns |  52,594.32 ns | 1.136 |    0.12 | 30.2734 | 21.4844 |  766208 B |        1.00 |
+| MultiTenant                  | 1             | 765,342.8 ns | 97,410.61 ns | 145,799.63 ns | 1.196 |    0.24 | 29.2969 |  9.7656 |  757760 B |        0.99 |
+| GroupOnly                    | 1             |     998.2 ns |     34.32 ns |      48.11 ns | 0.002 |    0.00 |       - |       - |         - |        0.00 |
+| SingleTenant_NoRoutingTags   | 3             | 658,007.1 ns | 68,808.27 ns | 102,988.99 ns | 1.020 |    0.21 | 30.2734 | 21.4844 |  766208 B |        1.00 |
+| SingleTenant_WithRoutingTags | 3             | 703,885.8 ns | 31,395.07 ns |  46,990.67 ns | 1.092 |    0.16 | 30.2734 | 21.4844 |  766208 B |        1.00 |
+| MultiTenant                  | 3             | 686,400.9 ns | 40,725.12 ns |  60,955.45 ns | 1.064 |    0.17 | 29.2969 |  9.7656 |  757760 B |        0.99 |
+| GroupOnly                    | 3             |   2,522.1 ns |    111.31 ns |     159.64 ns | 0.004 |    0.00 |       - |       - |         - |        0.00 |
+| SingleTenant_NoRoutingTags   | 25            | 588,613.8 ns | 13,589.76 ns |  19,050.95 ns | 1.000 |    0.04 | 30.2734 | 21.4844 |  766208 B |        1.00 |
+| SingleTenant_WithRoutingTags | 25            | 690,046.4 ns | 18,759.69 ns |  27,497.71 ns | 1.170 |    0.06 | 30.2734 | 21.4844 |  766208 B |        1.00 |
+| MultiTenant                  | 25            | 818,049.2 ns | 60,325.65 ns |  86,517.25 ns | 1.390 |    0.15 | 29.2969 |  9.7656 |  757760 B |        0.99 |
+| GroupOnly                    | 25            |  16,216.6 ns |    733.30 ns |   1,097.56 ns | 0.030 |    0.00 |       - |       - |         - |        0.00 |
 
-Reading these numbers:
+Pooled baselines: 630 us without the routing attributes, 707 us with them.
 
-The noise floor is about 12%: SingleTenant_NoRoutingTags does identical work in all three rows and
-came out 644, 658 and 589 us. Nothing below that is a result.
+1. Grouping is cheap and allocates nothing. GroupOnly sorts 512 Activities into N buckets and does
+   nothing else. GetOrAdd scans the buckets already open, so the average scan is (N+1)/2 deep, and
+   the measured cost is a flat ~2.4 ns per comparison at every N: 1.95, 2.46 and 2.44. That is 1 us
+   at one endpoint and 16 us at 25, against roughly 800 us to convert the same batch, so about 2%.
+   Extrapolating the same 2.4 ns to the 64-partition cap gives about 41 us, or 5%. Not worth
+   replacing with a hash, which would add an allocation to the one-to-three endpoint case that every
+   deployment pays.
 
-Grouping is linear in the endpoint count and allocates nothing. 998 ns, 2.5 us and 16.2 us for 512
-lookups is roughly 2, 5 and 32 ns per lookup against 1, 3 and 25 open groups, which is the ordinal
-scan doing exactly what a scan does. The zero in the allocation column is the useful part: it is
-direct evidence that the group and list pooling holds, with no garbage per export. In absolute terms
-16.2 us against 818 us of conversion is about 2% of a routed export at 25 endpoints, and a linear
-extrapolation to the 64-partition cap gives roughly 40 us, or 5%. The scan is not worth replacing;
-a hash would add an allocation to the one-to-three endpoint case that every deployment pays.
+2. The routing attributes cost the single-tenant path about 12% (707 us against 630 us pooled).
+   That is the bias that has to come out before routing is judged at all.
 
-Routing is not cheaper than single-tenant. The two extra custom dimensions cost the baseline 7 to
-17% (SingleTenant_WithRoutingTags against SingleTenant_NoRoutingTags), and once that bias is
-accounted for MultiTenant is within noise of its like-for-like partner at 1 and 3 endpoints and
-about 19% slower at 25, where grouping and route validation have grown. Against the realistic
-single-tenant workload, which carries no routing attributes at all, the routed path costs 4 to 39%
-more depending on endpoint count.
+3. Routing itself costs roughly 9% to 30% over a plain single-tenant conversion, depending on
+   endpoint count, and the endpoint count is what moves it. Against the like-for-like baseline that
+   also carries the attributes, the routed path is within noise at 1 and 3 endpoints and about 16%
+   slower at 25.
 
-The one stable non-time result is allocation: MultiTenant allocates 757,760 B against 766,208 B,
-about 1% less, identically in all three parameter rows. That is the routed path consuming the two
-routing attributes instead of serializing them as custom dimensions, and it is consistent enough
-across rows to be believed where the timings are not.
+4. The routed path allocates 8,448 B less per batch, identically in all three rows. This is not the
+   routing attributes: both baselines allocate 766,208 B whether they carry those attributes or not,
+   so serializing them costs nothing measurable. It is the two per-call objects the single-tenant
+   path builds and the routed path does not - a List<TelemetryItem> grown to 512 entries (8,384 B of
+   backing arrays plus the list) and a TelemetrySchemaTypeCounter (64 B) - which sums to exactly the
+   observed gap. The routed path writes into the pooled group list instead. The Gen1 column carries
+   the same story more usefully: 21.5 against 9.8.
+
+MemoryDiagnoser does not count ArrayPool rents, and AzMonList rents on both paths, so the Allocated
+column excludes that traffic. GroupOnly's zero is unaffected: EndpointRouteBatch uses no pool.
 */
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 {


### PR DESCRIPTION
Adds benchmarks for multi-tenant trace export (#62707)

## What it found

**1. The shared redirect policy costs nothing meaningful.** This is the part that matters most,
because it runs for every single-tenant caller whether multi-tenant is on or not.

| | Time | Allocated |
|---|---|---|
| No redirect learned (almost everyone) | 358 ns | 968 B |
| After a redirect is learned | 731 ns | 1,216 B |
| Per-request URI builder alone | 48 ns | 168 B |

A learned redirect adds **373 ns** — about 0.04% of an ingestion POST, which costs milliseconds.
It splits evenly: 176 ns to build the cache key and take the lock, 197 ns for the trust check and
rewrite.

**2. Grouping by endpoint is cheap and allocates nothing.**

`GroupOnly` sorts 512 Activities into N buckets and does nothing else. `GetOrAdd` scans the buckets
already open, so the average scan is (N+1)/2 deep:

| Endpoints | Time | Per comparison | Allocated |
|---|---|---|---|
| 1 | 1.0 µs | 1.95 ns | 0 B |
| 3 | 2.5 µs | 2.46 ns | 0 B |
| 25 | 16.2 µs | 2.44 ns | 0 B |

Flat cost per comparison, so nothing surprising happens as endpoints grow. At 25 endpoints grouping
is 16 µs against ~800 µs to convert the same batch — about **2%**. At the 64-partition cap it would
be ~41 µs, or 5%. Not worth replacing with a hash, which would add an allocation to the
one-to-three endpoint case every deployment pays. The zero allocation is evidence the pooling works.

**3. Routing costs 9–30% more per batch than plain single-tenant**, depending on endpoint count.

Two baselines are measured, because the routing attributes are custom dimensions to one path and
consumed input to the other:

| | 512-Activity batch |
|---|---|
| Single-tenant, no routing attributes | 630 µs |
| Single-tenant, carrying them | 707 µs |
| Multi-tenant | 686–818 µs |

The attributes alone cost the baseline **12%**. Against the like-for-like baseline that also carries
them, routing is within noise at 1–3 endpoints and ~16% slower at 25.

**4. The routed path allocates 8,448 B less per batch.** Not from the routing attributes — both
baselines allocate identically whether they carry them or not. It is the `List<TelemetryItem>` grown
to 512 entries (8,384 B) and the `TelemetrySchemaTypeCounter` (64 B) that single-tenant allocates
per call and the routed path does not, because it writes into the pooled group list. Gen1 collections
drop from 21.5 to 9.8.

## Reading the numbers

The single-tenant baseline does identical work at all three endpoint counts and varied 589–658 µs,
so the noise floor is ~12%. Baselines are pooled across their three rows before any percentage is
computed. The redirect table is tight (StdDev under 2%) and needs no such caveat.

`MemoryDiagnoser` does not count `ArrayPool` rents, and `AzMonList` rents on both paths, so the
allocation column excludes that traffic. `GroupOnly`'s zero is unaffected — `EndpointRouteBatch`
uses no pool.
