### PR TITLE
[Storage] [BlobBatch] Fix bug where header values were not being sanitized CRLF for Blob Batch

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 12.28.0-beta.1 (Unreleased)
+
+### Bugs Fixed
+- Prevented carriage-return and line-feed injection in Blob Batch subrequest headers.
+
 ## 12.27.0-beta.1 (2026-07-22)
 
 ### Features Added

--- a/sdk/storage/Azure.Storage.Blobs.Batch/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Release History
 
-## 12.28.0-beta.1 (Unreleased)
+## 12.27.0-beta.2 (Unreleased)
 
 ### Bugs Fixed
-- Prevented carriage-return and line-feed injection in Blob Batch subrequest headers.
+- Fixed bug where header values were not being sanitized for CR or LF characters when using `BlobBatchClient` APIs.
 
 ## 12.27.0-beta.1 (2026-07-22)
 

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/Azure.Storage.Blobs.Batch.csproj
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/Azure.Storage.Blobs.Batch.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks></PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.Blobs.Batch client library</AssemblyTitle>
-    <Version>12.27.0-beta.1</Version>
+    <Version>12.27.0-beta.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>12.26.0</ApiCompatVersion>
     <DefineConstants>BlobSDK;$(DefineConstants)</DefineConstants>

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BatchErrors.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BatchErrors.cs
@@ -50,6 +50,9 @@ namespace Azure.Storage.Blobs.Specialized
         public static RequestFailedException InvalidResponse(ClientDiagnostics clientDiagnostics, Response response, Exception innerException) =>
             new RequestFailedException(response, innerException, new BatchRequestFailedDetailsParser());
 
+        public static ArgumentException HeaderValueCannotContainCrlf(string headerName) =>
+            new ArgumentException($"The value of header '{headerName}' cannot contain CR or LF characters.");
+
         private class BatchRequestFailedDetailsParser : RequestFailedDetailsParser
         {
             public override bool TryParse(Response response, out ResponseError error, out IDictionary<string, string> data)

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/Multipart.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/Multipart.cs
@@ -96,6 +96,11 @@ namespace Azure.Storage.Blobs.Specialized
                 // Write the request headers
                 foreach (HttpHeader header in message.Request.Headers)
                 {
+                    if (header.Value.IndexOf('\r') >= 0 || header.Value.IndexOf('\n') >= 0)
+                    {
+                        throw BatchErrors.HeaderValueCannotContainCrlf(header.Name);
+                    }
+
                     content.Append(header.Name).Append(": ").Append(header.Value).Append(newline);
                 }
 

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/MultipartTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/MultipartTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Storage.Blobs.Specialized;
+using NUnit.Framework;
+
+namespace Azure.Storage.Blobs.Test
+{
+    public class MultipartTests
+    {
+        [TestCase("tag\r\nx-ms-delete-snapshots: include")]
+        [TestCase("tag\nx-ms-delete-snapshots: include")]
+        public void CreateAsync_RejectsHeaderValuesContainingNewLines(string ifTags)
+        {
+            using HttpMessage message = new HttpMessage(new MockRequest(), new ResponseClassifier());
+            message.Request.Method = RequestMethod.Delete;
+            message.Request.Uri.Reset(new Uri("https://account.blob.core.windows.net/container/blob"));
+            message.Request.Headers.SetValue("x-ms-if-tags", ifTags);
+
+            ArgumentException exception = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await Multipart.CreateAsync(new[] { message }, "batch", async: true, CancellationToken.None));
+
+            StringAssert.Contains("x-ms-if-tags", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
Adding check to throw if we see CR/LF in the header value in Blob Batch before we append the value.