### PR TITLE
Add CI pipeline for Device Registry Software Update

### DIFF
--- a/sdk/deviceregistry/ci.yml
+++ b/sdk/deviceregistry/ci.yml
@@ -1,0 +1,22 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+
+trigger:
+  branches:
+    include:
+    - main
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - sdk/deviceregistry/
+    exclude:
+    - sdk/deviceregistry/Azure.ResourceManager.DeviceRegistry/
+
+extends:
+  template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: deviceregistry
+    ArtifactName: packages
+    Artifacts:
+    - name: Azure.IoT.DeviceRegistry.SoftwareUpdate
+      safeName: AzureIoTDeviceRegistrySoftwareUpdate


### PR DESCRIPTION
## Summary
- Add sdk/deviceregistry/ci.yml using the shared SDK client pipeline.
- Include Azure.IoT.DeviceRegistry.SoftwareUpdate as the package artifact.
- Trigger on main, hotfix/*, and release/* while excluding management-package changes.
- Leave the existing management pipeline unchanged.

## Validation
- Matches the existing Device Update CI pattern.
- Staged git diff --check passed; no editor diagnostics.
- .NET formatting, generation, API export, and snippet updates are not applicable to this YAML-only change.
- Remote CI has not been run locally.