### PR TITLE
Add README template guidance comment

### DIFF
--- a/sdk/template/Azure.Template/README.md
+++ b/sdk/template/Azure.Template/README.md
@@ -1,5 +1,7 @@
 # Azure Template client library for .NET
 
+<!-- Use this README as a starting point and replace template guidance with package-specific content. -->
+
 Azure Template is a template project for creating Azure SDK libraries generated from TypeSpec.
 
 Use this template as a starting point for:


### PR DESCRIPTION
Adds a non-rendered comment clarifying that package authors should replace the template guidance with package-specific content.