### PR TITLE
Presize the trace telemetry list to the batch size

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Reduced allocations when converting a batch of Activities. The list holding the converted telemetry is now sized from the batch up front instead of growing from the default capacity, which removes roughly 8 KB of garbage per export for a full batch.
+- Reduced allocations when converting a batch of Activities. The list holding the converted telemetry is now sized from the batch up front instead of growing from the default capacity, which removes about 4 KB of transient garbage per export for a 512-Activity batch.
   ([#62853](https://github.com/Azure/azure-sdk-for-net/pull/62853))
 
 ## 1.9.0 (2026-09-04)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,9 +10,6 @@
 
 ### Other Changes
 
-- Reduced allocations when converting a batch of Activities. The list holding the converted telemetry is now sized from the batch up front instead of growing from the default capacity, which removes about 4 KB of transient garbage per export for a 512-Activity batch.
-  ([#62853](https://github.com/Azure/azure-sdk-for-net/pull/62853))
-
 ## 1.9.0 (2026-09-04)
 
 ### Features Added

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+- Reduced allocations when converting a batch of Activities. The list holding the converted telemetry is now sized from the batch up front instead of growing from the default capacity, which removes roughly 8 KB of garbage per export for a full batch.
+  ([#62853](https://github.com/Azure/azure-sdk-for-net/pull/62853))
+
 ## 1.9.0 (2026-09-04)
 
 ### Features Added

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -25,8 +25,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal static (List<TelemetryItem> TelemetryItems, TelemetrySchemaTypeCounter TelemetrySchemaTypeCounter) OtelToAzureMonitorTrace(Batch<Activity> batchActivity, AzureMonitorResource? azureMonitorResource, string instrumentationKey, float sampleRate)
         {
             // One item per Activity plus the optional resource envelope. Activity events add more, so
-            // this is a floor rather than an exact size, but it removes the repeated doubling that a
-            // default-capacity list performs on every export.
+            // this is a floor rather than an exact size, but it removes the seven intermediate arrays
+            // a default-capacity list discards on the way to holding a full batch.
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>(capacity: (int)batchActivity.Count + 1);
             TelemetryItem telemetryItem;
             var telemetrySchemaTypeCounter = new TelemetrySchemaTypeCounter();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -24,7 +24,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal static (List<TelemetryItem> TelemetryItems, TelemetrySchemaTypeCounter TelemetrySchemaTypeCounter) OtelToAzureMonitorTrace(Batch<Activity> batchActivity, AzureMonitorResource? azureMonitorResource, string instrumentationKey, float sampleRate)
         {
-            List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
+            // One item per Activity plus the optional resource envelope. Activity events add more, so
+            // this is a floor rather than an exact size, but it removes the repeated doubling that a
+            // default-capacity list performs on every export.
+            List<TelemetryItem> telemetryItems = new List<TelemetryItem>(capacity: (int)batchActivity.Count + 1);
             TelemetryItem telemetryItem;
             var telemetrySchemaTypeCounter = new TelemetrySchemaTypeCounter();
 


### PR DESCRIPTION
`OtelToAzureMonitorTrace` built its `List<TelemetryItem>` with the default capacity, so a full
512-Activity batch grew it through eight arrays and discarded the first seven.

```diff
- List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
+ List<TelemetryItem> telemetryItems = new List<TelemetryItem>(capacity: (int)batchActivity.Count + 1);
```

`LogsHelper` already does exactly this (`capacity: (int)batchLogRecord.Count`), so this makes traces
consistent with logs rather than introducing a new pattern.

Activity events can add further items, so the capacity is a floor rather than an exact size. The
`+ 1` covers the optional resource-metric envelope.

## Measured

`MultiTenantExportBenchmarks.SingleTenant_*`, 512-Activity batch, `MemoryDiagnoser`:

| | Allocated |
|---|---|
| Before | 766,208 B |
| After | 761,984 B |
| **Saved** | **4,224 B per export** |

Identical at all three endpoint counts, and allocation counting is deterministic, so this is not a
noisy measurement.

That figure is what the seven discarded arrays cost: 56 + 88 + 152 + 280 + 536 + 1048 + 2072 =
4,232 B, less the 8 extra bytes the presized array carries for the `+ 1`. The eighth array survives
as the returned list's backing store, so it is not removed — only the garbage on the way there is.

`Gen0`/`Gen1` counts are unchanged at this batch size; the win is bytes, not collections.

No behaviour change, no API change.
