### PR TITLE
Add additional service owners for the Functions service label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -328,7 +328,7 @@
 
 # AzureSdkOwners: @jsquire
 # ServiceLabel: %Functions
-# ServiceOwners: @fabiocav
+# ServiceOwners: @fabiocav @mathewc @alrod
 
 # PRLabel: %HDInsight
 /sdk/hdinsight/    @aim-for-better


### PR DESCRIPTION
### Problem

The `%Functions` service label currently has a single service owner:

```
# AzureSdkOwners: @jsquire
# ServiceLabel: %Functions
# ServiceOwners: @fabiocav
```

The `Verify Codeowners` CI check (`eng/common/scripts/Test-CodeownersForArtifacts.ps1`) requires **at least two service owners per PR label**. Because `%Functions` appears in the `# PRLabel:` directive for the WebJobs extension paths, that check fails for every PR touching them:

```
check-package failed for path 'sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs':
PR label "Functions" has 1 unique service owner(s); at least 2 are required.
Service owners: [fabiocav]
```

Affected paths (their matched `# PRLabel:` includes `%Functions`):

| Path | Status |
| --- | --- |
| `/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/` | observed failing (#62774) |
| `/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/` | resolves the same way, would fail identically |
| `/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/` | not currently failing, see note below |

This is unrelated to the content of any individual PR - it blocks the release PRs for these extensions (for example #62774).

### Change

```diff
  # AzureSdkOwners: @jsquire
  # ServiceLabel: %Functions
- # ServiceOwners: @fabiocav
+ # ServiceOwners: @fabiocav @mathewc @alrod
```

`@mathewc` and `@alrod` are on the Azure Functions team alongside `@fabiocav` and already triage Functions issues, so this reflects the actual owners rather than just satisfying the threshold.

### Note on Service Bus

The Service Bus extension does not hit this failure today, but only by accident of ordering. Its specific entry is at line 327, while the generic `/sdk/servicebus/` entry is at line 445. CODEOWNERS resolution is last-match-wins, so the generic entry wins and the `%Functions` label never resolves for that path. Lines 326-327 are effectively dead. This PR does not change that, but it does mean Service Bus will not break if the ordering is ever corrected.

### Validation

Once this merges, the `Verify Codeowners` check on #62774 needs a fresh build to pick it up (a retry reuses the previous run's artifacts).
