### PR TITLE
Exercise codeowners validation on the template package

### DIFF
--- a/sdk/template/Azure.Template/README.md
+++ b/sdk/template/Azure.Template/README.md
@@ -90,3 +90,5 @@ This is a template, but your SDK readme should include details on how to contrib
 <!-- LINKS -->
 [style-guide-msft]: https://learn.microsoft.com/style-guide/capitalization
 [style-guide-cloud]: https://aka.ms/azsdk/cloud-style-guide
+
+<!-- Touched to exercise codeowners validation for this package. Revert before merge. -->

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -37,7 +37,6 @@ extends:
     Artifacts:
     - name: Azure.Template
       safeName: AzureTemplate
-      skipCodeownersVerification: true
       triggeringPaths:
       - /.config
       - /.devcontainer


### PR DESCRIPTION
Demo branch for the ownership YAML migration. Exercises the codeowners gates against a real package instead of a test fixture.

- Stops exempting the template package from codeowners verification
- Touches a file in the package so it registers as changed

Targets the migration branch so the diff stays scoped to the template package. Do not merge.
