### PR TITLE
Add Communication Identity API version 2026-09-23

### DIFF
--- a/sdk/communication/Azure.Communication.Identity/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Identity/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Added support for the `2026-09-23` service API version, which is now the default. Use
+  `CommunicationIdentityClientOptions.ServiceVersion.V2026_09_23` to target it explicitly.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/communication/Azure.Communication.Identity/api/Azure.Communication.Identity.net10.0.cs
+++ b/sdk/communication/Azure.Communication.Identity/api/Azure.Communication.Identity.net10.0.cs
@@ -34,7 +34,7 @@ namespace Azure.Communication.Identity
     }
     public partial class CommunicationIdentityClientOptions : Azure.Core.ClientOptions
     {
-        public CommunicationIdentityClientOptions(Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion version = Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion.V2025_03_02_PREVIEW) { }
+        public CommunicationIdentityClientOptions(Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion version = Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion.V2026_09_23) { }
         public enum ServiceVersion
         {
             V2021_03_07 = 1,
@@ -42,6 +42,7 @@ namespace Azure.Communication.Identity
             V2022_10_01 = 3,
             V2023_10_01 = 4,
             V2025_03_02_PREVIEW = 5,
+            V2026_09_23 = 6,
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/communication/Azure.Communication.Identity/api/Azure.Communication.Identity.net8.0.cs
+++ b/sdk/communication/Azure.Communication.Identity/api/Azure.Communication.Identity.net8.0.cs
@@ -34,7 +34,7 @@ namespace Azure.Communication.Identity
     }
     public partial class CommunicationIdentityClientOptions : Azure.Core.ClientOptions
     {
-        public CommunicationIdentityClientOptions(Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion version = Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion.V2025_03_02_PREVIEW) { }
+        public CommunicationIdentityClientOptions(Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion version = Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion.V2026_09_23) { }
         public enum ServiceVersion
         {
             V2021_03_07 = 1,
@@ -42,6 +42,7 @@ namespace Azure.Communication.Identity
             V2022_10_01 = 3,
             V2023_10_01 = 4,
             V2025_03_02_PREVIEW = 5,
+            V2026_09_23 = 6,
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/communication/Azure.Communication.Identity/api/Azure.Communication.Identity.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.Identity/api/Azure.Communication.Identity.netstandard2.0.cs
@@ -34,7 +34,7 @@ namespace Azure.Communication.Identity
     }
     public partial class CommunicationIdentityClientOptions : Azure.Core.ClientOptions
     {
-        public CommunicationIdentityClientOptions(Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion version = Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion.V2025_03_02_PREVIEW) { }
+        public CommunicationIdentityClientOptions(Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion version = Azure.Communication.Identity.CommunicationIdentityClientOptions.ServiceVersion.V2026_09_23) { }
         public enum ServiceVersion
         {
             V2021_03_07 = 1,
@@ -42,6 +42,7 @@ namespace Azure.Communication.Identity
             V2022_10_01 = 3,
             V2023_10_01 = 4,
             V2025_03_02_PREVIEW = 5,
+            V2026_09_23 = 6,
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/communication/Azure.Communication.Identity/src/CommunicationIdentityClientOptions.cs
+++ b/sdk/communication/Azure.Communication.Identity/src/CommunicationIdentityClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Communication.Identity
         /// <summary>
         /// The latest version of the identity service.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2025_03_02_PREVIEW;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2026_09_23;
 
         internal string ApiVersion { get; }
 
@@ -30,6 +30,7 @@ namespace Azure.Communication.Identity
                 ServiceVersion.V2022_10_01 => "2022-10-01",
                 ServiceVersion.V2023_10_01 => "2023-10-01",
                 ServiceVersion.V2025_03_02_PREVIEW => "2025-03-02-preview",
+                ServiceVersion.V2026_09_23 => "2026-09-23",
                 _ => throw new ArgumentOutOfRangeException(nameof(version))
             };
         }
@@ -60,6 +61,10 @@ namespace Azure.Communication.Identity
             /// The V2025_04_01_PREVIEW of the identity service.
             /// </summary>
             V2025_03_02_PREVIEW = 5,
+            /// <summary>
+            /// The V2026_09_23 of the identity service.
+            /// </summary>
+            V2026_09_23 = 6,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
     }

--- a/sdk/communication/Azure.Communication.Identity/tests/ApiVersionTests.cs
+++ b/sdk/communication/Azure.Communication.Identity/tests/ApiVersionTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Communication.Identity.Tests
+{
+    public class ApiVersionTests
+    {
+        [TestCase(null, "2026-09-23")]
+        [TestCase(CommunicationIdentityClientOptions.ServiceVersion.V2025_03_02_PREVIEW, "2025-03-02-preview")]
+        [TestCase(CommunicationIdentityClientOptions.ServiceVersion.V2026_09_23, "2026-09-23")]
+        public void ClientSendsExpectedApiVersion(
+            CommunicationIdentityClientOptions.ServiceVersion? version,
+            string expectedApiVersion)
+        {
+            var requests = new List<Request>();
+            var response = new MockResponse(201);
+            response.SetContent("{\"identity\":{\"id\":\"8:acs:test\"}}");
+            var options = version.HasValue
+                ? new CommunicationIdentityClientOptions(version.Value)
+                : new CommunicationIdentityClientOptions();
+            options.Transport = new MockTransport(request =>
+            {
+                requests.Add(request);
+                return response;
+            });
+
+            var client = new CommunicationIdentityClient(
+                new Uri("https://contoso.communication.azure.com"),
+                new AzureKeyCredential(Convert.ToBase64String(Encoding.UTF8.GetBytes("test-key"))),
+                options);
+
+            client.CreateUser();
+
+            Assert.That(requests, Has.Count.EqualTo(1));
+            Assert.That(requests[0].Uri.Query, Does.Contain($"api-version={expectedApiVersion}"));
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.Identity/tests/Infrastructure/CommunicationIdentityClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.Identity/tests/Infrastructure/CommunicationIdentityClientLiveTestBase.cs
@@ -19,6 +19,7 @@ namespace Azure.Communication.Identity.Tests
     {
         private const string URIDomainNameReplacerRegEx = @"https://([^/?]+)";
         private const string URIIdentityReplacerRegEx = @"/identities/([^/?]+)";
+        private const string URIApiVersionReplacerRegEx = @"api-version=[^&]+";
 
         public CommunicationIdentityClientLiveTestBase(bool isAsync) : base(isAsync)
         {
@@ -29,6 +30,7 @@ namespace Azure.Communication.Identity.Tests
             SanitizedHeaders.Add("x-ms-content-sha256");
             UriRegexSanitizers.Add(new UriRegexSanitizer(URIIdentityReplacerRegEx) { Value = "/identities/Sanitized" });
             UriRegexSanitizers.Add(new UriRegexSanitizer(URIDomainNameReplacerRegEx) { Value = "https://sanitized.communication.azure.com" });
+            UriRegexSanitizers.Add(new UriRegexSanitizer(URIApiVersionReplacerRegEx) { Value = "api-version=Sanitized" });
         }
 
         /// <summary>


### PR DESCRIPTION
## Why

Communication Identity needs a simplified SDK update that targets the `2026-09-23` service API while preserving the existing client surface and older service-version options.

```text
CommunicationIdentityClient
└── CommunicationIdentityClientOptions
    └── V2026_09_23 (default)
        └── api-version=2026-09-23
```

## What changed

- Added `ServiceVersion.V2026_09_23` and made it the default API version.
- Preserved all existing service-version mappings, including the prior preview version.
- Updated the public API listings and changelog.
- Added offline transport tests that verify both default and explicitly selected API versions on the request URI.
- Sanitized `api-version` in recorded tests so existing recordings remain usable across version changes.

## Testing

- `dotnet format` for the source and test projects
- `dotnet build sdk\communication\Azure.Communication.Identity\src\Azure.Communication.Identity.csproj /t:GenerateCode`
- `eng\scripts\Export-API.ps1 communication`
- `dotnet test sdk\communication\Azure.Communication.Identity\tests\Azure.Communication.Identity.Tests.csproj -f net8.0 --no-restore` - 138 passed, 11 skipped
- `dotnet test sdk\communication\Azure.Communication.Identity\tests\Azure.Communication.Identity.Tests.csproj -f net10.0 --no-restore` - 138 passed, 11 skipped

The .NET 9 test target was not run because the .NET 9 runtime is not installed in the validation environment.