### PR TITLE
Add missing standard Spector tests for the Azure C# emitter

### DIFF
--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/BodyRoot/BodyRootTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/BodyRoot/BodyRootTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Parameters.BodyRoot;
+
+namespace TestProjects.Spector.Tests.Http.Parameters.BodyRoot
+{
+    public class BodyRootTests : SpectorTestBase
+    {
+        [SpectorTest]
+        public Task Nested() => Test(async (host) =>
+        {
+            var body = new NestedParameterBody(new BodyRootModel
+            {
+                Category = "widget",
+                LinkType = "hard",
+                WasSuccessful = true
+            });
+
+            var response = await new BodyRootClient(host, null).NestedAsync(body);
+            Assert.AreEqual(204, response.Status);
+        });
+    }
+}

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/Query/QueryTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/Query/QueryTests.cs
@@ -15,5 +15,12 @@ namespace TestProjects.Spector.Tests.Http.Parameters.Query
             var response = await new QueryClient(host, null).GetConstantClient().PostAsync();
             Assert.AreEqual(204, response.Status);
         });
+
+        [SpectorTest]
+        public Task Parameters_Query_SpecialChar_DollarSign() => Test(async (host) =>
+        {
+            var response = await new QueryClient(host, null).GetSpecialCharClient().DollarSignAsync("status eq 'active'");
+            Assert.AreEqual(204, response.Status);
+        });
     }
 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Head/HeadTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Head/HeadTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Payload.Head;
+
+namespace TestProjects.Spector.Tests.Http.Payload.Head
+{
+    public class HeadTests : SpectorTestBase
+    {
+        [SpectorTest]
+        public Task ContentTypeHeaderInResponse() => Test(async (host) =>
+        {
+            var response = await new HeadClient(host, null).ContentTypeHeaderInResponseAsync();
+            Assert.AreEqual(200, response.Status);
+            Assert.IsTrue(response.Headers.TryGetValue("Content-Type", out var contentType));
+            Assert.AreEqual("text/plain; charset=utf-8", contentType);
+            Assert.IsTrue(response.Headers.TryGetValue("x-ms-meta", out var metadata));
+            Assert.AreEqual("hello", metadata);
+        });
+    }
+}

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Pageable/NextLinkPaginationTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Pageable/NextLinkPaginationTests.cs
@@ -14,10 +14,12 @@ namespace TestProjects.Spector.Tests.Http.Payload.Pageable
     public class NextLinkPaginationTests : SpectorTestBase
     {
         [SpectorTest]
-        public Task ConvenienceMethod() => Test(async (host) =>
+        [TestCase(false)]
+        [TestCase(true)]
+        public Task ConvenienceMethod(bool stringNextLink) => Test(async (host) =>
         {
-            var client = new PageableClient(host, null);
-            var result = client.GetServerDrivenPaginationClient().LinkAsync();
+            var client = new PageableClient(host, null).GetServerDrivenPaginationClient();
+            var result = stringNextLink ? client.LinkStringAsync() : client.LinkAsync();
             int count = 0;
             var expectedPets = new Dictionary<string, string>()
             {
@@ -32,13 +34,16 @@ namespace TestProjects.Spector.Tests.Http.Payload.Pageable
                 Assert.AreEqual((++count).ToString(), pet.Id);
                 Assert.AreEqual(expectedPets[pet.Id], pet.Name);
             }
+            Assert.AreEqual(4, count);
         });
 
         [SpectorTest]
-        public Task ConvenienceMethodSync() => Test((host) =>
+        [TestCase(false)]
+        [TestCase(true)]
+        public Task ConvenienceMethodSync(bool stringNextLink) => Test((host) =>
         {
-            var client = new PageableClient(host, null);
-            var result = client.GetServerDrivenPaginationClient().Link();
+            var client = new PageableClient(host, null).GetServerDrivenPaginationClient();
+            var result = stringNextLink ? client.LinkString() : client.Link();
             int count = 0;
             var expectedPets = new Dictionary<string, string>()
             {
@@ -53,14 +58,17 @@ namespace TestProjects.Spector.Tests.Http.Payload.Pageable
                 Assert.AreEqual((++count).ToString(), pet.Id);
                 Assert.AreEqual(expectedPets[pet.Id], pet.Name);
             }
+            Assert.AreEqual(4, count);
             return Task.CompletedTask;
         });
 
         [SpectorTest]
-        public Task ProtocolMethod() => Test(async (host) =>
+        [TestCase(false)]
+        [TestCase(true)]
+        public Task ProtocolMethod(bool stringNextLink) => Test(async (host) =>
         {
-            var client = new PageableClient(host, null);
-            var result = client.GetServerDrivenPaginationClient().LinkAsync(new RequestContext());
+            var client = new PageableClient(host, null).GetServerDrivenPaginationClient();
+            var result = stringNextLink ? client.LinkStringAsync(new RequestContext()) : client.LinkAsync(new RequestContext());
             int count = 0;
             var expectedPets = new Dictionary<string, string>()
             {
@@ -81,13 +89,16 @@ namespace TestProjects.Spector.Tests.Http.Payload.Pageable
                     Assert.AreEqual(expectedPets[pet["id"]!.ToString()], pet["name"]!.ToString());
                 }
             }
+            Assert.AreEqual(4, count);
         });
 
         [SpectorTest]
-        public Task ProtocolMethodSync() => Test((host) =>
+        [TestCase(false)]
+        [TestCase(true)]
+        public Task ProtocolMethodSync(bool stringNextLink) => Test((host) =>
         {
-            var client = new PageableClient(host, null);
-            var result = client.GetServerDrivenPaginationClient().Link(new RequestContext());
+            var client = new PageableClient(host, null).GetServerDrivenPaginationClient();
+            var result = stringNextLink ? client.LinkString(new RequestContext()) : client.Link(new RequestContext());
             int count = 0;
             var expectedPets = new Dictionary<string, string>()
             {
@@ -108,17 +119,21 @@ namespace TestProjects.Spector.Tests.Http.Payload.Pageable
                     Assert.AreEqual(expectedPets[pet["id"]!.ToString()], pet["name"]!.ToString());
                 }
             }
+            Assert.AreEqual(4, count);
             return Task.CompletedTask;
         });
 
         [SpectorTest]
-        public Task ContinuationTokenResumesFromNextPage() => Test(async (host) =>
+        [TestCase(false)]
+        [TestCase(true)]
+        public Task ContinuationTokenResumesFromNextPage(bool stringNextLink) => Test(async (host) =>
         {
-            var client = new PageableClient(host, null);
+            var client = new PageableClient(host, null).GetServerDrivenPaginationClient();
+            var result = stringNextLink ? client.LinkStringAsync(new RequestContext()) : client.LinkAsync(new RequestContext());
 
             // Capture the continuation token exposed by the first page.
             string? firstPageToken = null;
-            await foreach (var page in client.GetServerDrivenPaginationClient().LinkAsync(new RequestContext()).AsPages())
+            await foreach (var page in result.AsPages())
             {
                 firstPageToken = page.ContinuationToken;
                 break;
@@ -132,7 +147,7 @@ namespace TestProjects.Spector.Tests.Http.Payload.Pageable
             // Resuming from the captured token should return the remaining pages only (pets 3 and 4).
             var resumedIds = new List<string>();
             string? lastPageToken = "unset";
-            await foreach (var page in client.GetServerDrivenPaginationClient().LinkAsync(new RequestContext()).AsPages(firstPageToken))
+            await foreach (var page in result.AsPages(firstPageToken))
             {
                 lastPageToken = page.ContinuationToken;
                 var pageResult = JsonNode.Parse(page.GetRawResponse().Content.ToString())!;

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Pageable/PageSizePaginationTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Pageable/PageSizePaginationTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure;
+using NUnit.Framework;
+using Payload.Pageable;
+
+namespace TestProjects.Spector.Tests.Http.Payload.Pageable
+{
+    public class PageSizePaginationTests : SpectorTestBase
+    {
+        private static readonly string[] ExpectedPetNames = ["dog", "cat", "bird", "fish"];
+
+        [SpectorTest]
+        public Task WithoutContinuationConvenienceMethod() => Test(async (host) =>
+        {
+            var result = new PageableClient(host, null).GetPageSizeClient().GetWithoutContinuationAsync();
+            await ValidatePagesAsync(result.AsPages(), 4, ValidatePet);
+        });
+
+        [SpectorTest]
+        public Task WithoutContinuationConvenienceMethodSync() => Test((host) =>
+        {
+            var result = new PageableClient(host, null).GetPageSizeClient().GetWithoutContinuation();
+            ValidatePages(result.AsPages(), 4, ValidatePet);
+            return Task.CompletedTask;
+        });
+
+        [SpectorTest]
+        public Task WithoutContinuationProtocolMethod() => Test(async (host) =>
+        {
+            var result = new PageableClient(host, null).GetPageSizeClient().GetWithoutContinuationAsync(new RequestContext());
+            await ValidatePagesAsync(result.AsPages(), 4, ValidatePet);
+        });
+
+        [SpectorTest]
+        public Task WithoutContinuationProtocolMethodSync() => Test((host) =>
+        {
+            var result = new PageableClient(host, null).GetPageSizeClient().GetWithoutContinuation(new RequestContext());
+            ValidatePages(result.AsPages(), 4, ValidatePet);
+            return Task.CompletedTask;
+        });
+
+        [SpectorTest]
+        [TestCase(2, null, 2)]
+        [TestCase(4, null, 4)]
+        [TestCase(null, 2, 2)]
+        [TestCase(null, 4, 4)]
+        [TestCase(2, 4, 4)]
+        [TestCase(4, 2, 2)]
+        public Task WithPageSizeConvenienceMethod(int? pageSize, int? pageSizeHint, int expectedCount) => Test(async (host) =>
+        {
+            var result = new PageableClient(host, null).GetPageSizeClient().GetWithPageSizeAsync(pageSize);
+            await ValidatePagesAsync(result.AsPages(pageSizeHint: pageSizeHint), expectedCount, ValidatePet);
+        });
+
+        [SpectorTest]
+        [TestCase(2, null, 2)]
+        [TestCase(4, null, 4)]
+        [TestCase(null, 2, 2)]
+        [TestCase(null, 4, 4)]
+        [TestCase(2, 4, 4)]
+        [TestCase(4, 2, 2)]
+        public Task WithPageSizeConvenienceMethodSync(int? pageSize, int? pageSizeHint, int expectedCount) => Test((host) =>
+        {
+            var result = new PageableClient(host, null).GetPageSizeClient().GetWithPageSize(pageSize);
+            ValidatePages(result.AsPages(pageSizeHint: pageSizeHint), expectedCount, ValidatePet);
+            return Task.CompletedTask;
+        });
+
+        [SpectorTest]
+        [TestCase(2, null, 2)]
+        [TestCase(4, null, 4)]
+        [TestCase(null, 2, 2)]
+        [TestCase(null, 4, 4)]
+        [TestCase(2, 4, 4)]
+        [TestCase(4, 2, 2)]
+        public Task WithPageSizeProtocolMethod(int? pageSize, int? pageSizeHint, int expectedCount) => Test(async (host) =>
+        {
+            var result = new PageableClient(host, null).GetPageSizeClient().GetWithPageSizeAsync(pageSize, new RequestContext());
+            await ValidatePagesAsync(result.AsPages(pageSizeHint: pageSizeHint), expectedCount, ValidatePet);
+        });
+
+        [SpectorTest]
+        [TestCase(2, null, 2)]
+        [TestCase(4, null, 4)]
+        [TestCase(null, 2, 2)]
+        [TestCase(null, 4, 4)]
+        [TestCase(2, 4, 4)]
+        [TestCase(4, 2, 2)]
+        public Task WithPageSizeProtocolMethodSync(int? pageSize, int? pageSizeHint, int expectedCount) => Test((host) =>
+        {
+            var result = new PageableClient(host, null).GetPageSizeClient().GetWithPageSize(pageSize, new RequestContext());
+            ValidatePages(result.AsPages(pageSizeHint: pageSizeHint), expectedCount, ValidatePet);
+            return Task.CompletedTask;
+        });
+
+        private static async Task ValidatePagesAsync<T>(IAsyncEnumerable<Page<T>> pages, int expectedCount, Action<T, string, string> validatePet)
+        {
+            int pageCount = 0;
+            await foreach (var page in pages)
+            {
+                ValidatePage(page, expectedCount, validatePet);
+                pageCount++;
+            }
+            Assert.AreEqual(1, pageCount);
+        }
+
+        private static void ValidatePages<T>(IEnumerable<Page<T>> pages, int expectedCount, Action<T, string, string> validatePet)
+        {
+            int pageCount = 0;
+            foreach (var page in pages)
+            {
+                ValidatePage(page, expectedCount, validatePet);
+                pageCount++;
+            }
+            Assert.AreEqual(1, pageCount);
+        }
+
+        private static void ValidatePage<T>(Page<T> page, int expectedCount, Action<T, string, string> validatePet)
+        {
+            Assert.AreEqual(200, page.GetRawResponse().Status);
+            Assert.IsNull(page.ContinuationToken);
+            Assert.AreEqual(expectedCount, page.Values.Count);
+            for (int i = 0; i < page.Values.Count; i++)
+            {
+                validatePet(page.Values[i], (i + 1).ToString(), ExpectedPetNames[i]);
+            }
+        }
+
+        private static void ValidatePet(Pet pet, string expectedId, string expectedName)
+        {
+            Assert.AreEqual(expectedId, pet.Id);
+            Assert.AreEqual(expectedName, pet.Name);
+        }
+
+        private static void ValidatePet(BinaryData pet, string expectedId, string expectedName)
+        {
+            using var document = JsonDocument.Parse(pet);
+            Assert.AreEqual(expectedId, document.RootElement.GetProperty("id").GetString());
+            Assert.AreEqual(expectedName, document.RootElement.GetProperty("name").GetString());
+        }
+    }
+}

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Xml/XmlTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Xml/XmlTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Xml.Linq;
+using Azure;
 using NUnit.Framework;
 using Payload.Xml;
 
@@ -614,6 +616,22 @@ namespace TestProjects.Spector.Tests.Http.Payload.Xml
             var model = new ModelWithNamespaceOnProperties(123, "The Great Gatsby", "F. Scott Fitzgerald");
             var response = await new XmlClient(host, null).GetModelWithNamespaceOnPropertiesValueClient().PutAsync(model);
             Assert.AreEqual(204, response.Status);
+        });
+
+        [SpectorTest]
+        public Task GetXmlError() => Test((host) =>
+        {
+            var exception = Assert.ThrowsAsync<RequestFailedException>(
+                () => new XmlClient(host, null).GetXmlErrorValueClient().GetAsync());
+
+            Assert.AreEqual(400, exception!.Status);
+            var response = exception.GetRawResponse();
+            Assert.IsNotNull(response);
+            var body = XDocument.Parse(response!.Content.ToString());
+            Assert.AreEqual("XmlErrorBody", body.Root!.Name.LocalName);
+            Assert.AreEqual("Something went wrong", body.Root.Element("message")?.Value);
+            Assert.AreEqual("400", body.Root.Element("code")?.Value);
+            return Task.CompletedTask;
         });
     }
 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Routes/PathParameterTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Routes/PathParameterTests.cs
@@ -71,6 +71,26 @@ namespace TestProjects.Spector.Tests.Http.Routes
         });
 
         [SpectorTest]
+        public Task SimpleExpansionPrimitive() => Test(async (host) =>
+        {
+            var response = await new RoutesClient(host, null).GetPathParametersClient()
+                .GetPathParametersSimpleExpansionClient()
+                .GetPathParametersSimpleExpansionStandardClient()
+                .PrimitiveAsync("a");
+            Assert.AreEqual(204, response.Status);
+        });
+
+        [SpectorTest]
+        public Task SimpleExpansionExplodePrimitive() => Test(async (host) =>
+        {
+            var response = await new RoutesClient(host, null).GetPathParametersClient()
+                .GetPathParametersSimpleExpansionClient()
+                .GetPathParametersSimpleExpansionExplodeClient()
+                .PrimitiveAsync("a");
+            Assert.AreEqual(204, response.Status);
+        });
+
+        [SpectorTest]
         [Ignore("https://github.com/microsoft/typespec/issues/5561")]
         public Task LabelExpansionExplodeArray() => Test(async (host) =>
         {

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.Parameters.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.Parameters.cs
@@ -10,6 +10,14 @@ namespace TestProjects.Spector.Tests.Http.SpecialWords
     public partial class SpecialWordsTests : SpectorTestBase
     {
         [SpectorTest]
+        public Task ReservedOperationBodyParamsWithItemsAsync() => Test(async (host) =>
+        {
+            var client = new SpecialWordsClient(host, null).GetReservedOperationBodyParamsClient();
+            var response = await client.WithItemsAsync(["item"]);
+            Assert.AreEqual(204, response.Status);
+        });
+
+        [SpectorTest]
         public Task ParametersWithAndAsync() => Test(async (host) =>
         {
             var client = new SpecialWordsClient(host, null).GetParametersClient();

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/_Type/Model/Inheritance/SingleDiscriminator/SingleDiscriminatorTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/_Type/Model/Inheritance/SingleDiscriminator/SingleDiscriminatorTests.cs
@@ -100,5 +100,22 @@ namespace TestProjects.Spector.Tests.Http._Type.Model.Inheritance.SingleDiscrimi
             Assert.IsTrue(result.Value is TRex);
             Assert.AreEqual(20, ((TRex)result.Value).Size);
         });
+
+        [SpectorTest]
+        public Task GetNoSubtypesModel() => Test(async (host) =>
+        {
+            var response = await new SingleDiscriminatorClient(host, null).GetNoSubtypesModelAsync();
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.AreEqual(10, response.Value.Size);
+            Assert.AreEqual("salmon", GetProperty(response.Value, "Kind"));
+        });
+
+        [SpectorTest]
+        public Task PutNoSubtypesModel() => Test(async (host) =>
+        {
+            var body = TypeModelInheritanceSingleDiscriminatorModelFactory.Fish("salmon", 10);
+            var response = await new SingleDiscriminatorClient(host, null).PutNoSubtypesModelAsync(body);
+            Assert.AreEqual(204, response.Status);
+        });
     }
 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj
@@ -70,11 +70,13 @@
     <ProjectReference Include="..\Spector\http\encode\numeric\src\Encode.Numeric.csproj" />
     <ProjectReference Include="..\Spector\http\parameters\basic\src\Parameters.Basic.csproj" />
     <ProjectReference Include="..\Spector\http\parameters\body-optionality\src\Parameters.BodyOptionality.csproj" />
+    <ProjectReference Include="..\Spector\http\parameters\body-root\src\Parameters.BodyRoot.csproj" />
     <ProjectReference Include="..\Spector\http\parameters\collection-format\src\Parameters.CollectionFormat.csproj" />
     <ProjectReference Include="..\Spector\http\parameters\spread\src\Parameters.Spread.csproj" />
     <ProjectReference Include="..\Spector\http\parameters\path\src\Parameters.Path.csproj" />
     <ProjectReference Include="..\Spector\http\parameters\query\src\Parameters.Query.csproj" />
     <ProjectReference Include="..\Spector\http\payload\content-negotiation\src\Payload.ContentNegotiation.csproj" />
+    <ProjectReference Include="..\Spector\http\payload\head\src\Payload.Head.csproj" />
     <ProjectReference Include="..\Spector\http\payload\json-merge-patch\src\Payload.JsonMergePatch.csproj" />
     <ProjectReference Include="..\Spector\http\payload\media-type\src\Payload.MediaType.csproj" />
     <ProjectReference Include="..\Spector\http\payload\multipart\src\Payload.MultiPart.csproj" />


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

Adds twelve missing standard HTTP Spector scenarios for the Azure C# emitter:

- Nested body-root parameters and HEAD response headers.
- `$filter` query parameters and reserved `items` body parameters.
- GET/PUT of discriminator models without defined subtypes.
- XML error responses, including their status and response body.
- Standard and exploded simple primitive route expansion.
- Pagination without continuation, explicit page sizes of 2 and 4, and string-valued next links.

The pageable coverage exercises sync/async convenience and protocol methods, method-level page sizes, `AsPages(pageSizeHint: ...)` and hint precedence, exact item counts, and continuation-token resumption. Existing URL-next-link tests remain covered through parameterized cases.

Adds the two required project references. No generator changes, new ignores, or generated-code changes are included.

**Deferred:** Boolean string encoding awaits the upstream dependency upgrade. The 16 unsupported route-expansion scenarios remain deferred under https://github.com/microsoft/typespec/issues/5561; existing ignored tests are unchanged.

**Remaining pageable limitation:** `AlternateInitialVerb_post` is not covered by this tests-only change. The generated continuation request uses POST, while the scenario requires a POST initial request followed by GET. This requires a generator fix rather than just additional tests.

### Validation

Regenerated the affected clients unstubbed with `Generate.ps1` and ran targeted Spector groups: 2 passed for body-root/HEAD; 206 passed and 9 existing ignored for the other initial groups; all 64 pageable cases passed with no skips. The pageable follow-up adds 33 test cases covering the three omitted scenarios. All twelve newly covered Spector scenarios reported `pass`. Restored generated clients to the committed stubbed form afterward. `npm run lint` and `npm run prettier` also passed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR — N/A; tests only.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above. — N/A.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. — N/A.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. — N/A.