### PR TITLE
Update Azure.ClientSdk.Analyzers to 0.1.1-dev.20260910.1

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -234,7 +234,7 @@
   <!--                  package dependencies                          -->
   <!-- ============================================================== -->
   <ItemGroup>
-    <PackageVersion Include="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20260819.1" PrivateAssets="All" />
+    <PackageVersion Include="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20260910.1" PrivateAssets="All" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20251023.1" PrivateAssets="All" />
 


### PR DESCRIPTION
Bumps `Azure.ClientSdk.Analyzers` from `0.1.1-dev.20260819.1` to `0.1.1-dev.20260910.1`.

This picks up the AZC0032 removal from Azure/azure-sdk-tools#16970, so the analyzer migrated in #62847 becomes the only active AZC0032 implementation. Until this bump both the pinned package and the in-repo analyzer reported AZC0032, producing duplicate diagnostics for legacy-recognized models. This is the follow-up promised in the #62847 review thread.

## Verification

**The delta is exactly the AZC0032 removal.** Comparing `Azure.ClientSdk.Analyzers.dll` in both packages:

| Package | AZC0032 | AZC0004 | AZC0031 |
| --- | --- | --- | --- |
| `0.1.1-dev.20260819.1` (old) | present | absent | present |
| `0.1.1-dev.20260910.1` (new) | absent | absent | present |

AZC0004 was already absent from the pinned build (removed by Azure/azure-sdk-tools#16775 on the same day that build was produced), so nothing else changes.

**Duplicate diagnostics are eliminated.** Building `Azure.ResourceManager.PrivateDns` with an identical probe type under each pin:

| Pin | Raw AZC0032 diagnostic lines |
| --- | --- |
| old | 4 (2 distinct, duplicated) |
| new | 2 (1 distinct) |

The rule still fires; it is now reported once rather than twice.

**No collateral impact.** Both build with 0 errors:

- `Azure.ResourceManager.PrivateDns` (analyzer enabled)
- `Azure.Health.Insights.RadiologyInsights` (has existing AZC0032 suppressions, which continue to apply)

---
🤖 m-nash-copilot
