### PR TITLE
Microsoft.Extensions.Azure: Add ClientCertificateCredential using subject name to IConfiguration-based client factory

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for configuring a `ClientCertificateCredential` by certificate subject name and issuer.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Extensions.Azure
             var objectId = configuration["managedIdentityObjectId"];
             var clientSecret = configuration["clientSecret"];
             var certificate = configuration["clientCertificate"];
+            var certificateSubject = configuration["clientCertificateSubject"];
             var certificateStoreName = configuration["clientCertificateStoreName"];
             var certificateStoreLocation = configuration["clientCertificateStoreLocation"];
             var systemAccessToken = configuration["systemAccessToken"];
@@ -109,6 +110,11 @@ namespace Microsoft.Extensions.Azure
             var tokenFilePath = configuration["tokenFilePath"];
             var azureCloud = configuration["azureCloud"];
             var managedIdentityClientId = configuration["managedIdentityClientId"];
+
+            if (!string.IsNullOrWhiteSpace(certificate) && !string.IsNullOrWhiteSpace(certificateSubject))
+            {
+                throw new ArgumentException("'clientCertificate' and 'clientCertificateSubject' are mutually exclusive.");
+            }
 
             IEnumerable<string> additionallyAllowedTenantsList = null;
 
@@ -252,9 +258,19 @@ namespace Microsoft.Extensions.Azure
                 return new ClientSecretCredential(tenantId, clientId, clientSecret, options);
             }
 
+            bool findCertificateBySubject = !string.IsNullOrWhiteSpace(certificateSubject);
+            if (findCertificateBySubject &&
+                (string.IsNullOrWhiteSpace(tenantId) ||
+                 string.IsNullOrWhiteSpace(clientId) ||
+                 string.IsNullOrWhiteSpace(certificateStoreName) ||
+                 string.IsNullOrWhiteSpace(certificateStoreLocation)))
+            {
+                throw new ArgumentException("For a client certificate subject, 'tenantId', 'clientId', 'clientCertificateStoreName', and 'clientCertificateStoreLocation' must be specified via the configuration.");
+            }
+
             if (!string.IsNullOrWhiteSpace(tenantId) &&
                 !string.IsNullOrWhiteSpace(clientId) &&
-                !string.IsNullOrWhiteSpace(certificate))
+                (!string.IsNullOrWhiteSpace(certificate) || findCertificateBySubject))
             {
                 StoreLocation storeLocation = StoreLocation.CurrentUser;
 
@@ -270,14 +286,20 @@ namespace Microsoft.Extensions.Azure
 
                 using var store = new X509Store(certificateStoreName, storeLocation);
                 store.Open(OpenFlags.ReadOnly);
-                X509Certificate2Collection certs = store.Certificates.Find(X509FindType.FindByThumbprint, certificate, false);
+                X509FindType findType = findCertificateBySubject ? X509FindType.FindBySubjectName : X509FindType.FindByThumbprint;
+                string findValue = findCertificateBySubject ? certificateSubject : certificate;
+                X509Certificate2Collection certs = store.Certificates.Find(findType, findValue, false);
 
                 if (certs.Count == 0)
                 {
-                    throw new InvalidOperationException($"Unable to find a certificate with thumbprint '{certificate}'");
+                    string certificateIdentifier = findCertificateBySubject ? "subject name" : "thumbprint";
+                    throw new InvalidOperationException($"Unable to find a certificate with {certificateIdentifier} '{findValue}'");
                 }
 
-                var options = new ClientCertificateCredentialOptions();
+                var options = new ClientCertificateCredentialOptions
+                {
+                    SendCertificateChain = findCertificateBySubject
+                };
 
                 if (additionallyAllowedTenantsList != null)
                 {

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Extensions.Azure
             bool findCertificateBySubject = !string.IsNullOrWhiteSpace(certificateSubject);
             if (findCertificateByThumbprint && findCertificateBySubject)
             {
-                throw new ArgumentException("'clientCertificate' and 'clientCertificateSubject' are mutually exclusive.");
+                throw new ArgumentException("For Client Certificates, only one of 'clientCertificate' or 'clientCertificateSubject' can be specified.");
             }
 
             if (!string.IsNullOrWhiteSpace(tenantId) &&

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -260,15 +260,6 @@ namespace Microsoft.Extensions.Azure
                 throw new ArgumentException("'clientCertificate' and 'clientCertificateSubject' are mutually exclusive.");
             }
 
-            if (findCertificateBySubject &&
-                (string.IsNullOrWhiteSpace(tenantId) ||
-                 string.IsNullOrWhiteSpace(clientId) ||
-                 string.IsNullOrWhiteSpace(certificateStoreName) ||
-                 string.IsNullOrWhiteSpace(certificateStoreLocation)))
-            {
-                throw new ArgumentException("For a client certificate subject, 'tenantId', 'clientId', 'clientCertificateStoreName', and 'clientCertificateStoreLocation' must be specified via the configuration.");
-            }
-
             if (!string.IsNullOrWhiteSpace(tenantId) &&
                 !string.IsNullOrWhiteSpace(clientId) &&
                 (findCertificateByThumbprint || findCertificateBySubject))

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -111,11 +111,6 @@ namespace Microsoft.Extensions.Azure
             var azureCloud = configuration["azureCloud"];
             var managedIdentityClientId = configuration["managedIdentityClientId"];
 
-            if (!string.IsNullOrWhiteSpace(certificate) && !string.IsNullOrWhiteSpace(certificateSubject))
-            {
-                throw new ArgumentException("'clientCertificate' and 'clientCertificateSubject' are mutually exclusive.");
-            }
-
             IEnumerable<string> additionallyAllowedTenantsList = null;
 
             if (!string.IsNullOrWhiteSpace(additionallyAllowedTenants))
@@ -258,7 +253,13 @@ namespace Microsoft.Extensions.Azure
                 return new ClientSecretCredential(tenantId, clientId, clientSecret, options);
             }
 
+            bool findCertificateByThumbprint = !string.IsNullOrWhiteSpace(certificate);
             bool findCertificateBySubject = !string.IsNullOrWhiteSpace(certificateSubject);
+            if (findCertificateByThumbprint && findCertificateBySubject)
+            {
+                throw new ArgumentException("'clientCertificate' and 'clientCertificateSubject' are mutually exclusive.");
+            }
+
             if (findCertificateBySubject &&
                 (string.IsNullOrWhiteSpace(tenantId) ||
                  string.IsNullOrWhiteSpace(clientId) ||
@@ -270,7 +271,7 @@ namespace Microsoft.Extensions.Azure
 
             if (!string.IsNullOrWhiteSpace(tenantId) &&
                 !string.IsNullOrWhiteSpace(clientId) &&
-                (!string.IsNullOrWhiteSpace(certificate) || findCertificateBySubject))
+                (findCertificateByThumbprint || findCertificateBySubject))
             {
                 StoreLocation storeLocation = StoreLocation.CurrentUser;
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -259,7 +259,7 @@ namespace Azure.Core.Extensions.Tests
 
             Assert.That(
                 () => ClientFactory.CreateCredential(configuration),
-                Throws.ArgumentException.With.Message.Contains("mutually exclusive"));
+                Throws.ArgumentException.With.Message.EqualTo("For Client Certificates, only one of 'clientCertificate' or 'clientCertificateSubject' can be specified."));
         }
 
         [Test]

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -262,25 +262,6 @@ namespace Azure.Core.Extensions.Tests
                 Throws.ArgumentException.With.Message.Contains("mutually exclusive"));
         }
 
-        [TestCase(null, "client", "My", "CurrentUser")]
-        [TestCase("tenant", null, "My", "CurrentUser")]
-        [TestCase("tenant", "client", null, "CurrentUser")]
-        [TestCase("tenant", "client", "My", null)]
-        public void CertificateSubjectRequiresAllConfiguration(string tenantId, string clientId, string storeName, string storeLocation)
-        {
-            IConfiguration configuration = GetConfiguration(
-                new KeyValuePair<string, string>("tenantId", tenantId),
-                new KeyValuePair<string, string>("clientId", clientId),
-                new KeyValuePair<string, string>("clientCertificateSubject", "subject"),
-                new KeyValuePair<string, string>("clientCertificateStoreName", storeName),
-                new KeyValuePair<string, string>("clientCertificateStoreLocation", storeLocation)
-            );
-
-            Assert.That(
-                () => ClientFactory.CreateCredential(configuration),
-                Throws.ArgumentException.With.Message.Contains("'tenantId', 'clientId', 'clientCertificateStoreName', and 'clientCertificateStoreLocation'"));
-        }
-
         [Test]
         public void CreatesClientSecretCredentials()
         {

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -219,6 +219,69 @@ namespace Azure.Core.Extensions.Tests
         }
 
         [Test]
+        public void CreatesCertificateCredentialsBySubject()
+        {
+            var storeLocation = StoreLocation.CurrentUser;
+            var storeName = StoreName.My;
+            using var localCert = new X509Store(storeName, storeLocation);
+            localCert.Open(OpenFlags.ReadOnly);
+            X509Certificate2 certificate = localCert.Certificates
+                .OfType<X509Certificate2>()
+                .First(cert => !string.IsNullOrWhiteSpace(cert.GetNameInfo(X509NameType.SimpleName, false)));
+            string subjectName = certificate.GetNameInfo(X509NameType.SimpleName, false);
+
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("clientId", "ConfigurationClientId"),
+                new KeyValuePair<string, string>("clientCertificateSubject", subjectName),
+                new KeyValuePair<string, string>("clientCertificateStoreLocation", storeLocation.ToString()),
+                new KeyValuePair<string, string>("clientCertificateStoreName", storeName.ToString()),
+                new KeyValuePair<string, string>("tenantId", "ConfigurationTenantId"),
+                new KeyValuePair<string, string>("additionallyAllowedTenants", "tenantId1; tenantId2")
+            );
+
+            var credential = (ClientCertificateCredential)ClientFactory.CreateCredential(configuration);
+
+            Assert.That(GetNonPublicPropertyValue(typeof(ClientCertificateCredential), credential, "ClientId"), Is.EqualTo("ConfigurationClientId"));
+            Assert.That(GetNonPublicPropertyValue(typeof(ClientCertificateCredential), credential, "TenantId"), Is.EqualTo("ConfigurationTenantId"));
+            Assert.That(GetNonPublicFieldValueBySuffix(typeof(ClientCertificateCredential), credential, "dditionallyAllowedTenantIds"), Is.EqualTo(new[] { "tenantId1", "tenantId2" }));
+
+            object client = GetNonPublicPropertyValue(typeof(ClientCertificateCredential), credential, "Client");
+            Assert.That(GetNonPublicFieldValueBySuffix(client.GetType(), client, "includeX5CClaimHeader"), Is.True);
+        }
+
+        [Test]
+        public void CertificateAndCertificateSubjectAreMutuallyExclusive()
+        {
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("clientCertificate", "thumbprint"),
+                new KeyValuePair<string, string>("clientCertificateSubject", "subject")
+            );
+
+            Assert.That(
+                () => ClientFactory.CreateCredential(configuration),
+                Throws.ArgumentException.With.Message.Contains("mutually exclusive"));
+        }
+
+        [TestCase(null, "client", "My", "CurrentUser")]
+        [TestCase("tenant", null, "My", "CurrentUser")]
+        [TestCase("tenant", "client", null, "CurrentUser")]
+        [TestCase("tenant", "client", "My", null)]
+        public void CertificateSubjectRequiresAllConfiguration(string tenantId, string clientId, string storeName, string storeLocation)
+        {
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("tenantId", tenantId),
+                new KeyValuePair<string, string>("clientId", clientId),
+                new KeyValuePair<string, string>("clientCertificateSubject", "subject"),
+                new KeyValuePair<string, string>("clientCertificateStoreName", storeName),
+                new KeyValuePair<string, string>("clientCertificateStoreLocation", storeLocation)
+            );
+
+            Assert.That(
+                () => ClientFactory.CreateCredential(configuration),
+                Throws.ArgumentException.With.Message.Contains("'tenantId', 'clientId', 'clientCertificateStoreName', and 'clientCertificateStoreLocation'"));
+        }
+
+        [Test]
         public void CreatesClientSecretCredentials()
         {
             IConfiguration configuration = GetConfiguration(


### PR DESCRIPTION
Add `clientCertificateSubject` configuration key-value to specify the subject name of the certificate to use for `ClientCertificateCredential` for scenarios with Subject Name + Issuer allow-listing instead of specific thumbprint allow-lists. Since certificate lookup by subject name can dynamically change at runtime (i.e. a certificate auto-rotation that installs the "new" cert thumbprint and links to the "existing" cert so that the "new" replacement is automatically used), the `ClientCertificateCredentialOptions.SendCertificateChain` is set to `true` in this case.

Unit tests added for new subject name configuration and for ensuring `clientCertificate` and `clientCertificateSubject` settings throw an exception (can't specify both a thumbprint and subject name simultaneously).